### PR TITLE
fix: manifest path in build

### DIFF
--- a/crates/dojo-cli/src/build.rs
+++ b/crates/dojo-cli/src/build.rs
@@ -32,7 +32,8 @@ pub fn run(args: BuildArgs) -> Result<()> {
     let mut compilers = CompilerRepository::empty();
     compilers.add(Box::new(DojoCompiler)).unwrap();
 
-    let config = Config::builder(source_dir)
+    let manifest_path = source_dir.join("Scarb.toml");
+    let config = Config::builder(manifest_path)
         .ui_verbosity(Verbosity::Verbose)
         .log_filter_directive(env::var_os("SCARB_LOG"))
         .compilers(compilers)


### PR DESCRIPTION
Running `cargo run --bin dojo build examples` didn't work for me because the `Config::builder` should take the manifest path and not the directory of the project as parameter