### PR TITLE
fix: added delete_entity to interface

### DIFF
--- a/crates/dojo-core/src/interfaces.cairo
+++ b/crates/dojo-core/src/interfaces.cairo
@@ -18,6 +18,7 @@ trait IWorld {
     );
     fn entities(component: ShortString, partition: u250) -> Array::<u250>;
     fn set_executor(contract_address: starknet::ContractAddress);
+    fn delete_entity(component: ShortString, query: Query) {};
 }
 
 #[abi]


### PR DESCRIPTION
very small change. Just added the delete_entity function to the interface so that i can use it. 

For now, i can use it without the command synthax but ill create an issue to add is as a command as well