### PR TITLE
#224 add index check and code creation

### DIFF
--- a/crates/dojo-lang/src/component.rs
+++ b/crates/dojo-lang/src/component.rs
@@ -6,10 +6,11 @@ use cairo_lang_semantic::plugin::DynPluginAuxData;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 
+
 use crate::plugin::DojoAuxData;
 
-pub fn handle_component_struct(db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct) -> PluginResult {
-    let body_nodes = vec![RewriteNode::interpolate_patched(
+pub fn handle_component_struct(db: &dyn SyntaxGroup, ref struct_ast: ast::ItemStruct, indexed: bool) -> PluginResult {
+    let mut body_nodes = vec![RewriteNode::interpolate_patched(
         "
             #[view]
             fn name() -> felt252 {
@@ -33,6 +34,33 @@ pub fn handle_component_struct(db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct
             ),
         ]),
     )];
+
+    // let is_indexed = get_indexed_attr_value(&struct_ast, db).unwrap_or(false);
+
+    let is_indexed_fn = if indexed {
+        RewriteNode::interpolate_patched(
+            "
+                #[view]
+                fn is_indexed() -> bool {
+                    bool::True(())
+                }
+            ",
+            HashMap::new(),
+        )
+    } else {
+        RewriteNode::interpolate_patched(
+            "
+                #[view]
+                fn is_indexed() -> bool {
+                    bool::False(())
+                }
+            ",
+            HashMap::new(),
+        )
+    };
+
+    // Add the is_indexed function to the body
+    body_nodes.push(is_indexed_fn);
 
     let mut serialize = vec![];
     let mut deserialize = vec![];

--- a/crates/dojo-lang/src/component.rs
+++ b/crates/dojo-lang/src/component.rs
@@ -6,10 +6,13 @@ use cairo_lang_semantic::plugin::DynPluginAuxData;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 
-
 use crate::plugin::DojoAuxData;
 
-pub fn handle_component_struct(db: &dyn SyntaxGroup, ref struct_ast: ast::ItemStruct, indexed: bool) -> PluginResult {
+pub fn handle_component_struct(
+    db: &dyn SyntaxGroup,
+    ref struct_ast: ast::ItemStruct,
+    indexed: bool,
+) -> PluginResult {
     let mut body_nodes = vec![RewriteNode::interpolate_patched(
         "
             #[view]

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -96,7 +96,7 @@ impl MacroPlugin for DojoPlugin {
             ast::Item::Struct(struct_ast) => {
                 let mut diagnostics = vec![];
                 
-                let indexed = is_indexed(db,  struct_ast.clone());
+                
                 
                 for attr in struct_ast.attributes(db).query_attr(db, "derive") {
                     let attr = attr.structurize(db);
@@ -137,7 +137,7 @@ impl MacroPlugin for DojoPlugin {
 
                         let derived = segment.ident(db).text(db);
                         if matches!(derived.as_str(), "Component") {
-                            return handle_component_struct(db, struct_ast, indexed.unwrap_or(false));
+                            return handle_component_struct(db, struct_ast);
                         }
                     }
                 }
@@ -160,36 +160,3 @@ impl AsDynMacroPlugin for DojoPlugin {
 }
 impl SemanticPlugin for DojoPlugin {}
 
-fn is_indexed(db: &dyn SyntaxGroup, struct_ast: ast::ItemStruct) -> Option<bool> {
-    for attr in struct_ast.attributes(db).query_attr(db, "component") {
-        let attr = attr.structurize(db);
-
-        for arg in attr.args {
-            let AttributeArg {
-                variant: AttributeArgVariant::Unnamed {
-                    value: ast::Expr::Path(path),
-                    ..
-                },
-                ..
-            } = arg else {
-                continue;
-            };
-
-            let path_elements = path.elements(db);
-            if path_elements.len() != 1 {
-                continue;
-            }
-
-            let segment = match &path_elements[0] {
-                ast::PathSegment::Simple(segment) => segment,
-                _ => continue,
-            };
-
-            let derived = segment.ident(db).text(db);
-            if matches!(derived.as_str(), "Indexed") {
-                return Some(true);
-            }
-        }
-    }
-    None
-}

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -12,7 +12,6 @@ use cairo_lang_semantic::SemanticDiagnostic;
 use cairo_lang_syntax::attribute::structured::{
     AttributeArg, AttributeArgVariant, AttributeStructurize,
 };
-use cairo_lang_syntax::node::ast::ItemStruct;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{ast, Terminal};

--- a/examples/src/components.cairo
+++ b/examples/src/components.cairo
@@ -1,6 +1,7 @@
 use array::ArrayTrait;
 
 #[derive(Component)]
+#[component(Indexed)]
 struct Moves {
     remaining: u8, 
 }
@@ -39,6 +40,9 @@ fn test_position_is_zero() {
 #[available_gas(100000)]
 fn test_position_is_equal() {
     assert(
-        PositionTrait::is_equal(Position { x: 420_u32, y: 0_u32 }, Position { x: 420_u32, y: 0_u32 }), 'not equal'
+        PositionTrait::is_equal(
+            Position { x: 420_u32, y: 0_u32 }, Position { x: 420_u32, y: 0_u32 }
+        ),
+        'not equal'
     );
 }


### PR DESCRIPTION
completes #224

- index check on component and generate helper

Have added it like this, I think it's cleaner

```
#[derive(Component)]
#[component(Indexed)]
struct Moves {
    remaining: u8, 
}
```