### PR TITLE
chore: removing contract attr from kv module

### DIFF
--- a/crates/dojo-core/src/storage/kv.cairo
+++ b/crates/dojo-core/src/storage/kv.cairo
@@ -2,6 +2,7 @@ mod KeyValueStore {
     use array::ArrayTrait;
     use array::SpanTrait;
     use traits::Into;
+    use starknet::SyscallResultTrait;
 
     use dojo_core::serde::SpanSerde;
 


### PR DESCRIPTION
As discussed in Discord, the storage kv module doesn't have to be a `#[contract]` because it uses syscalls for reading and writing.