### PR TITLE
chore: update cairo to ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -644,12 +644,12 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 
 [[package]]
 name = "cairo-lang-defs"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-formatter"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-language-server"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-debug",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-filesystem",
  "serde",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-utils",
  "const-fnv1a-hash",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-starknet"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-utils",
  "genco",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-test-utils"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "cairo-lang-utils",
  "env_logger",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=03468599c4d290762795fecf838f1037331e6e47#03468599c4d290762795fecf838f1037331e6e47"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -644,12 +644,12 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 
 [[package]]
 name = "cairo-lang-defs"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -729,7 +729,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-formatter"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -750,7 +750,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-language-server"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-debug",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -800,7 +800,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -817,7 +817,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -846,7 +846,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-filesystem",
  "serde",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -881,7 +881,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-utils",
  "const-fnv1a-hash",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -972,7 +972,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-starknet"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -1010,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-utils",
  "genco",
@@ -1033,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-test-utils"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "cairo-lang-utils",
  "env_logger",
@@ -1044,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01#ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01"
 dependencies = [
  "chrono",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef05d137e34b7ac51dbec170ee523a9b728cff71385796771d259771d592f8"
+checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
 dependencies = [
  "borsh-derive",
  "hashbrown 0.13.2",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190b1188f062217531748807129459c8c14641b648e887e39681a433db7fc939"
+checksum = "598b3eacc6db9c3ee57b22707ad8f6a8d2f6d442bfe24ffeb8cbb70ca59e6a35"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
@@ -482,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fcf747a3e4eb47869441664df09d0eb88dcc9a85d499860efb82c2cfe6affc"
+checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -493,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f671d085f791c5fd3331c843ded45454b034b6188bf0f78ed28e7fd66a8b3f69"
+checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -520,6 +520,16 @@ dependencies = [
  "serde_json",
  "time 0.3.17",
  "uuid 1.3.0",
+]
+
+[[package]]
+name = "bstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -598,7 +608,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-casm"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-utils",
  "indoc",
@@ -610,7 +620,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-compiler"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -634,12 +644,12 @@ dependencies = [
 [[package]]
 name = "cairo-lang-debug"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 
 [[package]]
 name = "cairo-lang-defs"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-diagnostics",
@@ -656,7 +666,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-diagnostics"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-utils",
@@ -696,7 +706,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-eq-solver"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-utils",
  "good_lp",
@@ -707,7 +717,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-filesystem"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-utils",
@@ -719,7 +729,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-formatter"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "anyhow",
  "cairo-lang-diagnostics",
@@ -730,6 +740,7 @@ dependencies = [
  "clap",
  "colored",
  "diffy",
+ "ignore",
  "itertools",
  "log",
  "salsa",
@@ -739,7 +750,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-language-server"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-debug",
@@ -766,7 +777,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-lowering"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -789,7 +800,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-parser"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-diagnostics",
  "cairo-lang-filesystem",
@@ -806,7 +817,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-plugins"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
@@ -825,7 +836,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-proc-macros"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-debug",
  "quote",
@@ -835,7 +846,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-project"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-filesystem",
  "serde",
@@ -847,7 +858,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-semantic"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -870,7 +881,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-utils",
  "const-fnv1a-hash",
@@ -892,7 +903,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-ap-change"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -904,7 +915,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-gas"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-eq-solver",
  "cairo-lang-sierra",
@@ -916,7 +927,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-generator"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-defs",
@@ -941,7 +952,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-sierra-to-casm"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "assert_matches",
  "cairo-felt",
@@ -961,7 +972,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-starknet"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -999,7 +1010,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-debug",
  "cairo-lang-filesystem",
@@ -1011,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-syntax-codegen"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-utils",
  "genco",
@@ -1022,7 +1033,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-test-utils"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "cairo-lang-utils",
  "env_logger",
@@ -1033,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "cairo-lang-utils"
 version = "1.0.0-alpha.2"
-source = "git+https://github.com/starkware-libs/cairo.git?rev=255bde8b3d798bcef7832edab6edc21b76e216fb#255bde8b3d798bcef7832edab6edc21b76e216fb"
+source = "git+https://github.com/starkware-libs/cairo.git?rev=b51c511ab39dae631362d4157853db46c2c49d64#b51c511ab39dae631362d4157853db46c2c49d64"
 dependencies = [
  "chrono",
  "env_logger",
@@ -1896,9 +1907,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -2206,6 +2217,19 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "good_lp"
@@ -2520,6 +2544,23 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3170,14 +3211,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3606,9 +3647,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -4734,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
 ]
@@ -4843,9 +4884,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
 dependencies = [
  "bytecheck",
  "hashbrown 0.12.3",
@@ -4857,9 +4898,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.39"
+version = "0.7.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5051,6 +5092,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -6631,6 +6681,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
 ]
 
 [[package]]

--- a/crates/cairo-lang-dojo/Cargo.toml
+++ b/crates/cairo-lang-dojo/Cargo.toml
@@ -10,16 +10,16 @@ description = "Dojo capabilities and utilities on top of Starknet."
 
 [dependencies]
 anyhow = "1.0.66"
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "447182a90839a3e4f096a01afe75ef474186d911" }
 indoc.workspace = true
 itertools.workspace = true
@@ -29,11 +29,11 @@ smol_str.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
-cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb", features = [
+cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64", features = [
     "testing",
 ] }
-cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
+cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
 test-case = "2.2.2"
 test-case-macros = "2.2.2"
 test-log.workspace = true

--- a/crates/cairo-lang-dojo/Cargo.toml
+++ b/crates/cairo-lang-dojo/Cargo.toml
@@ -10,16 +10,16 @@ description = "Dojo capabilities and utilities on top of Starknet."
 
 [dependencies]
 anyhow = "1.0.66"
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "447182a90839a3e4f096a01afe75ef474186d911" }
 indoc.workspace = true
 itertools.workspace = true
@@ -29,11 +29,11 @@ smol_str.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
-cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01", features = [
+cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47", features = [
     "testing",
 ] }
-cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
 test-case = "2.2.2"
 test-case-macros = "2.2.2"
 test-log.workspace = true

--- a/crates/cairo-lang-dojo/Cargo.toml
+++ b/crates/cairo-lang-dojo/Cargo.toml
@@ -10,16 +10,16 @@ description = "Dojo capabilities and utilities on top of Starknet."
 
 [dependencies]
 anyhow = "1.0.66"
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-defs = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-diagnostics = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-lowering = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-parser = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-sierra-generator = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-syntax = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
 starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "447182a90839a3e4f096a01afe75ef474186d911" }
 indoc.workspace = true
 itertools.workspace = true
@@ -29,11 +29,11 @@ smol_str.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
-cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64", features = [
+cairo-lang-formatter = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-semantic = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01", features = [
     "testing",
 ] }
-cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-test-utils = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
 test-case = "2.2.2"
 test-case-macros = "2.2.2"
 test-log.workspace = true

--- a/crates/dojo-cli/Cargo.toml
+++ b/crates/dojo-cli/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 anyhow = "1.0.66"
 clap = { version = "4.0", features = ["derive"] }
 cairo-lang-dojo = { path = "../cairo-lang-dojo" }
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
 toml.workspace = true
 
 [[bin]]

--- a/crates/dojo-cli/Cargo.toml
+++ b/crates/dojo-cli/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 anyhow = "1.0.66"
 clap = { version = "4.0", features = ["derive"] }
 cairo-lang-dojo = { path = "../cairo-lang-dojo" }
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
 toml.workspace = true
 
 [[bin]]

--- a/crates/dojo-cli/Cargo.toml
+++ b/crates/dojo-cli/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 anyhow = "1.0.66"
 clap = { version = "4.0", features = ["derive"] }
 cairo-lang-dojo = { path = "../cairo-lang-dojo" }
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-filesystem = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-project = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
 toml.workspace = true
 
 [[bin]]

