### PR TITLE
feat: add and remove liquidity cpm implementation

### DIFF
--- a/crates/dojo-defi/Scarb.toml
+++ b/crates/dojo-defi/Scarb.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 description = "Implementations of a defi primitives for the Dojo framework"
 
 [dependencies]
-cubit = { version = "0.1.0", git = "https://github.com/influenceth/cubit" }
+# This is a fork of https://github.com/influenceth/cubit with Serde support
+cubit = { version = "0.1.0", git = "https://github.com/ftupas/cubit" }
 dojo_core = { path = "../dojo-core" }
 
 [[target.dojo]]

--- a/crates/dojo-defi/Scarb.toml
+++ b/crates/dojo-defi/Scarb.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Implementations of a defi primitives for the Dojo framework"
 
 [dependencies]
+cubit = { version = "0.1.0", git = "https://github.com/influenceth/cubit" }
 dojo_core = { path = "../dojo-core" }
 
 [[target.dojo]]

--- a/crates/dojo-defi/src/constant_product_market/components.cairo
+++ b/crates/dojo-defi/src/constant_product_market/components.cairo
@@ -6,10 +6,6 @@ use option::OptionTrait;
 use cubit::types::fixed::Fixed;
 use cubit::types::fixed::FixedInto;
 use cubit::types::fixed::FixedType;
-use cubit::types::fixed::FixedAdd;
-use cubit::types::fixed::FixedDiv;
-use cubit::types::fixed::FixedMul;
-use cubit::types::fixed::FixedNeg;
 use cubit::types::fixed::ONE_u128;
 
 use cubit::test::helpers::assert_precise;
