### PR TITLE
dev(dojo-core): immutable length param in storage

### DIFF
--- a/crates/dojo-core/src/storage/db.cairo
+++ b/crates/dojo-core/src/storage/db.cairo
@@ -28,10 +28,10 @@ mod Database {
         table: felt252,
         query: Query,
         offset: u8,
-        mut length: usize
+        length: usize
     ) -> Option<Span<felt252>> {
         if length == 0_usize {
-            length = IComponentLibraryDispatcher { class_hash: class_hash }.len()
+            let length = IComponentLibraryDispatcher { class_hash: class_hash }.len();
         }
 
         let id = query.id();

--- a/crates/dojo-core/src/storage/kv.cairo
+++ b/crates/dojo-core/src/storage/kv.cairo
@@ -18,7 +18,7 @@ mod KeyValueStore {
         table: felt252,
         key: felt252,
         offset: u8,
-        mut length: usize
+        length: usize
     ) -> Span<felt252> {
         let address_domain = 0_u32;
         let base = address(table, key);

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -114,7 +114,7 @@ mod World {
     }
 
     #[view]
-    fn entity(component: felt252, query: Query, offset: u8, mut length: usize) -> Span<felt252> {
+    fn entity(component: felt252, query: Query, offset: u8, length: usize) -> Span<felt252> {
         let class_hash = component_registry::read(component);
         match Database::get(class_hash, component, query, offset, length) {
             Option::Some(res) => res,


### PR DESCRIPTION
`length` was passed around in storage fns marked as `mut` but it shouldn't be. In the case where it's value is potentially changed (db.cairo::get), it is shadowed now.