### PR TITLE
deps: prefer rustls over native-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7495,6 +7495,8 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
+ "rustls 0.20.8",
+ "rustls-pemfile",
  "serde",
  "sha2",
  "smallvec",
@@ -7505,6 +7507,7 @@ dependencies = [
  "tokio-stream",
  "url",
  "uuid 1.3.3",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -7535,10 +7538,9 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804d3f245f894e61b1e6263c84b23ca675d96753b5abfd5cc8597d86806e8024"
 dependencies = [
- "native-tls",
  "once_cell",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]

--- a/crates/torii/Cargo.toml
+++ b/crates/torii/Cargo.toml
@@ -17,7 +17,7 @@ num = "0.4.0"
 serde.workspace = true
 serde_json.workspace = true
 sqlx = { version = "0.6.2", features = [
-    "runtime-actix-native-tls",
+    "runtime-actix-rustls",
     "uuid",
     "chrono",
     "macros",


### PR DESCRIPTION
Hi, awesome project!

I wanted to try this out with `dojoup` but ran into OpenSSL issues:

```console
$ ~/.dojo/bin/torii 
/home/bing/.dojo/bin/torii: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
$ ~/.dojo/bin/sozo 
/home/bing/.dojo/bin/sozo: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```

This is probably because there are dependencies on `native-tls`, which rely on the system's libssl headers ([which is a PITA for binary distribution](https://users.rust-lang.org/t/any-reasons-to-prefer-native-tls-over-rustls/37626)).

This PR updates `torii` to use `rustls` over `native-tls`:

Old:
```console
$ ldd target/debug/torii
        linux-vdso.so.1 (0x00007ffe15b80000)
        libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007fdb53e69000)
        libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007fdb51800000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fdb53e49000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fdb51d19000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fdb51400000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fdb53f23000)
$ ldd target/debug/sozo
	linux-vdso.so.1 (0x00007fffd0dd9000)
	libssl.so.3 => /lib/x86_64-linux-gnu/libssl.so.3 (0x00007f94a5692000)
	libcrypto.so.3 => /lib/x86_64-linux-gnu/libcrypto.so.3 (0x00007f94a0a00000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f94a5672000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f94a0f19000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f94a0600000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f94a574c000)
```

Now:
```console
$ ldd target/debug/torii
        linux-vdso.so.1 (0x00007fff020bf000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f2ef2bc9000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f2ef0b19000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f2ef0800000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f2ef2bff000)
$ ldd target/debug/sozo
        linux-vdso.so.1 (0x00007ffddf1e7000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f18e695d000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f18e2319000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f18e2000000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f18e6993000)
```

There's also another PR required in the [starknet-api](https://github.com/dojoengine/starknet-api) crate. EDIT: PR [here](https://github.com/dojoengine/starknet-api/pull/1)