@@ -35,19 +31,6 @@ struct Liquidity {
 struct Market {
     cash_amount: u128,
     item_quantity: usize,
-}
-
-// Add serde implementation for FixedType
-// TODO: Remove once cubit fixed point math library implements serde
-impl FixedTypeSerde of serde::Serde<FixedType> {
-    fn serialize(ref output: Array<felt252>, input: FixedType) {
-        serde::Serde::serialize(ref output, input.into());
-    }
-    fn deserialize(ref serialized: Span<felt252>) -> Option<FixedType> {
-        Option::Some(
-            Fixed::from_unscaled_felt(serde::Serde::<felt252>::deserialize(ref serialized)?)
-        )
-    }
 }
 
 trait MarketTrait {

--- a/crates/dojo-defi/src/constant_product_market/components.cairo
+++ b/crates/dojo-defi/src/constant_product_market/components.cairo
@@ -2,6 +2,18 @@ use traits::Into;
 use traits::TryInto;
 use option::OptionTrait;
 
+// Cubit fixed point math library
+use cubit::types::fixed::Fixed;
+use cubit::types::fixed::FixedInto;
+use cubit::types::fixed::FixedType;
+use cubit::types::fixed::FixedAdd;
+use cubit::types::fixed::FixedDiv;
+use cubit::types::fixed::FixedMul;
+use cubit::types::fixed::FixedNeg;
+use cubit::types::fixed::ONE_u128;
+
+use cubit::test::helpers::assert_precise;
+
 const SCALING_FACTOR: u128 = 10000;
 
 #[derive(Component)]
@@ -11,7 +23,12 @@ struct Cash {
 
 #[derive(Component)]
 struct Item {
-    quantity: usize,
+    quantity: usize, 
+}
+
+#[derive(Component)]
+struct Liquidity {
+    shares: FixedType, 
 }
 
 #[derive(Component)]
@@ -20,9 +37,30 @@ struct Market {
     item_quantity: usize,
 }
 
+// Add serde implementation for FixedType
+// TODO: Remove once cubit fixed point math library implements serde
+impl FixedTypeSerde of serde::Serde<FixedType> {
+    fn serialize(ref output: Array<felt252>, input: FixedType) {
+        serde::Serde::serialize(ref output, input.into());
+    }
+    fn deserialize(ref serialized: Span<felt252>) -> Option<FixedType> {
+        Option::Some(
+            Fixed::from_unscaled_felt(serde::Serde::<felt252>::deserialize(ref serialized)?)
+        )
+    }
+}
+
 trait MarketTrait {
     fn buy(self: @Market, quantity: usize) -> u128;
     fn sell(self: @Market, quantity: usize) -> u128;
+    fn get_reserves(self: @Market) -> (u128, u128);
+    fn liquidity(self: @Market) -> FixedType;
+    fn has_liquidity(self: @Market) -> bool;
+    fn quote_quantity(self: @Market, amount: u128) -> usize;
+    fn quote_amount(self: @Market, quantity: usize) -> u128;
+    fn add_liquidity_inner(self: @Market, amount: u128, quantity: usize) -> (u128, usize);
+    fn add_liquidity(self: @Market, amount: u128, quantity: usize) -> (u128, usize, FixedType);
+    fn mint_shares(self: @Market, amount: u128, quantity: usize) -> FixedType;
 }
 
 impl MarketImpl of MarketTrait {
@@ -40,6 +78,154 @@ impl MarketImpl of MarketTrait {
         let payout = cash - (k / (available + quantity));
         payout
     }
+
+    // Get normalized reserve cash amount and item quantity
+    fn get_reserves(self: @Market) -> (u128, u128) {
+        (*self.cash_amount, (*self.item_quantity).into().try_into().unwrap() * SCALING_FACTOR)
+    }
+
+    // Get the liquidity of the market
+    // Use cubit fixed point math library to compute the square root of the product of the reserves
+    fn liquidity(self: @Market) -> FixedType {
+        // Get normalized reserve cash amount and item quantity
+        let (reserve_amount, reserve_quantity) = self.get_reserves();
+
+        // Convert reserve amount to fixed point
+        let reserve_amount = Fixed::new_unscaled(reserve_amount, false);
+        let reserve_quantity = Fixed::new_unscaled(reserve_quantity, false);
+
+        // L = sqrt(X * Y)
+        (reserve_amount * reserve_quantity).sqrt()
+    }
+
+    // Check if the market has liquidity
+    fn has_liquidity(self: @Market) -> bool {
+        *self.cash_amount > 0 | *self.item_quantity > 0
+    }
+
+    // Given some amount of cash, return the equivalent/optimal quantity of items
+    // based on the reserves in the market
+    fn quote_quantity(self: @Market, amount: u128) -> usize {
+        assert(amount > 0, 'insufficient amount');
+        assert(self.has_liquidity(), 'insufficient liquidity');
+
+        // Get normalized reserve cash amount and item quantity
+        let (reserve_amount, reserve_quantity) = self.get_reserves();
+
+        // Convert amount to fixed point
+        let amount = Fixed::new_unscaled(amount, false);
+
+        // Convert reserve amount and quantity to fixed point
+        let reserve_amount = Fixed::new_unscaled(reserve_amount, false);
+        let reserve_quantity = Fixed::new_unscaled(reserve_quantity, false);
+
+        // dy = Y * dx / X
+        let quantity_optimal = (reserve_quantity * amount) / reserve_amount;
+        // Unscale and convert to usize
+        (quantity_optimal.into().try_into().unwrap() / ONE_u128).into().try_into().unwrap()
+    }
+
+    // Given some quantity of items, return the equivalent/optimal amount of cash
+    // based on the reserves in the market
+    fn quote_amount(self: @Market, quantity: usize) -> u128 {
+        assert(quantity > 0, 'insufficient quantity');
+        assert(self.has_liquidity(), 'insufficient liquidity');
+
+        // Get normalized reserve cash amount and item quantity
+        let (reserve_amount, reserve_quantity) = self.get_reserves();
+
+        // Convert reserve amount and quantity to fixed point
+        let reserve_amount = Fixed::new_unscaled(reserve_amount, false);
+        let reserve_quantity = Fixed::new_unscaled(reserve_quantity, false);
+
+        // Normalize quantity
+        let quantity = quantity.into().try_into().unwrap() * SCALING_FACTOR;
+
+        // Convert quantity to fixed point
+        let quantity = Fixed::new_unscaled(quantity, false);
+
+        // dx = X * dy / Y
+        let amount_optimal = (reserve_amount * quantity) / reserve_quantity;
+        // Convert amount to u128 and unscale
+        amount_optimal.into().try_into().unwrap() / ONE_u128
+    }
+
+    // Inner function to add liquidity to the market, computes the optimal amount and quantity
+    //
+    // Arguments:
+    //
+    // amount: The amount of cash to add to the market
+    // quantity: The quantity of items to add to the market
+    //
+    // Returns:
+    //
+    // (amount, quantity): The amount of cash and quantity of items added to the market
+    fn add_liquidity_inner(self: @Market, amount: u128, quantity: usize) -> (u128, usize) {
+        // If there is no liquidity, then the amount and quantity are the optimal
+        if !self.has_liquidity() {
+            // Ensure that the amount and quantity are greater than zero
+            assert(amount > 0, 'insufficient amount');
+            assert(quantity > 0, 'insufficient quantity');
+            (amount, quantity)
+        } else {
+            // Given the amount, get optimal quantity to add to the market
+            let quantity_optimal = self.quote_quantity(amount);
+            if quantity_optimal <= quantity {
+                // Add the given amount and optimal quantity to the market
+                (amount, quantity_optimal)
+            } else {
+                let amount_optimal = self.quote_amount(quantity);
+                // Ensure that the optimal amount is less than or equal to the given amount
+                assert(amount_optimal <= amount, 'insufficient amount');
+                (amount_optimal, quantity)
+            }
+        }
+    }
+
+    // Add liquidity to the market, mints shares for the given amount of liquidity provided
+    //
+    // Arguments:
+    //
+    // amount: The amount of cash to add to the market
+    // quantity: The quantity of items to add to the market
+    //
+    // Returns:
+    //
+    // (amount, quantity, shares): The amount of cash and quantity of items added to the market and the shares minted
+    fn add_liquidity(self: @Market, amount: u128, quantity: usize) -> (u128, usize, FixedType) {
+        // Compute the amount and quantity to add to the market
+        let (amount, quantity) = self.add_liquidity_inner(amount, quantity);
+        // Mint shares for the given amount of liquidity provided
+        let shares = self.mint_shares(amount, quantity);
+        (amount, quantity, shares)
+    }
+
+    // Mint shares for the given amount of liquidity provided
+    fn mint_shares(self: @Market, amount: u128, quantity: usize) -> FixedType {
+        // If there is no liquidity, then mint total shares
+        if !self.has_liquidity() {
+            (Fixed::new_unscaled(amount, false)
+                * Fixed::new_unscaled(
+                    quantity.into().try_into().unwrap() * SCALING_FACTOR, false
+                )).sqrt()
+        } else {
+            // Convert amount to fixed point
+            let amount = Fixed::new_unscaled(amount, false);
+
+            // Get normalized reserve cash amount and item quantity
+            let (reserve_amount, _) = self.get_reserves();
+
+            // Convert reserve amount to fixed point
+            let reserve_amount = Fixed::new_unscaled(reserve_amount, false);
+
+            // Get total liquidity
+            let liquidity = self.liquidity();
+
+            // Compute the amount of shares to mint
+            // S = dx * L/X = dy * L/Y
+            (amount * liquidity) / reserve_amount
+        }
+    }
 }
 
 fn normalize(quantity: usize, market: @Market) -> (u128, u128, u128) {
@@ -52,18 +238,14 @@ fn normalize(quantity: usize, market: @Market) -> (u128, u128, u128) {
 #[test]
 #[should_panic(expected: ('not enough liquidity', ))]
 fn test_not_enough_quantity() {
-    let market = Market {
-        cash_amount: SCALING_FACTOR * 1, item_quantity: 1
-    }; // pool 1:1
+    let market = Market { cash_amount: SCALING_FACTOR * 1, item_quantity: 1 }; // pool 1:1
     let cost = market.buy(10_usize);
 }
 
 #[test]
 #[available_gas(100000)]
 fn test_market_buy() {
-    let market = Market {
-        cash_amount: SCALING_FACTOR * 1, item_quantity: 10
-    }; // pool 1:10
+    let market = Market { cash_amount: SCALING_FACTOR * 1, item_quantity: 10 }; // pool 1:10
     let cost = market.buy(5);
     assert(cost == SCALING_FACTOR * 1, 'wrong cost');
 }
@@ -71,9 +253,97 @@ fn test_market_buy() {
 #[test]
 #[available_gas(100000)]
 fn test_market_sell() {
-    let market = Market {
-        cash_amount: SCALING_FACTOR * 1, item_quantity: 10
-    }; // pool 1:10
+    let market = Market { cash_amount: SCALING_FACTOR * 1, item_quantity: 10 }; // pool 1:10
     let payout = market.sell(5);
     assert(payout == 3334, 'wrong payout');
+}
+
+#[test]
+#[available_gas(500000)]
+fn test_market_add_liquidity_no_initial() {
+    // Without initial liquidity
+    let market = Market { cash_amount: 0, item_quantity: 0 };
+
+    // Add liquidity
+    let (amount, quantity) = (SCALING_FACTOR * 5, 5); // pool 1:1
+    let (amount_add, quantity_add, liquidity_add) = market.add_liquidity(amount, quantity);
+
+    // Assert that the amount and quantity added are the same as the given amount and quantity
+    // and that the liquidity shares minted are the same as the entire liquidity
+    assert(amount_add == amount, 'wrong cash amount');
+    assert(quantity_add == quantity, 'wrong item quantity');
+
+    // Convert amount and quantity to fixed point
+    let amount = Fixed::new_unscaled(amount, false);
+    let quantity = Fixed::new_unscaled(quantity.into().try_into().unwrap() * SCALING_FACTOR, false);
+    assert(liquidity_add == (amount * quantity).sqrt(), 'wrong liquidity');
+}
+
+#[test]
+#[available_gas(600000)]
+fn test_market_add_liquidity_optimal() {
+    // With initial liquidity
+    let market = Market { cash_amount: SCALING_FACTOR * 1, item_quantity: 10 }; // pool 1:10
+    let initial_liquidity = market.liquidity();
+
+    // Add liquidity with the same ratio
+    let (amount, quantity) = (SCALING_FACTOR * 2, 20); // pool 1:10
+    let (amount_add, quantity_add, liquidity_add) = market.add_liquidity(amount, quantity);
+
+    // Assert 
+    assert(amount_add == amount, 'wrong cash amount');
+    assert(quantity_add == quantity, 'wrong item quantity');
+
+    // Get expected amount and convert to fixed point
+    let expected_amount = Fixed::new_unscaled(SCALING_FACTOR * 1 + amount, false);
+    let expected_quantity = Fixed::new_unscaled(
+        (10 + quantity).into().try_into().unwrap() * SCALING_FACTOR, false
+    );
+
+    // Compute the expected liquidity shares
+    let expected_liquidity = Fixed::sqrt(expected_amount * expected_quantity);
+
+    assert_precise(
+        expected_liquidity, (initial_liquidity + liquidity_add).into(), 'wrong liquidity'
+    );
+}
+
+#[test]
+#[available_gas(1000000)]
+fn test_market_add_liquidity_not_optimal() {
+    // With initial liquidity
+    let market = Market { cash_amount: SCALING_FACTOR * 1, item_quantity: 10 }; // pool 1:10
+    let initial_liquidity = market.liquidity();
+
+    // Add liquidity without the same ratio
+    let (amount, quantity) = (SCALING_FACTOR * 2, 10); // pool 1:5
+
+    let (amount_add, quantity_add, liquidity_add) = market.add_liquidity(amount, quantity);
+
+    // Assert that the amount added is optimal even though the
+    // amount originally requested was not
+    let amount_optimal = SCALING_FACTOR * 1;
+    assert(amount_add == amount_optimal, 'wrong cash amount');
+    assert(quantity_add == quantity, 'wrong item quantity');
+
+    // Get expected amount and convert to fixed point
+    let expected_amount = Fixed::new_unscaled(SCALING_FACTOR * 1 + amount_add, false);
+    let expected_quantity = Fixed::new_unscaled(
+        (10 + quantity_add).into().try_into().unwrap() * SCALING_FACTOR, false
+    );
+    let expected_liquidity = Fixed::sqrt(expected_amount * expected_quantity);
+
+    let final_liquidity = initial_liquidity + liquidity_add;
+    assert_precise(
+        expected_liquidity, (initial_liquidity + liquidity_add).into(), 'wrong liquidity'
+    );
+}
+
+#[test]
+#[should_panic(expected: ('insufficient amount', ))]
+fn test_market_add_liquidity_insufficient_amount() {
+    let market = Market { cash_amount: SCALING_FACTOR * 1, item_quantity: 10 }; // pool 1:10
+    // Adding 20 items requires (SCALING_FACTOR * 2) cash amount to maintain the ratio
+    // Therefore this should fail
+    let (amount_add, quantity_add, liquidity_add) = market.add_liquidity(SCALING_FACTOR * 1, 20);
 }

--- a/crates/dojo-defi/src/constant_product_market/components.cairo
+++ b/crates/dojo-defi/src/constant_product_market/components.cairo
@@ -2,7 +2,7 @@ use traits::Into;
 use traits::TryInto;
 use option::OptionTrait;
 
-const SCALING_FACTOR: u128 = 10000_u128;
+const SCALING_FACTOR: u128 = 10000;
 
 #[derive(Component)]
 struct Cash {
@@ -53,7 +53,7 @@ fn normalize(quantity: usize, market: @Market) -> (u128, u128, u128) {
 #[should_panic(expected: ('not enough liquidity', ))]
 fn test_not_enough_quantity() {
     let market = Market {
-        cash_amount: SCALING_FACTOR * 1_u128, item_quantity: 1_usize
+        cash_amount: SCALING_FACTOR * 1, item_quantity: 1
     }; // pool 1:1
     let cost = market.buy(10_usize);
 }
@@ -62,18 +62,18 @@ fn test_not_enough_quantity() {
 #[available_gas(100000)]
 fn test_market_buy() {
     let market = Market {
-        cash_amount: SCALING_FACTOR * 1_u128, item_quantity: 10_usize
+        cash_amount: SCALING_FACTOR * 1, item_quantity: 10
     }; // pool 1:10
-    let cost = market.buy(5_usize);
-    assert(cost == SCALING_FACTOR * 1_u128, 'wrong cost');
+    let cost = market.buy(5);
+    assert(cost == SCALING_FACTOR * 1, 'wrong cost');
 }
 
 #[test]
 #[available_gas(100000)]
 fn test_market_sell() {
     let market = Market {
-        cash_amount: SCALING_FACTOR * 1_u128, item_quantity: 10_usize
+        cash_amount: SCALING_FACTOR * 1, item_quantity: 10
     }; // pool 1:10
-    let payout = market.sell(5_usize);
-    assert(payout == 3334_u128, 'wrong payout');
+    let payout = market.sell(5);
+    assert(payout == 3334, 'wrong payout');
 }

--- a/crates/dojo-defi/src/constant_product_market/systems.cairo
+++ b/crates/dojo-defi/src/constant_product_market/systems.cairo
@@ -7,10 +7,7 @@ mod Buy {
     use dojo_defi::constant_product_market::components::Item;
     use dojo_defi::constant_product_market::components::Cash;
     use dojo_defi::constant_product_market::components::Market;
-    use dojo_defi::constant_product_market::components::Liquidity;
     use dojo_defi::constant_product_market::components::MarketTrait;
-    use cubit::types::fixed::FixedType;
-    use cubit::types::fixed::Fixed;
 
     fn execute(partition: u250, item_id: u250, quantity: usize) {
         let player: u250 = starknet::get_caller_address().into();
@@ -102,7 +99,10 @@ mod AddLiquidity {
     use dojo_defi::constant_product_market::components::Item;
     use dojo_defi::constant_product_market::components::Cash;
     use dojo_defi::constant_product_market::components::Market;
+    use dojo_defi::constant_product_market::components::Liquidity;
     use dojo_defi::constant_product_market::components::MarketTrait;
+
+    use cubit::types::fixed::FixedType;
 
     fn execute(partition: u250, item_id: u250, amount: u128, quantity: usize) {
         let player: u250 = starknet::get_caller_address().into();
@@ -137,56 +137,70 @@ mod AddLiquidity {
 
         // update player item
         commands::set_entity(item_sk, (Item { quantity: player_quantity - cost_quantity }));
-    // update player liquidity
-    // TODO: uncomment once error: Plugin diagnostic: Type not found is solved
-    // let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
-    // let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
-    // commands::set_entity(
-    //     lquidity_sk, (Liquidity { shares: player_liquidity.shares + liquidity_shares })
-    // );
+
+        // update player liquidity
+        let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
+        let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
+        commands::set_entity(
+            liquidity_sk, (Liquidity { shares: player_liquidity.shares + liquidity_shares })
+        );
     }
 }
-// TODO: uncomment once error: Plugin diagnostic: Type not found is solved
-// #[system]
-// mod RemoveLiquidity {
-//     use traits::Into;
-//     use array::ArrayTrait;
-//     use dojo_core::integer::u250;
-//     use dojo_core::integer::ContractAddressIntoU250;
-//     use dojo_defi::constant_product_market::components::Item;
-//     use dojo_defi::constant_product_market::components::Cash;
-//     use dojo_defi::constant_product_market::components::Market;
-//     use dojo_defi::constant_product_market::components::MarketTrait;
 
-//     fn execute(partition: u250, item_id: u250, shares: FixedType) {
-//         let player: u250 = starknet::get_caller_address().into();
+#[system]
+mod RemoveLiquidity {
+    use traits::Into;
+    use array::ArrayTrait;
+    use dojo_core::integer::u250;
+    use dojo_core::integer::ContractAddressIntoU250;
+    use dojo_defi::constant_product_market::components::Item;
+    use dojo_defi::constant_product_market::components::Cash;
+    use dojo_defi::constant_product_market::components::Market;
+    use dojo_defi::constant_product_market::components::Liquidity;
+    use dojo_defi::constant_product_market::components::MarketTrait;
 
-//         let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
-//         let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
-//         assert(player_liquidity.shares >= shares, 'not enough shares');
+    use cubit::types::fixed::FixedType;
+    use serde::Serde;
 
-//         let market_sk: Query = (partition, (item_id)).into_partitioned();
-//         let market = commands::<Market>::entity(market_sk);
-//         let (payout_cash, payout_quantity) = market.remove_liquidity(shares);
+    fn execute(partition: u250, item_id: u250, shares: FixedType) {
+        let player: u250 = starknet::get_caller_address().into();
 
-//         // update market
-//         commands::set_entity(
-//             market_sk,
-//             (Market {
-//                 cash_amount: market.cash_amount + cost_cash,
-//                 item_quantity: market.item_quantity + cost_quantity
-//             })
-//         );
+        let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
+        let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
+        assert(player_liquidity.shares >= shares, 'not enough shares');
 
-//         // update player cash
-//         commands::set_entity(cash_sk, (Cash { amount: player_cash.amount + cost_cash }));
+        let market_sk: Query = (partition, (item_id)).into_partitioned();
+        let market = commands::<Market>::entity(market_sk);
+        let (payout_cash, payout_quantity) = market.remove_liquidity(shares);
 
-//         // update player item
-//         commands::set_entity(item_sk, (Item { quantity: player_quantity + cost_quantity }));
-//         // update player liquidity
-//         let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
-//         let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
-//         commands::set_entity(lquidity_sk, (Liquidity { shares: player_liquidity.shares - shares }));
-//     }
-// }
+        // update market
+        commands::set_entity(
+            market_sk,
+            (Market {
+                cash_amount: market.cash_amount - payout_cash,
+                item_quantity: market.item_quantity - payout_quantity
+            })
+        );
 
+        // update player cash
+        let cash_sk: Query = (partition, (player)).into_partitioned();
+        let player_cash = commands::<Cash>::entity(cash_sk);
+        commands::set_entity(cash_sk, (Cash { amount: player_cash.amount + payout_cash }));
+
+        // update player item
+        let item_sk: Query = (partition, (player, item_id)).into_partitioned();
+        let maybe_item = commands::<Item>::try_entity(item_sk);
+        let player_quantity = match maybe_item {
+            Option::Some(item) => item.quantity,
+            Option::None(_) => 0_u32,
+        };
+        commands::set_entity(item_sk, (Item { quantity: player_quantity + payout_quantity }));
+
+        // update player liquidity
+        let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
+        let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
+        commands::set_entity(
+            liquidity_sk, (Liquidity { shares: player_liquidity.shares - shares })
+        );
+    }
+}

--- a/crates/dojo-defi/src/constant_product_market/systems.cairo
+++ b/crates/dojo-defi/src/constant_product_market/systems.cairo
@@ -7,6 +7,7 @@ mod Buy {
     use dojo_defi::constant_product_market::components::Item;
     use dojo_defi::constant_product_market::components::Cash;
     use dojo_defi::constant_product_market::components::Market;
+    use dojo_defi::constant_product_market::components::Liquidity;
     use dojo_defi::constant_product_market::components::MarketTrait;
 
     fn execute(partition: u250, item_id: u250, quantity: usize) {
@@ -19,7 +20,7 @@ mod Buy {
         let market = commands::<Market>::entity(market_sk);
 
         let cost = market.buy(quantity);
-        assert(cost < player_cash.amount, 'not enough cash');
+        assert(cost <= player_cash.amount, 'not enough cash');
 
         // update market
         commands::set_entity(
@@ -78,7 +79,7 @@ mod Sell {
             market_sk,
             (Market {
                 cash_amount: market.cash_amount - payout,
-                item_quantity: market.item_quantity + quantity
+                item_quantity: market.item_quantity + quantity,
             })
         );
 
@@ -87,5 +88,59 @@ mod Sell {
 
         // update player item
         commands::set_entity(item_sk, (Item { quantity: player_quantity - quantity }));
+    }
+}
+
+#[system]
+mod AddLiquidity {
+    use traits::Into;
+    use array::ArrayTrait;
+    use dojo_core::integer::u250;
+    use dojo_core::integer::ContractAddressIntoU250;
+    use dojo_defi::constant_product_market::components::Item;
+    use dojo_defi::constant_product_market::components::Cash;
+    use dojo_defi::constant_product_market::components::Market;
+    use dojo_defi::constant_product_market::components::MarketTrait;
+
+    fn execute(partition: u250, item_id: u250, amount: u128, quantity: usize) {
+        let player: u250 = starknet::get_caller_address().into();
+
+        let item_sk: Query = (partition, (player, item_id)).into_partitioned();
+        let maybe_item = commands::<Item>::try_entity(item_sk);
+        let player_quantity = match maybe_item {
+            Option::Some(item) => item.quantity,
+            Option::None(_) => 0_u32,
+        };
+        assert(player_quantity >= quantity, 'not enough items');
+
+        let cash_sk: Query = (partition, (player)).into_partitioned();
+        let player_cash = commands::<Cash>::entity(cash_sk);
+        assert(amount <= player_cash.amount, 'not enough cash');
+
+        let market_sk: Query = (partition, (item_id)).into_partitioned();
+        let market = commands::<Market>::entity(market_sk);
+        let (cost_cash, cost_quantity, liquidity_shares) = market.add_liquidity(amount, quantity);
+
+        // update market
+        commands::set_entity(
+            market_sk,
+            (Market {
+                cash_amount: market.cash_amount + cost_cash,
+                item_quantity: market.item_quantity + cost_quantity
+            })
+        );
+
+        // update player cash
+        commands::set_entity(cash_sk, (Cash { amount: player_cash.amount - cost_cash }));
+
+        // update player item
+        commands::set_entity(item_sk, (Item { quantity: player_quantity - cost_quantity }));
+    // update player liquidity
+    // TODO: uncomment once error: Plugin diagnostic: Type not found is solved
+    // let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
+    // let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
+    // commands::set_entity(
+    //     lquidity_sk, (Liquidity { shares: player_liquidity.shares + liquidity_shares })
+    // );
     }
 }

--- a/crates/dojo-defi/src/constant_product_market/systems.cairo
+++ b/crates/dojo-defi/src/constant_product_market/systems.cairo
@@ -9,6 +9,8 @@ mod Buy {
     use dojo_defi::constant_product_market::components::Market;
     use dojo_defi::constant_product_market::components::Liquidity;
     use dojo_defi::constant_product_market::components::MarketTrait;
+    use cubit::types::fixed::FixedType;
+    use cubit::types::fixed::Fixed;
 
     fn execute(partition: u250, item_id: u250, quantity: usize) {
         let player: u250 = starknet::get_caller_address().into();
@@ -144,3 +146,47 @@ mod AddLiquidity {
     // );
     }
 }
+// TODO: uncomment once error: Plugin diagnostic: Type not found is solved
+// #[system]
+// mod RemoveLiquidity {
+//     use traits::Into;
+//     use array::ArrayTrait;
+//     use dojo_core::integer::u250;
+//     use dojo_core::integer::ContractAddressIntoU250;
+//     use dojo_defi::constant_product_market::components::Item;
+//     use dojo_defi::constant_product_market::components::Cash;
+//     use dojo_defi::constant_product_market::components::Market;
+//     use dojo_defi::constant_product_market::components::MarketTrait;
+
+//     fn execute(partition: u250, item_id: u250, shares: FixedType) {
+//         let player: u250 = starknet::get_caller_address().into();
+
+//         let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
+//         let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
+//         assert(player_liquidity.shares >= shares, 'not enough shares');
+
+//         let market_sk: Query = (partition, (item_id)).into_partitioned();
+//         let market = commands::<Market>::entity(market_sk);
+//         let (payout_cash, payout_quantity) = market.remove_liquidity(shares);
+
+//         // update market
+//         commands::set_entity(
+//             market_sk,
+//             (Market {
+//                 cash_amount: market.cash_amount + cost_cash,
+//                 item_quantity: market.item_quantity + cost_quantity
+//             })
+//         );
+
+//         // update player cash
+//         commands::set_entity(cash_sk, (Cash { amount: player_cash.amount + cost_cash }));
+
+//         // update player item
+//         commands::set_entity(item_sk, (Item { quantity: player_quantity + cost_quantity }));
+//         // update player liquidity
+//         let liquidity_sk: Query = (partition, (player, item_id)).into_partitioned();
+//         let player_liquidity = commands::<Liquidity>::entity(liquidity_sk);
+//         commands::set_entity(lquidity_sk, (Liquidity { shares: player_liquidity.shares - shares }));
+//     }
+// }
+


### PR DESCRIPTION
This pr implements the following:
- Use [cubit](https://github.com/influenceth/cubit) for Fixed Point Math to calculate for liquidity
- `AddLiquidity` system to add liquidity to the market given an amount and quantity
- `RemoveLiquidity` system to remove liquidity from the market given a certain amount of shares
- Testing `add_liquidity` and `remove_liquidity` in `Market` component

~~TODO:~~

~~When adding `FixedType` and `Liquidity` in [systems.cairo](crates/dojo-defi/src/constant_product_market/systems.cairo)~~
- [x] Solve `error: Plugin diagnostic: Type not found.`
```
 --> RemoveLiquidity:34:68
                fn execute(partition: u250, item_id: u250, shares: FixedType, world_address: starknet::ContractAddress)  {
                                                                   ^*******^

error: Plugin diagnostic: Type not found.
 --> RemoveLiquidity:43:71
                    let __player_liquidity_liquidity = serde::Serde::<Liquidity>::deserialize(
                                                                      ^*******^
```