### PR TITLE
katana(feat): add genesis block

### DIFF
--- a/crates/katana-core/src/accounts.rs
+++ b/crates/katana-core/src/accounts.rs
@@ -7,7 +7,6 @@ use blockifier::abi::abi_utils::get_storage_var_address;
 use blockifier::execution::contract_class::{ContractClass, ContractClassV0};
 use rand::rngs::SmallRng;
 use rand::{RngCore, SeedableRng};
-use starknet::core::types::FieldElement;
 use starknet::signers::SigningKey;
 use starknet_api::core::{calculate_contract_address, ClassHash, ContractAddress, PatriciaKey};
 use starknet_api::hash::{StarkFelt, StarkHash};
@@ -150,7 +149,7 @@ impl PredeployedAccounts {
             let mut private_key_bytes = [0u8; 32];
 
             rng.fill_bytes(&mut private_key_bytes);
-            private_key_bytes[0] = 0;
+            private_key_bytes[0] %= 0x9;
             seed = private_key_bytes;
 
             let private_key =
@@ -175,7 +174,5 @@ impl PredeployedAccounts {
 
 // TODO: remove starknet-rs dependency
 fn compute_public_key_from_private_key(private_key: StarkFelt) -> StarkFelt {
-    StarkFelt::from(
-        SigningKey::from_secret_scalar(FieldElement::from(private_key)).verifying_key().scalar(),
-    )
+    StarkFelt::from(SigningKey::from_secret_scalar(private_key.into()).verifying_key().scalar())
 }

--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -39,6 +39,7 @@ impl KatanaSequencer {
     // The starting point of the sequencer
     // Once we add support periodic block generation, the logic should be here.
     pub fn start(&mut self) {
+        self.starknet.generate_genesis_block();
         self.starknet.generate_pending_block();
     }
 

--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -33,7 +33,9 @@ pub struct KatanaSequencer {
 
 impl KatanaSequencer {
     pub fn new(config: StarknetConfig) -> Self {
-        Self { starknet: StarknetWrapper::new(config) }
+        Self {
+            starknet: StarknetWrapper::new(config).expect("should create new Starknet instance"),
+        }
     }
 
     // The starting point of the sequencer

--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -33,9 +33,7 @@ pub struct KatanaSequencer {
 
 impl KatanaSequencer {
     pub fn new(config: StarknetConfig) -> Self {
-        Self {
-            starknet: StarknetWrapper::new(config).expect("should create new Starknet instance"),
-        }
+        Self { starknet: StarknetWrapper::new(config) }
     }
 
     // The starting point of the sequencer
@@ -124,8 +122,8 @@ impl Sequencer for KatanaSequencer {
         Ok((tx_hash, contract_address))
     }
 
-    fn add_account_transaction(&mut self, transaction: AccountTransaction) -> Result<()> {
-        self.starknet.handle_transaction(Transaction::AccountTransaction(transaction))
+    fn add_account_transaction(&mut self, transaction: AccountTransaction) {
+        self.starknet.handle_transaction(Transaction::AccountTransaction(transaction));
     }
 
     fn estimate_fee(
@@ -334,17 +332,16 @@ impl Sequencer for KatanaSequencer {
         )
     }
 
-    fn generate_new_block(&mut self) -> Result<()> {
-        self.starknet.generate_latest_block()?;
+    fn generate_new_block(&mut self) {
+        self.starknet.generate_latest_block();
         self.starknet.generate_pending_block();
-        Ok(())
     }
 }
 
 pub trait Sequencer {
     fn chain_id(&self) -> ChainId;
 
-    fn generate_new_block(&mut self) -> Result<()>;
+    fn generate_new_block(&mut self);
 
     fn nonce_at(
         &mut self,
@@ -389,7 +386,7 @@ pub trait Sequencer {
         signature: TransactionSignature,
     ) -> anyhow::Result<(TransactionHash, ContractAddress)>;
 
-    fn add_account_transaction(&mut self, transaction: AccountTransaction) -> Result<()>;
+    fn add_account_transaction(&mut self, transaction: AccountTransaction);
 
     fn estimate_fee(
         &self,

--- a/crates/katana-core/src/starknet/block.rs
+++ b/crates/katana-core/src/starknet/block.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use anyhow::{ensure, Result};
 use starknet::providers::jsonrpc::models::StateUpdate;
 use starknet_api::block::{
     Block, BlockBody, BlockHash, BlockHeader, BlockNumber, BlockStatus, BlockTimestamp, GasPrice,
@@ -109,20 +108,10 @@ pub struct StarknetBlocks {
 }
 
 impl StarknetBlocks {
-    pub fn append_block(&mut self, block: StarknetBlock) -> Result<()> {
+    pub fn insert(&mut self, block: StarknetBlock) {
         let block_number = block.block_number();
-        let expected_block_number = BlockNumber(self.num_to_block.len() as u64);
-
-        ensure!(
-            expected_block_number == block_number,
-            "unable to append block; expected block number {expected_block_number}, actual \
-             {block_number}"
-        );
-
         self.hash_to_num.insert(block.block_hash(), block_number);
         self.num_to_block.insert(block_number, block);
-
-        Ok(())
     }
 
     pub fn current_block_number(&self) -> Option<BlockNumber> {

--- a/crates/katana-core/src/starknet/mod.rs
+++ b/crates/katana-core/src/starknet/mod.rs
@@ -15,9 +15,10 @@ use starknet::providers::jsonrpc::models::{
     BlockId, BlockTag, PendingStateUpdate, StateUpdate, TransactionStatus,
 };
 use starknet_api::block::{BlockHash, BlockNumber, BlockTimestamp, GasPrice};
-use starknet_api::core::GlobalRoot;
-use starknet_api::hash::StarkFelt;
-use starknet_api::stark_felt;
+use starknet_api::core::{ClassHash, ContractAddress, GlobalRoot, PatriciaKey};
+use starknet_api::hash::{StarkFelt, StarkHash};
+use starknet_api::transaction::{DeclareTransactionV0V1, DeployTransaction, TransactionHash};
+use starknet_api::{patricia_key, stark_felt};
 use tracing::info;
 
 pub mod block;
@@ -30,7 +31,10 @@ use transaction::{StarknetTransaction, StarknetTransactions};
 use self::transaction::ExternalFunctionCall;
 use crate::accounts::PredeployedAccounts;
 use crate::block_context::block_context_from_config;
-use crate::constants::DEFAULT_PREFUNDED_ACCOUNT_BALANCE;
+use crate::constants::{
+    DEFAULT_PREFUNDED_ACCOUNT_BALANCE, ERC20_CONTRACT_CLASS_HASH, FEE_TOKEN_ADDRESS, UDC_ADDRESS,
+    UDC_CLASS_HASH,
+};
 use crate::state::DictStateReader;
 use crate::util::{
     convert_blockifier_tx_to_starknet_api_tx, convert_state_diff_to_rpc_state_diff,
@@ -183,9 +187,10 @@ impl StarknetWrapper {
         let mut new_block = if let Some(ref pending) = self.blocks.pending_block {
             pending.clone()
         } else {
-            self.create_new_empty_block()
+            self.create_empty_block()
         };
 
+        new_block.inner.header.block_number = self.block_context.block_number;
         let block_hash = new_block.compute_block_hash();
         new_block.inner.header.block_hash = block_hash;
 
@@ -233,7 +238,7 @@ impl StarknetWrapper {
         self.blocks.pending_block = None;
 
         // TODO: Compute state root
-        self.blocks.insert(new_block.clone());
+        self.blocks.insert(new_block);
 
         self.apply_state_diff_to_state(pending_state_diff);
 
@@ -241,7 +246,7 @@ impl StarknetWrapper {
     }
 
     pub fn generate_pending_block(&mut self) {
-        self.blocks.pending_block = Some(self.create_new_empty_block());
+        self.blocks.pending_block = Some(self.create_empty_block());
         // Update the pending state to the latest committed state
         self.pending_state = CachedState::new(self.state.clone());
     }
@@ -308,30 +313,69 @@ impl StarknetWrapper {
 
     /// Generate the genesis block and append it to the chain.
     /// This block should include transactions which set the initial state of the chain.
-    // TODO: Include transactions in the block
     pub fn generate_genesis_block(&mut self) {
-        self.create_new_empty_block();
+        self.generate_pending_block();
+
+        let mut transactions = vec![];
+        let deploy_data =
+            vec![(*UDC_CLASS_HASH, *UDC_ADDRESS), (*ERC20_CONTRACT_CLASS_HASH, *FEE_TOKEN_ADDRESS)];
+
+        deploy_data.into_iter().for_each(|(class_hash, address)| {
+            let declare_tx = starknet_api::transaction::Transaction::Declare(
+                starknet_api::transaction::DeclareTransaction::V1(DeclareTransactionV0V1 {
+                    class_hash: ClassHash(class_hash),
+                    transaction_hash: TransactionHash(
+                        stark_felt!(self.transactions.total() as u32),
+                    ),
+                    ..Default::default()
+                }),
+            );
+
+            self.store_transaction(StarknetTransaction {
+                execution_info: None,
+                execution_error: None,
+                inner: declare_tx.clone(),
+                block_hash: Default::default(),
+                block_number: Default::default(),
+                status: TransactionStatus::AcceptedOnL2,
+            });
+
+            let deploy_tx = starknet_api::transaction::Transaction::Deploy(DeployTransaction {
+                class_hash: ClassHash(class_hash),
+                transaction_hash: TransactionHash(stark_felt!(self.transactions.total() as u32)),
+                contract_address: ContractAddress(patricia_key!(address)),
+                ..Default::default()
+            });
+
+            self.store_transaction(StarknetTransaction {
+                execution_info: None,
+                execution_error: None,
+                inner: deploy_tx.clone(),
+                block_hash: Default::default(),
+                block_number: Default::default(),
+                status: TransactionStatus::AcceptedOnL2,
+            });
+
+            transactions.push(declare_tx);
+            transactions.push(deploy_tx);
+        });
+
+        self.blocks.pending_block.as_mut().unwrap().inner.body.transactions = transactions;
+
+        self.generate_latest_block();
     }
 
-    fn create_new_empty_block(&self) -> StarknetBlock {
-        let block_number = self.block_context.block_number;
-
-        let parent_hash = if block_number.0 == 0 {
-            BlockHash(stark_felt!(0_u8))
-        } else {
-            self.blocks.latest().map(|last_block| last_block.block_hash()).unwrap()
-        };
-
+    fn create_empty_block(&self) -> StarknetBlock {
         StarknetBlock::new(
-            BlockHash(stark_felt!(0_u8)),
-            parent_hash,
-            block_number,
+            BlockHash::default(),
+            BlockHash::default(),
+            BlockNumber::default(),
             GasPrice(self.block_context.gas_price),
-            GlobalRoot(stark_felt!(0_u8)),
+            GlobalRoot::default(),
             self.block_context.sequencer_address,
             BlockTimestamp(get_current_timestamp().as_secs()),
-            vec![],
-            vec![],
+            Vec::default(),
+            Vec::default(),
             None,
         )
     }

--- a/crates/katana-core/src/starknet/mod.rs
+++ b/crates/katana-core/src/starknet/mod.rs
@@ -79,7 +79,7 @@ impl StarknetWrapper {
         .expect("should be able to generate accounts");
         predeployed_accounts.deploy_accounts(&mut state);
 
-        let mut starknet = Self {
+        Self {
             state,
             config,
             blocks,
@@ -87,11 +87,7 @@ impl StarknetWrapper {
             block_context,
             pending_state,
             predeployed_accounts,
-        };
-
-        starknet.generate_genesis_block();
-
-        starknet
+        }
     }
 
     pub fn state_from_block_id(&self, block_id: BlockId) -> Option<DictStateReader> {

--- a/crates/katana-core/src/starknet/transaction.rs
+++ b/crates/katana-core/src/starknet/transaction.rs
@@ -175,4 +175,8 @@ impl StarknetTransactions {
     pub fn by_hash(&self, hash: &TransactionHash) -> Option<&StarknetTransaction> {
         self.transactions.get(hash)
     }
+
+    pub fn total(&self) -> usize {
+        self.transactions.len()
+    }
 }

--- a/crates/katana-core/tests/starknet.rs
+++ b/crates/katana-core/tests/starknet.rs
@@ -39,9 +39,9 @@ fn test_creating_blocks() {
         "pending block should not increment block context number"
     );
 
-    starknet.generate_latest_block().unwrap();
-    starknet.generate_latest_block().unwrap();
-    starknet.generate_latest_block().unwrap();
+    starknet.generate_latest_block();
+    starknet.generate_latest_block();
+    starknet.generate_latest_block();
 
     assert_eq!(starknet.blocks.hash_to_num.len(), 3);
     assert_eq!(starknet.blocks.num_to_block.len(), 3);
@@ -82,16 +82,14 @@ fn test_add_transaction() {
         stark_felt!(0_u8)           // Calldata: num.
     ];
 
-    starknet
-        .handle_transaction(Transaction::AccountTransaction(AccountTransaction::Invoke(
-            InvokeTransaction::V1(InvokeTransactionV1 {
-                sender_address: a.account_address,
-                calldata: execute_calldata,
-                transaction_hash: TransactionHash(stark_felt!("0x6969")),
-                ..Default::default()
-            }),
-        )))
-        .unwrap();
+    starknet.handle_transaction(Transaction::AccountTransaction(AccountTransaction::Invoke(
+        InvokeTransaction::V1(InvokeTransactionV1 {
+            sender_address: a.account_address,
+            calldata: execute_calldata,
+            transaction_hash: TransactionHash(stark_felt!("0x6969")),
+            ..Default::default()
+        }),
+    )));
 
     // SEND INVOKE TRANSACTION
     //
@@ -139,7 +137,7 @@ fn test_add_reverted_transaction() {
         InvokeTransaction::V1(InvokeTransactionV1 { transaction_hash, ..Default::default() }),
     ));
 
-    starknet.handle_transaction(transaction).unwrap();
+    starknet.handle_transaction(transaction);
 
     let tx = starknet.transactions.transactions.get(&transaction_hash);
 

--- a/crates/katana-rpc/src/katana/mod.rs
+++ b/crates/katana-rpc/src/katana/mod.rs
@@ -21,7 +21,7 @@ impl<S: Sequencer + Send + Sync + 'static> KatanaRpc<S> {
 #[async_trait]
 impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
     async fn generate_block(&self) -> Result<(), Error> {
-        self.sequencer.write().await.generate_new_block()?;
+        self.sequencer.write().await.generate_new_block();
         Ok(())
     }
 }

--- a/crates/katana-rpc/src/utils/transaction.rs
+++ b/crates/katana-rpc/src/utils/transaction.rs
@@ -5,17 +5,17 @@ use starknet::core::crypto::compute_hash_on_elements;
 use starknet::core::types::FieldElement;
 use starknet::providers::jsonrpc::models::{
     DeclareTransaction, DeclareTransactionV1, DeclareTransactionV2, DeployAccountTransaction,
-    InvokeTransaction, InvokeTransactionV1, L1HandlerTransaction, MaybePendingTransactionReceipt,
-    Transaction,
+    DeployTransaction, InvokeTransaction, InvokeTransactionV1, L1HandlerTransaction,
+    MaybePendingTransactionReceipt, Transaction,
 };
 use starknet_api::block::{BlockHash, BlockNumber};
 use starknet_api::hash::StarkFelt;
 use starknet_api::transaction::{
     DeclareTransaction as InnerDeclareTransaction,
     DeployAccountTransaction as InnerDeployAccountTransaction,
-    InvokeTransaction as InnerInvokeTransaction, InvokeTransactionOutput,
-    L1HandlerTransaction as InnerL1HandlerTransaction, Transaction as InnerTransaction,
-    TransactionOutput, TransactionReceipt,
+    DeployTransaction as InnerDeployTransaction, InvokeTransaction as InnerInvokeTransaction,
+    InvokeTransactionOutput, L1HandlerTransaction as InnerL1HandlerTransaction,
+    Transaction as InnerTransaction, TransactionOutput, TransactionReceipt,
 };
 
 const PREFIX_INVOKE: FieldElement = FieldElement::from_mont([
@@ -119,7 +119,7 @@ pub fn convert_inner_to_rpc_tx(transaction: InnerTransaction) -> Result<Transact
         InnerTransaction::L1Handler(l1handler) => {
             Transaction::L1Handler(convert_l1_handle_to_rpc(l1handler)?)
         }
-        InnerTransaction::Deploy(_) => unimplemented!("deploy transaction not supported"),
+        InnerTransaction::Deploy(deploy) => Transaction::Deploy(convert_deploy_to_rpc(deploy)?),
     };
     Ok(tx)
 }
@@ -134,6 +134,18 @@ fn convert_l1_handle_to_rpc(
         version: <StarkFelt as Into<FieldElement>>::into(transaction.version.0).try_into().unwrap(),
         entry_point_selector: transaction.entry_point_selector.0.into(),
         calldata: convert_stark_felt_array_to_field_element_array(&transaction.calldata.0)?,
+    })
+}
+
+fn convert_deploy_to_rpc(transaction: InnerDeployTransaction) -> Result<DeployTransaction> {
+    Ok(DeployTransaction {
+        transaction_hash: transaction.transaction_hash.0.into(),
+        version: <StarkFelt as Into<FieldElement>>::into(transaction.version.0).try_into()?,
+        class_hash: transaction.class_hash.0.into(),
+        contract_address_salt: transaction.contract_address_salt.0.into(),
+        constructor_calldata: convert_stark_felt_array_to_field_element_array(
+            &transaction.constructor_calldata.0,
+        )?,
     })
 }
 

--- a/crates/katana/src/main.rs
+++ b/crates/katana/src/main.rs
@@ -22,7 +22,6 @@ async fn main() {
     let starknet_config = config.starknet_config();
 
     let sequencer = Arc::new(RwLock::new(KatanaSequencer::new(starknet_config)));
-    sequencer.write().await.start();
 
     let predeployed_accounts = if config.hide_predeployed_accounts {
         None
@@ -38,6 +37,7 @@ async fn main() {
                 format!("🚀 JSON-RPC server started: {}", Paint::red(format!("http://{addr}"))),
             );
 
+            sequencer.write().await.start();
             server_handle.stopped().await;
         }
         Err(err) => {

--- a/examples/rpc/starknet/starknet_getTransactionByHash.hurl
+++ b/examples/rpc/starknet/starknet_getTransactionByHash.hurl
@@ -4,7 +4,7 @@ Content-Type: application/json
     "jsonrpc": "2.0",
     "method": "starknet_getTransactionByHash",
     "params": [
-        "0x02e2a98c1731ece2691edfbb4ed9b057182cec569735bd89825f17e3b342583a"
+        "0x1"
     ],
     "id":1
 }

--- a/examples/rpc/starknet/starknet_getTransactionByHash.hurl
+++ b/examples/rpc/starknet/starknet_getTransactionByHash.hurl
@@ -4,7 +4,7 @@ Content-Type: application/json
     "jsonrpc": "2.0",
     "method": "starknet_getTransactionByHash",
     "params": [
-        "0x1"
+        "0x02e2a98c1731ece2691edfbb4ed9b057182cec569735bd89825f17e3b342583a"
     ],
     "id":1
 }


### PR DESCRIPTION
- Generate genesis block with some `declare` and `deploy` transactions for the pre-deployed contracts.
- Refactor how latest block is appended to the chain.
