### PR TITLE
(fix) remove the need to client hashing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "cairo1.languageServerPath": "/home/os/Documents/code/dojo/dojo/target/release/dojo-language-server",
+    "cairo1.languageServerPath": "/workspaces/dojo/target/release/dojo-language-server",
     "cairo1.enableLanguageServer": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "cairo1.languageServerPath": "/workspaces/dojo/target/release/dojo-language-server",
+    "cairo1.languageServerPath": "/home/os/Documents/code/dojo/dojo/target/release/dojo-language-server",
     "cairo1.enableLanguageServer": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "cairo1.languageServerPath": "/workspaces/dojo/target/release/dojo-language-server",
+    "cairo1.languageServerPath": "",
     "cairo1.enableLanguageServer": true
 }

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -225,7 +225,7 @@ mod World {
     ) -> Span<felt252> {
         let class_hash = component_registry::read(component);
 
-        let query = QueryTrait::new(address_domain, partition, keys.span());
+        let query = QueryTrait::new(address_domain, partition, keys);
 
         match Database::get(class_hash, component.into(), query, offset, length) {
             Option::Some(res) => res,

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -5,12 +5,18 @@ mod World {
     use option::OptionTrait;
     use box::BoxTrait;
     use serde::Serde;
-    use starknet::{get_caller_address, get_contract_address, get_tx_info, contract_address::ContractAddressIntoFelt252, ClassHash, Zeroable, ContractAddress};
+    use starknet::{
+        get_caller_address, get_contract_address, get_tx_info,
+        contract_address::ContractAddressIntoFelt252, ClassHash, Zeroable, ContractAddress
+    };
 
     use dojo_core::storage::{db::Database, query::{Query, QueryTrait}};
     use dojo_core::integer::{u250, ContractAddressIntoU250};
     use dojo_core::{string::ShortString, auth::systems::Route};
-    use dojo_core::interfaces::{IComponentLibraryDispatcher, IComponentDispatcherTrait, IExecutorDispatcher, IExecutorDispatcherTrait, ISystemLibraryDispatcher, ISystemDispatcherTrait};
+    use dojo_core::interfaces::{
+        IComponentLibraryDispatcher, IComponentDispatcherTrait, IExecutorDispatcher,
+        IExecutorDispatcherTrait, ISystemLibraryDispatcher, ISystemDispatcherTrait
+    };
 
     #[event]
     fn WorldSpawned(address: ContractAddress, caller: ContractAddress, name: ShortString) {}
@@ -209,8 +215,18 @@ mod World {
     }
 
     #[view]
-    fn entity(component: ShortString, query: Query, offset: u8, length: usize) -> Span<felt252> {
+    fn entity(
+        component: ShortString,
+        address_domain: u32,
+        partition: u250,
+        keys: Span<u250>,
+        offset: u8,
+        length: usize
+    ) -> Span<felt252> {
         let class_hash = component_registry::read(component);
+
+        let query = QueryTrait::new(address_domain, partition, keys.span());
+
         match Database::get(class_hash, component.into(), query, offset, length) {
             Option::Some(res) => res,
             Option::None(_) => {

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -33,7 +33,7 @@ fn test_component() {
     data.append(1337);
     let id = World::uuid();
     World::set_entity(name, QueryTrait::new_from_id(id.into()), 0, data.span());
-    let stored = World::entity(name, QueryTrait::new_from_id(id.into()), 0, 1);
+    let stored = World::entity(name, 0, 0, 0, 0, 1);
     assert(*stored.snapshot.at(0) == 1337, 'data not stored');
 }
 

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -7,11 +7,9 @@ use option::OptionTrait;
 use starknet::class_hash::Felt252TryIntoClassHash;
 use starknet::syscalls::deploy_syscall;
 
-use dojo_core::integer::u250;
-use dojo_core::integer::U32IntoU250;
+use dojo_core::integer::{u250, U32IntoU250};
 use dojo_core::storage::query::QueryTrait;
-use dojo_core::interfaces::IWorldDispatcher;
-use dojo_core::interfaces::IWorldDispatcherTrait;
+use dojo_core::interfaces::{IWorldDispatcher, IWorldDispatcherTrait};
 use dojo_core::executor::Executor;
 use dojo_core::world::World;
 use dojo_core::test_utils::mock_auth_components_systems;
@@ -33,7 +31,11 @@ fn test_component() {
     data.append(1337);
     let id = World::uuid();
     World::set_entity(name, QueryTrait::new_from_id(id.into()), 0, data.span());
-    let stored = World::entity(name, 0, 0, 0, 0, 1);
+
+    let mut keys = ArrayTrait::new();
+    keys.append(0.into());
+
+    let stored = World::entity(name, 0, 0.into(), keys.span(), 0, 1);
     assert(*stored.snapshot.at(0) == 1337, 'data not stored');
 }
 


### PR DESCRIPTION
Adjusts `entity` api in the world so clients do not need to parse the hash