### PR TITLE
Refactor: build World for migration from local and remote manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3043,6 +3043,7 @@ dependencies = [
  "cairo-lang-test-utils",
  "cairo-lang-utils",
  "camino",
+ "dojo-project",
  "env_logger",
  "indoc 1.0.9",
  "itertools 0.10.5",
@@ -3051,12 +3052,15 @@ dependencies = [
  "scarb",
  "serde",
  "serde_json",
+ "serde_with",
  "smol_str",
+ "starknet 0.2.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=327be477312d1c0fc5951edb9801791b19f60cbd)",
  "test-case",
  "test-case-macros",
  "test-log",
  "thiserror",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/dojo-cli/src/migrate.rs
+++ b/crates/dojo-cli/src/migrate.rs
@@ -127,7 +127,8 @@ impl World {
         for system in local_manifest.systems {
             systems.push(Class {
                 world: world_config.address.unwrap(),
-                // because the name returns by the `name` method of a system contract is without the 'System' suffix
+                // because the name returns by the `name` method of a
+                // system contract is without the 'System' suffix
                 name: system.name.strip_suffix("System").unwrap_or(&system.name).to_string(),
                 local: system.class_hash,
                 remote: remote_manifest
@@ -163,7 +164,7 @@ impl World {
         Ok(World {
             world: Contract {
                 name: "World".into(),
-                address: world_config.address.clone(),
+                address: world_config.address,
                 local: local_manifest.world.unwrap(),
                 remote: remote_manifest.world,
             },

--- a/crates/dojo-cli/src/migrate.rs
+++ b/crates/dojo-cli/src/migrate.rs
@@ -1,22 +1,15 @@
 use std::env::{self, current_dir};
 use std::fmt::Display;
-use std::fs;
-use std::str::FromStr;
 
-use anyhow::Context;
-use async_trait::async_trait;
-use cairo_lang_starknet::casm_contract_class::CasmContractClass;
+use anyhow::anyhow;
 use camino::Utf8PathBuf;
 use clap::Args;
+use dojo_lang::manifest::Manifest;
 use dojo_project::WorldConfig;
 use scarb::core::Config;
 use scarb::ops;
 use scarb::ui::Verbosity;
-use starknet::core::types::contract::CompiledClass;
 use starknet::core::types::FieldElement;
-use starknet::core::utils::get_storage_var_address;
-use starknet::providers::jsonrpc::models::{BlockId, BlockTag};
-use starknet::providers::jsonrpc::{HttpTransport, JsonRpcClient};
 use url::Url;
 
 #[derive(Args)]
@@ -50,34 +43,11 @@ pub async fn run(args: MigrateArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[async_trait]
-trait ResolveRemote {
-    async fn resolve_remote(&mut self, rpc: &JsonRpcClient<HttpTransport>) -> anyhow::Result<()>;
-}
-
 struct Contract {
     name: String,
     address: Option<FieldElement>,
     local: FieldElement,
     remote: Option<FieldElement>,
-}
-
-#[async_trait]
-impl ResolveRemote for Contract {
-    async fn resolve_remote(
-        self: &mut Contract,
-        rpc: &JsonRpcClient<HttpTransport>,
-    ) -> anyhow::Result<()> {
-        if let Some(address) = self.address {
-            if let Ok(remote_class_hash) =
-                rpc.get_class_hash_at(&BlockId::Tag(BlockTag::Latest), address).await
-            {
-                self.remote = Some(remote_class_hash);
-            }
-        }
-
-        Ok(())
-    }
 }
 
 impl Display for Contract {
@@ -97,41 +67,11 @@ impl Display for Contract {
 }
 
 struct Class {
+    #[allow(unused)]
     world: FieldElement,
     name: String,
     local: FieldElement,
     remote: Option<FieldElement>,
-}
-
-#[async_trait]
-impl ResolveRemote for Class {
-    async fn resolve_remote(
-        self: &mut Class,
-        rpc: &JsonRpcClient<HttpTransport>,
-    ) -> anyhow::Result<()> {
-        if !matches!(self.name.as_str(), "Indexer" | "Store") {
-            let remote_class_hash = rpc
-                .get_storage_at(
-                    self.world,
-                    get_storage_var_address(&self.name.to_lowercase(), &[]).unwrap(),
-                    &BlockId::Tag(BlockTag::Latest),
-                )
-                .await?;
-            self.remote = Some(remote_class_hash);
-            return Ok(());
-        }
-
-        let remote_class_hash = rpc
-            .get_storage_at(
-                self.world,
-                get_storage_var_address("indexer", &[FieldElement::from_str(&self.name).unwrap()])
-                    .unwrap(),
-                &BlockId::Tag(BlockTag::Latest),
-            )
-            .await?;
-        self.remote = Some(remote_class_hash);
-        Ok(())
-    }
 }
 
 impl Display for Class {
@@ -148,7 +88,6 @@ impl Display for Class {
 }
 
 struct World {
-    rpc: JsonRpcClient<HttpTransport>,
     world: Contract,
     executor: Contract,
     indexer: Class,
@@ -160,9 +99,7 @@ struct World {
 
 impl World {
     async fn from_path(source_dir: Utf8PathBuf) -> anyhow::Result<World> {
-        let rpc_client = JsonRpcClient::new(HttpTransport::new(
-            Url::parse("https://starknet-goerli.cartridge.gg/").unwrap(),
-        ));
+        let url = Url::parse("https://starknet-goerli.cartridge.gg/").unwrap();
 
         let manifest_path = source_dir.join("Scarb.toml");
         let config = Config::builder(manifest_path)
@@ -171,134 +108,87 @@ impl World {
             .build()
             .unwrap();
         let ws = ops::read_workspace(config.manifest_path(), &config).unwrap_or_else(|err| {
-            eprintln!("error: {}", err);
+            eprintln!("error: {err}");
             std::process::exit(1);
         });
-        let world_config =
-            WorldConfig::from_workspace(&ws).unwrap_or_else(|_| WorldConfig::default());
+        let world_config = WorldConfig::from_workspace(&ws).unwrap_or_default();
 
-        let mut world: Option<Contract> = None;
-        let mut executor: Option<Contract> = None;
-        let mut indexer: Option<Class> = None;
-        let mut store: Option<Class> = None;
+        let local_manifest =
+            Manifest::load_from_path(source_dir.join("target/release/manifest.json"))?;
 
+        let remote_manifest = Manifest::from_remote(url, &local_manifest, &world_config)
+            .await
+            .map_err(|e| anyhow!("Problem creating remote manifest: {e}"))?;
+
+        let mut systems = vec![];
         let mut contracts = vec![];
         let mut components = vec![];
-        let mut systems = vec![];
 
-        // Read the directory
-        let entries = fs::read_dir(source_dir.join("target/release")).unwrap_or_else(|error| {
-            panic!("Problem reading source directory: {:?}", error);
-        });
-
-        for entry in entries.flatten() {
-            let file_name = entry.file_name();
-            let file_name_str = file_name.to_string_lossy();
-            if file_name_str == "manifest.json" || !file_name_str.ends_with(".json") {
-                continue;
-            }
-
-            let name = file_name_str.split('_').last().unwrap().to_string();
-            let contract_class = serde_json::from_reader(fs::File::open(entry.path()).unwrap())
-                .unwrap_or_else(|error| {
-                    panic!("Problem parsing {} artifact: {:?}", file_name_str, error);
-                });
-
-            let casm_contract = CasmContractClass::from_contract_class(contract_class, true)
-                .with_context(|| "Compilation failed.")?;
-            let res = serde_json::to_string_pretty(&casm_contract)
-                .with_context(|| "Casm contract Serialization failed.")?;
-
-            let compiled_class: CompiledClass =
-                serde_json::from_str(res.as_str()).unwrap_or_else(|error| {
-                    panic!("Problem parsing {} artifact: {:?}", file_name_str, error);
-                });
-
-            let local = compiled_class
-                .class_hash()
-                .with_context(|| "Casm contract Serialization failed.")?;
-
-            if name.ends_with("Component.json") {
-                components.push(Class {
-                    world: world_config.address.unwrap(),
-                    name: name.strip_suffix("Component.json").unwrap().to_string(),
-                    local,
-                    remote: None,
-                });
-            } else if name.ends_with("System.json") {
-                systems.push(Class {
-                    world: world_config.address.unwrap(),
-                    name: name.strip_suffix("System.json").unwrap().to_string(),
-                    local,
-                    remote: None,
-                });
-            } else {
-                let name = name.strip_suffix(".json").unwrap().to_string();
-                match name.as_str() {
-                    "World" => {
-                        world = Some(Contract {
-                            name,
-                            local,
-                            remote: None,
-                            address: world_config.address,
-                        })
-                    }
-                    "Executor" => {
-                        executor = Some(Contract { name, local, remote: None, address: None })
-                    }
-                    "Indexer" => {
-                        indexer = Some(Class {
-                            world: world_config.address.unwrap(),
-                            name,
-                            local,
-                            remote: None,
-                        })
-                    }
-                    "Store" => {
-                        store = Some(Class {
-                            world: world_config.address.unwrap(),
-                            name,
-                            local,
-                            remote: None,
-                        })
-                    }
-                    _ => contracts.push(Class {
-                        world: world_config.address.unwrap(),
-                        name,
-                        local,
-                        remote: None,
-                    }),
-                }
-            };
+        for system in local_manifest.systems {
+            systems.push(Class {
+                world: world_config.address.unwrap(),
+                // because the name returns by the `name` method of a system contract is without the 'System' suffix
+                name: system.name.strip_suffix("System").unwrap_or(&system.name).to_string(),
+                local: system.class_hash,
+                remote: remote_manifest
+                    .systems
+                    .iter()
+                    .find(|e| e.name == system.name)
+                    .map(|s| s.class_hash),
+            });
         }
 
-        let mut world = World {
-            rpc: rpc_client,
-            world: world.unwrap_or_else(|| {
-                panic!("World contract not found. Did you include `dojo` as a dependency?");
-            }),
-            executor: executor.unwrap_or_else(|| {
-                panic!("Executor contract not found. Did you include `dojo` as a dependency?");
-            }),
-            indexer: indexer.unwrap_or_else(|| {
-                panic!("Indexer contract not found. Did you include `dojo` as a dependency?");
-            }),
-            store: store.unwrap_or_else(|| {
-                panic!("Store contract not found. Did you include `dojo` as a dependency?");
-            }),
+        for component in local_manifest.components {
+            components.push(Class {
+                world: world_config.address.unwrap(),
+                name: component.name.to_string(),
+                local: component.class_hash,
+                remote: remote_manifest
+                    .components
+                    .iter()
+                    .find(|e| e.name == component.name)
+                    .map(|s| s.class_hash),
+            });
+        }
+
+        for contract in local_manifest.contracts {
+            contracts.push(Class {
+                world: world_config.address.unwrap(),
+                name: contract.name.to_string(),
+                local: contract.class_hash,
+                remote: None,
+            });
+        }
+
+        Ok(World {
+            world: Contract {
+                name: "World".into(),
+                address: world_config.address.clone(),
+                local: local_manifest.world.unwrap(),
+                remote: remote_manifest.world,
+            },
+            executor: Contract {
+                name: "Executor".into(),
+                address: None,
+                local: local_manifest.world.unwrap(),
+                remote: remote_manifest.world,
+            },
+            indexer: Class {
+                world: world_config.address.unwrap(),
+                name: "Indexer".into(),
+                local: local_manifest.indexer.unwrap(),
+                remote: remote_manifest.indexer,
+            },
+            store: Class {
+                world: world_config.address.unwrap(),
+                name: "Store".into(),
+                local: local_manifest.store.unwrap(),
+                remote: remote_manifest.store,
+            },
+            systems,
             contracts,
             components,
-            systems,
-        };
-
-        world.resolve_remote().await?;
-
-        Ok(world)
-    }
-
-    async fn resolve_remote(self: &mut World) -> anyhow::Result<()> {
-        self.world.resolve_remote(&self.rpc).await?;
-        Ok(())
+        })
     }
 }
 

--- a/crates/dojo-lang/Cargo.toml
+++ b/crates/dojo-lang/Cargo.toml
@@ -24,6 +24,7 @@ cairo-lang-sierra-generator.workspace = true
 cairo-lang-syntax.workspace = true
 cairo-lang-starknet.workspace = true
 cairo-lang-utils.workspace = true
+dojo-project = { path = "../dojo-project" }
 indoc.workspace = true
 itertools.workspace = true
 scarb.workspace = true
@@ -33,6 +34,9 @@ smol_str.workspace = true
 thiserror = "1.0.32"
 tracing = "0.1.37"
 sanitizer = "0.1.6"
+starknet.workspace = true
+serde_with = "2.3.1"
+url = "2.2.2"
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -5,14 +5,18 @@ use anyhow::{Context, Result};
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::CrateLongId;
+use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract::find_contracts;
-use cairo_lang_starknet::contract_class::compile_prepared_db;
+use cairo_lang_starknet::contract_class::{compile_prepared_db, ContractClass};
 use cairo_lang_utils::Upcast;
 use scarb::compiler::helpers::{
     build_compiler_config, build_project_config, collect_main_crate_ids,
 };
 use scarb::compiler::{CompilationUnit, Compiler};
 use scarb::core::Workspace;
+use smol_str::SmolStr;
+use starknet::core::types::contract::CompiledClass;
+use starknet::core::types::FieldElement;
 use tracing::{trace, trace_span};
 
 use crate::db::DojoRootDatabaseBuilderEx;
@@ -59,23 +63,42 @@ impl Compiler for DojoCompiler {
             compile_prepared_db(&mut db, &contracts, compiler_config)?
         };
 
+        // (contract name, class hash)
+        let mut compiled_classes: Vec<(SmolStr, FieldElement)> = vec![];
+
         for (decl, class) in zip(contracts, classes) {
             let target_name = &unit.target().name;
             let contract_name = decl.submodule_id.name(db.upcast());
-            let mut file = target_dir.open_rw(
-                format!("{target_name}_{contract_name}.json"),
-                "output file",
-                ws.config(),
-            )?;
+            let file_name = format!("{target_name}_{contract_name}.json");
+
+            let mut file = target_dir.open_rw(file_name.clone(), "output file", ws.config())?;
             serde_json::to_writer_pretty(file.deref_mut(), &class)
                 .with_context(|| format!("failed to serialize contract: {contract_name}"))?;
+
+            let class_hash = compute_class_hash_of_contract_class(&contract_name, class)?;
+            compiled_classes.push((contract_name, class_hash));
         }
 
         let mut file = target_dir.open_rw("manifest.json", "output file", ws.config())?;
-        let manifest = Manifest::new(&db, &main_crate_ids);
+        let manifest = Manifest::new(&db, &main_crate_ids, compiled_classes);
         serde_json::to_writer_pretty(file.deref_mut(), &manifest)
             .with_context(|| "failed to serialize manifest")?;
 
         Ok(())
     }
+}
+
+fn compute_class_hash_of_contract_class(
+    contract_name: &str,
+    class: ContractClass,
+) -> Result<FieldElement> {
+    let casm_contract = CasmContractClass::from_contract_class(class, true)
+        .with_context(|| "Compilation failed.")?;
+    let class_json = serde_json::to_string_pretty(&casm_contract)
+        .with_context(|| "Casm contract Serialization failed.")?;
+    let compiled_class: CompiledClass = serde_json::from_str(&class_json).unwrap_or_else(|error| {
+        panic!("Problem parsing {contract_name} artifact: {error:?}");
+    });
+
+    compiled_class.class_hash().with_context(|| "Casm contract Serialization failed.")
 }

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::iter::zip;
 use std::ops::DerefMut;
 
@@ -64,7 +65,7 @@ impl Compiler for DojoCompiler {
         };
 
         // (contract name, class hash)
-        let mut compiled_classes: Vec<(SmolStr, FieldElement)> = vec![];
+        let mut compiled_classes: HashMap<SmolStr, FieldElement> = HashMap::new();
 
         for (decl, class) in zip(contracts, classes) {
             let target_name = &unit.target().name;
@@ -76,7 +77,7 @@ impl Compiler for DojoCompiler {
                 .with_context(|| format!("failed to serialize contract: {contract_name}"))?;
 
             let class_hash = compute_class_hash_of_contract_class(&contract_name, class)?;
-            compiled_classes.push((contract_name, class_hash));
+            compiled_classes.insert(contract_name, class_hash);
         }
 
         let mut file = target_dir.open_rw("manifest.json", "output file", ws.config())?;

--- a/crates/dojo-lang/src/manifest.rs
+++ b/crates/dojo-lang/src/manifest.rs
@@ -233,7 +233,8 @@ impl Manifest {
                     &FunctionCall {
                         contract_address: world_address,
                         calldata: vec![cairo_short_string_to_felt(
-                            // because the name returns by the `name` method of a system contract is without the 'System' suffix
+                            // because the name returns by the `name` method of
+                            // a system contract is without the 'System' suffix
                             system.name.strip_suffix("System").unwrap_or(&system.name),
                         )?],
                         entry_point_selector: get_selector_from_name("system")?,

--- a/crates/dojo-lang/src/manifest.rs
+++ b/crates/dojo-lang/src/manifest.rs
@@ -113,17 +113,17 @@ impl Manifest {
         let mut manifest = Manifest::default();
 
         let world = get_compiled_class_hash(&compiled_classes, "World").unwrap_or_else(|| {
-            panic!("World contract not found. Did you include `dojo` as a dependency?");
+            panic!("World contract not found. Did you include `dojo_core` as a dependency?");
         });
         let store = get_compiled_class_hash(&compiled_classes, "Store").unwrap_or_else(|| {
-            panic!("Store contract not found. Did you include `dojo` as a dependency?");
+            panic!("Store contract not found. Did you include `dojo_core` as a dependency?");
         });
         let indexer = get_compiled_class_hash(&compiled_classes, "Indexer").unwrap_or_else(|| {
-            panic!("Indexer contract not found. Did you include `dojo` as a dependency?");
+            panic!("Indexer contract not found. Did you include `dojo_core` as a dependency?");
         });
         let executor =
             get_compiled_class_hash(&compiled_classes, "Executor").unwrap_or_else(|| {
-                panic!("Executor contract not found. Did you include `dojo` as a dependency?");
+                panic!("Executor contract not found. Did you include `dojo_core` as a dependency?");
             });
 
         manifest.world = Some(world);

--- a/crates/dojo-lang/src/manifest.rs
+++ b/crates/dojo-lang/src/manifest.rs
@@ -123,10 +123,10 @@ impl Manifest {
             panic!("Executor contract not found. Did you include `dojo_core` as a dependency?");
         });
 
-        manifest.world = Some(world.clone());
-        manifest.store = Some(store.clone());
-        manifest.indexer = Some(indexer.clone());
-        manifest.executor = Some(executor.clone());
+        manifest.world = Some(*world);
+        manifest.store = Some(*store);
+        manifest.indexer = Some(*indexer);
+        manifest.executor = Some(*executor);
 
         for crate_id in crate_ids {
             let modules = db.crate_modules(*crate_id);
@@ -288,7 +288,7 @@ impl Manifest {
                 self.components.push(Component {
                     members,
                     name: name.to_string(),
-                    class_hash: class_hash.clone(),
+                    class_hash: *class_hash,
                 });
             }
         }
@@ -342,7 +342,7 @@ impl Manifest {
                         name: name.clone(),
                         inputs,
                         outputs,
-                        class_hash: class_hash.clone(),
+                        class_hash: *class_hash,
                         dependencies: dependencies
                             .iter()
                             .map(|s| s.to_string())

--- a/crates/dojo-lang/src/manifest.rs
+++ b/crates/dojo-lang/src/manifest.rs
@@ -176,7 +176,7 @@ impl Manifest {
         let world_class_hash =
             starknet.get_class_hash_at(&BlockId::Tag(BlockTag::Latest), world_address).await.ok();
 
-        if let None = world_class_hash {
+        if world_class_hash.is_none() {
             return Ok(manifest);
         }
 
@@ -234,7 +234,7 @@ impl Manifest {
                         contract_address: world_address,
                         calldata: vec![cairo_short_string_to_felt(
                             // because the name returns by the `name` method of a system contract is without the 'System' suffix
-                            &system.name.strip_suffix("System").unwrap_or(&system.name),
+                            system.name.strip_suffix("System").unwrap_or(&system.name),
                         )?],
                         entry_point_selector: get_selector_from_name("system")?,
                     },
@@ -264,7 +264,7 @@ impl Manifest {
         db: &dyn SemanticGroup,
         aux_data: &DojoAuxData,
         module_id: ModuleId,
-        compiled_classes: &Vec<(SmolStr, FieldElement)>,
+        compiled_classes: &[(SmolStr, FieldElement)],
     ) {
         for name in &aux_data.components {
             if let Ok(Some(ModuleItemId::Struct(struct_id))) =
@@ -296,7 +296,7 @@ impl Manifest {
         db: &dyn SemanticGroup,
         aux_data: &DojoAuxData,
         module_id: ModuleId,
-        compiled_classes: &Vec<(SmolStr, FieldElement)>,
+        compiled_classes: &[(SmolStr, FieldElement)],
     ) -> Result<(), ManifestError> {
         for SystemAuxData { name, dependencies } in &aux_data.systems {
             if let Ok(Some(ModuleItemId::Submodule(submodule_id))) =
@@ -355,7 +355,7 @@ impl Manifest {
 }
 
 fn get_compiled_class_hash(
-    contracts: &Vec<(SmolStr, FieldElement)>,
+    contracts: &[(SmolStr, FieldElement)],
     name: impl AsRef<str>,
 ) -> Option<FieldElement> {
     contracts.iter().find_map(|c| if c.0 == name.as_ref() { Some(c.1) } else { None })

--- a/crates/dojo-lang/src/manifest_test.rs
+++ b/crates/dojo-lang/src/manifest_test.rs
@@ -1,14 +1,16 @@
 #![allow(unused)]
+use std::collections::HashMap;
+
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_semantic::test_utils::setup_test_crate;
 use pretty_assertions::assert_eq;
+use smol_str::SmolStr;
+use starknet::core::types::FieldElement;
 
 use crate::manifest::Manifest;
 use crate::testing::build_test_db;
 
-// ignore for a while
 #[test]
-#[ignore]
 fn test_manifest_generation() {
     let db = &mut build_test_db().unwrap();
     let _crate_id = setup_test_crate(
@@ -27,7 +29,16 @@ fn test_manifest_generation() {
         ",
     );
 
-    // let manifest = Manifest::new(db, &db.crates());
-    // assert_eq!(manifest.components.len(), 1);
-    // assert_eq!(manifest.systems.len(), 1);
+    let mut compiled_contracts: HashMap<SmolStr, FieldElement> = HashMap::new();
+    compiled_contracts.insert("World".into(), FieldElement::from_hex_be("0x123").unwrap());
+    compiled_contracts.insert("Store".into(), FieldElement::from_hex_be("0x123").unwrap());
+    compiled_contracts.insert("Indexer".into(), FieldElement::from_hex_be("0x123").unwrap());
+    compiled_contracts.insert("Executor".into(), FieldElement::from_hex_be("0x123").unwrap());
+    compiled_contracts
+        .insert("PositionComponent".into(), FieldElement::from_hex_be("0x123").unwrap());
+    compiled_contracts.insert("MoveSystem".into(), FieldElement::from_hex_be("0x123").unwrap());
+
+    let manifest = Manifest::new(db, &db.crates(), compiled_contracts);
+    assert_eq!(manifest.components.len(), 1);
+    assert_eq!(manifest.systems.len(), 1);
 }

--- a/crates/dojo-lang/src/manifest_test.rs
+++ b/crates/dojo-lang/src/manifest_test.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_semantic::test_utils::setup_test_crate;
 use pretty_assertions::assert_eq;
@@ -5,7 +6,9 @@ use pretty_assertions::assert_eq;
 use crate::manifest::Manifest;
 use crate::testing::build_test_db;
 
+// ignore for a while
 #[test]
+#[ignore]
 fn test_manifest_generation() {
     let db = &mut build_test_db().unwrap();
     let _crate_id = setup_test_crate(
@@ -24,7 +27,7 @@ fn test_manifest_generation() {
         ",
     );
 
-    let manifest = Manifest::new(db, &db.crates());
-    assert_eq!(manifest.components.len(), 1);
-    assert_eq!(manifest.systems.len(), 1);
+    // let manifest = Manifest::new(db, &db.crates());
+    // assert_eq!(manifest.components.len(), 1);
+    // assert_eq!(manifest.systems.len(), 1);
 }

--- a/crates/dojo-lang/src/manifest_test.rs
+++ b/crates/dojo-lang/src/manifest_test.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 use std::collections::HashMap;
 
 use cairo_lang_filesystem::db::FilesGroup;


### PR DESCRIPTION
Resolves #162 

- Update `Manifest` to store the world contracts.

I could perhaps use a map for searching through the compiled contracts but probably will have to benchmark first how much improvement it can give.