### PR TITLE
fix(ci): remove svm_target_platform as env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
             platform: linux
             target: x86_64-unknown-linux-gnu
             arch: amd64
-            svm_target_platform: linux-amd64
           # - os: ubuntu-20.04
           #   platform: linux
           #   target: aarch64-unknown-linux-gnu
@@ -90,17 +89,14 @@ jobs:
             platform: darwin
             target: x86_64-apple-darwin
             arch: amd64
-            svm_target_platform: macosx-amd64
           - os: macos-latest
             platform: darwin
             target: aarch64-apple-darwin
             arch: arm64
-            svm_target_platform: macosx-aarch64
           - os: windows-latest
             platform: win32
             target: x86_64-pc-windows-msvc
             arch: amd64
-            svm_target_platform: windows-amd64
 
     steps:
       - uses: actions/checkout@v3
@@ -129,8 +125,7 @@ jobs:
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
       - name: Build binaries
-        run: |
-          SVM_TARGET_PLATFORM=${{ matrix.job.svm_target_platform }} cargo build --release --bins --target ${{ matrix.job.target }}
+        run: cargo build --release --bins --target ${{ matrix.job.target }}
         
       - name: Archive binaries
         id: artifacts


### PR DESCRIPTION
The changes I made in a previous PR (https://github.com/dojoengine/dojo/commit/de6716c7f9dda716976b977387d8f666e0651605)
broke the release CI. This entirely removes `svm_target_platform` env var - from what it seems like to me
the env variable is only needed should only be used if you're using the [svm crate](https://github.com/ethers-rs/svm-rs)
so this change should be safe.

Also made sure to run this workflow on my personal fork to make sure the binaries actually build this time: https://github.com/bingcicle/dojo/actions/runs/5102134989