### PR TITLE
refactor(katana): improve error handling

### DIFF
--- a/crates/katana-core/src/lib.rs
+++ b/crates/katana-core/src/lib.rs
@@ -5,3 +5,5 @@ pub mod sequencer;
 pub mod starknet;
 pub mod state;
 pub mod util;
+
+pub mod sequencer_error;

--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -400,7 +400,7 @@ pub trait Sequencer {
     fn block(&self, block_id: BlockId) -> Option<StarknetBlock>;
 
     fn transaction(&self, hash: &TransactionHash)
-        -> Option<starknet_api::transaction::Transaction>;
+    -> Option<starknet_api::transaction::Transaction>;
 
     fn class_hash_at(
         &mut self,

--- a/crates/katana-core/src/sequencer.rs
+++ b/crates/katana-core/src/sequencer.rs
@@ -21,11 +21,14 @@ use starknet_api::{
     },
 };
 
+use crate::sequencer_error::SequencerError;
 use crate::starknet::block::StarknetBlock;
 use crate::starknet::event::EmittedEvent;
 use crate::starknet::transaction::ExternalFunctionCall;
 use crate::starknet::{StarknetConfig, StarknetWrapper};
 use crate::util::starkfelt_to_u128;
+
+type SequencerResult<T> = Result<T, SequencerError>;
 
 pub struct KatanaSequencer {
     pub starknet: StarknetWrapper,
@@ -51,17 +54,18 @@ impl KatanaSequencer {
         constructor_calldata: Calldata,
         signature: TransactionSignature,
         balance: u64,
-    ) -> anyhow::Result<(TransactionHash, ContractAddress)> {
+    ) -> SequencerResult<(TransactionHash, ContractAddress)> {
         let contract_address = calculate_contract_address(
             contract_address_salt,
             class_hash,
             &constructor_calldata,
             ContractAddress::default(),
         )
-        .unwrap();
+        .map_err(SequencerError::StarknetApi)?;
 
         let deployed_account_balance_key =
-            get_storage_var_address("ERC20_balances", &[*contract_address.0.key()]).unwrap();
+            get_storage_var_address("ERC20_balances", &[*contract_address.0.key()])
+                .map_err(SequencerError::StarknetApi)?;
 
         self.starknet.pending_state.set_storage_at(
             self.starknet.block_context.fee_token_address,
@@ -87,27 +91,28 @@ impl Sequencer for KatanaSequencer {
         contract_address_salt: ContractAddressSalt,
         constructor_calldata: Calldata,
         signature: TransactionSignature,
-    ) -> anyhow::Result<(TransactionHash, ContractAddress)> {
+    ) -> SequencerResult<(TransactionHash, ContractAddress)> {
         let contract_address = calculate_contract_address(
             contract_address_salt,
             class_hash,
             &constructor_calldata,
             ContractAddress::default(),
         )
-        .unwrap();
+        .map_err(SequencerError::StarknetApi)?;
 
         let account_balance_key =
-            get_storage_var_address("ERC20_balances", &[*contract_address.0.key()]).unwrap();
+            get_storage_var_address("ERC20_balances", &[*contract_address.0.key()])
+                .map_err(SequencerError::StarknetApi)?;
+
         let max_fee = {
-            self.starknet.state.get_storage_at(
-                self.starknet.block_context.fee_token_address,
-                account_balance_key,
-            )?
+            self.starknet
+                .state
+                .get_storage_at(self.starknet.block_context.fee_token_address, account_balance_key)
+                .map_err(SequencerError::State)?
         };
         // TODO: Compute txn hash
         let tx_hash = TransactionHash::default();
         let tx = AccountTransaction::DeployAccount(DeployAccountTransaction {
-            max_fee: Fee(starkfelt_to_u128(max_fee)?),
             version,
             class_hash,
             contract_address,
@@ -116,9 +121,17 @@ impl Sequencer for KatanaSequencer {
             nonce: Nonce(stark_felt!(0_u8)),
             signature,
             transaction_hash: tx_hash,
+            max_fee: Fee(starkfelt_to_u128(max_fee).map_err(|e| {
+                SequencerError::ConversionError {
+                    message: e.to_string(),
+                    to: "u128".to_string(),
+                    from: "StarkFelt".to_string(),
+                }
+            })?),
         });
 
-        tx.execute(&mut self.starknet.pending_state, &self.starknet.block_context)?;
+        tx.execute(&mut self.starknet.pending_state, &self.starknet.block_context)
+            .map_err(SequencerError::TransactionExecution)?;
 
         Ok((tx_hash, contract_address))
     }
@@ -131,18 +144,21 @@ impl Sequencer for KatanaSequencer {
         &self,
         account_transaction: AccountTransaction,
         block_id: BlockId,
-    ) -> Result<FeeEstimate> {
-        let state = self.starknet.state_from_block_id(block_id).ok_or(
-            blockifier::state::errors::StateError::StateReadError(format!(
-                "block {block_id:?} not found",
-            )),
-        )?;
+    ) -> SequencerResult<FeeEstimate> {
+        let state = self
+            .starknet
+            .state_from_block_id(block_id)
+            .ok_or(SequencerError::StateNotFound(block_id))?;
 
-        let exec_info = self.starknet.simulate_transaction(account_transaction, Some(state))?;
+        let exec_info = self
+            .starknet
+            .simulate_transaction(account_transaction, Some(state))
+            .map_err(SequencerError::TransactionExecution)?;
 
         let (l1_gas_usage, vm_resources) = extract_l1_gas_and_vm_usage(&exec_info.actual_resources);
         let l1_gas_by_vm_usage =
-            calculate_l1_gas_by_vm_usage(&self.starknet.block_context, &vm_resources)?;
+            calculate_l1_gas_by_vm_usage(&self.starknet.block_context, &vm_resources)
+                .map_err(SequencerError::TransactionExecution)?;
 
         let total_l1_gas_usage = l1_gas_usage as f64 + l1_gas_by_vm_usage;
 
@@ -162,10 +178,15 @@ impl Sequencer for KatanaSequencer {
 
     fn class_hash_at(
         &mut self,
-        _block_id: BlockId,
+        block_id: BlockId,
         contract_address: ContractAddress,
-    ) -> Result<ClassHash, blockifier::state::errors::StateError> {
-        self.starknet.state.get_class_hash_at(contract_address)
+    ) -> SequencerResult<ClassHash> {
+        let mut state = self
+            .starknet
+            .state_from_block_id(block_id)
+            .ok_or(SequencerError::StateNotFound(block_id))?;
+
+        state.get_class_hash_at(contract_address).map_err(SequencerError::State)
     }
 
     fn storage_at(
@@ -173,14 +194,13 @@ impl Sequencer for KatanaSequencer {
         contract_address: ContractAddress,
         storage_key: StorageKey,
         block_id: BlockId,
-    ) -> Result<StarkFelt, blockifier::state::errors::StateError> {
-        let mut state = self.starknet.state_from_block_id(block_id).ok_or(
-            blockifier::state::errors::StateError::StateReadError(format!(
-                "block {block_id:?} not found",
-            )),
-        )?;
+    ) -> SequencerResult<StarkFelt> {
+        let mut state = self
+            .starknet
+            .state_from_block_id(block_id)
+            .ok_or(SequencerError::StateNotFound(block_id))?;
 
-        state.get_storage_at(contract_address, storage_key)
+        state.get_storage_at(contract_address, storage_key).map_err(SequencerError::State)
     }
 
     fn chain_id(&self) -> ChainId {
@@ -204,20 +224,31 @@ impl Sequencer for KatanaSequencer {
 
     fn nonce_at(
         &mut self,
-        _block_id: BlockId,
+        block_id: BlockId,
         contract_address: ContractAddress,
-    ) -> Result<Nonce, blockifier::state::errors::StateError> {
-        self.starknet.state.get_nonce_at(contract_address)
+    ) -> SequencerResult<Nonce> {
+        let mut state = self
+            .starknet
+            .state_from_block_id(block_id)
+            .ok_or(SequencerError::StateNotFound(block_id))?;
+
+        state.get_nonce_at(contract_address).map_err(SequencerError::State)
     }
 
     fn call(
         &self,
         block_id: BlockId,
         function_call: ExternalFunctionCall,
-    ) -> Result<Vec<StarkFelt>> {
-        let block_number = self.starknet.block_number_from_block_id(block_id);
-        let execution_info = self.starknet.call(function_call, block_number)?;
-        Ok(execution_info.execution.retdata.0)
+    ) -> SequencerResult<Vec<StarkFelt>> {
+        let state = self
+            .starknet
+            .state_from_block_id(block_id)
+            .ok_or(SequencerError::StateNotFound(block_id))?;
+
+        self.starknet
+            .call(function_call, Some(state))
+            .map_err(SequencerError::EntryPointExecution)
+            .map(|execution_info| execution_info.execution.retdata.0)
     }
 
     fn transaction_status(&self, hash: &TransactionHash) -> Option<TransactionStatus> {
@@ -246,23 +277,24 @@ impl Sequencer for KatanaSequencer {
         keys: Option<Vec<Vec<StarkFelt>>>,
         _continuation_token: Option<String>,
         _chunk_size: u64,
-    ) -> Result<Vec<EmittedEvent>, blockifier::state::errors::StateError> {
-        let from_block = self.starknet.block_number_from_block_id(from_block).ok_or(
-            blockifier::state::errors::StateError::StateReadError(
-                "invalid `from_block`; block not found".into(),
-            ),
-        )?;
-        let to_block = self.starknet.block_number_from_block_id(to_block).ok_or(
-            blockifier::state::errors::StateError::StateReadError(
-                "invalid `to_block`; block not found".into(),
-            ),
-        )?;
+    ) -> SequencerResult<Vec<EmittedEvent>> {
+        let from_block = self
+            .starknet
+            .block_number_from_block_id(from_block)
+            .ok_or(SequencerError::BlockNotFound(from_block))?;
+
+        let to_block = self
+            .starknet
+            .block_number_from_block_id(to_block)
+            .ok_or(SequencerError::BlockNotFound(to_block))?;
 
         let mut events = Vec::new();
         for i in from_block.0..to_block.0 {
-            let block = self.starknet.blocks.by_number(BlockNumber(i)).ok_or(
-                blockifier::state::errors::StateError::StateReadError("block not found".into()),
-            )?;
+            let block = self
+                .starknet
+                .blocks
+                .by_number(BlockNumber(i))
+                .ok_or(SequencerError::BlockNotFound(BlockId::Number(i)))?;
 
             for tx in block.transactions() {
                 match tx {
@@ -270,12 +302,12 @@ impl Sequencer for KatanaSequencer {
                     _ => continue,
                 }
 
-                let sn_tx =
-                    self.starknet.transactions.transactions.get(&tx.transaction_hash()).ok_or(
-                        blockifier::state::errors::StateError::StateReadError(
-                            "transaction not found".to_string(),
-                        ),
-                    )?;
+                let sn_tx = self
+                    .starknet
+                    .transactions
+                    .transactions
+                    .get(&tx.transaction_hash())
+                    .ok_or(SequencerError::TxnNotFound(tx.transaction_hash()))?;
 
                 events.extend(
                     sn_tx
@@ -327,21 +359,16 @@ impl Sequencer for KatanaSequencer {
         Ok(events)
     }
 
-    fn state_update(
-        &self,
-        block_id: BlockId,
-    ) -> Result<StateUpdate, blockifier::state::errors::StateError> {
-        let block_number = self.starknet.block_number_from_block_id(block_id).ok_or(
-            blockifier::state::errors::StateError::StateReadError(format!(
-                "block id {block_id:?} not found",
-            )),
-        )?;
+    fn state_update(&self, block_id: BlockId) -> SequencerResult<StateUpdate> {
+        let block_number = self
+            .starknet
+            .block_number_from_block_id(block_id)
+            .ok_or(SequencerError::BlockNotFound(block_id))?;
 
-        self.starknet.blocks.get_state_update(block_number).ok_or(
-            blockifier::state::errors::StateError::StateReadError(format!(
-                "storage diff for block id {block_id:?} not found"
-            )),
-        )
+        self.starknet
+            .blocks
+            .get_state_update(block_number)
+            .ok_or(SequencerError::StateUpdateNotFound(block_id))
     }
 
     fn generate_new_block(&mut self) {
@@ -366,20 +393,20 @@ pub trait Sequencer {
         &mut self,
         block_id: BlockId,
         contract_address: ContractAddress,
-    ) -> Result<Nonce, blockifier::state::errors::StateError>;
+    ) -> SequencerResult<Nonce>;
 
     fn block_number(&self) -> BlockNumber;
 
     fn block(&self, block_id: BlockId) -> Option<StarknetBlock>;
 
     fn transaction(&self, hash: &TransactionHash)
-    -> Option<starknet_api::transaction::Transaction>;
+        -> Option<starknet_api::transaction::Transaction>;
 
     fn class_hash_at(
         &mut self,
         block_id: BlockId,
         contract_address: ContractAddress,
-    ) -> Result<ClassHash, blockifier::state::errors::StateError>;
+    ) -> SequencerResult<ClassHash>;
 
     fn block_hash_and_number(&self) -> Option<(BlockHash, BlockNumber)>;
 
@@ -387,14 +414,14 @@ pub trait Sequencer {
         &self,
         block_id: BlockId,
         function_call: ExternalFunctionCall,
-    ) -> Result<Vec<StarkFelt>>;
+    ) -> SequencerResult<Vec<StarkFelt>>;
 
     fn storage_at(
         &mut self,
         contract_address: ContractAddress,
         storage_key: StorageKey,
         block_id: BlockId,
-    ) -> Result<StarkFelt, blockifier::state::errors::StateError>;
+    ) -> SequencerResult<StarkFelt>;
 
     fn deploy_account(
         &mut self,
@@ -403,7 +430,7 @@ pub trait Sequencer {
         contract_address_salt: ContractAddressSalt,
         constructor_calldata: Calldata,
         signature: TransactionSignature,
-    ) -> anyhow::Result<(TransactionHash, ContractAddress)>;
+    ) -> SequencerResult<(TransactionHash, ContractAddress)>;
 
     fn add_account_transaction(&mut self, transaction: AccountTransaction);
 
@@ -411,7 +438,7 @@ pub trait Sequencer {
         &self,
         account_transaction: AccountTransaction,
         block_id: BlockId,
-    ) -> Result<FeeEstimate>;
+    ) -> SequencerResult<FeeEstimate>;
 
     fn events(
         &self,
@@ -419,12 +446,9 @@ pub trait Sequencer {
         to_block: BlockId,
         address: Option<StarkFelt>,
         keys: Option<Vec<Vec<StarkFelt>>>,
-        continuation_token: Option<String>,
-        chunk_size: u64,
-    ) -> Result<Vec<EmittedEvent>, blockifier::state::errors::StateError>;
+        _continuation_token: Option<String>,
+        _chunk_size: u64,
+    ) -> SequencerResult<Vec<EmittedEvent>>;
 
-    fn state_update(
-        &self,
-        block_id: BlockId,
-    ) -> Result<StateUpdate, blockifier::state::errors::StateError>;
+    fn state_update(&self, block_id: BlockId) -> SequencerResult<StateUpdate>;
 }

--- a/crates/katana-core/src/sequencer_error.rs
+++ b/crates/katana-core/src/sequencer_error.rs
@@ -1,0 +1,28 @@
+use blockifier::execution::errors::EntryPointExecutionError;
+use blockifier::state::errors::StateError;
+use blockifier::transaction::errors::TransactionExecutionError;
+use starknet::providers::jsonrpc::models::BlockId;
+use starknet_api::transaction::TransactionHash;
+use starknet_api::StarknetApiError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SequencerError {
+    #[error("Block {0:?} not found.")]
+    BlockNotFound(BlockId),
+    #[error("State update for block {0:?} not found.")]
+    StateUpdateNotFound(BlockId),
+    #[error("State for block {0:?} not found.")]
+    StateNotFound(BlockId),
+    #[error("Transaction with {0} hash not found.")]
+    TxnNotFound(TransactionHash),
+    #[error(transparent)]
+    State(#[from] StateError),
+    #[error(transparent)]
+    TransactionExecution(#[from] TransactionExecutionError),
+    #[error("Error converting {from} into {to}: {message}")]
+    ConversionError { from: String, to: String, message: String },
+    #[error(transparent)]
+    StarknetApi(#[from] StarknetApiError),
+    #[error(transparent)]
+    EntryPointExecution(#[from] EntryPointExecutionError),
+}

--- a/crates/katana-core/src/state.rs
+++ b/crates/katana-core/src/state.rs
@@ -58,11 +58,10 @@ impl StateReader for DictStateReader {
         &mut self,
         class_hash: &ClassHash,
     ) -> StateResult<ContractClass> {
-        let contract_class = self.class_hash_to_class.get(class_hash).cloned();
-        match contract_class {
-            Some(contract_class) => Ok(contract_class),
-            None => Err(StateError::UndeclaredClassHash(*class_hash)),
-        }
+        self.class_hash_to_class
+            .get(class_hash)
+            .cloned()
+            .ok_or(StateError::UndeclaredClassHash(*class_hash))
     }
 
     fn get_class_hash_at(&mut self, contract_address: ContractAddress) -> StateResult<ClassHash> {
@@ -75,9 +74,10 @@ impl StateReader for DictStateReader {
         &mut self,
         class_hash: ClassHash,
     ) -> StateResult<starknet_api::core::CompiledClassHash> {
-        let compiled_class_hash =
-            self.class_hash_to_compiled_class_hash.get(&class_hash).copied().unwrap_or_default();
-        Ok(compiled_class_hash)
+        self.class_hash_to_compiled_class_hash
+            .get(&class_hash)
+            .copied()
+            .ok_or(StateError::UndeclaredClassHash(class_hash))
     }
 }
 

--- a/crates/katana-core/src/util.rs
+++ b/crates/katana-core/src/util.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use blockifier::execution::contract_class::{
     ContractClass, ContractClassV0, ContractClassV1 as BlockifierContractClass,
 };
@@ -132,13 +132,13 @@ pub fn field_element_to_starkfelt(field_element: &FieldElement) -> StarkFelt {
         .expect("must be able to convert to StarkFelt from FieldElement")
 }
 
-pub fn starkfelt_to_u128(felt: StarkFelt) -> Result<u128> {
+pub fn starkfelt_to_u128(felt: StarkFelt) -> Result<u128, StarknetApiError> {
     const COMPLIMENT_OF_U128: usize =
         std::mem::size_of::<StarkFelt>() - std::mem::size_of::<u128>();
 
     let (rest, u128_bytes) = felt.bytes().split_at(COMPLIMENT_OF_U128);
     if rest != [0u8; COMPLIMENT_OF_U128] {
-        Err(anyhow!(StarknetApiError::OutOfRange { string: felt.to_string() }))
+        Err(StarknetApiError::OutOfRange { string: felt.to_string() })
     } else {
         Ok(u128::from_be_bytes(u128_bytes.try_into().expect("u128_bytes should be of size usize.")))
     }


### PR DESCRIPTION
- Add error type for `KatanaSequencer`
- Refactor some RPC endpoints to follow error types as defined in the [specs](https://github.com/starkware-libs/starknet-specs).