### PR TITLE
feat: Remove `derive` magic and explictly derive traits for Components

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cairo"]
-	path = cairo
-	url = https://github.com/starkware-libs/cairo

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Components form the schema of the world, holding state for systems to operate on
 ##### Components Example
 
 ```rust
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Position {
     x: u32,
     y: u32

--- a/crates/dojo-core/src/auth/components.cairo
+++ b/crates/dojo-core/src/auth/components.cairo
@@ -1,11 +1,11 @@
 use dojo_core::integer::u250;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Status {
     is_authorized: bool
 }
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Role {
     id: u250
 }

--- a/crates/dojo-core/tests/src/executor.cairo
+++ b/crates/dojo-core/tests/src/executor.cairo
@@ -10,7 +10,7 @@ use dojo_core::interfaces::IExecutorDispatcher;
 use dojo_core::interfaces::IExecutorDispatcherTrait;
 use dojo_core::executor::Executor;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Foo {
     a: felt252,
     b: u128,

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -14,7 +14,7 @@ use dojo_core::interfaces::IWorldDispatcherTrait;
 use dojo_core::executor::Executor;
 use dojo_core::world::World;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Foo {
     a: felt252,
     b: u128,

--- a/crates/dojo-core/tests/src/world_factory.cairo
+++ b/crates/dojo-core/tests/src/world_factory.cairo
@@ -14,7 +14,7 @@ use dojo_core::executor::Executor;
 use dojo_core::world::World;
 use dojo_core::world_factory::WorldFactory;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Foo {
     a: felt252,
     b: u128,

--- a/crates/dojo-defi/src/constant_product_market/components.cairo
+++ b/crates/dojo-defi/src/constant_product_market/components.cairo
@@ -12,22 +12,22 @@ use cubit::test::helpers::assert_precise;
 
 const SCALING_FACTOR: u128 = 10000;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Cash {
     amount: u128, 
 }
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Item {
     quantity: usize, 
 }
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Liquidity {
     shares: FixedType, 
 }
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Market {
     cash_amount: u128,
     item_quantity: usize,

--- a/crates/dojo-erc/src/erc20/components.cairo
+++ b/crates/dojo-erc/src/erc20/components.cairo
@@ -1,9 +1,9 @@
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Approval {
     amount: felt252,
 }
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Ownership {
     balance: felt252,
 }

--- a/crates/dojo-lang/src/manifest_test.rs
+++ b/crates/dojo-lang/src/manifest_test.rs
@@ -39,7 +39,7 @@ fn test_manifest_generation() {
     let _crate_id = setup_test_crate(
         db,
         "
-            #[derive(Component)]
+            #[derive(Component, Copy, Drop, Serde)]
             struct Position {
                 x: usize,
                 y: usize,

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -95,9 +95,11 @@ impl MacroPlugin for DojoPlugin {
             ast::Item::Struct(struct_ast) => {
                 let mut diagnostics = vec![];
 
+                // Iterate over all the derive attributes of the struct
                 for attr in struct_ast.attributes(db).query_attr(db, "derive") {
                     let attr = attr.structurize(db);
 
+                    // Check if the derive attribute has arguments
                     if attr.args.is_empty() {
                         diagnostics.push(PluginDiagnostic {
                             stable_ptr: attr.args_stable_ptr.untyped(),
@@ -106,7 +108,9 @@ impl MacroPlugin for DojoPlugin {
                         continue;
                     }
 
+                    // Iterate over all the arguments of the derive attribute
                     for arg in attr.args {
+                        // Check if the argument is a path then set it to arg
                         let AttributeArg{
                             variant: AttributeArgVariant::Unnamed {
                                 value: ast::Expr::Path(path),
@@ -122,6 +126,7 @@ impl MacroPlugin for DojoPlugin {
                             continue;
                         };
 
+                        // Check if the path has a single segment
                         let [ast::PathSegment::Simple(segment)] = &path.elements(db)[..] else {
                             diagnostics.push(PluginDiagnostic {
                                 stable_ptr: value_stable_ptr.untyped(),
@@ -130,7 +135,10 @@ impl MacroPlugin for DojoPlugin {
                             continue;
                         };
 
+                        // Get the text of the segment and check if it is "Component"
                         let derived = segment.ident(db).text(db);
+
+                        // If struct has a derive attribute with "Component" then handle it
                         if matches!(derived.as_str(), "Component") {
                             return handle_component_struct(db, struct_ast);
                         }

--- a/crates/dojo-lang/src/plugin_test_data/component
+++ b/crates/dojo-lang/src/plugin_test_data/component
@@ -5,6 +5,7 @@ ExpandContractTestRunner
 
 //! > cairo_code
 use serde::Serde;
+use dict::Felt252Dict;
 
 #[derive(Component)]
 struct Position {
@@ -30,8 +31,23 @@ impl PositionImpl of PositionTrait {
     }
 }
 
+#[derive(Component)]
+#[component(custom: true, traits: (Destruct))]
+struct Roles {
+    is_authorized: Felt252Dict<u8>,
+    roles_len: u8
+}
+
+#[derive(Component)]
+#[component(custom: true, traits: (Copy, Drop))]
+struct Player {
+    name: felt252, 
+}
+
 //! > generated_cairo_code
 use serde::Serde;
+
+use dict::Felt252Dict;
 
 trait PositionTrait {
     fn is_zero(self: Position) -> bool;
@@ -94,4 +110,87 @@ mod PositionComponent {
     }
 }
 
+#[derive(Destruct)]
+struct Roles {
+    is_authorized: Felt252Dict<u8>,
+    roles_len: u8
+}
+
+#[abi]
+trait IRoles {
+    fn name() -> felt252;
+    fn len() -> u8;
+}
+
+#[contract]
+mod RolesComponent {
+    use dojo_core::serde::SpanSerde;
+    use super::Roles;
+
+    #[view]
+    fn schema() -> Array<(felt252, felt252, u8)> {
+        let mut arr = array::ArrayTrait::new();
+        array::ArrayTrait::append(ref arr, ('is_authorized', 'Felt252Dict<u8>', 252));
+        array::ArrayTrait::append(ref arr, ('roles_len', 'u8', 252));
+
+        arr
+    }
+
+
+    #[view]
+    fn name() -> felt252 {
+        'Roles'
+    }
+
+    #[view]
+    fn len() -> usize {
+        2_usize
+    }
+
+    #[view]
+    fn is_indexed() -> bool {
+        bool::False(())
+    }
+}
+
+#[derive(Copy, Drop)]
+struct Player {
+    name: felt252, 
+}
+
+#[abi]
+trait IPlayer {
+    fn name() -> felt252;
+    fn len() -> u8;
+}
+
+#[contract]
+mod PlayerComponent {
+    use dojo_core::serde::SpanSerde;
+    use super::Player;
+
+    #[view]
+    fn schema() -> Array<(felt252, felt252, u8)> {
+        let mut arr = array::ArrayTrait::new();
+        array::ArrayTrait::append(ref arr, ('name', 'felt252', 252));
+
+        arr
+    }
+
+
+    #[view]
+    fn name() -> felt252 {
+        'Player'
+    }
+
+    #[view]
+    fn len() -> usize {
+        1_usize
+    }
+
+    #[view]
+    fn is_indexed() -> bool {
+        bool::False(())
+    }
+}
 //! > expected_diagnostics

--- a/crates/dojo-lang/src/plugin_test_data/component
+++ b/crates/dojo-lang/src/plugin_test_data/component
@@ -5,9 +5,8 @@ ExpandContractTestRunner
 
 //! > cairo_code
 use serde::Serde;
-use dict::Felt252Dict;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Position {
     x: felt252,
     y: felt252
@@ -31,23 +30,18 @@ impl PositionImpl of PositionTrait {
     }
 }
 
-#[derive(Component)]
-#[component(custom: true, traits: (Destruct))]
+#[derive(Component, Serde)]
 struct Roles {
-    is_authorized: Felt252Dict<u8>,
-    roles_len: u8
+    role_ids: Array<u8>
 }
 
-#[derive(Component)]
-#[component(custom: true, traits: (Copy, Drop))]
+#[derive(Component, Copy, Drop, Serde)]
 struct Player {
     name: felt252, 
 }
 
 //! > generated_cairo_code
 use serde::Serde;
-
-use dict::Felt252Dict;
 
 trait PositionTrait {
     fn is_zero(self: Position) -> bool;
@@ -67,7 +61,6 @@ impl PositionImpl of PositionTrait {
     }
 }
 
-#[derive(Copy, Drop, Serde)]
 struct Position {
     x: felt252,
     y: felt252
@@ -110,10 +103,8 @@ mod PositionComponent {
     }
 }
 
-#[derive(Destruct)]
 struct Roles {
-    is_authorized: Felt252Dict<u8>,
-    roles_len: u8
+    role_ids: Array<u8>
 }
 
 #[abi]
@@ -130,8 +121,7 @@ mod RolesComponent {
     #[view]
     fn schema() -> Array<(felt252, felt252, u8)> {
         let mut arr = array::ArrayTrait::new();
-        array::ArrayTrait::append(ref arr, ('is_authorized', 'Felt252Dict<u8>', 252));
-        array::ArrayTrait::append(ref arr, ('roles_len', 'u8', 252));
+        array::ArrayTrait::append(ref arr, ('role_ids', 'Array<u8>', 252));
 
         arr
     }
@@ -144,7 +134,7 @@ mod RolesComponent {
 
     #[view]
     fn len() -> usize {
-        2_usize
+        1_usize
     }
 
     #[view]
@@ -153,7 +143,6 @@ mod RolesComponent {
     }
 }
 
-#[derive(Copy, Drop)]
 struct Player {
     name: felt252, 
 }

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -7,13 +7,13 @@ ExpandContractTestRunner
 use array::ArrayTrait;
 use serde::Serde;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Position {
     x: felt252,
     y: felt252,
 }
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 #[component(indexed: true)]
 struct Player {
     name: felt252, 
@@ -172,7 +172,6 @@ use array::ArrayTrait;
 
 use serde::Serde;
 
-#[derive(Copy, Drop, Serde)]
 struct Position {
     x: felt252,
     y: felt252,
@@ -215,7 +214,6 @@ mod PositionComponent {
     }
 }
 
-#[derive(Copy, Drop, Serde)]
 struct Player {
     name: felt252, 
 }

--- a/examples/src/components.cairo
+++ b/examples/src/components.cairo
@@ -1,12 +1,12 @@
 use array::ArrayTrait;
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 #[component(indexed = true)]
 struct Moves {
     remaining: u8, 
 }
 
-#[derive(Component)]
+#[derive(Component, Copy, Drop, Serde)]
 struct Position {
     x: u32,
     y: u32


### PR DESCRIPTION
This pr does the following:
- Remove the `derive` magic that derives the `Copy`, `Drop`, `Serde` automatically for all components
- Derived traits are now explicitly defined and can be customized.
  ```Rust
  #[derive(Component, Serde)]
  struct Roles {
      is_authorized: Array<u8>,
  }

  #[derive(Component, Copy, Drop, Serde)]
  struct Player {
      name: felt252, 
  }
  ```
- Developers will have to explicitly state the traits to be derived. It also allows them to use a custom implementation
- fix #301 