### PR TITLE
ci: update ci to use dtolnay/rust-toolchain instead.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
           components: clippy
       
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,20 @@ on:
       - main
   pull_request:
 
+env:
+  CARGO_TERM_COLOR: always
+  NIGHTLY_RUST_VERSION: nightly-2022-11-03
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@master
         with:
-          components: rustfmt
-          toolchain: nightly-2022-11-03
-      - uses: dtolnay/rust-toolchain@stable
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
+
       - uses: Swatinem/rust-cache@v2
       - uses: arduino/setup-protoc@v1
         with:
@@ -39,10 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: nightly-2022-11-03
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
+
       - uses: Swatinem/rust-cache@v2
       - run: scripts/cairo_test.sh
 
@@ -50,10 +55,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
           components: clippy
-          toolchain: nightly-2022-11-03
+      
       - uses: Swatinem/rust-cache@v2
       - uses: arduino/setup-protoc@v1
         with:
@@ -65,11 +72,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
           components: rustfmt
-          toolchain: nightly-2022-11-03
+      
       - uses: Swatinem/rust-cache@v2
       - uses: arduino/setup-protoc@v1
         with:
@@ -81,11 +89,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        name: "Rust Toolchain Setup"
+
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: nightly-2022-11-03
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
+      
       - uses: Swatinem/rust-cache@v2
       - uses: arduino/setup-protoc@v1
         with:
@@ -110,9 +118,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2022-11-03
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
+
       - uses: Swatinem/rust-cache@v2
       - uses: arduino/setup-protoc@v1
         with:
@@ -128,11 +138,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        name: "Rust Toolchain Setup"
+
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
-          toolchain: nightly-2022-11-03
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
+      
       - uses: Swatinem/rust-cache@v2
       - name: Install Hurl
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 env:
   IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
   CARGO_TERM_COLOR: always
+  NIGHTLY_RUST_VERSION: nightly-2022-11-03
 
 jobs:
   prepare:
@@ -103,13 +104,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+
+      - uses: dtolnay/rust-toolchain@master
         name: Rust Toolchain Setup
         with:
-          profile: minimal
-          toolchain: nightly-2022-11-03
-          target: ${{ matrix.job.target }}
-          override: true
+          targets: ${{ matrix.job.target }}
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
 
       - uses: Swatinem/rust-cache@v1
         with:
@@ -129,13 +129,9 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build binaries
-        uses: actions-rs/cargo@v1
-        env:
-          SVM_TARGET_PLATFORM: ${{ matrix.job.svm_target_platform }}
-        with:
-          command: build
-          args: --release --bins --target ${{ matrix.job.target }}
-
+        run: |
+          SVM_TARGET_PLATFORM=${{ matrix.job.svm_target_platform }} cargo build --release --bins --target ${{ matrix.job.target }}
+        
       - name: Archive binaries
         id: artifacts
         env:


### PR DESCRIPTION
This is another unsolicited PR so please feel free to close if this is unnecessary!

actions-rs is basically [unmaintained](https://github.com/actions-rs/toolchain/issues/216), so it would be ideal to move towards a different CI solution for the Rust toolchain.

[dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) also happens to be more concise with their syntax, eg. `minimal` is installed by default.