### PR TITLE
chore(dojo-test-runner): removing -p arg

### DIFF
--- a/crates/dojo-test-runner/src/cli.rs
+++ b/crates/dojo-test-runner/src/cli.rs
@@ -49,7 +49,6 @@ mod test_config;
 #[clap(version, verbatim_doc_comment)]
 struct Args {
     /// The path to compile and run its tests.
-    #[arg(short, long)]
     path: Utf8PathBuf,
     /// The filter for the tests, running only tests containing the filter string.
     #[arg(short, long, default_value_t = String::default())]

--- a/scripts/cairo_test.sh
+++ b/scripts/cairo_test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
-cargo +nightly-2022-11-03 run --bin dojo-test -- -p crates/dojo-core
+cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-core
 # Uncomment once erc crate passes
-# cargo +nightly-2022-11-03 run --bin dojo-test -- -p crates/dojo-erc
-cargo +nightly-2022-11-03 run --bin dojo-test -- -p crates/dojo-physics
-cargo +nightly-2022-11-03 run --bin dojo-test -- -p examples
+# cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-erc
+cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-physics
+cargo +nightly-2022-11-03 run --bin dojo-test -- examples


### PR DESCRIPTION
No need to use `-p` with `dojo-test` anymore, same as [recently merged update](https://github.com/starkware-libs/cairo/pull/2597) in Cairo.