### PR TITLE
feat(dojo-core): u250 useful traits

### DIFF
--- a/crates/dojo-core/src/integer.cairo
+++ b/crates/dojo-core/src/integer.cairo
@@ -1,12 +1,16 @@
 use hash::LegacyHash;
+use integer::BoundedInt;
 use option::OptionTrait;
-use traits::Into;
+use traits::{Into, TryInto};
 
 use starknet::ContractAddress;
 use starknet::contract_address::ContractAddressIntoFelt252;
 use starknet::SyscallResult;
 use starknet::storage_access::StorageAccess;
 use starknet::storage_access::StorageBaseAddress;
+
+// max value of u256's high part when u250::max is converted into u256
+const HIGH_BOUND: u128 = 0x3ffffffffffffffffffffffffffffff_u128;
 
 #[derive(Copy, Drop, Serde)]
 struct u250 {
@@ -17,14 +21,14 @@ trait u250Trait {
     fn new(inner: felt252) -> u250;
 }
 
-impl u250Impl of u250Trait {
+impl U250Impl of u250Trait {
     fn new(inner: felt252) -> u250 {
         u250 { inner }
     }
 }
 
 // Implements the PartialEq trait for u250.
-impl u250PartialEq of PartialEq<u250> {
+impl U250PartialEq of PartialEq<u250> {
     fn eq(lhs: u250, rhs: u250) -> bool {
         lhs.inner == rhs.inner
     }
@@ -46,10 +50,12 @@ impl U250IntoU250 of Into<u250, u250> {
     }
 }
 
-
 impl Felt252TryIntoU250 of TryInto<felt252, u250> {
     fn try_into(self: felt252) -> Option<u250> {
-        // TODO: Bounds check
+        let v: u256 = self.into();
+        if v.high > HIGH_BOUND {
+            return Option::None(());
+        }
         Option::Some(u250 { inner: self })
     }
 }
@@ -89,5 +95,69 @@ impl StorageAccessU250 of StorageAccess<u250> {
     #[inline(always)]
     fn write(address_domain: u32, base: StorageBaseAddress, value: u250) -> SyscallResult<()> {
         StorageAccess::<felt252>::write(address_domain, base, U250IntoFelt252::into(value))
+    }
+}
+
+impl U250Zeroable of Zeroable<u250> {
+    #[inline(always)]
+    fn zero() -> u250 {
+        u250 { inner: 0 }
+    }
+
+    #[inline(always)]
+    fn is_zero(self: u250) -> bool {
+        self.inner == 0
+    }
+
+    #[inline(always)]
+    fn is_non_zero(self: u250) -> bool {
+        self.inner != 0
+    }
+}
+
+impl U250BoundedInt of BoundedInt<u250> {
+    #[inline(always)]
+    fn min() -> u250 nopanic {
+        u250 { inner: 0 }
+    }
+
+    #[inline(always)]
+    fn max() -> u250 nopanic {
+        // 2^250 - 1
+        u250 { inner: 0x3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff }
+    }
+}
+
+impl U250Add of Add<u250> {
+    #[inline(always)]
+    fn add(lhs: u250, rhs: u250) -> u250 {
+        let r = u250 { inner: lhs.inner + rhs.inner };
+        let r256: u256 = r.inner.into();
+        assert(r256.high <= HIGH_BOUND, 'u250 overflow');
+        r
+    }
+}
+
+impl U250AddEq of AddEq<u250> {
+    #[inline(always)]
+    fn add_eq(ref self: u250, other: u250) {
+        self = self + other;
+    }
+}
+
+impl U250Sub of Sub<u250> {
+    #[inline(always)]
+    fn sub(lhs: u250, rhs: u250) -> u250 {
+        let lhs256: u256 = lhs.inner.into();
+        let rhs256: u256 = rhs.inner.into();
+        assert(lhs256 >= rhs256, 'u250 underflow');
+        u250 { inner: (lhs256 - rhs256).try_into().unwrap() }
+    }
+}
+
+impl U250SubEq of SubEq<u250> {
+    #[inline(always)]
+    fn sub_eq(ref self: u250, other: u250) {
+        self = self - other;
     }
 }

--- a/crates/dojo-core/src/integer.cairo
+++ b/crates/dojo-core/src/integer.cairo
@@ -12,6 +12,26 @@ use starknet::storage_access::StorageBaseAddress;
 // max value of u256's high part when u250::max is converted into u256
 const HIGH_BOUND: u128 = 0x3ffffffffffffffffffffffffffffff_u128;
 
+// temporary, until we (Scarb) catches up with Cairo
+// src: https://github.com/starkware-libs/cairo/pull/3055/
+impl U256TryIntoFelt252 of TryInto<u256, felt252> {
+    fn try_into(self: u256) -> Option<felt252> {
+        let FELT252_PRIME_HIGH = 0x8000000000000110000000000000000_u128;
+        if self.high > FELT252_PRIME_HIGH {
+            return Option::None(());
+        }
+        if self.high == FELT252_PRIME_HIGH {
+            // since FELT252_PRIME_LOW is 1.
+            if self.low != 0 {
+                return Option::None(());
+            }
+        }
+        Option::Some(
+            self.high.into() * 0x100000000000000000000000000000000_felt252 + self.low.into()
+        )
+    }
+}
+
 #[derive(Copy, Drop, Serde)]
 struct u250 {
     inner: felt252

--- a/crates/dojo-core/tests/src/integer.cairo
+++ b/crates/dojo-core/tests/src/integer.cairo
@@ -1,0 +1,60 @@
+use integer::BoundedInt;
+use option::OptionTrait;
+use traits::TryInto;
+use zeroable::Zeroable;
+
+use dojo_core::integer::u250;
+use dojo_core::integer::Felt252TryIntoU250;
+
+#[test]
+fn test_u250_felt252_conv() {
+    let a: Option<u250> = 1_felt252.try_into();
+    assert(a.is_some(), '1 try_into u250');
+
+    // 250^2 - 1, max u250
+    let m: Option<u250> = 0x3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_felt252.try_into();
+    assert(m.is_some(), 'max try_into u250');
+
+    // 250^2, max u250 + 1
+    let o: Option<u250> = 0x400000000000000000000000000000000000000000000000000000000000000_felt252.try_into();
+    assert(o.is_none(), 'max + 1 try_into u250');
+}
+
+#[test]
+fn test_u250_zeroable() {
+    let zero: u250 = Zeroable::zero();
+    assert(zero.inner == 0, 'u250 Zeroable::zero');
+    assert(zero.is_zero(), 'u250 Zeroable::is_zero');
+    assert(u250 { inner: 250 }.is_non_zero(), 'u250 Zeroable::is_non_zero');
+}
+
+#[test]
+fn test_u250_addition() {
+    let one = u250 { inner: 1 };
+    let two = u250 { inner: 2 };
+    let three = u250 { inner: 3 };
+    assert(one + two == three, 'u250 1 + 2 = 3');
+
+    let mut n = three;
+    n += one;
+    assert(n == u250 { inner: 4 }, 'u250 (3 += 1) = 4')
+}
+
+#[test]
+#[should_panic(expected: ('u250 overflow', ))]
+fn test_u250_addition_overflow() {
+    let _ = BoundedInt::max() + u250 { inner: 1 };
+}
+
+#[test]
+fn test_u250_subtraction() {
+    let one = u250 { inner: 1 };
+    let two = u250 { inner: 2 };
+    let three = u250 { inner: 3 };
+
+    assert(three - one == two, 'u250 3 - 1 = 2');
+
+    let mut n = three;
+    n -= one;
+    assert(n == two, 'u250 (3 -= 1) = 2');
+}

--- a/crates/dojo-core/tests/src/lib.cairo
+++ b/crates/dojo-core/tests/src/lib.cairo
@@ -1,4 +1,5 @@
 mod executor;
+mod integer;
 mod storage;
 mod world;
 mod world_factory;


### PR DESCRIPTION
Adding the following traits to u250:
* Zeroable (`zero`, `is_zero`, `is_non_zero`)
* Add and AddEq (to have inline + and +=)
* Sub and SubEq (to have inline - and -=)
* BoundedInt (`min` and `max` for the type)

Since u250 is backed by felt252 which is now a second class citizen, the addition and subtraction have to convert to u256 to check for overflow and underflow. I didn't add Mul, Div and Rem, can open an issue for that if anyone wants to have a go.