### PR TITLE
dev: truncating component error messages to 31

### DIFF
--- a/crates/dojo-lang/src/commands/entity.rs
+++ b/crates/dojo-lang/src/commands/entity.rs
@@ -12,6 +12,8 @@ use smol_str::SmolStr;
 use super::entities::find_components;
 use super::{command_name, CommandData, CommandTrait};
 
+const CAIRO_ERR_MSG_LEN: usize = 31;
+
 pub struct EntityCommand {
     query_id: String,
     query_pattern: String,
@@ -78,16 +80,20 @@ impl CommandTrait for EntityCommand {
 impl EntityCommand {
     fn handle_entity(&mut self, components: Vec<SmolStr>, query: &Arg, part_names: Vec<String>) {
         for component in components.iter() {
+            let mut lookup_err_msg = format!("{} not found", component.to_string());
+            lookup_err_msg.truncate(CAIRO_ERR_MSG_LEN);
+            let mut deser_err_msg = format!("{} failed to deserialize", component.to_string());
+            deser_err_msg.truncate(CAIRO_ERR_MSG_LEN);
+
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
                 "
                     let mut __$query_id$_$query_subtype$_raw = IWorldDispatcher {
                         contract_address: world_address
                     }.entity('$component$', $query$, 0_u8, 0_usize);
-                    assert(__$query_id$_$query_subtype$_raw.len() > 0_usize, 'Failed to find \
-                 $component$');
+                    assert(__$query_id$_$query_subtype$_raw.len() > 0_usize, '$lookup_err_msg$');
                     let __$query_id$_$query_subtype$ = serde::Serde::<$component$>::deserialize(
                         ref __$query_id$_$query_subtype$_raw
-                    ).expect('Failed to deserialize $component$');
+                    ).expect('$deser_err_msg$');
                     ",
                 HashMap::from([
                     ("component".to_string(), RewriteNode::Text(component.to_string())),
@@ -97,6 +103,8 @@ impl EntityCommand {
                     ),
                     ("query_id".to_string(), RewriteNode::Text(self.query_id.clone())),
                     ("query".to_string(), RewriteNode::new_trimmed(query.as_syntax_node())),
+                    ("lookup_err_msg".to_string(), RewriteNode::Text(lookup_err_msg)),
+                    ("deser_err_msg".to_string(), RewriteNode::Text(deser_err_msg)),
                 ]),
             ));
         }
@@ -124,6 +132,9 @@ impl EntityCommand {
         part_names: Vec<String>,
     ) {
         for component in components.iter() {
+            let mut deser_err_msg = format!("{} failed to deserialize", component.to_string());
+            deser_err_msg.truncate(CAIRO_ERR_MSG_LEN);
+
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
                 "
                     let mut __$query_id$_$query_subtype$_raw = IWorldDispatcher {
@@ -137,7 +148,7 @@ impl EntityCommand {
                         bool::True(()) => {
                             Option::Some(serde::Serde::<$component$>::deserialize(
                                 ref __$query_id$_$query_subtype$_raw
-                            ).expect('Failed to deserialize $component$'))
+                            ).expect('$deser_err_msg$'))
                         }
                     };
                     ",
@@ -149,6 +160,7 @@ impl EntityCommand {
                     ),
                     ("query_id".to_string(), RewriteNode::Text(self.query_id.clone())),
                     ("query".to_string(), RewriteNode::new_trimmed(query.as_syntax_node())),
+                    ("deser_err_msg".to_string(), RewriteNode::Text(deser_err_msg)),
                 ]),
             ));
         }

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -396,27 +396,27 @@ mod MoveSystem {
         let mut __player_player_raw = IWorldDispatcher {
             contract_address: world_address
         }.entity('Player', player_id.into(), 0_u8, 0_usize);
-        assert(__player_player_raw.len() > 0_usize, 'Failed to find Player');
+        assert(__player_player_raw.len() > 0_usize, 'Player not found');
         let __player_player = serde::Serde::<Player>::deserialize(
             ref __player_player_raw
-        ).expect('Failed to deserialize Player');
+        ).expect('Player failed to deserialize');
         let player = __player_player;
 
         let mut __player_position_position_raw = IWorldDispatcher {
             contract_address: world_address
         }.entity('Position', player_id.into(), 0_u8, 0_usize);
