### PR TITLE
fix: use sierra class hash in manifest

### DIFF
--- a/crates/dojo-cli/src/migrate.rs
+++ b/crates/dojo-cli/src/migrate.rs
@@ -36,7 +36,7 @@ pub async fn run(args: MigrateArgs) -> Result<()> {
     };
 
     let world = World::from_path(source_dir.clone()).await?;
-    let mut migration = world.prepare_for_migration(source_dir);
+    let mut migration = world.prepare_for_migration(source_dir)?;
 
     let provider = SequencerGatewayProvider::new(
         Url::parse("http://127.0.0.1:5050/gateway").unwrap(),

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 use std::iter::zip;
 use std::ops::DerefMut;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use cairo_lang_compiler::db::RootDatabase;
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::CrateLongId;
-use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract::find_contracts;
 use cairo_lang_starknet::contract_class::{compile_prepared_db, ContractClass};
 use cairo_lang_utils::Upcast;
@@ -16,7 +15,7 @@ use scarb::compiler::helpers::{
 use scarb::compiler::{CompilationUnit, Compiler};
 use scarb::core::Workspace;
 use smol_str::SmolStr;
-use starknet::core::types::contract::CompiledClass;
+use starknet::core::types::contract::SierraClass;
 use starknet::core::types::FieldElement;
 use tracing::{trace, trace_span};
 
@@ -80,7 +79,9 @@ impl Compiler for DojoCompiler {
             serde_json::to_writer_pretty(file.deref_mut(), &class)
                 .with_context(|| format!("failed to serialize contract: {contract_name}"))?;
 
-            let class_hash = compute_class_hash_of_contract_class(&contract_name, class)?;
+            let class_hash = compute_class_hash_of_contract_class(class).with_context(|| {
+                format!("problem computing class hash for contract `{contract_name}`")
+            })?;
             compiled_classes.insert(contract_name, class_hash);
         }
 
@@ -93,17 +94,9 @@ impl Compiler for DojoCompiler {
     }
 }
 
-fn compute_class_hash_of_contract_class(
-    contract_name: &str,
-    class: ContractClass,
-) -> Result<FieldElement> {
-    let casm_contract = CasmContractClass::from_contract_class(class, true)
-        .with_context(|| "Compilation failed.")?;
-    let class_json = serde_json::to_string_pretty(&casm_contract)
-        .with_context(|| "Casm contract Serialization failed.")?;
-    let compiled_class: CompiledClass = serde_json::from_str(&class_json).unwrap_or_else(|error| {
-        panic!("Problem parsing {contract_name} artifact: {error:?}");
-    });
-
-    compiled_class.class_hash().with_context(|| "Casm contract Serialization failed.")
+fn compute_class_hash_of_contract_class(class: ContractClass) -> Result<FieldElement> {
+    let class_str = serde_json::to_string(&class)?;
+    let sierra_class = serde_json::from_str::<SierraClass>(&class_str)
+        .map_err(|e| anyhow!("error parsing Sierra class: {e}"))?;
+    sierra_class.class_hash().map_err(|e| anyhow!("problem hashing sierra contract: {e}"))
 }

--- a/crates/dojo-lang/src/manifest_test.rs
+++ b/crates/dojo-lang/src/manifest_test.rs
@@ -28,16 +28,31 @@ fn test_manifest_generation() {
         ",
     );
 
+    let class_hash = FieldElement::from_hex_be("0x123").unwrap();
+
     let mut compiled_contracts: HashMap<SmolStr, FieldElement> = HashMap::new();
-    compiled_contracts.insert("World".into(), FieldElement::from_hex_be("0x123").unwrap());
-    compiled_contracts.insert("Store".into(), FieldElement::from_hex_be("0x123").unwrap());
-    compiled_contracts.insert("Indexer".into(), FieldElement::from_hex_be("0x123").unwrap());
-    compiled_contracts.insert("Executor".into(), FieldElement::from_hex_be("0x123").unwrap());
+    compiled_contracts.insert("World".into(), class_hash);
+    compiled_contracts.insert("Store".into(), class_hash);
+    compiled_contracts.insert("Indexer".into(), class_hash);
+    compiled_contracts.insert("Executor".into(), class_hash);
     compiled_contracts
-        .insert("PositionComponent".into(), FieldElement::from_hex_be("0x123").unwrap());
-    compiled_contracts.insert("MoveSystem".into(), FieldElement::from_hex_be("0x123").unwrap());
+        .insert("PositionComponent".into(), FieldElement::from_hex_be("0x420").unwrap());
+    compiled_contracts.insert("MoveSystem".into(), FieldElement::from_hex_be("0x69").unwrap());
 
     let manifest = Manifest::new(db, &db.crates(), compiled_contracts);
+
     assert_eq!(manifest.components.len(), 1);
     assert_eq!(manifest.systems.len(), 1);
+    assert_eq!(manifest.world.unwrap(), class_hash);
+    assert_eq!(manifest.executor.unwrap(), class_hash);
+    assert_eq!(manifest.indexer.unwrap(), class_hash);
+    assert_eq!(manifest.store.unwrap(), class_hash);
+    assert_eq!(
+        manifest.components.iter().find(|c| &c.name == "Position").unwrap().class_hash,
+        FieldElement::from_hex_be("0x420").unwrap()
+    );
+    assert_eq!(
+        manifest.systems.iter().find(|c| &c.name == "MoveSystem").unwrap().class_hash,
+        FieldElement::from_hex_be("0x69").unwrap()
+    );
 }

--- a/crates/dojo-project/src/migration/mod.rs
+++ b/crates/dojo-project/src/migration/mod.rs
@@ -274,7 +274,7 @@ fn prepare_contract_declaration_params(
 }
 
 fn get_flattened_class(artifact_path: &PathBuf) -> Result<FlattenedSierraClass> {
-    let file = File::open(&artifact_path)?;
+    let file = File::open(artifact_path)?;
     let contract_artifact: SierraClass = serde_json::from_reader(&file)?;
     Ok(contract_artifact.flatten()?)
 }

--- a/crates/dojo-project/src/migration/mod.rs
+++ b/crates/dojo-project/src/migration/mod.rs
@@ -1,13 +1,15 @@
 pub mod world;
 
-use std::fs;
+use std::fs::File;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+use cairo_lang_starknet::casm_contract_class::CasmContractClass;
+use cairo_lang_starknet::contract_class::ContractClass;
 use starknet::accounts::{Account, Call, SingleOwnerAccount};
-use starknet::core::types::contract::SierraClass;
+use starknet::core::types::contract::{CompiledClass, FlattenedSierraClass, SierraClass};
 use starknet::core::types::FieldElement;
 use starknet::core::utils::{get_contract_address, get_selector_from_name};
 use starknet::providers::SequencerGatewayProvider;
@@ -22,8 +24,6 @@ pub struct ContractMigration {
     pub salt: FieldElement,
     pub contract: Contract,
     pub artifact_path: PathBuf,
-    // not to be confused with `compiled_class_hash` fields in `contract`: `local` and `remote`
-    pub class_hash: FieldElement,
     pub contract_address: Option<FieldElement>,
 }
 
@@ -32,8 +32,6 @@ pub struct ClassMigration {
     pub declared: bool,
     pub class: Class,
     pub artifact_path: PathBuf,
-    // not to be confused with `compiled_class_hash` fields in `class`: `local` and `remote`
-    pub class_hash: FieldElement,
 }
 
 // TODO: migration error
@@ -82,8 +80,8 @@ impl Migration {
             .deploy(
                 vec![
                     self.executor.contract_address.unwrap(),
-                    self.store.class_hash,
-                    self.indexer.class_hash,
+                    self.store.class.local,
+                    self.indexer.class.local,
                 ],
                 account,
             )
@@ -115,7 +113,7 @@ impl Migration {
             .map(|c| Call {
                 to: world_address,
                 selector: get_selector_from_name("register_component").unwrap(),
-                calldata: vec![c.class_hash],
+                calldata: vec![c.class.local],
             })
             .collect::<Vec<_>>();
 
@@ -144,7 +142,7 @@ impl Migration {
             .map(|s| Call {
                 to: world_address,
                 selector: get_selector_from_name("register_system").unwrap(),
-                calldata: vec![s.class_hash],
+                calldata: vec![s.class.local],
             })
             .collect::<Vec<_>>();
 
@@ -172,13 +170,11 @@ trait Deployable: Declarable {
 #[async_trait]
 impl Declarable for ClassMigration {
     async fn declare(&self, account: &SingleOwnerAccount<SequencerGatewayProvider, LocalWallet>) {
-        let contract_artifact =
-            serde_json::from_reader::<_, SierraClass>(fs::File::open(&self.artifact_path).unwrap())
-                .unwrap();
-        let flattened_class = contract_artifact.flatten().unwrap();
+        let (flattened_class, casm_class_hash) =
+            prepare_contract_declaration_params(&self.artifact_path).unwrap();
 
         let result = account
-            .declare(Arc::new(flattened_class), self.class.local)
+            .declare(Arc::new(flattened_class), casm_class_hash)
             .send()
             .await
             .unwrap_or_else(|error| {
@@ -195,13 +191,11 @@ impl Declarable for ClassMigration {
 #[async_trait]
 impl Declarable for ContractMigration {
     async fn declare(&self, account: &SingleOwnerAccount<SequencerGatewayProvider, LocalWallet>) {
-        let contract_artifact =
-            serde_json::from_reader::<_, SierraClass>(fs::File::open(&self.artifact_path).unwrap())
-                .unwrap();
-        let flattened_class = contract_artifact.flatten().unwrap();
+        let (flattened_class, casm_class_hash) =
+            prepare_contract_declaration_params(&self.artifact_path).unwrap();
 
         let result = account
-            .declare(Arc::new(flattened_class), self.contract.local)
+            .declare(Arc::new(flattened_class), casm_class_hash)
             .send()
             .await
             .unwrap_or_else(|error| {
@@ -226,7 +220,7 @@ impl Deployable for ContractMigration {
 
         let calldata = [
             vec![
-                self.class_hash,                                // class hash
+                self.contract.local,                            // class hash
                 self.salt,                                      // salt
                 FieldElement::ZERO,                             // unique
                 FieldElement::from(constructor_calldata.len()), // constructor calldata len
@@ -251,7 +245,7 @@ impl Deployable for ContractMigration {
 
         let contract_address = get_contract_address(
             self.salt,
-            self.class_hash,
+            self.contract.local,
             &constructor_calldata,
             FieldElement::ZERO,
         );
@@ -267,4 +261,30 @@ impl Deployable for ContractMigration {
         self.deployed = true;
         self.contract.address = Some(contract_address);
     }
+}
+
+fn prepare_contract_declaration_params(
+    artifact_path: &PathBuf,
+) -> Result<(FlattenedSierraClass, FieldElement)> {
+    let flattened_class = get_flattened_class(artifact_path)
+        .map_err(|e| anyhow!("error flattening the contract class: {e}"))?;
+    let compiled_class_hash = get_compiled_class_hash(artifact_path)
+        .map_err(|e| anyhow!("error computing compiled class hash: {e}"))?;
+    Ok((flattened_class, compiled_class_hash))
+}
+
+fn get_flattened_class(artifact_path: &PathBuf) -> Result<FlattenedSierraClass> {
+    let file = File::open(&artifact_path)?;
+    let contract_artifact: SierraClass = serde_json::from_reader(&file)?;
+    Ok(contract_artifact.flatten()?)
+}
+
+fn get_compiled_class_hash(artifact_path: &PathBuf) -> Result<FieldElement> {
+    let file = File::open(artifact_path)?;
+    let casm_contract_class: ContractClass = serde_json::from_reader(file)?;
+    let casm_contract = CasmContractClass::from_contract_class(casm_contract_class, true)
+        .with_context(|| "Compilation failed.")?;
+    let res = serde_json::to_string_pretty(&casm_contract)?;
+    let compiled_class: CompiledClass = serde_json::from_str(&res)?;
+    Ok(compiled_class.class_hash()?)
 }

--- a/crates/dojo-project/src/migration/world.rs
+++ b/crates/dojo-project/src/migration/world.rs
@@ -237,7 +237,7 @@ fn evaluate_systems_to_be_declared(
         match s.remote {
             Some(remote) if remote == s.local => continue,
             _ => {
-                let path = find_artifact_path(&format!("{}System", s.name), &artifact_paths)?;
+                let path = find_artifact_path(&format!("{}System", s.name), artifact_paths)?;
                 syst_to_migrate.push(ClassMigration {
                     declared: false,
                     class: s.clone(),
@@ -260,7 +260,7 @@ fn evaluate_components_to_be_declared(
         match c.remote {
             Some(remote) if remote == c.local => continue,
             _ => {
-                let path = find_artifact_path(&format!("{}Component", c.name), &artifact_paths)?;
+                let path = find_artifact_path(&format!("{}Component", c.name), artifact_paths)?;
                 comps_to_migrate.push(ClassMigration {
                     declared: false,
                     class: c.clone(),
@@ -279,7 +279,7 @@ fn evaluate_class_for_migration(
 ) -> Result<ClassMigration> {
     let should_declare = !matches!(class.remote, Some(remote_hash) if remote_hash == class.local);
 
-    let path = find_artifact_path(&class.name, &artifact_paths)?;
+    let path = find_artifact_path(&class.name, artifact_paths)?;
 
     Ok(ClassMigration {
         declared: !should_declare,
@@ -299,7 +299,7 @@ fn evaluate_contract_for_migration(
         !matches!(contract.remote, Some(remote_hash) if remote_hash == contract.local)
     };
 
-    let path = find_artifact_path(&contract.name, &artifact_paths)?;
+    let path = find_artifact_path(&contract.name, artifact_paths)?;
 
     Ok(ContractMigration {
         deployed: !should_deploy,


### PR DESCRIPTION
- Fix wrong class hash used in manifest. Before, it was the class hash of Casm contract where it's supposed to be the Sierra class hash.
- Some refactoring and error handling stuff.