### PR TITLE
feat(dojo-lang): support components with primitive types

### DIFF
--- a/crates/dojo-lang/src/component.rs
+++ b/crates/dojo-lang/src/component.rs
@@ -40,6 +40,11 @@ pub fn handle_generated_component(
             "
                 #[contract]
                 mod $name$Component {
+                    use option::OptionTrait;
+                    use starknet::SyscallResult;
+                    use traits::Into;
+                    use traits::TryInto;
+
                     $body$
                     $members$
                 }
@@ -164,45 +169,70 @@ pub fn handle_component_struct(db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct
     let mut deserialize = vec![];
     let mut read = vec![];
     let mut write = vec![];
+
     struct_ast.members(db).elements(db).iter().enumerate().for_each(|(i, member)| {
+        let member_type_string = member.type_clause(db).ty(db).as_syntax_node().get_text(db);
+        let is_felt = member_type_string.as_str().trim().eq("felt");
+
         serialize.push(RewriteNode::interpolate_patched(
-            "serde::Serde::<felt>::serialize(ref serialized, input.$key$);",
-            HashMap::from([(
-                "key".to_string(),
-                RewriteNode::new_trimmed(member.name(db).as_syntax_node()),
-            )]),
-        ));
-
-        deserialize.push(RewriteNode::interpolate_patched(
-            "$key$: serde::Serde::<felt>::deserialize(ref serialized)?,",
-            HashMap::from([(
-                "key".to_string(),
-                RewriteNode::new_trimmed(member.name(db).as_syntax_node()),
-            )]),
-        ));
-
-        read.push(RewriteNode::interpolate_patched(
-            "$key$: starknet::storage_read_syscall(
-                address_domain, starknet::storage_address_from_base_and_offset(base, $offset$_u8)
-            )?,",
+            "serde::Serde::<$type_clause$>::serialize(ref serialized, input.$key$);",
             HashMap::from([
                 ("key".to_string(), RewriteNode::new_trimmed(member.name(db).as_syntax_node())),
-                ("offset".to_string(), RewriteNode::Text(i.to_string())),
+                (
+                    "type_clause".to_string(),
+                    RewriteNode::new_trimmed(member.type_clause(db).ty(db).as_syntax_node()),
+                ),
             ]),
         ));
 
-        let final_token =
-            if i != struct_ast.members(db).elements(db).len() - 1 { "?;" } else { "" };
-        write.push(RewriteNode::interpolate_patched(
+        deserialize.push(RewriteNode::interpolate_patched(
+            "$key$: serde::Serde::<$type_clause$>::deserialize(ref serialized)?,",
+            HashMap::from([
+                ("key".to_string(), RewriteNode::new_trimmed(member.name(db).as_syntax_node())),
+                (
+                    "type_clause".to_string(),
+                    RewriteNode::new_trimmed(member.type_clause(db).ty(db).as_syntax_node()),
+                ),
+            ]),
+        ));
+
+        let try_into_unwrap_token = if is_felt { "?," } else { "?.try_into().unwrap()," };
+        read.push(RewriteNode::interpolate_patched(
             format!(
-                "
-                starknet::storage_write_syscall(
-                    address_domain, starknet::storage_address_from_base_and_offset(base, \
-                 $offset$_u8), value.$key$){final_token}"
+                "$key$: starknet::storage_read_syscall(
+                    address_domain,
+                    starknet::storage_address_from_base_and_offset(base, $offset$_u8)
+                ){try_into_unwrap_token}"
             )
             .as_str(),
             HashMap::from([
                 ("key".to_string(), RewriteNode::new_trimmed(member.name(db).as_syntax_node())),
+                (
+                    "type_clause".to_string(),
+                    RewriteNode::new_trimmed(member.type_clause(db).ty(db).as_syntax_node()),
+                ),
+                ("offset".to_string(), RewriteNode::Text(i.to_string())),
+            ]),
+        ));
+
+        let into_token = if is_felt { "" } else { ".into()" };
+        let final_token =
+            if i != struct_ast.members(db).elements(db).len() - 1 { "?;" } else { "" };
+        write.push(RewriteNode::interpolate_patched(
+            format!(
+                "starknet::storage_write_syscall(
+                    address_domain,
+                    starknet::storage_address_from_base_and_offset(base, $offset$_u8),
+                    value.$key${into_token}
+                ){final_token}"
+            )
+            .as_str(),
+            HashMap::from([
+                ("key".to_string(), RewriteNode::new_trimmed(member.name(db).as_syntax_node())),
+                (
+                    "type_clause".to_string(),
+                    RewriteNode::new_trimmed(member.type_clause(db).ty(db).as_syntax_node()),
+                ),
                 ("offset".to_string(), RewriteNode::Text(i.to_string())),
             ]),
         ));

--- a/crates/dojo-lang/src/plugin_test.rs
+++ b/crates/dojo-lang/src/plugin_test.rs
@@ -83,6 +83,7 @@ cairo_lang_test_utils::test_file_test_with_runner!(
     "src/plugin_test_data",
     {
         component: "component",
+        component2: "component2",
         system: "system",
     },
     ExpandContractTestRunner

--- a/crates/dojo-lang/src/plugin_test_data/component
+++ b/crates/dojo-lang/src/plugin_test_data/component
@@ -32,6 +32,11 @@ use dojo::world::ComponentTrait;
 
 #[contract]
 mod PositionComponent {
+    use option::OptionTrait;
+    use starknet::SyscallResult;
+    use traits::Into;
+    use traits::TryInto;
+
     #[derive(Copy, Drop)]
     struct Position {
         x: felt,

--- a/crates/dojo-lang/src/plugin_test_data/component2
+++ b/crates/dojo-lang/src/plugin_test_data/component2
@@ -1,0 +1,135 @@
+//! > Test expansion of the component contract.
+
+//! > test_runner_name
+ExpandContractTestRunner
+
+//! > cairo_code
+use dojo::world::ComponentTrait;
+
+#[derive(Component)]
+struct Fighter {
+    attack: u16,
+    defense: u16,
+    speed: u32,
+    luck: u8,
+    name: felt
+}
+
+//! > generated_cairo_code
+use dojo::world::ComponentTrait;
+
+#[contract]
+mod FighterComponent {
+    use option::OptionTrait;
+    use starknet::SyscallResult;
+    use traits::Into;
+    use traits::TryInto;
+
+    #[derive(Copy, Drop)]
+    struct Fighter {
+        attack: u16,
+        defense: u16,
+        speed: u32,
+        luck: u8,
+        name: felt
+    }
+
+    impl FighterSerde of serde::Serde::<Fighter> {
+        fn serialize(ref serialized: Array::<felt>, input: Fighter) {
+            serde::Serde::<u16>::serialize(ref serialized, input.attack);
+            serde::Serde::<u16>::serialize(ref serialized, input.defense);
+            serde::Serde::<u32>::serialize(ref serialized, input.speed);
+            serde::Serde::<u8>::serialize(ref serialized, input.luck);
+            serde::Serde::<felt>::serialize(ref serialized, input.name);
+        }
+        fn deserialize(ref serialized: Span::<felt>) -> Option::<Fighter> {
+            Option::Some(
+                Fighter {
+                    attack: serde::Serde::<u16>::deserialize(ref serialized)?,
+                    defense: serde::Serde::<u16>::deserialize(ref serialized)?,
+                    speed: serde::Serde::<u32>::deserialize(ref serialized)?,
+                    luck: serde::Serde::<u8>::deserialize(ref serialized)?,
+                    name: serde::Serde::<felt>::deserialize(ref serialized)?,
+                }
+            )
+        }
+    }
+
+    impl StorageAccessFighter of starknet::StorageAccess::<Fighter> {
+        fn read(
+            address_domain: felt, base: starknet::StorageBaseAddress
+        ) -> starknet::SyscallResult::<Fighter> {
+            Result::Ok(
+                Fighter {
+                    attack: starknet::storage_read_syscall(
+                        address_domain, starknet::storage_address_from_base_and_offset(base, 0_u8)
+                    )?.try_into().unwrap(),
+                    defense: starknet::storage_read_syscall(
+                        address_domain, starknet::storage_address_from_base_and_offset(base, 1_u8)
+                    )?.try_into().unwrap(),
+                    speed: starknet::storage_read_syscall(
+                        address_domain, starknet::storage_address_from_base_and_offset(base, 2_u8)
+                    )?.try_into().unwrap(),
+                    luck: starknet::storage_read_syscall(
+                        address_domain, starknet::storage_address_from_base_and_offset(base, 3_u8)
+                    )?.try_into().unwrap(),
+                    name: starknet::storage_read_syscall(
+                        address_domain, starknet::storage_address_from_base_and_offset(base, 4_u8)
+                    )?,
+                }
+            )
+        }
+        fn write(
+            address_domain: felt, base: starknet::StorageBaseAddress, value: Fighter
+        ) -> starknet::SyscallResult::<()> {
+            starknet::storage_write_syscall(
+                address_domain,
+                starknet::storage_address_from_base_and_offset(base, 0_u8),
+                value.attack.into()
+            )?;
+            starknet::storage_write_syscall(
+                address_domain,
+                starknet::storage_address_from_base_and_offset(base, 1_u8),
+                value.defense.into()
+            )?;
+            starknet::storage_write_syscall(
+                address_domain,
+                starknet::storage_address_from_base_and_offset(base, 2_u8),
+                value.speed.into()
+            )?;
+            starknet::storage_write_syscall(
+                address_domain,
+                starknet::storage_address_from_base_and_offset(base, 3_u8),
+                value.luck.into()
+            )?;
+            starknet::storage_write_syscall(
+                address_domain,
+                starknet::storage_address_from_base_and_offset(base, 4_u8),
+                value.name
+            )
+        }
+    }
+
+
+    struct Storage {
+        state: LegacyMap::<felt, Fighter>, 
+    }
+
+    // Initialize Fighter.
+    #[external]
+    fn initialize() {}
+
+    // Set the state of an entity.
+    #[external]
+    fn set(entity_id: felt, value: Fighter) {
+        state::write(entity_id, value);
+    }
+
+    // Get the state of an entity.
+    #[view]
+    fn get(entity_id: felt) -> Fighter {
+        return state::read(entity_id);
+    }
+}
+
+//! > expected_diagnostics

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -54,6 +54,11 @@ mod MoveSystem {
 
 #[contract]
 mod PositionComponent {
+    use option::OptionTrait;
+    use starknet::SyscallResult;
+    use traits::Into;
+    use traits::TryInto;
+
     #[derive(Copy, Drop)]
     struct Position {
         x: felt,
@@ -126,6 +131,11 @@ mod PositionComponent {
 
 #[contract]
 mod HealthComponent {
+    use option::OptionTrait;
+    use starknet::SyscallResult;
+    use traits::Into;
+    use traits::TryInto;
+
     #[derive(Copy, Drop)]
     struct Health {
         hp: felt, 


### PR DESCRIPTION
Resolves #87.

We can now build Components with all primitive types (felts as well as u8, u16, etc.).

Had to add a bunch of `use` clauses to the generated Component file. They aren't necessary if the component is only made out of felts, but we need them for the rest. Not sure if it's ok like this.

There's also one part of the code I'm not very fond of - the one where it checks if a member is a felt type (`is_felt`). I'm converting the syntax node into String, trimming it and comparing to `"felt"`. I didn't find any other way how to do this. Is there a better alternative?