--- a/crates/dojo-language-server/Cargo.toml
+++ b/crates/dojo-language-server/Cargo.toml
@@ -10,12 +10,12 @@ path = "src/bin/language_server.rs"
 
 [dependencies]
 cairo-lang-dojo = {path = "../../crates/cairo-lang-dojo"}
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-semantic= { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
-cairo-lang-filesystem= { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-semantic= { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
+cairo-lang-filesystem= { git = "https://github.com/starkware-libs/cairo.git", rev = "03468599c4d290762795fecf838f1037331e6e47" }
 tokio = { version = "1.18.2", features = ["full", "sync"] }
 tower-lsp = "0.17.0"
 salsa = "0.16.1"

--- a/crates/dojo-language-server/Cargo.toml
+++ b/crates/dojo-language-server/Cargo.toml
@@ -10,12 +10,12 @@ path = "src/bin/language_server.rs"
 
 [dependencies]
 cairo-lang-dojo = {path = "../../crates/cairo-lang-dojo"}
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-semantic= { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
-cairo-lang-filesystem= { git = "https://github.com/starkware-libs/cairo.git", rev = "255bde8b3d798bcef7832edab6edc21b76e216fb" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-semantic= { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-filesystem= { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
 tokio = { version = "1.18.2", features = ["full", "sync"] }
 tower-lsp = "0.17.0"
 salsa = "0.16.1"

--- a/crates/dojo-language-server/Cargo.toml
+++ b/crates/dojo-language-server/Cargo.toml
@@ -10,12 +10,12 @@ path = "src/bin/language_server.rs"
 
 [dependencies]
 cairo-lang-dojo = {path = "../../crates/cairo-lang-dojo"}
-cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-semantic= { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
-cairo-lang-filesystem= { git = "https://github.com/starkware-libs/cairo.git", rev = "b51c511ab39dae631362d4157853db46c2c49d64" }
+cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-language-server = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-semantic= { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-plugins = { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
+cairo-lang-filesystem= { git = "https://github.com/starkware-libs/cairo.git", rev = "ff2db010ceb62d4e4dd14be36f2dbdf9ea82ae01" }
 tokio = { version = "1.18.2", features = ["full", "sync"] }
 tower-lsp = "0.17.0"
 salsa = "0.16.1"

--- a/lib/initializer.cairo
+++ b/lib/initializer.cairo
@@ -12,11 +12,11 @@ trait IUpgradable {
 #[contract]
 mod ConstantIntializer {
     use dojo::syscalls::replace_class;
+    use dojo::syscalls::get_contract_address;
 
     #[external]
     fn initialize(class_hash: felt, init_calldata: Array::<felt>) {
-        // TODO: Replace with starknet::get_contract_address once it is ready.
-        let self_address = starknet::contract_address_const::<17>();
+        let self_address = get_contract_address();
         replace_class(class_hash);
         super::IUpgradableDispatcher::initialize(self_address, init_calldata);
     }

--- a/lib/initializer.cairo
+++ b/lib/initializer.cairo
@@ -12,7 +12,7 @@ trait IUpgradable {
 #[contract]
 mod ConstantIntializer {
     use dojo::syscalls::replace_class;
-    use dojo::syscalls::get_contract_address;
+    use starknet::get_contract_address;
 
     #[external]
     fn initialize(class_hash: felt, init_calldata: Array::<felt>) {

--- a/lib/syscalls.cairo
+++ b/lib/syscalls.cairo
@@ -7,9 +7,5 @@ fn deploy(
     starknet::contract_address_const::<0x420>()
 }
 
-fn get_contract_address() -> starknet::ContractAddress {
-    starknet::contract_address_const::<0x420>()
-}
-
 // NOTE: Not available yet: https://docs.starknet.io/documentation/starknet_versions/upcoming_versions/#replace_class_syscall
 fn replace_class(class_hash: felt) {}

--- a/lib/syscalls.cairo
+++ b/lib/syscalls.cairo
@@ -1,16 +1,14 @@
-// TODO: I think these should return starknet::ContractAddress but
-// I'm not sure how to cast that to a felt.
 fn deploy(
     class_hash: felt,
     contract_address_salt: felt,
     constructor_calldata: Array::<felt>,
     deploy_from_zero: bool
-) -> felt {
-    0x420
+) -> starknet::ContractAddress {
+    starknet::contract_address_const::<0x420>()
 }
 
-fn get_contract_address() -> felt {
-    0x420
+fn get_contract_address() -> starknet::ContractAddress {
+    starknet::contract_address_const::<0x420>()
 }
 
 // NOTE: Not available yet: https://docs.starknet.io/documentation/starknet_versions/upcoming_versions/#replace_class_syscall

--- a/lib/world.cairo
+++ b/lib/world.cairo
@@ -3,13 +3,14 @@ use array::ArrayTrait;
 #[abi]
 trait IProxy {
     fn set_implementation(class_hash: felt);
-    fn initialize(world_address: felt);
+    fn initialize(world_address: starknet::ContractAddress);
 }
 
 #[contract]
 mod World {
     use hash::pedersen;
     use starknet::get_caller_address;
+    use starknet::contract_address_to_felt;
     use dojo::syscalls::deploy;
     use dojo::syscalls::get_contract_address;
 
@@ -19,40 +20,32 @@ mod World {
         module_registry: LegacyMap::<felt, felt>,
     }
 
-    // TODO: Uncommenting this gives:
-    // error: Variable was previously moved.
-    // --> contract:131:9
-    //         serde::Serde::<felt>::serialize(ref data, entity_id);
-    // #[event]
-    // fn ComponentValueSet(component_id: felt, entity_id: felt, data: Array::<felt>) {}
+    #[event]
+    fn ComponentValueSet(component_id: felt, entity_id: felt, data: Array::<felt>) {}
 
     #[external]
     fn register(class_hash: felt, module_id: felt) {
         let module_id = pedersen(0, module_id);
         let proxy_class_hash = 420;
-        let address = deploy(proxy_class_hash, module_id, ArrayTrait::new(), bool::False(()));
+        let module_address = deploy(proxy_class_hash, module_id, ArrayTrait::new(), bool::False(()));
+        let world_address = get_contract_address();
+        super::IProxyDispatcher::set_implementation(module_address, class_hash);
+        super::IProxyDispatcher::initialize(module_address, world_address);
 
-        match starknet::contract_address_try_from_felt(address) {
-            Option::Some(ca) => {
-                let world_address = get_contract_address();
-                super::IProxyDispatcher::set_implementation(ca, class_hash);
-                super::IProxyDispatcher::initialize(ca, world_address);
-
-                module_registry::write(module_id, address);
-                module_registry::write(address, module_id);
-            },
-            Option::None(_) => {},
-        };
+        let module_address_felt = contract_address_to_felt(module_address);
+        module_registry::write(module_id, module_address_felt);
+        module_registry::write(module_address_felt, module_id);
     }
 
     #[external]
     fn on_component_set(entity_id: felt, data: Array::<felt>) {
         let caller_address = get_caller_address();
-        assert(caller_address != 0, 'World: caller is not a registered');
-        // ComponentValueSet(caller_address, entity_id, data);
-        let entities_len = entity_registry_len::read(caller_address);
-        entity_registry::write((caller_address, entities_len), entity_id);
-        entity_registry_len::write(caller_address, entities_len + 1);
+        let caller_address_felt = contract_address_to_felt(caller_address);
+        assert(caller_address_felt != 0, 'World: not a registered');
+        let entities_len = entity_registry_len::read(caller_address_felt);
+        entity_registry::write((caller_address_felt, entities_len), entity_id);
+        entity_registry_len::write(caller_address_felt, entities_len + 1);
+        ComponentValueSet(caller_address_felt, entity_id, data);
     }
 
     #[view]

--- a/lib/world.cairo
+++ b/lib/world.cairo
@@ -3,16 +3,16 @@ use array::ArrayTrait;
 #[abi]
 trait IProxy {
     fn set_implementation(class_hash: felt);
-    fn initialize(world_address: starknet::ContractAddress);
+// fn initialize(world_address: starknet::ContractAddress);
 }
 
 #[contract]
 mod World {
     use hash::pedersen;
     use starknet::get_caller_address;
+    use starknet::get_contract_address;
     use starknet::contract_address_to_felt;
     use dojo::syscalls::deploy;
-    use dojo::syscalls::get_contract_address;
 
     struct Storage {
         entity_registry_len: LegacyMap::<felt, felt>,
@@ -27,10 +27,13 @@ mod World {
     fn register(class_hash: felt, module_id: felt) {
         let module_id = pedersen(0, module_id);
         let proxy_class_hash = 420;
-        let module_address = deploy(proxy_class_hash, module_id, ArrayTrait::new(), bool::False(()));
+        let module_address = deploy(
+            proxy_class_hash, module_id, ArrayTrait::new(), bool::False(())
+        );
         let world_address = get_contract_address();
         super::IProxyDispatcher::set_implementation(module_address, class_hash);
-        super::IProxyDispatcher::initialize(module_address, world_address);
+        // TODO: Uncomment once https://github.com/starkware-libs/cairo/issues/2114 is addressed.
+        // super::IProxyDispatcher::initialize(module_address, world_address);
 
         let module_address_felt = contract_address_to_felt(module_address);
         module_registry::write(module_id, module_address_felt);


### PR DESCRIPTION
update to new syscall interfaces. blocked by the issue linked below