### PR TITLE
ci: bump nightly version with minor changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_RUST_VERSION: nightly-2022-11-03
+  NIGHTLY_RUST_VERSION: nightly-2023-05-28
 
 jobs:
   test:
@@ -56,16 +56,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.NIGHTLY_RUST_VERSION }}
           components: clippy
       
       - uses: Swatinem/rust-cache@v2
       - uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - run: >
-          scripts/clippy.sh
+      - run: scripts/clippy.sh
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -111,7 +111,7 @@ jobs:
           fi
           ~/.cargo-udeps-cache/cargo-udeps udeps
         env:
-          RUSTUP_TOOLCHAIN: nightly-2022-11-03
+          RUSTUP_TOOLCHAIN: ${{ env.NIGHTLY_RUST_VERSION }}
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 env:
   IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
   CARGO_TERM_COLOR: always
-  NIGHTLY_RUST_VERSION: nightly-2022-11-03
+  NIGHTLY_RUST_VERSION: nightly-2023-05-28
 
 jobs:
   prepare:

--- a/crates/dojo-language-server/src/bin/language_server.rs
+++ b/crates/dojo-language-server/src/bin/language_server.rs
@@ -21,7 +21,7 @@ async fn main() {
 
     let db = RootDatabase::builder()
         .with_cfg(CfgSet::from_iter([Cfg::name("test")]))
-        .with_semantic_plugin(Arc::new(DojoPlugin::default()))
+        .with_semantic_plugin(Arc::new(DojoPlugin))
         .with_semantic_plugin(Arc::new(StarkNetPlugin::default()))
         .build()
         .unwrap_or_else(|error| {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -23,11 +23,11 @@ wrap_comments = true
 #     "rust-analyzer.rustfmt.overrideCommand": [
 #         "rustup",
 #         "run",
-#         "nightly-2022-11-03",
+#         "nightly-2023-05-28",
 #         "--",
 #         "rustfmt",
 #         "--edition",
 #         "2021",
 #         "--"
 #     ]
-# and run "rustup toolchain install nightly-2022-11-03".
+# and run "rustup toolchain install nightly-2023-05-28".

--- a/scripts/cairo_test.sh
+++ b/scripts/cairo_test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euxo pipefail
 
-cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-core
-cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-erc
-#cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-physics
-cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-core/tests
-cargo +nightly-2022-11-03 run --bin dojo-test -- crates/dojo-defi
-cargo +nightly-2022-11-03 run --bin dojo-test -- examples
+cargo +nightly-2023-05-28 run --bin dojo-test -- crates/dojo-core
+cargo +nightly-2023-05-28 run --bin dojo-test -- crates/dojo-erc
+#cargo +nightly-2023-05-28 run --bin dojo-test -- crates/dojo-physics
+cargo +nightly-2023-05-28 run --bin dojo-test -- crates/dojo-core/tests
+cargo +nightly-2023-05-28 run --bin dojo-test -- crates/dojo-defi
+cargo +nightly-2023-05-28 run --bin dojo-test -- examples

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-cargo clippy "$@" --all-targets --all-features -- -D warnings -D future-incompatible \
+cargo +nightly-2023-05-28 clippy --all-targets --all-features \
+    -- -D warnings \
+    -D future-incompatible \
     -D nonstandard-style -D rust-2018-idioms -D unused

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2022-11-03 fmt --all -- "$@"
+cargo +nightly-2023-05-28 fmt --all -- "$@"


### PR DESCRIPTION
followup to #373 ([comment](https://github.com/dojoengine/dojo/pull/373#discussion_r1207803483)):

> we inherited this rust version from the cairo repo and i haven't had time to update it. i think it is worth updating though

- bump all nightly versions from 2022-11-03 to 2023-05-28
- update clippy script to use nightly instead of stable
- add line breaks to clippy script for readability