### PR TITLE
fix(dojo-core): use correct length in db::get

### DIFF
--- a/crates/dojo-core/src/storage/db.cairo
+++ b/crates/dojo-core/src/storage/db.cairo
@@ -30,8 +30,9 @@ mod Database {
         offset: u8,
         length: usize
     ) -> Option<Span<felt252>> {
+        let mut length = length;
         if length == 0_usize {
-            let length = IComponentLibraryDispatcher { class_hash: class_hash }.len();
+            length = IComponentLibraryDispatcher { class_hash: class_hash }.len();
         }
 
         let id = query.id();


### PR DESCRIPTION
In #263 I accidentally introduced an error where `length` will always be 0 in db::get, because setting it in the if block is only valid in that scope 🤦 This PR fixes it.