-        assert(__player_position_position_raw.len() > 0_usize, 'Failed to find Position');
+        assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
         let __player_position_position = serde::Serde::<Position>::deserialize(
             ref __player_position_position_raw
-        ).expect('Failed to deserialize Position');
+        ).expect('Position failed to deserialize');
 
         let mut __player_position_player_raw = IWorldDispatcher {
             contract_address: world_address
         }.entity('Player', player_id.into(), 0_u8, 0_usize);
-        assert(__player_position_player_raw.len() > 0_usize, 'Failed to find Player');
+        assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
         let __player_position_player = serde::Serde::<Player>::deserialize(
             ref __player_position_player_raw
-        ).expect('Failed to deserialize Player');
+        ).expect('Player failed to deserialize');
         let player_position = (__player_position_position, __player_position_player);
 
         let mut bar = 123;
@@ -426,18 +426,18 @@ mod MoveSystem {
             let mut __player_position_position_raw = IWorldDispatcher {
                 contract_address: world_address
             }.entity('Position', player_id.into(), 0_u8, 0_usize);
-            assert(__player_position_position_raw.len() > 0_usize, 'Failed to find Position');
+            assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
             let __player_position_position = serde::Serde::<Position>::deserialize(
                 ref __player_position_position_raw
-            ).expect('Failed to deserialize Position');
+            ).expect('Position failed to deserialize');
 
             let mut __player_position_player_raw = IWorldDispatcher {
                 contract_address: world_address
             }.entity('Player', player_id.into(), 0_u8, 0_usize);
-            assert(__player_position_player_raw.len() > 0_usize, 'Failed to find Player');
+            assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
             let __player_position_player = serde::Serde::<Player>::deserialize(
                 ref __player_position_player_raw
-            ).expect('Failed to deserialize Player');
+            ).expect('Player failed to deserialize');
             let player_position = (__player_position_position, __player_position_player);
             if foo.len() > 0_u32 {
                 let positions_query = ArrayTrait::<usize>::new();
@@ -461,7 +461,7 @@ mod MoveSystem {
                     Option::Some(
                         serde::Serde::<Player>::deserialize(
                             ref __maybe_player_player_raw
-                        ).expect('Failed to deserialize Player')
+                        ).expect('Player failed to deserialize')
                     )
                 }
             };
@@ -484,7 +484,7 @@ mod MoveSystem {
                     Option::Some(
                         serde::Serde::<Position>::deserialize(
                             ref __positions_query_position_raw
-                        ).expect('Failed to deserialize Position')
+                        ).expect('Position failed to deserialize')
                     )
                 }
             };
@@ -500,7 +500,7 @@ mod MoveSystem {
                     Option::Some(
                         serde::Serde::<Player>::deserialize(
                             ref __positions_query_player_raw
-                        ).expect('Failed to deserialize Player')
+                        ).expect('Player failed to deserialize')
                     )
                 }
             };
@@ -520,36 +520,36 @@ mod MoveSystem {
             let mut __player_position_position_raw = IWorldDispatcher {
                 contract_address: world_address
             }.entity('Position', player_id.into(), 0_u8, 0_usize);
-            assert(__player_position_position_raw.len() > 0_usize, 'Failed to find Position');
+            assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
             let __player_position_position = serde::Serde::<Position>::deserialize(
                 ref __player_position_position_raw
-            ).expect('Failed to deserialize Position');
+            ).expect('Position failed to deserialize');
 
             let mut __player_position_player_raw = IWorldDispatcher {
                 contract_address: world_address
             }.entity('Player', player_id.into(), 0_u8, 0_usize);
