### PR TITLE
query derives copy trait

### DIFF
--- a/crates/dojo-core/src/storage/query.cairo
+++ b/crates/dojo-core/src/storage/query.cairo
@@ -7,7 +7,7 @@ use traits::Into;
 use starknet::ClassHashIntoFelt252;
 use dojo_core::serde::SpanSerde;
 
-#[derive(Drop, Serde)]
+#[derive(Copy, Drop, Serde)]
 struct Query {
     address_domain: u32,
     partition: felt252,


### PR DESCRIPTION
Be able to use same storage key variable to get and then set entity

```
let market_sk: Query = (game_id, (item_id)).into();
let market = commands::<Market>::entity(market_sk);
...
commands::set_entity( market_sk, (Market{...});
```