-            assert(__player_position_player_raw.len() > 0_usize, 'Failed to find Player');
+            assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
             let __player_position_player = serde::Serde::<Player>::deserialize(
                 ref __player_position_player_raw
-            ).expect('Failed to deserialize Player');
+            ).expect('Player failed to deserialize');
             let player_position = (__player_position_position, __player_position_player);
         }
         {
             let mut __player_position_position_raw = IWorldDispatcher {
                 contract_address: world_address
             }.entity('Position', player_id.into(), 0_u8, 0_usize);
-            assert(__player_position_position_raw.len() > 0_usize, 'Failed to find Position');
+            assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
             let __player_position_position = serde::Serde::<Position>::deserialize(
                 ref __player_position_position_raw
-            ).expect('Failed to deserialize Position');
+            ).expect('Position failed to deserialize');
 
             let mut __player_position_player_raw = IWorldDispatcher {
                 contract_address: world_address
             }.entity('Player', player_id.into(), 0_u8, 0_usize);
-            assert(__player_position_player_raw.len() > 0_usize, 'Failed to find Player');
+            assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
             let __player_position_player = serde::Serde::<Player>::deserialize(
                 ref __player_position_player_raw
-            ).expect('Failed to deserialize Player');
+            ).expect('Player failed to deserialize');
             let player_position = (__player_position_position, __player_position_player);
         }
         let foo_bar = Option::Some(1);
@@ -560,18 +560,18 @@ mod MoveSystem {
                 let mut __player_position_position_raw = IWorldDispatcher {
                     contract_address: world_address
                 }.entity('Position', player_id.into(), 0_u8, 0_usize);
-                assert(__player_position_position_raw.len() > 0_usize, 'Failed to find Position');
+                assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
                 let __player_position_position = serde::Serde::<Position>::deserialize(
                     ref __player_position_position_raw
-                ).expect('Failed to deserialize Position');
+                ).expect('Position failed to deserialize');
 
                 let mut __player_position_player_raw = IWorldDispatcher {
                     contract_address: world_address
                 }.entity('Player', player_id.into(), 0_u8, 0_usize);
-                assert(__player_position_player_raw.len() > 0_usize, 'Failed to find Player');
+                assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
                 let __player_position_player = serde::Serde::<Player>::deserialize(
                     ref __player_position_player_raw
-                ).expect('Failed to deserialize Player');
+                ).expect('Player failed to deserialize');
                 let player_position = (__player_position_position, __player_position_player);
                 if bar == 123 {
                     let positions_query = ArrayTrait::<usize>::new();
@@ -588,18 +588,18 @@ mod MoveSystem {
                 let mut __player_position_position_raw = IWorldDispatcher {
                     contract_address: world_address
                 }.entity('Position', player_id.into(), 0_u8, 0_usize);
-                assert(__player_position_position_raw.len() > 0_usize, 'Failed to find Position');
+                assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
                 let __player_position_position = serde::Serde::<Position>::deserialize(
                     ref __player_position_position_raw
-                ).expect('Failed to deserialize Position');
+                ).expect('Position failed to deserialize');
 
                 let mut __player_position_player_raw = IWorldDispatcher {
                     contract_address: world_address
                 }.entity('Player', player_id.into(), 0_u8, 0_usize);
-                assert(__player_position_player_raw.len() > 0_usize, 'Failed to find Player');
+                assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
                 let __player_position_player = serde::Serde::<Player>::deserialize(
                     ref __player_position_player_raw
-                ).expect('Failed to deserialize Player');
+                ).expect('Player failed to deserialize');
                 let player_position = (__player_position_position, __player_position_player);
             },
         }


### PR DESCRIPTION
Resolves #229.

I moved the component name to the beginning of the error messages so it does not get truncated.