### PR TITLE
feat(katana): add support to declare V1 (#385)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,6 +5125,7 @@ dependencies = [
  "anyhow",
  "blockifier",
  "cairo-lang-starknet",
+ "flate2",
  "futures",
  "lazy_static",
  "rand",

--- a/crates/katana-core/Cargo.toml
+++ b/crates/katana-core/Cargo.toml
@@ -20,3 +20,4 @@ serde_json = "1.0.70"
 cairo-lang-starknet.workspace = true
 rand = { version = "0.8.5", features = ["small_rng"] }
 lazy_static = "1.4.0"
+flate2 = "1.0.26"

--- a/crates/katana-core/src/util.rs
+++ b/crates/katana-core/src/util.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Result;
@@ -7,10 +8,12 @@ use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::transaction_execution::Transaction as BlockifierTransaction;
 use blockifier::transaction::transactions::DeclareTransaction;
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
-use starknet::core::types::contract::legacy::LegacyContractClass;
+use flate2::bufread::GzDecoder;
+use serde_json::json;
+use starknet::core::types::contract::legacy::{LegacyContractClass, LegacyProgram};
 use starknet::core::types::{
-    ContractStorageDiffItem, DeclaredClassItem, DeployedContractItem, FieldElement, NonceUpdate,
-    StateDiff, StorageEntry,
+    CompressedLegacyContractClass, ContractStorageDiffItem, DeclaredClassItem,
+    DeployedContractItem, FieldElement, NonceUpdate, StateDiff, StorageEntry,
 };
 use starknet_api::core::ClassHash;
 use starknet_api::hash::StarkFelt;
@@ -195,5 +198,25 @@ pub fn convert_state_diff_to_rpc_state_diff(state_diff: CommitmentStateDiff) -> 
                 nonce: nonce.0.into(),
             })
             .collect(),
+    }
+}
+
+pub fn flattened_legacy_contract_from_compressed(raw_compressed_contract: &str) -> Result<String> {
+    let compressed_legacy_contract: CompressedLegacyContractClass =
+        serde_json::from_str(raw_compressed_contract)?;
+    let mut gz = GzDecoder::new(&compressed_legacy_contract.program[..]);
+    let mut legacy_program_json = String::new();
+    gz.read_to_string(&mut legacy_program_json)?;
+    let legacy_program: LegacyProgram = serde_json::from_str(&legacy_program_json)?;
+
+    let value = json!({
+        "program": legacy_program,
+        "entry_points_by_type": compressed_legacy_contract.entry_points_by_type,
+        "abi": compressed_legacy_contract.abi,
+    });
+    let flattened = serde_json::to_string(&value);
+    match flattened {
+        Ok(flattened) => Ok(flattened),
+        Err(err) => Err(anyhow::Error::msg(format!("{err}"))),
     }
 }

--- a/crates/katana-rpc/src/starknet/mod.rs
+++ b/crates/katana-rpc/src/starknet/mod.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use blockifier::execution::contract_class::ContractClassV0;
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::transactions::DeclareTransaction;
-
 use jsonrpsee::core::{async_trait, Error};
 use jsonrpsee::types::error::CallError;
 use katana_core::constants::SEQUENCER_ADDRESS;

--- a/crates/katana-rpc/src/starknet/mod.rs
+++ b/crates/katana-rpc/src/starknet/mod.rs
@@ -1,15 +1,21 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
+use blockifier::execution::contract_class::ContractClassV0;
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::transactions::DeclareTransaction;
+
 use jsonrpsee::core::{async_trait, Error};
 use jsonrpsee::types::error::CallError;
 use katana_core::constants::SEQUENCER_ADDRESS;
 use katana_core::sequencer::Sequencer;
 use katana_core::sequencer_error::SequencerError;
 use katana_core::starknet::transaction::ExternalFunctionCall;
-use katana_core::util::{blockifier_contract_class_from_flattened_sierra_class, starkfelt_to_u128};
+use katana_core::util::{
+    blockifier_contract_class_from_flattened_sierra_class,
+    flattened_legacy_contract_from_compressed, starkfelt_to_u128,
+};
+use starknet::core::types::contract::legacy::LegacyContractClass;
 use starknet::core::types::{
     BlockHashAndNumber, BlockId, BlockStatus, BlockTag, BlockWithTxHashes, BlockWithTxs,
     BroadcastedDeclareTransaction, BroadcastedDeployAccountTransaction,
@@ -30,14 +36,14 @@ use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::patricia_key;
 use starknet_api::state::StorageKey;
 use starknet_api::transaction::{
-    Calldata, ContractAddressSalt, DeclareTransactionV2, Fee, InvokeTransaction,
-    InvokeTransactionV1, Transaction as InnerTransaction, TransactionHash, TransactionOutput,
-    TransactionSignature,
+    Calldata, ContractAddressSalt, DeclareTransactionV0V1, DeclareTransactionV2, Fee,
+    InvokeTransaction, InvokeTransactionV1, Transaction as InnerTransaction, TransactionHash,
+    TransactionOutput, TransactionSignature,
 };
 use tokio::sync::RwLock;
 use utils::transaction::{
-    compute_declare_v2_transaction_hash, compute_invoke_v1_transaction_hash,
-    convert_inner_to_rpc_tx,
+    compute_declare_v1_transaction_hash, compute_declare_v2_transaction_hash,
+    compute_invoke_v1_transaction_hash, convert_inner_to_rpc_tx,
 };
 
 use self::api::{Felt, StarknetApiError, StarknetApiServer};
@@ -804,10 +810,47 @@ impl<S: Sequencer + Send + Sync + 'static> StarknetApiServer for StarknetRpc<S> 
     ) -> Result<DeclareTransactionResult, Error> {
         let chain_id = FieldElement::from_hex_be(&self.sequencer.read().await.chain_id().as_hex())
             .map_err(|_| Error::from(StarknetApiError::InternalServerError))?;
-
         let (transaction_hash, class_hash, transaction) = match transaction {
-            BroadcastedDeclareTransaction::V1(_) => {
-                return Err(Error::from(StarknetApiError::UnsupportedTransactionVersion));
+            BroadcastedDeclareTransaction::V1(tx) => {
+                let raw_class_str = serde_json::to_string(&tx.contract_class)
+                    .map_err(|_| Error::from(StarknetApiError::InvalidContractClass))?;
+                let flattened = flattened_legacy_contract_from_compressed(&raw_class_str)?;
+
+                let legacy_contract_class: LegacyContractClass =
+                    ::serde_json::from_str(&flattened)?;
+                let class_hash = legacy_contract_class.class_hash().unwrap();
+
+                let contract_class = serde_json::from_str::<ContractClassV0>(&flattened)?;
+
+                let transaction_hash = compute_declare_v1_transaction_hash(
+                    tx.sender_address,
+                    class_hash,
+                    tx.max_fee,
+                    chain_id,
+                    tx.nonce,
+                );
+
+                let transaction = DeclareTransactionV0V1 {
+                    transaction_hash: TransactionHash(StarkFelt::from(transaction_hash)),
+                    class_hash: ClassHash(StarkFelt::from(class_hash)),
+                    sender_address: ContractAddress(patricia_key!(tx.sender_address)),
+                    nonce: Nonce(StarkFelt::from(tx.nonce)),
+                    max_fee: Fee(starkfelt_to_u128(StarkFelt::from(tx.max_fee))
+                        .map_err(|_| Error::from(StarknetApiError::InternalServerError))?),
+                    signature: TransactionSignature(
+                        tx.signature.into_iter().map(StarkFelt::from).collect(),
+                    ),
+                };
+                (
+                    transaction_hash,
+                    class_hash,
+                    AccountTransaction::Declare(DeclareTransaction {
+                        tx: starknet_api::transaction::DeclareTransaction::V1(transaction),
+                        contract_class: blockifier::execution::contract_class::ContractClass::V0(
+                            contract_class,
+                        ),
+                    }),
+                )
             }
             BroadcastedDeclareTransaction::V2(tx) => {
                 let raw_class_str = serde_json::to_string(&tx.contract_class)

--- a/crates/katana-rpc/tests/rpc.rs
+++ b/crates/katana-rpc/tests/rpc.rs
@@ -4,10 +4,11 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{Ok, Result};
+use starknet::core::types::contract::legacy::LegacyContractClass;
 use starknet::core::types::contract::SierraClass;
 use starknet::core::types::{
-    BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV2, FieldElement,
-    FlattenedSierraClass,
+    BroadcastedDeclareTransaction, BroadcastedDeclareTransactionV1,
+    BroadcastedDeclareTransactionV2, FieldElement, FlattenedSierraClass,
 };
 use starknet::providers::jsonrpc::{HttpTransport, JsonRpcClient};
 use starknet::providers::Provider;
@@ -51,4 +52,35 @@ async fn test_send_declare_v2_tx() {
 
     println!("{res:?}");
     assert!(res.is_ok())
+}
+
+// #[ignore]
+#[tokio::test]
+async fn test_send_declare_v1_tx() {
+    let provider =
+        JsonRpcClient::new(HttpTransport::new(Url::parse("http://localhost:5050").unwrap()));
+
+    let path: PathBuf =
+        [env!("CARGO_MANIFEST_DIR"), "tests/test_data/cairo0_contract.json"].iter().collect();
+
+    let legacy_contract: LegacyContractClass =
+        serde_json::from_reader(fs::File::open(path).unwrap()).unwrap();
+    let contract_class = Arc::new(legacy_contract.compress().unwrap());
+    let res = provider
+        .add_declare_transaction(&BroadcastedDeclareTransaction::V1(
+            BroadcastedDeclareTransactionV1 {
+                max_fee: FieldElement::ZERO,
+                nonce: FieldElement::ZERO,
+                sender_address: FieldElement::from_str(
+                    "0x03819aca4f147e3b589807dd81257c02c4d616328f8b6bdc097b4ae517130a97",
+                )
+                .unwrap(),
+                signature: vec![],
+                contract_class,
+            },
+        ))
+        .await;
+
+    println!("{res:?}");
+    assert!(res.is_ok());
 }

--- a/crates/katana-rpc/tests/rpc.rs
+++ b/crates/katana-rpc/tests/rpc.rs
@@ -54,7 +54,7 @@ async fn test_send_declare_v2_tx() {
     assert!(res.is_ok())
 }
 
-// #[ignore]
+#[ignore]
 #[tokio::test]
 async fn test_send_declare_v1_tx() {
     let provider =

--- a/crates/katana-rpc/tests/test_data/cairo0_contract.json
+++ b/crates/katana-rpc/tests/test_data/cairo0_contract.json
@@ -1,0 +1,10678 @@
+{
+    "abi": [
+        {
+            "members": [
+                {
+                    "name": "amount",
+                    "offset": 0,
+                    "type": "Uint256"
+                },
+                {
+                    "name": "id",
+                    "offset": 2,
+                    "type": "felt"
+                }
+            ],
+            "name": "MyAccount",
+            "size": 3,
+            "type": "struct"
+        },
+        {
+            "members": [
+                {
+                    "name": "low",
+                    "offset": 0,
+                    "type": "felt"
+                },
+                {
+                    "name": "high",
+                    "offset": 1,
+                    "type": "felt"
+                }
+            ],
+            "name": "Uint256",
+            "size": 2,
+            "type": "struct"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "answer_",
+                    "type": "felt"
+                }
+            ],
+            "name": "constructor",
+            "outputs": [],
+            "type": "constructor"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "amount",
+                    "type": "felt"
+                }
+            ],
+            "name": "increase_balance",
+            "outputs": [],
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "a_len",
+                    "type": "felt"
+                },
+                {
+                    "name": "a",
+                    "type": "felt*"
+                }
+            ],
+            "name": "array",
+            "outputs": [
+                {
+                    "name": "b_len",
+                    "type": "felt"
+                },
+                {
+                    "name": "b",
+                    "type": "felt*"
+                }
+            ],
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "get_balance",
+            "outputs": [
+                {
+                    "name": "balance",
+                    "type": "felt"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [],
+            "name": "get_answer",
+            "outputs": [
+                {
+                    "name": "answer",
+                    "type": "felt"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "felt"
+                },
+                {
+                    "name": "b",
+                    "type": "felt"
+                }
+            ],
+            "name": "sum",
+            "outputs": [
+                {
+                    "name": "sum",
+                    "type": "felt"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "a_len",
+                    "type": "felt"
+                },
+                {
+                    "name": "a",
+                    "type": "felt*"
+                }
+            ],
+            "name": "copy_array",
+            "outputs": [
+                {
+                    "name": "b_len",
+                    "type": "felt"
+                },
+                {
+                    "name": "b",
+                    "type": "felt*"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "id",
+                    "type": "felt"
+                }
+            ],
+            "name": "multiple_outputs",
+            "outputs": [
+                {
+                    "name": "account",
+                    "type": "MyAccount"
+                },
+                {
+                    "name": "total",
+                    "type": "Uint256"
+                },
+                {
+                    "name": "ref",
+                    "type": "felt"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "name": "a_len",
+                    "type": "felt"
+                },
+                {
+                    "name": "a",
+                    "type": "felt*"
+                },
+                {
+                    "name": "id",
+                    "type": "felt"
+                }
+            ],
+            "name": "multiple_outputs_with_array",
+            "outputs": [
+                {
+                    "name": "id",
+                    "type": "felt"
+                },
+                {
+                    "name": "b_len",
+                    "type": "felt"
+                },
+                {
+                    "name": "b",
+                    "type": "felt*"
+                },
+                {
+                    "name": "answer",
+                    "type": "felt"
+                }
+            ],
+            "stateMutability": "view",
+            "type": "function"
+        }
+    ],
+    "entry_points_by_type": {
+        "CONSTRUCTOR": [
+            {
+                "offset": "0x62",
+                "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
+            }
+        ],
+        "EXTERNAL": [
+            {
+                "offset": "0xab",
+                "selector": "0x11df9302a3d4661054b99616723b49f594b0c96a39b6f41a479eb98ae896396"
+            },
+            {
+                "offset": "0x140",
+                "selector": "0x1518d30a52d9a52341536c6d37539132244f54365de47f53d0fa0f94b6559ce"
+            },
+            {
+                "offset": "0x1b2",
+                "selector": "0x1fefacaf5c8e0b11b1e55a2b16c4bd9b7a54f3ab505477ea9941e768edf47dd"
+            },
+            {
+                "offset": "0xf7",
+                "selector": "0x298e9302f767302ef01a73bd0eb829d07557feda65f60c3eee0695b28257627"
+            },
+            {
+                "offset": "0x80",
+                "selector": "0x362398bec32bc0ebb411203221a35a0301193a96f317ebe5e40be9f60d15320"
+            },
+            {
+                "offset": "0x17c",
+                "selector": "0x373eabcf35eaa1c80b05b733b0d0036a309ca367182fd939840f75271416f19"
+            },
+            {
+                "offset": "0xd9",
+                "selector": "0x39e11d48192e4333233c7eb19d10ad67c362bb28580c604d67884c85da39695"
+            },
+            {
+                "offset": "0x114",
+                "selector": "0x3dbd160736e9b9b51ea9a79a8ed86f427a62e0e377d60335d2ec895c27025bb"
+            }
+        ],
+        "L1_HANDLER": []
+    },
+    "program": {
+        "attributes": [],
+        "builtins": [
+            "pedersen",
+            "range_check"
+        ],
+        "compiler_version": "0.10.3",
+        "data": [
+            "0x20780017fff7ffd",
+            "0x3",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480080007fff8000",
+            "0x400080007ffd7fff",
+            "0x482480017ffd8001",
+            "0x1",
+            "0x482480017ffd8001",
+            "0x1",
+            "0xa0680017fff7ffe",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb",
+            "0x402a7ffc7ffd7fff",
+            "0x208b7fff7fff7ffe",
+            "0x480680017fff8000",
+            "0x53746f7261676552656164",
+            "0x400280007ffc7fff",
+            "0x400380017ffc7ffd",
+            "0x482680017ffc8000",
+            "0x3",
+            "0x480280027ffc8000",
+            "0x208b7fff7fff7ffe",
+            "0x480680017fff8000",
+            "0x53746f726167655772697465",
+            "0x400280007ffb7fff",
+            "0x400380017ffb7ffc",
+            "0x400380027ffb7ffd",
+            "0x482680017ffb8000",
+            "0x3",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x480680017fff8000",
+            "0x206f38f7e4f15e87567361213c28f235cccdaa1d7fd34c9db1dfe9489c6a091",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffa",
+            "0x480a7ffb7fff8000",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe6",
+            "0x48127ffe7fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ffc7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+            "0x480a7ffa7fff8000",
+            "0x48127ffe7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe0",
+            "0x48127ff67fff8000",
+            "0x48127ff67fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x480680017fff8000",
+            "0x2713d2d8ce8ee141e4e6c2cea57d07d08f80cf040c0785cb486d47981c38657",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffa",
+            "0x480a7ffb7fff8000",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc8",
+            "0x48127ffe7fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ff57fff8000",
+            "0x48127ffc7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+            "0x480a7ffa7fff8000",
+            "0x48127ffe7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc2",
+            "0x48127ff67fff8000",
+            "0x48127ff67fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff1",
+            "0x208b7fff7fff7ffe",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x402a7ffd7ffc7fff",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff3",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffae",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48287ffd7ffc8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb5",
+            "0x208b7fff7fff7ffe",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x402a7ffd7ffc7fff",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffee",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ff97fff8000",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x3",
+            "0x4003800080007ffb",
+            "0x400380007ffd7ffb",
+            "0x402780017ffd8001",
+            "0x1",
+            "0x4826800180008000",
+            "0x1",
+            "0x40297ffb7fff8002",
+            "0x4826800180008000",
+            "0x1",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff5c",
+            "0x480a80017fff8000",
+            "0x4829800080008002",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x2",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x400080007ffe7fff",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x480280007ffd8000",
+            "0x48307fff7ffe8000",
+            "0x402a7ffd7ffc7fff",
+            "0x480280027ffb8000",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x482480017ffd8000",
+            "0x1",
+            "0x480280007ffd8000",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd6",
+            "0x40137ffb7fff8000",
+            "0x40137ffc7fff8001",
+            "0x48127ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd7",
+            "0x480a80007fff8000",
+            "0x480a80017fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff58",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x4003800080007ffc",
+            "0x4826800180008000",
+            "0x1",
+            "0x480a7ffd7fff8000",
+            "0x4828800080007ffe",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x402b7ffd7ffc7ffd",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffee",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff1",
+            "0x48127ff47fff8000",
+            "0x48127ff47fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffff58",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x4003800080007ffc",
+            "0x4826800180008000",
+            "0x1",
+            "0x480a7ffd7fff8000",
+            "0x4828800080007ffe",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x402b7ffd7ffc7ffd",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffee",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff1",
+            "0x48127ff47fff8000",
+            "0x48127ff47fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ff97fff8000",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x482a7ffd7ffc8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x4003800080007ffc",
+            "0x4826800180008000",
+            "0x1",
+            "0x480a7ffd7fff8000",
+            "0x4828800080007ffe",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x482680017ffd8000",
+            "0x2",
+            "0x402a7ffd7ffc7fff",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x480280017ffd8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffeb",
+            "0x48127ffe7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+            "0x48127ff47fff8000",
+            "0x48127ff47fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ff97fff8000",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x3",
+            "0x4003800080007ffb",
+            "0x400380007ffd7ffb",
+            "0x402780017ffd8001",
+            "0x1",
+            "0x4826800180008000",
+            "0x1",
+            "0x40297ffb7fff8002",
+            "0x4826800180008000",
+            "0x1",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffec7",
+            "0x480a80017fff8000",
+            "0x4829800080008002",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x2",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x400080007ffe7fff",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x480280007ffd8000",
+            "0x48307fff7ffe8000",
+            "0x402a7ffd7ffc7fff",
+            "0x480280027ffb8000",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x482480017ffd8000",
+            "0x1",
+            "0x480280007ffd8000",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd6",
+            "0x40137ffb7fff8000",
+            "0x40137ffc7fff8001",
+            "0x48127ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd7",
+            "0x480a80007fff8000",
+            "0x480a80017fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffa7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x480680017fff8000",
+            "0x1",
+            "0x480680017fff8000",
+            "0x0",
+            "0x480a7ffd7fff8000",
+            "0x480680017fff8000",
+            "0x3e8",
+            "0x480680017fff8000",
+            "0x0",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x4003800080007ff7",
+            "0x4003800180007ff8",
+            "0x4003800280007ff9",
+            "0x4003800380007ffa",
+            "0x4003800480007ffb",
+            "0x4003800580007ffc",
+            "0x4826800180008000",
+            "0x6",
+            "0x480a7ffd7fff8000",
+            "0x4828800080007ffe",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x402a7ffd7ffc7fff",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffdd",
+            "0x48127ff97fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe9",
+            "0x48127fef7fff8000",
+            "0x48127fef7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ff87fff8000",
+            "0x480a7ff97fff8000",
+            "0x480a7ffa7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffeb2",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x48127ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffc7fff8000",
+            "0x48127ff97fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x3",
+            "0x4003800080007ff9",
+            "0x4003800180007ffa",
+            "0x400380007ffd7ffa",
+            "0x402780017ffd8001",
+            "0x1",
+            "0x4826800180008000",
+            "0x2",
+            "0x40297ffa7fff8002",
+            "0x4826800180008000",
+            "0x2",
+            "0x480a7ffb7fff8000",
+            "0x480a7ffa7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe58",
+            "0x4003800080027ffc",
+            "0x4826800180028000",
+            "0x1",
+            "0x480a80017fff8000",
+            "0x4828800080007ffe",
+            "0x480a80007fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x40780017fff7fff",
+            "0x2",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x400080007ffe7fff",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x480280007ffd8000",
+            "0x48307fff7ffe8000",
+            "0x482480017fff8000",
+            "0x1",
+            "0x402a7ffd7ffc7fff",
+            "0x480280027ffb8000",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x482480017ffd8000",
+            "0x1",
+            "0x480280007ffd8000",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x480080007ff88000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffc8",
+            "0x40137ff97fff8000",
+            "0x40137ffa7fff8001",
+            "0x48127ffb7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd0",
+            "0x480a80007fff8000",
+            "0x480a80017fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x48127ffb7fff8000",
+            "0x208b7fff7fff7ffe"
+        ],
+        "debug_info": null,
+        "hints": {
+            "3": [
+                {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.memcpy",
+                        "starkware.cairo.common.memcpy.memcpy"
+                    ],
+                    "code": "vm_enter_scope({'n': ids.len})",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 0,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "starkware.cairo.common.memcpy.memcpy.dst": 0,
+                            "starkware.cairo.common.memcpy.memcpy.len": 2,
+                            "starkware.cairo.common.memcpy.memcpy.src": 1
+                        }
+                    }
+                }
+            ],
+            "11": [
+                {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.memcpy",
+                        "starkware.cairo.common.memcpy.memcpy"
+                    ],
+                    "code": "n -= 1\nids.continue_copying = 1 if n > 0 else 0",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 0,
+                            "offset": 5
+                        },
+                        "reference_ids": {
+                            "starkware.cairo.common.memcpy.memcpy.__temp0": 5,
+                            "starkware.cairo.common.memcpy.memcpy.continue_copying": 6,
+                            "starkware.cairo.common.memcpy.memcpy.dst": 0,
+                            "starkware.cairo.common.memcpy.memcpy.frame": 4,
+                            "starkware.cairo.common.memcpy.memcpy.len": 2,
+                            "starkware.cairo.common.memcpy.memcpy.next_frame": 7,
+                            "starkware.cairo.common.memcpy.memcpy.src": 1
+                        }
+                    }
+                }
+            ],
+            "14": [
+                {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.memcpy",
+                        "starkware.cairo.common.memcpy.memcpy"
+                    ],
+                    "code": "vm_exit_scope()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 0,
+                            "offset": 6
+                        },
+                        "reference_ids": {
+                            "starkware.cairo.common.memcpy.memcpy.__temp0": 5,
+                            "starkware.cairo.common.memcpy.memcpy.continue_copying": 6,
+                            "starkware.cairo.common.memcpy.memcpy.dst": 0,
+                            "starkware.cairo.common.memcpy.memcpy.frame": 4,
+                            "starkware.cairo.common.memcpy.memcpy.len": 2,
+                            "starkware.cairo.common.memcpy.memcpy.next_frame": 7,
+                            "starkware.cairo.common.memcpy.memcpy.src": 1
+                        }
+                    }
+                }
+            ],
+            "19": [
+                {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_read"
+                    ],
+                    "code": "syscall_handler.storage_read(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 1,
+                            "offset": 1
+                        },
+                        "reference_ids": {
+                            "starkware.starknet.common.syscalls.storage_read.__temp1": 11,
+                            "starkware.starknet.common.syscalls.storage_read.address": 8,
+                            "starkware.starknet.common.syscalls.storage_read.syscall": 10,
+                            "starkware.starknet.common.syscalls.storage_read.syscall_ptr": 9
+                        }
+                    }
+                }
+            ],
+            "28": [
+                {
+                    "accessible_scopes": [
+                        "starkware.starknet.common.syscalls",
+                        "starkware.starknet.common.syscalls.storage_write"
+                    ],
+                    "code": "syscall_handler.storage_write(segments=segments, syscall_ptr=ids.syscall_ptr)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 2,
+                            "offset": 1
+                        },
+                        "reference_ids": {
+                            "starkware.starknet.common.syscalls.storage_write.__temp2": 17,
+                            "starkware.starknet.common.syscalls.storage_write.address": 14,
+                            "starkware.starknet.common.syscalls.storage_write.syscall_ptr": 16,
+                            "starkware.starknet.common.syscalls.storage_write.value": 15
+                        }
+                    }
+                }
+            ],
+            "107": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.constructor"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 10,
+                            "offset": 29
+                        },
+                        "reference_ids": {
+                            "__wrappers__.constructor.__calldata_actual_size": 78,
+                            "__wrappers__.constructor.__calldata_arg_answer_": 76,
+                            "__wrappers__.constructor.__calldata_ptr": 77,
+                            "__wrappers__.constructor.__temp3": 79,
+                            "__wrappers__.constructor.pedersen_ptr": 81,
+                            "__wrappers__.constructor.range_check_ptr": 82,
+                            "__wrappers__.constructor.ret_value": 83,
+                            "__wrappers__.constructor.syscall_ptr": 80
+                        }
+                    }
+                }
+            ],
+            "137": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.increase_balance"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 12,
+                            "offset": 52
+                        },
+                        "reference_ids": {
+                            "__wrappers__.increase_balance.__calldata_actual_size": 103,
+                            "__wrappers__.increase_balance.__calldata_arg_amount": 101,
+                            "__wrappers__.increase_balance.__calldata_ptr": 102,
+                            "__wrappers__.increase_balance.__temp4": 104,
+                            "__wrappers__.increase_balance.pedersen_ptr": 106,
+                            "__wrappers__.increase_balance.range_check_ptr": 107,
+                            "__wrappers__.increase_balance.ret_value": 108,
+                            "__wrappers__.increase_balance.syscall_ptr": 105
+                        }
+                    }
+                }
+            ],
+            "152": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.array_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 14,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "__wrappers__.array_encode_return.range_check_ptr": 117,
+                            "__wrappers__.array_encode_return.ret_value": 116
+                        }
+                    }
+                }
+            ],
+            "208": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.get_balance_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 19,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "__wrappers__.get_balance_encode_return.range_check_ptr": 157,
+                            "__wrappers__.get_balance_encode_return.ret_value": 156
+                        }
+                    }
+                }
+            ],
+            "238": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.get_answer_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 22,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "__wrappers__.get_answer_encode_return.range_check_ptr": 182,
+                            "__wrappers__.get_answer_encode_return.ret_value": 181
+                        }
+                    }
+                }
+            ],
+            "267": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.sum_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 25,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "__wrappers__.sum_encode_return.range_check_ptr": 206,
+                            "__wrappers__.sum_encode_return.ret_value": 205
+                        }
+                    }
+                }
+            ],
+            "301": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.copy_array_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 28,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "__wrappers__.copy_array_encode_return.range_check_ptr": 234,
+                            "__wrappers__.copy_array_encode_return.ret_value": 233
+                        }
+                    }
+                }
+            ],
+            "366": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.multiple_outputs_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 33,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "__wrappers__.multiple_outputs_encode_return.range_check_ptr": 275,
+                            "__wrappers__.multiple_outputs_encode_return.ret_value": 274
+                        }
+                    }
+                }
+            ],
+            "411": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.multiple_outputs_with_array_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 36,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "__wrappers__.multiple_outputs_with_array_encode_return.range_check_ptr": 310,
+                            "__wrappers__.multiple_outputs_with_array_encode_return.ret_value": 309
+                        }
+                    }
+                }
+            ]
+        },
+        "identifiers": {
+            "__main__.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "__main__.MyAccount": {
+                "full_name": "__main__.MyAccount",
+                "members": {
+                    "amount": {
+                        "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                        "offset": 0
+                    },
+                    "id": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.Uint256": {
+                "destination": "starkware.cairo.common.uint256.Uint256",
+                "type": "alias"
+            },
+            "__main__.answer": {
+                "type": "namespace"
+            },
+            "__main__.answer.Args": {
+                "full_name": "__main__.answer.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.answer.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "__main__.answer.ImplicitArgs": {
+                "full_name": "__main__.answer.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.answer.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.answer.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.answer.addr": {
+                "decorators": [],
+                "pc": 61,
+                "type": "function"
+            },
+            "__main__.answer.addr.Args": {
+                "full_name": "__main__.answer.addr.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.answer.addr.ImplicitArgs": {
+                "full_name": "__main__.answer.addr.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 0
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.answer.addr.Return": {
+                "cairo_type": "(res: felt)",
+                "type": "type_definition"
+            },
+            "__main__.answer.addr.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.answer.addr.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.answer.addr.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 6,
+                            "offset": 0
+                        },
+                        "pc": 61,
+                        "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.addr.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.addr.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 6,
+                            "offset": 0
+                        },
+                        "pc": 61,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.addr.res": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.addr.res",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 6,
+                            "offset": 0
+                        },
+                        "pc": 61,
+                        "value": "cast(1104701650050787127621698902278859233491966253026387283937380535844150150743, felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.hash2": {
+                "destination": "starkware.cairo.common.hash.hash2",
+                "type": "alias"
+            },
+            "__main__.answer.normalize_address": {
+                "destination": "starkware.starknet.common.storage.normalize_address",
+                "type": "alias"
+            },
+            "__main__.answer.read": {
+                "decorators": [],
+                "pc": 66,
+                "type": "function"
+            },
+            "__main__.answer.read.Args": {
+                "full_name": "__main__.answer.read.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.answer.read.ImplicitArgs": {
+                "full_name": "__main__.answer.read.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.answer.read.Return": {
+                "cairo_type": "(answer: felt)",
+                "type": "type_definition"
+            },
+            "__main__.answer.read.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.answer.read.__storage_var_temp0": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.read.__storage_var_temp0",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 14
+                        },
+                        "pc": 74,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 18
+                        },
+                        "pc": 78,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.read.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.answer.read.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 0
+                        },
+                        "pc": 66,
+                        "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 7
+                        },
+                        "pc": 70,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 16
+                        },
+                        "pc": 76,
+                        "value": "[cast(ap + (-1), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.read.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.read.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 0
+                        },
+                        "pc": 66,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 7
+                        },
+                        "pc": 70,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 17
+                        },
+                        "pc": 77,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.read.storage_addr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.read.storage_addr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 7
+                        },
+                        "pc": 70,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.read.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.answer.read.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 0
+                        },
+                        "pc": 66,
+                        "value": "[cast(fp + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 14
+                        },
+                        "pc": 74,
+                        "value": "[cast(ap + (-2), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 7,
+                            "offset": 15
+                        },
+                        "pc": 75,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.storage_read": {
+                "destination": "starkware.starknet.common.syscalls.storage_read",
+                "type": "alias"
+            },
+            "__main__.answer.storage_write": {
+                "destination": "starkware.starknet.common.syscalls.storage_write",
+                "type": "alias"
+            },
+            "__main__.answer.write": {
+                "decorators": [],
+                "pc": 79,
+                "type": "function"
+            },
+            "__main__.answer.write.Args": {
+                "full_name": "__main__.answer.write.Args",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.answer.write.ImplicitArgs": {
+                "full_name": "__main__.answer.write.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.answer.write.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.answer.write.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.answer.write.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.answer.write.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 0
+                        },
+                        "pc": 79,
+                        "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 7
+                        },
+                        "pc": 83,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.write.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.write.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 0
+                        },
+                        "pc": 79,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 7
+                        },
+                        "pc": 83,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.write.storage_addr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.write.storage_addr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 7
+                        },
+                        "pc": 83,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.write.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.answer.write.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 0
+                        },
+                        "pc": 79,
+                        "value": "[cast(fp + (-6), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 14
+                        },
+                        "pc": 88,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.answer.write.value": {
+                "cairo_type": "felt",
+                "full_name": "__main__.answer.write.value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 8,
+                            "offset": 0
+                        },
+                        "pc": 79,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.array": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 146,
+                "type": "function"
+            },
+            "__main__.array.Args": {
+                "full_name": "__main__.array.Args",
+                "members": {
+                    "a": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "a_len": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.array.ImplicitArgs": {
+                "full_name": "__main__.array.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.array.Return": {
+                "cairo_type": "(b_len: felt, b: felt*)",
+                "type": "type_definition"
+            },
+            "__main__.array.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.array.a": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.array.a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 13,
+                            "offset": 0
+                        },
+                        "pc": 146,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.array.a_len": {
+                "cairo_type": "felt",
+                "full_name": "__main__.array.a_len",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 13,
+                            "offset": 0
+                        },
+                        "pc": 146,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.array.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.array.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 13,
+                            "offset": 0
+                        },
+                        "pc": 146,
+                        "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.array.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.array.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 13,
+                            "offset": 0
+                        },
+                        "pc": 146,
+                        "value": "[cast(fp + (-5), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.array.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.array.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 13,
+                            "offset": 0
+                        },
+                        "pc": 146,
+                        "value": "[cast(fp + (-7), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance": {
+                "type": "namespace"
+            },
+            "__main__.balance.Args": {
+                "full_name": "__main__.balance.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.balance.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "__main__.balance.ImplicitArgs": {
+                "full_name": "__main__.balance.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.balance.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.balance.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.balance.addr": {
+                "decorators": [],
+                "pc": 31,
+                "type": "function"
+            },
+            "__main__.balance.addr.Args": {
+                "full_name": "__main__.balance.addr.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.balance.addr.ImplicitArgs": {
+                "full_name": "__main__.balance.addr.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 0
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.balance.addr.Return": {
+                "cairo_type": "(res: felt)",
+                "type": "type_definition"
+            },
+            "__main__.balance.addr.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.balance.addr.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.balance.addr.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 3,
+                            "offset": 0
+                        },
+                        "pc": 31,
+                        "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.addr.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.addr.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 3,
+                            "offset": 0
+                        },
+                        "pc": 31,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.addr.res": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.addr.res",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 3,
+                            "offset": 0
+                        },
+                        "pc": 31,
+                        "value": "cast(916907772491729262376534102982219947830828984996257231353398618781993312401, felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.hash2": {
+                "destination": "starkware.cairo.common.hash.hash2",
+                "type": "alias"
+            },
+            "__main__.balance.normalize_address": {
+                "destination": "starkware.starknet.common.storage.normalize_address",
+                "type": "alias"
+            },
+            "__main__.balance.read": {
+                "decorators": [],
+                "pc": 36,
+                "type": "function"
+            },
+            "__main__.balance.read.Args": {
+                "full_name": "__main__.balance.read.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.balance.read.ImplicitArgs": {
+                "full_name": "__main__.balance.read.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.balance.read.Return": {
+                "cairo_type": "(balance: felt)",
+                "type": "type_definition"
+            },
+            "__main__.balance.read.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.balance.read.__storage_var_temp0": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.read.__storage_var_temp0",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 14
+                        },
+                        "pc": 44,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 18
+                        },
+                        "pc": 48,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.read.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.balance.read.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 0
+                        },
+                        "pc": 36,
+                        "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 7
+                        },
+                        "pc": 40,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 16
+                        },
+                        "pc": 46,
+                        "value": "[cast(ap + (-1), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.read.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.read.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 0
+                        },
+                        "pc": 36,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 7
+                        },
+                        "pc": 40,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 17
+                        },
+                        "pc": 47,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.read.storage_addr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.read.storage_addr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 7
+                        },
+                        "pc": 40,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.read.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.balance.read.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 0
+                        },
+                        "pc": 36,
+                        "value": "[cast(fp + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 14
+                        },
+                        "pc": 44,
+                        "value": "[cast(ap + (-2), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 4,
+                            "offset": 15
+                        },
+                        "pc": 45,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.storage_read": {
+                "destination": "starkware.starknet.common.syscalls.storage_read",
+                "type": "alias"
+            },
+            "__main__.balance.storage_write": {
+                "destination": "starkware.starknet.common.syscalls.storage_write",
+                "type": "alias"
+            },
+            "__main__.balance.write": {
+                "decorators": [],
+                "pc": 49,
+                "type": "function"
+            },
+            "__main__.balance.write.Args": {
+                "full_name": "__main__.balance.write.Args",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.balance.write.ImplicitArgs": {
+                "full_name": "__main__.balance.write.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.balance.write.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.balance.write.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.balance.write.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.balance.write.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 0
+                        },
+                        "pc": 49,
+                        "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 7
+                        },
+                        "pc": 53,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.write.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.write.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 0
+                        },
+                        "pc": 49,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 7
+                        },
+                        "pc": 53,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.write.storage_addr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.write.storage_addr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 7
+                        },
+                        "pc": 53,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.write.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.balance.write.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 0
+                        },
+                        "pc": 49,
+                        "value": "[cast(fp + (-6), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 14
+                        },
+                        "pc": 58,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.balance.write.value": {
+                "cairo_type": "felt",
+                "full_name": "__main__.balance.write.value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 5,
+                            "offset": 0
+                        },
+                        "pc": 49,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.constructor": {
+                "decorators": [
+                    "constructor"
+                ],
+                "pc": 91,
+                "type": "function"
+            },
+            "__main__.constructor.Args": {
+                "full_name": "__main__.constructor.Args",
+                "members": {
+                    "answer_": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.constructor.ImplicitArgs": {
+                "full_name": "__main__.constructor.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.constructor.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.constructor.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.constructor.answer_": {
+                "cairo_type": "felt",
+                "full_name": "__main__.constructor.answer_",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 9,
+                            "offset": 0
+                        },
+                        "pc": 91,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.constructor.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.constructor.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 9,
+                            "offset": 0
+                        },
+                        "pc": 91,
+                        "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 9,
+                            "offset": 22
+                        },
+                        "pc": 97,
+                        "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.constructor.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.constructor.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 9,
+                            "offset": 0
+                        },
+                        "pc": 91,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 9,
+                            "offset": 22
+                        },
+                        "pc": 97,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.constructor.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.constructor.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 9,
+                            "offset": 0
+                        },
+                        "pc": 91,
+                        "value": "[cast(fp + (-6), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 9,
+                            "offset": 22
+                        },
+                        "pc": 97,
+                        "value": "[cast(ap + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.copy_array": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 295,
+                "type": "function"
+            },
+            "__main__.copy_array.Args": {
+                "full_name": "__main__.copy_array.Args",
+                "members": {
+                    "a": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "a_len": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.copy_array.ImplicitArgs": {
+                "full_name": "__main__.copy_array.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.copy_array.Return": {
+                "cairo_type": "(b_len: felt, b: felt*)",
+                "type": "type_definition"
+            },
+            "__main__.copy_array.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.copy_array.a": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.copy_array.a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 27,
+                            "offset": 0
+                        },
+                        "pc": 295,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.copy_array.a_len": {
+                "cairo_type": "felt",
+                "full_name": "__main__.copy_array.a_len",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 27,
+                            "offset": 0
+                        },
+                        "pc": 295,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.copy_array.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.copy_array.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 27,
+                            "offset": 0
+                        },
+                        "pc": 295,
+                        "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.copy_array.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.copy_array.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 27,
+                            "offset": 0
+                        },
+                        "pc": 295,
+                        "value": "[cast(fp + (-5), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.copy_array.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.copy_array.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 27,
+                            "offset": 0
+                        },
+                        "pc": 295,
+                        "value": "[cast(fp + (-7), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_answer": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 232,
+                "type": "function"
+            },
+            "__main__.get_answer.Args": {
+                "full_name": "__main__.get_answer.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.get_answer.ImplicitArgs": {
+                "full_name": "__main__.get_answer.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.get_answer.Return": {
+                "cairo_type": "(answer: felt)",
+                "type": "type_definition"
+            },
+            "__main__.get_answer.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.get_answer.answer_": {
+                "cairo_type": "felt",
+                "full_name": "__main__.get_answer.answer_",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 21,
+                            "offset": 23
+                        },
+                        "pc": 237,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_answer.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.get_answer.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 21,
+                            "offset": 0
+                        },
+                        "pc": 232,
+                        "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 21,
+                            "offset": 23
+                        },
+                        "pc": 237,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_answer.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.get_answer.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 21,
+                            "offset": 0
+                        },
+                        "pc": 232,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 21,
+                            "offset": 23
+                        },
+                        "pc": 237,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_answer.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.get_answer.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 21,
+                            "offset": 0
+                        },
+                        "pc": 232,
+                        "value": "[cast(fp + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 21,
+                            "offset": 23
+                        },
+                        "pc": 237,
+                        "value": "[cast(ap + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_balance": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 202,
+                "type": "function"
+            },
+            "__main__.get_balance.Args": {
+                "full_name": "__main__.get_balance.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__main__.get_balance.ImplicitArgs": {
+                "full_name": "__main__.get_balance.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.get_balance.Return": {
+                "cairo_type": "(balance: felt)",
+                "type": "type_definition"
+            },
+            "__main__.get_balance.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.get_balance.balance_": {
+                "cairo_type": "felt",
+                "full_name": "__main__.get_balance.balance_",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 18,
+                            "offset": 23
+                        },
+                        "pc": 207,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_balance.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.get_balance.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 18,
+                            "offset": 0
+                        },
+                        "pc": 202,
+                        "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 18,
+                            "offset": 23
+                        },
+                        "pc": 207,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_balance.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.get_balance.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 18,
+                            "offset": 0
+                        },
+                        "pc": 202,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 18,
+                            "offset": 23
+                        },
+                        "pc": 207,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.get_balance.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.get_balance.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 18,
+                            "offset": 0
+                        },
+                        "pc": 202,
+                        "value": "[cast(fp + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 18,
+                            "offset": 23
+                        },
+                        "pc": 207,
+                        "value": "[cast(ap + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.increase_balance": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 116,
+                "type": "function"
+            },
+            "__main__.increase_balance.Args": {
+                "full_name": "__main__.increase_balance.Args",
+                "members": {
+                    "amount": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.increase_balance.ImplicitArgs": {
+                "full_name": "__main__.increase_balance.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.increase_balance.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.increase_balance.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.increase_balance.amount": {
+                "cairo_type": "felt",
+                "full_name": "__main__.increase_balance.amount",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 0
+                        },
+                        "pc": 116,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.increase_balance.balance_": {
+                "cairo_type": "felt",
+                "full_name": "__main__.increase_balance.balance_",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 23
+                        },
+                        "pc": 121,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.increase_balance.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.increase_balance.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 0
+                        },
+                        "pc": 116,
+                        "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 23
+                        },
+                        "pc": 121,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 45
+                        },
+                        "pc": 127,
+                        "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.increase_balance.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.increase_balance.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 0
+                        },
+                        "pc": 116,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 23
+                        },
+                        "pc": 121,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 45
+                        },
+                        "pc": 127,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.increase_balance.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.increase_balance.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 0
+                        },
+                        "pc": 116,
+                        "value": "[cast(fp + (-6), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 23
+                        },
+                        "pc": 121,
+                        "value": "[cast(ap + (-4), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 11,
+                            "offset": 45
+                        },
+                        "pc": 127,
+                        "value": "[cast(ap + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 351,
+                "type": "function"
+            },
+            "__main__.multiple_outputs.Args": {
+                "full_name": "__main__.multiple_outputs.Args",
+                "members": {
+                    "id": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.multiple_outputs.ImplicitArgs": {
+                "full_name": "__main__.multiple_outputs.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.multiple_outputs.Return": {
+                "cairo_type": "(account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)",
+                "type": "type_definition"
+            },
+            "__main__.multiple_outputs.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.multiple_outputs.account": {
+                "cairo_type": "__main__.MyAccount",
+                "full_name": "__main__.multiple_outputs.account",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "cast(((1, 0), [fp + (-3)]), __main__.MyAccount)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs.amount": {
+                "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                "full_name": "__main__.multiple_outputs.amount",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "cast((1, 0), starkware.cairo.common.uint256.Uint256)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs.id": {
+                "cairo_type": "felt",
+                "full_name": "__main__.multiple_outputs.id",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.multiple_outputs.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.multiple_outputs.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs.ref": {
+                "cairo_type": "felt",
+                "full_name": "__main__.multiple_outputs.ref",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "cast([fp + (-3)] + 1, felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.multiple_outputs.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "[cast(fp + (-6), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs.total": {
+                "cairo_type": "starkware.cairo.common.uint256.Uint256",
+                "full_name": "__main__.multiple_outputs.total",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 32,
+                            "offset": 0
+                        },
+                        "pc": 351,
+                        "value": "cast((1000, 0), starkware.cairo.common.uint256.Uint256)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs_with_array": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 398,
+                "type": "function"
+            },
+            "__main__.multiple_outputs_with_array.Args": {
+                "full_name": "__main__.multiple_outputs_with_array.Args",
+                "members": {
+                    "a": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "a_len": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "id": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.multiple_outputs_with_array.ImplicitArgs": {
+                "full_name": "__main__.multiple_outputs_with_array.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.multiple_outputs_with_array.Return": {
+                "cairo_type": "(id: felt, b_len: felt, b: felt*, answer: felt)",
+                "type": "type_definition"
+            },
+            "__main__.multiple_outputs_with_array.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.multiple_outputs_with_array.a": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.multiple_outputs_with_array.a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 0
+                        },
+                        "pc": 398,
+                        "value": "[cast(fp + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs_with_array.a_len": {
+                "cairo_type": "felt",
+                "full_name": "__main__.multiple_outputs_with_array.a_len",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 0
+                        },
+                        "pc": 398,
+                        "value": "[cast(fp + (-5), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs_with_array.answer_": {
+                "cairo_type": "felt",
+                "full_name": "__main__.multiple_outputs_with_array.answer_",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 23
+                        },
+                        "pc": 403,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs_with_array.id": {
+                "cairo_type": "felt",
+                "full_name": "__main__.multiple_outputs_with_array.id",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 0
+                        },
+                        "pc": 398,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs_with_array.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.multiple_outputs_with_array.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 0
+                        },
+                        "pc": 398,
+                        "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 23
+                        },
+                        "pc": 403,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs_with_array.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.multiple_outputs_with_array.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 0
+                        },
+                        "pc": 398,
+                        "value": "[cast(fp + (-6), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 23
+                        },
+                        "pc": 403,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.multiple_outputs_with_array.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.multiple_outputs_with_array.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 0
+                        },
+                        "pc": 398,
+                        "value": "[cast(fp + (-8), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 35,
+                            "offset": 23
+                        },
+                        "pc": 403,
+                        "value": "[cast(ap + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.sum": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 262,
+                "type": "function"
+            },
+            "__main__.sum.Args": {
+                "full_name": "__main__.sum.Args",
+                "members": {
+                    "a": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "b": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__main__.sum.ImplicitArgs": {
+                "full_name": "__main__.sum.ImplicitArgs",
+                "members": {
+                    "pedersen_ptr": {
+                        "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                        "offset": 1
+                    },
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__main__.sum.Return": {
+                "cairo_type": "(sum: felt)",
+                "type": "type_definition"
+            },
+            "__main__.sum.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__main__.sum.a": {
+                "cairo_type": "felt",
+                "full_name": "__main__.sum.a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 24,
+                            "offset": 0
+                        },
+                        "pc": 262,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.sum.b": {
+                "cairo_type": "felt",
+                "full_name": "__main__.sum.b",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 24,
+                            "offset": 0
+                        },
+                        "pc": 262,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.sum.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__main__.sum.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 24,
+                            "offset": 0
+                        },
+                        "pc": 262,
+                        "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.sum.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__main__.sum.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 24,
+                            "offset": 0
+                        },
+                        "pc": 262,
+                        "value": "[cast(fp + (-5), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.sum.sum_": {
+                "cairo_type": "felt",
+                "full_name": "__main__.sum.sum_",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 24,
+                            "offset": 0
+                        },
+                        "pc": 262,
+                        "value": "cast([fp + (-4)] + [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__main__.sum.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__main__.sum.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 24,
+                            "offset": 0
+                        },
+                        "pc": 262,
+                        "value": "[cast(fp + (-7), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 171,
+                "type": "function"
+            },
+            "__wrappers__.array.Args": {
+                "full_name": "__wrappers__.array.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.array.ImplicitArgs": {
+                "full_name": "__wrappers__.array.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.array.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.array.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__wrappers__.array.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 7
+                        },
+                        "pc": 180,
+                        "value": "cast([ap + (-1)] - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__calldata_arg_a": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.array.__calldata_arg_a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 4
+                        },
+                        "pc": 176,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__calldata_arg_a_len": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.__calldata_arg_a_len",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 2
+                        },
+                        "pc": 173,
+                        "value": "[cast([fp + (-3)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.array.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 2
+                        },
+                        "pc": 173,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 2
+                        },
+                        "pc": 173,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 7
+                        },
+                        "pc": 180,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__temp10": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.__temp10",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 8
+                        },
+                        "pc": 182,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__temp6": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.__temp6",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 3
+                        },
+                        "pc": 174,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__temp7": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.__temp7",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 4
+                        },
+                        "pc": 175,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__temp8": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.__temp8",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 5
+                        },
+                        "pc": 178,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__temp9": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.__temp9",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 6
+                        },
+                        "pc": 179,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.__wrapped_func": {
+                "destination": "__main__.array",
+                "type": "alias"
+            },
+            "__wrappers__.array.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.array.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 2
+                        },
+                        "pc": 173,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 20
+                        },
+                        "pc": 191,
+                        "value": "[cast(ap + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 20
+                        },
+                        "pc": 193,
+                        "value": "[cast(fp + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 2
+                        },
+                        "pc": 173,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 4
+                        },
+                        "pc": 176,
+                        "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 20
+                        },
+                        "pc": 191,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 17,
+                            "offset": 0
+                        },
+                        "pc": 196,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.ret_value": {
+                "cairo_type": "(b_len: felt, b: felt*)",
+                "full_name": "__wrappers__.array.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 20
+                        },
+                        "pc": 191,
+                        "value": "[cast(ap + (-2), (b_len: felt, b: felt*)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.array.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 17,
+                            "offset": 0
+                        },
+                        "pc": 196,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 17,
+                            "offset": 0
+                        },
+                        "pc": 196,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.array.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 2
+                        },
+                        "pc": 173,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 20
+                        },
+                        "pc": 191,
+                        "value": "[cast(ap + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 16,
+                            "offset": 20
+                        },
+                        "pc": 192,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array_encode_return": {
+                "decorators": [],
+                "pc": 152,
+                "type": "function"
+            },
+            "__wrappers__.array_encode_return.Args": {
+                "full_name": "__wrappers__.array_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "ret_value": {
+                        "cairo_type": "(b_len: felt, b: felt*)",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__wrappers__.array_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.array_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.array_encode_return.Return": {
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.array_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 3
+            },
+            "__wrappers__.array_encode_return.__return_value_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.array_encode_return.__return_value_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 3
+                        },
+                        "pc": 154,
+                        "value": "[cast(fp, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 3
+                        },
+                        "pc": 155,
+                        "value": "cast([fp] + 1, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 4
+                        },
+                        "pc": 161,
+                        "value": "[cast(fp + 2, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array_encode_return.__return_value_ptr_copy": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.array_encode_return.__return_value_ptr_copy",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 3
+                        },
+                        "pc": 158,
+                        "value": "cast([fp] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array_encode_return.__return_value_ptr_start": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.array_encode_return.__return_value_ptr_start",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 3
+                        },
+                        "pc": 154,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array_encode_return.__temp5": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array_encode_return.__temp5",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 4
+                        },
+                        "pc": 160,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.array_encode_return.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.array_encode_return.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 0
+                        },
+                        "pc": 152,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 3
+                        },
+                        "pc": 158,
+                        "value": "[cast(fp + 1, felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.array_encode_return.ret_value": {
+                "cairo_type": "(b_len: felt, b: felt*)",
+                "full_name": "__wrappers__.array_encode_return.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 14,
+                            "offset": 0
+                        },
+                        "pc": 152,
+                        "value": "[cast(fp + (-5), (b_len: felt, b: felt*)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor": {
+                "decorators": [
+                    "constructor"
+                ],
+                "pc": 98,
+                "type": "function"
+            },
+            "__wrappers__.constructor.Args": {
+                "full_name": "__wrappers__.constructor.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.constructor.ImplicitArgs": {
+                "full_name": "__wrappers__.constructor.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.constructor.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.constructor.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.constructor.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.constructor.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 0
+                        },
+                        "pc": 98,
+                        "value": "cast([fp + (-3)] + 1 - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.__calldata_arg_answer_": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.constructor.__calldata_arg_answer_",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 0
+                        },
+                        "pc": 98,
+                        "value": "[cast([fp + (-3)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.constructor.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 0
+                        },
+                        "pc": 98,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 0
+                        },
+                        "pc": 98,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.__temp3": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.constructor.__temp3",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 1
+                        },
+                        "pc": 100,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.__wrapped_func": {
+                "destination": "__main__.constructor",
+                "type": "alias"
+            },
+            "__wrappers__.constructor.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.constructor.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 0
+                        },
+                        "pc": 98,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 29
+                        },
+                        "pc": 107,
+                        "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.constructor.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 0
+                        },
+                        "pc": 98,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 29
+                        },
+                        "pc": 107,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.ret_value": {
+                "cairo_type": "()",
+                "full_name": "__wrappers__.constructor.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 29
+                        },
+                        "pc": 107,
+                        "value": "[cast(ap + 0, ()*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.constructor.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 30
+                        },
+                        "pc": 109,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.constructor.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 30
+                        },
+                        "pc": 109,
+                        "value": "cast(0, felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.constructor.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 0
+                        },
+                        "pc": 98,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 10,
+                            "offset": 29
+                        },
+                        "pc": 107,
+                        "value": "[cast(ap + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.constructor_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.copy_array": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 320,
+                "type": "function"
+            },
+            "__wrappers__.copy_array.Args": {
+                "full_name": "__wrappers__.copy_array.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.copy_array.ImplicitArgs": {
+                "full_name": "__wrappers__.copy_array.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.copy_array.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.copy_array.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__wrappers__.copy_array.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 7
+                        },
+                        "pc": 329,
+                        "value": "cast([ap + (-1)] - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__calldata_arg_a": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.copy_array.__calldata_arg_a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 4
+                        },
+                        "pc": 325,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__calldata_arg_a_len": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.__calldata_arg_a_len",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 2
+                        },
+                        "pc": 322,
+                        "value": "[cast([fp + (-3)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.copy_array.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 2
+                        },
+                        "pc": 322,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 2
+                        },
+                        "pc": 322,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 7
+                        },
+                        "pc": 329,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__temp16": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.__temp16",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 3
+                        },
+                        "pc": 323,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__temp17": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.__temp17",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 4
+                        },
+                        "pc": 324,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__temp18": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.__temp18",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 5
+                        },
+                        "pc": 327,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__temp19": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.__temp19",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 6
+                        },
+                        "pc": 328,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__temp20": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.__temp20",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 8
+                        },
+                        "pc": 331,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.__wrapped_func": {
+                "destination": "__main__.copy_array",
+                "type": "alias"
+            },
+            "__wrappers__.copy_array.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.copy_array.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 2
+                        },
+                        "pc": 322,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 20
+                        },
+                        "pc": 340,
+                        "value": "[cast(ap + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 20
+                        },
+                        "pc": 342,
+                        "value": "[cast(fp + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 2
+                        },
+                        "pc": 322,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 4
+                        },
+                        "pc": 325,
+                        "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 20
+                        },
+                        "pc": 340,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 31,
+                            "offset": 0
+                        },
+                        "pc": 345,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.ret_value": {
+                "cairo_type": "(b_len: felt, b: felt*)",
+                "full_name": "__wrappers__.copy_array.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 20
+                        },
+                        "pc": 340,
+                        "value": "[cast(ap + (-2), (b_len: felt, b: felt*)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.copy_array.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 31,
+                            "offset": 0
+                        },
+                        "pc": 345,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 31,
+                            "offset": 0
+                        },
+                        "pc": 345,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.copy_array.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 2
+                        },
+                        "pc": 322,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 20
+                        },
+                        "pc": 340,
+                        "value": "[cast(ap + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 30,
+                            "offset": 20
+                        },
+                        "pc": 341,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array_encode_return": {
+                "decorators": [],
+                "pc": 301,
+                "type": "function"
+            },
+            "__wrappers__.copy_array_encode_return.Args": {
+                "full_name": "__wrappers__.copy_array_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "ret_value": {
+                        "cairo_type": "(b_len: felt, b: felt*)",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "__wrappers__.copy_array_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.copy_array_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.copy_array_encode_return.Return": {
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.copy_array_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 3
+            },
+            "__wrappers__.copy_array_encode_return.__return_value_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.copy_array_encode_return.__return_value_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 3
+                        },
+                        "pc": 303,
+                        "value": "[cast(fp, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 3
+                        },
+                        "pc": 304,
+                        "value": "cast([fp] + 1, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 4
+                        },
+                        "pc": 310,
+                        "value": "[cast(fp + 2, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array_encode_return.__return_value_ptr_copy": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.copy_array_encode_return.__return_value_ptr_copy",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 3
+                        },
+                        "pc": 307,
+                        "value": "cast([fp] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array_encode_return.__return_value_ptr_start": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.copy_array_encode_return.__return_value_ptr_start",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 3
+                        },
+                        "pc": 303,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array_encode_return.__temp15": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array_encode_return.__temp15",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 4
+                        },
+                        "pc": 309,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.copy_array_encode_return.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.copy_array_encode_return.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 0
+                        },
+                        "pc": 301,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 3
+                        },
+                        "pc": 307,
+                        "value": "[cast(fp + 1, felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.copy_array_encode_return.ret_value": {
+                "cairo_type": "(b_len: felt, b: felt*)",
+                "full_name": "__wrappers__.copy_array_encode_return.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 28,
+                            "offset": 0
+                        },
+                        "pc": 301,
+                        "value": "[cast(fp + (-5), (b_len: felt, b: felt*)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 247,
+                "type": "function"
+            },
+            "__wrappers__.get_answer.Args": {
+                "full_name": "__wrappers__.get_answer.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.get_answer.ImplicitArgs": {
+                "full_name": "__wrappers__.get_answer.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.get_answer.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.get_answer.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.get_answer.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_answer.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 247,
+                        "value": "cast([fp + (-3)] - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_answer.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 247,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer.__wrapped_func": {
+                "destination": "__main__.get_answer",
+                "type": "alias"
+            },
+            "__wrappers__.get_answer.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.get_answer.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 247,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 28
+                        },
+                        "pc": 253,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_answer.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 247,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 28
+                        },
+                        "pc": 253,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 36
+                        },
+                        "pc": 256,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer.ret_value": {
+                "cairo_type": "(answer: felt)",
+                "full_name": "__wrappers__.get_answer.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 28
+                        },
+                        "pc": 253,
+                        "value": "[cast(ap + (-1), (answer: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_answer.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 36
+                        },
+                        "pc": 256,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_answer.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 36
+                        },
+                        "pc": 256,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_answer.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 247,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 28
+                        },
+                        "pc": 253,
+                        "value": "[cast(ap + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer_encode_return": {
+                "decorators": [],
+                "pc": 238,
+                "type": "function"
+            },
+            "__wrappers__.get_answer_encode_return.Args": {
+                "full_name": "__wrappers__.get_answer_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "ret_value": {
+                        "cairo_type": "(answer: felt)",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__wrappers__.get_answer_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.get_answer_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.get_answer_encode_return.Return": {
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.get_answer_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 1
+            },
+            "__wrappers__.get_answer_encode_return.__return_value_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_answer_encode_return.__return_value_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 22,
+                            "offset": 1
+                        },
+                        "pc": 240,
+                        "value": "[cast(fp, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 22,
+                            "offset": 1
+                        },
+                        "pc": 241,
+                        "value": "cast([fp] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer_encode_return.__return_value_ptr_start": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_answer_encode_return.__return_value_ptr_start",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 22,
+                            "offset": 1
+                        },
+                        "pc": 240,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer_encode_return.__temp12": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_answer_encode_return.__temp12",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 22,
+                            "offset": 2
+                        },
+                        "pc": 243,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.get_answer_encode_return.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_answer_encode_return.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 22,
+                            "offset": 0
+                        },
+                        "pc": 238,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_answer_encode_return.ret_value": {
+                "cairo_type": "(answer: felt)",
+                "full_name": "__wrappers__.get_answer_encode_return.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 22,
+                            "offset": 0
+                        },
+                        "pc": 238,
+                        "value": "[cast(fp + (-4), (answer: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 217,
+                "type": "function"
+            },
+            "__wrappers__.get_balance.Args": {
+                "full_name": "__wrappers__.get_balance.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.get_balance.ImplicitArgs": {
+                "full_name": "__wrappers__.get_balance.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.get_balance.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.get_balance.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.get_balance.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_balance.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 0
+                        },
+                        "pc": 217,
+                        "value": "cast([fp + (-3)] - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_balance.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 0
+                        },
+                        "pc": 217,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance.__wrapped_func": {
+                "destination": "__main__.get_balance",
+                "type": "alias"
+            },
+            "__wrappers__.get_balance.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.get_balance.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 0
+                        },
+                        "pc": 217,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 28
+                        },
+                        "pc": 223,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_balance.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 0
+                        },
+                        "pc": 217,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 28
+                        },
+                        "pc": 223,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 36
+                        },
+                        "pc": 226,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance.ret_value": {
+                "cairo_type": "(balance: felt)",
+                "full_name": "__wrappers__.get_balance.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 28
+                        },
+                        "pc": 223,
+                        "value": "[cast(ap + (-1), (balance: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_balance.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 36
+                        },
+                        "pc": 226,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_balance.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 36
+                        },
+                        "pc": 226,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_balance.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 0
+                        },
+                        "pc": 217,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 20,
+                            "offset": 28
+                        },
+                        "pc": 223,
+                        "value": "[cast(ap + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance_encode_return": {
+                "decorators": [],
+                "pc": 208,
+                "type": "function"
+            },
+            "__wrappers__.get_balance_encode_return.Args": {
+                "full_name": "__wrappers__.get_balance_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "ret_value": {
+                        "cairo_type": "(balance: felt)",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__wrappers__.get_balance_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.get_balance_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.get_balance_encode_return.Return": {
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.get_balance_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 1
+            },
+            "__wrappers__.get_balance_encode_return.__return_value_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_balance_encode_return.__return_value_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 19,
+                            "offset": 1
+                        },
+                        "pc": 210,
+                        "value": "[cast(fp, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 19,
+                            "offset": 1
+                        },
+                        "pc": 211,
+                        "value": "cast([fp] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance_encode_return.__return_value_ptr_start": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.get_balance_encode_return.__return_value_ptr_start",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 19,
+                            "offset": 1
+                        },
+                        "pc": 210,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance_encode_return.__temp11": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_balance_encode_return.__temp11",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 19,
+                            "offset": 2
+                        },
+                        "pc": 213,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.get_balance_encode_return.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.get_balance_encode_return.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 19,
+                            "offset": 0
+                        },
+                        "pc": 208,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.get_balance_encode_return.ret_value": {
+                "cairo_type": "(balance: felt)",
+                "full_name": "__wrappers__.get_balance_encode_return.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 19,
+                            "offset": 0
+                        },
+                        "pc": 208,
+                        "value": "[cast(fp + (-4), (balance: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 128,
+                "type": "function"
+            },
+            "__wrappers__.increase_balance.Args": {
+                "full_name": "__wrappers__.increase_balance.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.increase_balance.ImplicitArgs": {
+                "full_name": "__wrappers__.increase_balance.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.increase_balance.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.increase_balance.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.increase_balance.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.increase_balance.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "pc": 128,
+                        "value": "cast([fp + (-3)] + 1 - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.__calldata_arg_amount": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.increase_balance.__calldata_arg_amount",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "pc": 128,
+                        "value": "[cast([fp + (-3)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.increase_balance.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "pc": 128,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "pc": 128,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.__temp4": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.increase_balance.__temp4",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 1
+                        },
+                        "pc": 130,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.__wrapped_func": {
+                "destination": "__main__.increase_balance",
+                "type": "alias"
+            },
+            "__wrappers__.increase_balance.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.increase_balance.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "pc": 128,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 52
+                        },
+                        "pc": 137,
+                        "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.increase_balance.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "pc": 128,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 52
+                        },
+                        "pc": 137,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.ret_value": {
+                "cairo_type": "()",
+                "full_name": "__wrappers__.increase_balance.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 52
+                        },
+                        "pc": 137,
+                        "value": "[cast(ap + 0, ()*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.increase_balance.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 53
+                        },
+                        "pc": 139,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.increase_balance.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 53
+                        },
+                        "pc": 139,
+                        "value": "cast(0, felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.increase_balance.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 0
+                        },
+                        "pc": 128,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 12,
+                            "offset": 52
+                        },
+                        "pc": 137,
+                        "value": "[cast(ap + (-3), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.increase_balance_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.multiple_outputs": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 380,
+                "type": "function"
+            },
+            "__wrappers__.multiple_outputs.Args": {
+                "full_name": "__wrappers__.multiple_outputs.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs.ImplicitArgs": {
+                "full_name": "__wrappers__.multiple_outputs.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.multiple_outputs.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.multiple_outputs.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 0
+                        },
+                        "pc": 380,
+                        "value": "cast([fp + (-3)] + 1 - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.__calldata_arg_id": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs.__calldata_arg_id",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 0
+                        },
+                        "pc": 380,
+                        "value": "[cast([fp + (-3)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 0
+                        },
+                        "pc": 380,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 0
+                        },
+                        "pc": 380,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.__temp22": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs.__temp22",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 1
+                        },
+                        "pc": 382,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.__wrapped_func": {
+                "destination": "__main__.multiple_outputs",
+                "type": "alias"
+            },
+            "__wrappers__.multiple_outputs.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.multiple_outputs.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 0
+                        },
+                        "pc": 380,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 16
+                        },
+                        "pc": 389,
+                        "value": "[cast(ap + (-8), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 0
+                        },
+                        "pc": 380,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 16
+                        },
+                        "pc": 389,
+                        "value": "[cast(ap + (-7), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 24
+                        },
+                        "pc": 392,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.ret_value": {
+                "cairo_type": "(account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)",
+                "full_name": "__wrappers__.multiple_outputs.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 16
+                        },
+                        "pc": 389,
+                        "value": "[cast(ap + (-6), (account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 24
+                        },
+                        "pc": 392,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 24
+                        },
+                        "pc": 392,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 0
+                        },
+                        "pc": 380,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 34,
+                            "offset": 16
+                        },
+                        "pc": 389,
+                        "value": "[cast(ap + (-9), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_encode_return": {
+                "decorators": [],
+                "pc": 366,
+                "type": "function"
+            },
+            "__wrappers__.multiple_outputs_encode_return.Args": {
+                "full_name": "__wrappers__.multiple_outputs_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 6
+                    },
+                    "ret_value": {
+                        "cairo_type": "(account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)",
+                        "offset": 0
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.multiple_outputs_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs_encode_return.Return": {
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.multiple_outputs_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 1
+            },
+            "__wrappers__.multiple_outputs_encode_return.__return_value_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_encode_return.__return_value_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 1
+                        },
+                        "pc": 368,
+                        "value": "[cast(fp, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 1
+                        },
+                        "pc": 371,
+                        "value": "cast([fp] + 3, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 1
+                        },
+                        "pc": 373,
+                        "value": "cast([fp] + 5, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 1
+                        },
+                        "pc": 374,
+                        "value": "cast([fp] + 6, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_encode_return.__return_value_ptr_start": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_encode_return.__return_value_ptr_start",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 1
+                        },
+                        "pc": 368,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_encode_return.__return_value_tmp": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_encode_return.__return_value_tmp",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 1
+                        },
+                        "pc": 368,
+                        "value": "cast(fp + (-9), felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 1
+                        },
+                        "pc": 371,
+                        "value": "cast(fp + (-6), felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_encode_return.__temp21": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_encode_return.__temp21",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 2
+                        },
+                        "pc": 376,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.multiple_outputs_encode_return.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_encode_return.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 0
+                        },
+                        "pc": 366,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_encode_return.ret_value": {
+                "cairo_type": "(account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)",
+                "full_name": "__wrappers__.multiple_outputs_encode_return.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 33,
+                            "offset": 0
+                        },
+                        "pc": 366,
+                        "value": "[cast(fp + (-9), (account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 434,
+                "type": "function"
+            },
+            "__wrappers__.multiple_outputs_with_array.Args": {
+                "full_name": "__wrappers__.multiple_outputs_with_array.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs_with_array.ImplicitArgs": {
+                "full_name": "__wrappers__.multiple_outputs_with_array.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs_with_array.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.multiple_outputs_with_array.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 2
+            },
+            "__wrappers__.multiple_outputs_with_array.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 7
+                        },
+                        "pc": 443,
+                        "value": "cast([ap + (-1)] + 1 - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__calldata_arg_a": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__calldata_arg_a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 4
+                        },
+                        "pc": 439,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__calldata_arg_a_len": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__calldata_arg_a_len",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 2
+                        },
+                        "pc": 436,
+                        "value": "[cast([fp + (-3)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__calldata_arg_id": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__calldata_arg_id",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 7
+                        },
+                        "pc": 443,
+                        "value": "[cast([ap + (-1)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 2
+                        },
+                        "pc": 436,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 2
+                        },
+                        "pc": 436,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 7
+                        },
+                        "pc": 443,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 7
+                        },
+                        "pc": 443,
+                        "value": "cast([ap + (-1)] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__temp25": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__temp25",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 3
+                        },
+                        "pc": 437,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__temp26": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__temp26",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 4
+                        },
+                        "pc": 438,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__temp27": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__temp27",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 5
+                        },
+                        "pc": 441,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__temp28": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__temp28",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 6
+                        },
+                        "pc": 442,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__temp29": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__temp29",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 8
+                        },
+                        "pc": 445,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__temp30": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.__temp30",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 9
+                        },
+                        "pc": 447,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.__wrapped_func": {
+                "destination": "__main__.multiple_outputs_with_array",
+                "type": "alias"
+            },
+            "__wrappers__.multiple_outputs_with_array.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.multiple_outputs_with_array.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 2
+                        },
+                        "pc": 436,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 47
+                        },
+                        "pc": 457,
+                        "value": "[cast(ap + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 47
+                        },
+                        "pc": 459,
+                        "value": "[cast(fp + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 2
+                        },
+                        "pc": 436,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 4
+                        },
+                        "pc": 439,
+                        "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 47
+                        },
+                        "pc": 457,
+                        "value": "[cast(ap + (-5), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 39,
+                            "offset": 0
+                        },
+                        "pc": 462,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.ret_value": {
+                "cairo_type": "(id: felt, b_len: felt, b: felt*, answer: felt)",
+                "full_name": "__wrappers__.multiple_outputs_with_array.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 47
+                        },
+                        "pc": 457,
+                        "value": "[cast(ap + (-4), (id: felt, b_len: felt, b: felt*, answer: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_with_array.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 39,
+                            "offset": 0
+                        },
+                        "pc": 462,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 39,
+                            "offset": 0
+                        },
+                        "pc": 462,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_with_array.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 2
+                        },
+                        "pc": 436,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 47
+                        },
+                        "pc": 457,
+                        "value": "[cast(ap + (-7), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 38,
+                            "offset": 47
+                        },
+                        "pc": 458,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return": {
+                "decorators": [],
+                "pc": 411,
+                "type": "function"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.Args": {
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 4
+                    },
+                    "ret_value": {
+                        "cairo_type": "(id: felt, b_len: felt, b: felt*, answer: felt)",
+                        "offset": 0
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.Return": {
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 3
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.__return_value_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.__return_value_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 3
+                        },
+                        "pc": 413,
+                        "value": "[cast(fp, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 3
+                        },
+                        "pc": 414,
+                        "value": "cast([fp] + 1, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 3
+                        },
+                        "pc": 415,
+                        "value": "cast([fp] + 2, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 4
+                        },
+                        "pc": 421,
+                        "value": "[cast(fp + 2, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 37,
+                            "offset": 0
+                        },
+                        "pc": 428,
+                        "value": "cast([fp + 2] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.__return_value_ptr_copy": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.__return_value_ptr_copy",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 3
+                        },
+                        "pc": 418,
+                        "value": "cast([fp] + 2, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.__return_value_ptr_start": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.__return_value_ptr_start",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 3
+                        },
+                        "pc": 413,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.__temp23": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.__temp23",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 4
+                        },
+                        "pc": 420,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.__temp24": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.__temp24",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 37,
+                            "offset": 1
+                        },
+                        "pc": 430,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 0
+                        },
+                        "pc": 411,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 3
+                        },
+                        "pc": 418,
+                        "value": "[cast(fp + 1, felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.multiple_outputs_with_array_encode_return.ret_value": {
+                "cairo_type": "(id: felt, b_len: felt, b: felt*, answer: felt)",
+                "full_name": "__wrappers__.multiple_outputs_with_array_encode_return.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 36,
+                            "offset": 0
+                        },
+                        "pc": 411,
+                        "value": "[cast(fp + (-7), (id: felt, b_len: felt, b: felt*, answer: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum": {
+                "decorators": [
+                    "view"
+                ],
+                "pc": 276,
+                "type": "function"
+            },
+            "__wrappers__.sum.Args": {
+                "full_name": "__wrappers__.sum.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.sum.ImplicitArgs": {
+                "full_name": "__wrappers__.sum.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.sum.Return": {
+                "cairo_type": "(syscall_ptr: felt*, pedersen_ptr: starkware.cairo.common.cairo_builtins.HashBuiltin*, range_check_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.sum.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.sum.__calldata_actual_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum.__calldata_actual_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "cast([fp + (-3)] + 2 - [fp + (-3)], felt)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.__calldata_arg_a": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum.__calldata_arg_a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "[cast([fp + (-3)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.__calldata_arg_b": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum.__calldata_arg_b",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "[cast([fp + (-3)] + 1, felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.__calldata_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.sum.__calldata_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "[cast(fp + (-3), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "cast([fp + (-3)] + 1, felt*)"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "cast([fp + (-3)] + 2, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.__temp14": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum.__temp14",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 1
+                        },
+                        "pc": 278,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.__wrapped_func": {
+                "destination": "__main__.sum",
+                "type": "alias"
+            },
+            "__wrappers__.sum.pedersen_ptr": {
+                "cairo_type": "starkware.cairo.common.cairo_builtins.HashBuiltin*",
+                "full_name": "__wrappers__.sum.pedersen_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 12
+                        },
+                        "pc": 286,
+                        "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "[cast([fp + (-5)] + 2, felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 12
+                        },
+                        "pc": 286,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 20
+                        },
+                        "pc": 289,
+                        "value": "[cast(ap + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.ret_value": {
+                "cairo_type": "(sum: felt)",
+                "full_name": "__wrappers__.sum.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 12
+                        },
+                        "pc": 286,
+                        "value": "[cast(ap + (-1), (sum: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.retdata": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.sum.retdata",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 20
+                        },
+                        "pc": 289,
+                        "value": "[cast(ap + (-1), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.retdata_size": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum.retdata_size",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 20
+                        },
+                        "pc": 289,
+                        "value": "[cast(ap + (-2), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.sum.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 0
+                        },
+                        "pc": 276,
+                        "value": "[cast([fp + (-5)], felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 26,
+                            "offset": 12
+                        },
+                        "pc": 286,
+                        "value": "[cast(ap + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum_encode_return": {
+                "decorators": [],
+                "pc": 267,
+                "type": "function"
+            },
+            "__wrappers__.sum_encode_return.Args": {
+                "full_name": "__wrappers__.sum_encode_return.Args",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "ret_value": {
+                        "cairo_type": "(sum: felt)",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "__wrappers__.sum_encode_return.ImplicitArgs": {
+                "full_name": "__wrappers__.sum_encode_return.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.sum_encode_return.Return": {
+                "cairo_type": "(range_check_ptr: felt, data_len: felt, data: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.sum_encode_return.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 1
+            },
+            "__wrappers__.sum_encode_return.__return_value_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.sum_encode_return.__return_value_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 25,
+                            "offset": 1
+                        },
+                        "pc": 269,
+                        "value": "[cast(fp, felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 25,
+                            "offset": 1
+                        },
+                        "pc": 270,
+                        "value": "cast([fp] + 1, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum_encode_return.__return_value_ptr_start": {
+                "cairo_type": "felt*",
+                "full_name": "__wrappers__.sum_encode_return.__return_value_ptr_start",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 25,
+                            "offset": 1
+                        },
+                        "pc": 269,
+                        "value": "[cast(fp, felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum_encode_return.__temp13": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum_encode_return.__temp13",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 25,
+                            "offset": 2
+                        },
+                        "pc": 272,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
+            "__wrappers__.sum_encode_return.range_check_ptr": {
+                "cairo_type": "felt",
+                "full_name": "__wrappers__.sum_encode_return.range_check_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 25,
+                            "offset": 0
+                        },
+                        "pc": 267,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "__wrappers__.sum_encode_return.ret_value": {
+                "cairo_type": "(sum: felt)",
+                "full_name": "__wrappers__.sum_encode_return.ret_value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 25,
+                            "offset": 0
+                        },
+                        "pc": 267,
+                        "value": "[cast(fp + (-4), (sum: felt)*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.bitwise.ALL_ONES": {
+                "type": "const",
+                "value": -106710729501573572985208420194530329073740042555888586719234
+            },
+            "starkware.cairo.common.bitwise.BitwiseBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+                "type": "alias"
+            },
+            "starkware.cairo.common.bool.FALSE": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.bool.TRUE": {
+                "type": "const",
+                "value": 1
+            },
+            "starkware.cairo.common.cairo_builtins.BitwiseBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+                "members": {
+                    "x": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "x_and_y": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "x_or_y": {
+                        "cairo_type": "felt",
+                        "offset": 4
+                    },
+                    "x_xor_y": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "y": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.EcOpBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.EcOpBuiltin",
+                "members": {
+                    "m": {
+                        "cairo_type": "felt",
+                        "offset": 4
+                    },
+                    "p": {
+                        "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                        "offset": 0
+                    },
+                    "q": {
+                        "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                        "offset": 2
+                    },
+                    "r": {
+                        "cairo_type": "starkware.cairo.common.ec_point.EcPoint",
+                        "offset": 5
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.EcPoint": {
+                "destination": "starkware.cairo.common.ec_point.EcPoint",
+                "type": "alias"
+            },
+            "starkware.cairo.common.cairo_builtins.HashBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "members": {
+                    "result": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "x": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "y": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.KeccakBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.KeccakBuiltin",
+                "members": {
+                    "input": {
+                        "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                        "offset": 0
+                    },
+                    "output": {
+                        "cairo_type": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                        "offset": 8
+                    }
+                },
+                "size": 16,
+                "type": "struct"
+            },
+            "starkware.cairo.common.cairo_builtins.KeccakBuiltinState": {
+                "destination": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                "type": "alias"
+            },
+            "starkware.cairo.common.cairo_builtins.SignatureBuiltin": {
+                "full_name": "starkware.cairo.common.cairo_builtins.SignatureBuiltin",
+                "members": {
+                    "message": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "pub_key": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.cairo.common.dict_access.DictAccess": {
+                "full_name": "starkware.cairo.common.dict_access.DictAccess",
+                "members": {
+                    "key": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "new_value": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "prev_value": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.cairo.common.ec_point.EcPoint": {
+                "full_name": "starkware.cairo.common.ec_point.EcPoint",
+                "members": {
+                    "x": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "y": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.cairo.common.hash.HashBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.HashBuiltin",
+                "type": "alias"
+            },
+            "starkware.cairo.common.keccak_state.KeccakBuiltinState": {
+                "full_name": "starkware.cairo.common.keccak_state.KeccakBuiltinState",
+                "members": {
+                    "s0": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "s1": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "s2": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "s3": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "s4": {
+                        "cairo_type": "felt",
+                        "offset": 4
+                    },
+                    "s5": {
+                        "cairo_type": "felt",
+                        "offset": 5
+                    },
+                    "s6": {
+                        "cairo_type": "felt",
+                        "offset": 6
+                    },
+                    "s7": {
+                        "cairo_type": "felt",
+                        "offset": 7
+                    }
+                },
+                "size": 8,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.FALSE": {
+                "destination": "starkware.cairo.common.bool.FALSE",
+                "type": "alias"
+            },
+            "starkware.cairo.common.math.TRUE": {
+                "destination": "starkware.cairo.common.bool.TRUE",
+                "type": "alias"
+            },
+            "starkware.cairo.common.math_cmp.RC_BOUND": {
+                "type": "const",
+                "value": 340282366920938463463374607431768211456
+            },
+            "starkware.cairo.common.math_cmp.assert_le_felt": {
+                "destination": "starkware.cairo.common.math.assert_le_felt",
+                "type": "alias"
+            },
+            "starkware.cairo.common.math_cmp.assert_lt_felt": {
+                "destination": "starkware.cairo.common.math.assert_lt_felt",
+                "type": "alias"
+            },
+            "starkware.cairo.common.memcpy.memcpy": {
+                "decorators": [],
+                "pc": 0,
+                "type": "function"
+            },
+            "starkware.cairo.common.memcpy.memcpy.Args": {
+                "full_name": "starkware.cairo.common.memcpy.memcpy.Args",
+                "members": {
+                    "dst": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    },
+                    "len": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "src": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.cairo.common.memcpy.memcpy.ImplicitArgs": {
+                "full_name": "starkware.cairo.common.memcpy.memcpy.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "starkware.cairo.common.memcpy.memcpy.LoopFrame": {
+                "full_name": "starkware.cairo.common.memcpy.memcpy.LoopFrame",
+                "members": {
+                    "dst": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    },
+                    "src": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.cairo.common.memcpy.memcpy.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "starkware.cairo.common.memcpy.memcpy.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.memcpy.memcpy.__temp0": {
+                "cairo_type": "felt",
+                "full_name": "starkware.cairo.common.memcpy.memcpy.__temp0",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 3
+                        },
+                        "pc": 6,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.memcpy.memcpy.continue_copying": {
+                "cairo_type": "felt",
+                "full_name": "starkware.cairo.common.memcpy.memcpy.continue_copying",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 3
+                        },
+                        "pc": 7,
+                        "value": "[cast(ap, felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.memcpy.memcpy.dst": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.cairo.common.memcpy.memcpy.dst",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 0
+                        },
+                        "pc": 0,
+                        "value": "[cast(fp + (-5), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.memcpy.memcpy.frame": {
+                "cairo_type": "starkware.cairo.common.memcpy.memcpy.LoopFrame",
+                "full_name": "starkware.cairo.common.memcpy.memcpy.frame",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 2
+                        },
+                        "pc": 5,
+                        "value": "[cast(ap + (-2), starkware.cairo.common.memcpy.memcpy.LoopFrame*)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 2
+                        },
+                        "pc": 5,
+                        "value": "[cast(ap + (-2), starkware.cairo.common.memcpy.memcpy.LoopFrame*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.memcpy.memcpy.len": {
+                "cairo_type": "felt",
+                "full_name": "starkware.cairo.common.memcpy.memcpy.len",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 0
+                        },
+                        "pc": 0,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.memcpy.memcpy.loop": {
+                "pc": 5,
+                "type": "label"
+            },
+            "starkware.cairo.common.memcpy.memcpy.next_frame": {
+                "cairo_type": "starkware.cairo.common.memcpy.memcpy.LoopFrame*",
+                "full_name": "starkware.cairo.common.memcpy.memcpy.next_frame",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 3
+                        },
+                        "pc": 7,
+                        "value": "cast(ap + 1, starkware.cairo.common.memcpy.memcpy.LoopFrame*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.memcpy.memcpy.src": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.cairo.common.memcpy.memcpy.src",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 0,
+                            "offset": 0
+                        },
+                        "pc": 0,
+                        "value": "[cast(fp + (-4), felt**)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.pow.assert_le": {
+                "destination": "starkware.cairo.common.math.assert_le",
+                "type": "alias"
+            },
+            "starkware.cairo.common.pow.get_ap": {
+                "destination": "starkware.cairo.common.registers.get_ap",
+                "type": "alias"
+            },
+            "starkware.cairo.common.pow.get_fp_and_pc": {
+                "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+                "type": "alias"
+            },
+            "starkware.cairo.common.registers.get_ap": {
+                "destination": "starkware.cairo.lang.compiler.lib.registers.get_ap",
+                "type": "alias"
+            },
+            "starkware.cairo.common.registers.get_fp_and_pc": {
+                "destination": "starkware.cairo.lang.compiler.lib.registers.get_fp_and_pc",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.ALL_ONES": {
+                "type": "const",
+                "value": 340282366920938463463374607431768211455
+            },
+            "starkware.cairo.common.uint256.BitwiseBuiltin": {
+                "destination": "starkware.cairo.common.cairo_builtins.BitwiseBuiltin",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.HALF_SHIFT": {
+                "type": "const",
+                "value": 18446744073709551616
+            },
+            "starkware.cairo.common.uint256.SHIFT": {
+                "type": "const",
+                "value": 340282366920938463463374607431768211456
+            },
+            "starkware.cairo.common.uint256.Uint256": {
+                "full_name": "starkware.cairo.common.uint256.Uint256",
+                "members": {
+                    "high": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "low": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.cairo.common.uint256.assert_in_range": {
+                "destination": "starkware.cairo.common.math.assert_in_range",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.assert_le": {
+                "destination": "starkware.cairo.common.math.assert_le",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.assert_nn_le": {
+                "destination": "starkware.cairo.common.math.assert_nn_le",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.assert_not_zero": {
+                "destination": "starkware.cairo.common.math.assert_not_zero",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.bitwise_and": {
+                "destination": "starkware.cairo.common.bitwise.bitwise_and",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.bitwise_or": {
+                "destination": "starkware.cairo.common.bitwise.bitwise_or",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.bitwise_xor": {
+                "destination": "starkware.cairo.common.bitwise.bitwise_xor",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.get_ap": {
+                "destination": "starkware.cairo.common.registers.get_ap",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.get_fp_and_pc": {
+                "destination": "starkware.cairo.common.registers.get_fp_and_pc",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.is_le": {
+                "destination": "starkware.cairo.common.math_cmp.is_le",
+                "type": "alias"
+            },
+            "starkware.cairo.common.uint256.pow": {
+                "destination": "starkware.cairo.common.pow.pow",
+                "type": "alias"
+            },
+            "starkware.starknet.common.storage.ADDR_BOUND": {
+                "type": "const",
+                "value": -106710729501573572985208420194530329073740042555888586719489
+            },
+            "starkware.starknet.common.storage.MAX_STORAGE_ITEM_SIZE": {
+                "type": "const",
+                "value": 256
+            },
+            "starkware.starknet.common.storage.assert_250_bit": {
+                "destination": "starkware.cairo.common.math.assert_250_bit",
+                "type": "alias"
+            },
+            "starkware.starknet.common.syscalls.CALL_CONTRACT_SELECTOR": {
+                "type": "const",
+                "value": 20853273475220472486191784820
+            },
+            "starkware.starknet.common.syscalls.CallContract": {
+                "full_name": "starkware.starknet.common.syscalls.CallContract",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.CallContractRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+                        "offset": 5
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.CallContractRequest": {
+                "full_name": "starkware.starknet.common.syscalls.CallContractRequest",
+                "members": {
+                    "calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "function_selector": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.CallContractResponse": {
+                "full_name": "starkware.starknet.common.syscalls.CallContractResponse",
+                "members": {
+                    "retdata": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "retdata_size": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DELEGATE_CALL_SELECTOR": {
+                "type": "const",
+                "value": 21167594061783206823196716140
+            },
+            "starkware.starknet.common.syscalls.DELEGATE_L1_HANDLER_SELECTOR": {
+                "type": "const",
+                "value": 23274015802972845247556842986379118667122
+            },
+            "starkware.starknet.common.syscalls.DEPLOY_SELECTOR": {
+                "type": "const",
+                "value": 75202468540281
+            },
+            "starkware.starknet.common.syscalls.Deploy": {
+                "full_name": "starkware.starknet.common.syscalls.Deploy",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.DeployRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.DeployResponse",
+                        "offset": 6
+                    }
+                },
+                "size": 9,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DeployRequest": {
+                "full_name": "starkware.starknet.common.syscalls.DeployRequest",
+                "members": {
+                    "class_hash": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "constructor_calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "constructor_calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "contract_address_salt": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "deploy_from_zero": {
+                        "cairo_type": "felt",
+                        "offset": 5
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 6,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DeployResponse": {
+                "full_name": "starkware.starknet.common.syscalls.DeployResponse",
+                "members": {
+                    "constructor_retdata": {
+                        "cairo_type": "felt*",
+                        "offset": 2
+                    },
+                    "constructor_retdata_size": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.DictAccess": {
+                "destination": "starkware.cairo.common.dict_access.DictAccess",
+                "type": "alias"
+            },
+            "starkware.starknet.common.syscalls.EMIT_EVENT_SELECTOR": {
+                "type": "const",
+                "value": 1280709301550335749748
+            },
+            "starkware.starknet.common.syscalls.EmitEvent": {
+                "full_name": "starkware.starknet.common.syscalls.EmitEvent",
+                "members": {
+                    "data": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "data_len": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "keys": {
+                        "cairo_type": "felt*",
+                        "offset": 2
+                    },
+                    "keys_len": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GET_BLOCK_NUMBER_SELECTOR": {
+                "type": "const",
+                "value": 1448089106835523001438702345020786
+            },
+            "starkware.starknet.common.syscalls.GET_BLOCK_TIMESTAMP_SELECTOR": {
+                "type": "const",
+                "value": 24294903732626645868215235778792757751152
+            },
+            "starkware.starknet.common.syscalls.GET_CALLER_ADDRESS_SELECTOR": {
+                "type": "const",
+                "value": 94901967781393078444254803017658102643
+            },
+            "starkware.starknet.common.syscalls.GET_CONTRACT_ADDRESS_SELECTOR": {
+                "type": "const",
+                "value": 6219495360805491471215297013070624192820083
+            },
+            "starkware.starknet.common.syscalls.GET_SEQUENCER_ADDRESS_SELECTOR": {
+                "type": "const",
+                "value": 1592190833581991703053805829594610833820054387
+            },
+            "starkware.starknet.common.syscalls.GET_TX_INFO_SELECTOR": {
+                "type": "const",
+                "value": 1317029390204112103023
+            },
+            "starkware.starknet.common.syscalls.GET_TX_SIGNATURE_SELECTOR": {
+                "type": "const",
+                "value": 1448089128652340074717162277007973
+            },
+            "starkware.starknet.common.syscalls.GetBlockNumber": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockNumber",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockNumberRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockNumberRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockNumberResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockNumberResponse",
+                "members": {
+                    "block_number": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockTimestamp": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockTimestamp",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockTimestampRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetBlockTimestampResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetBlockTimestampResponse",
+                "members": {
+                    "block_timestamp": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetCallerAddress": {
+                "full_name": "starkware.starknet.common.syscalls.GetCallerAddress",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetCallerAddressRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetCallerAddressRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetCallerAddressResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetCallerAddressResponse",
+                "members": {
+                    "caller_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetContractAddress": {
+                "full_name": "starkware.starknet.common.syscalls.GetContractAddress",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetContractAddressRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetContractAddressRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetContractAddressResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetContractAddressResponse",
+                "members": {
+                    "contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetSequencerAddress": {
+                "full_name": "starkware.starknet.common.syscalls.GetSequencerAddress",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetSequencerAddressRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetSequencerAddressResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetSequencerAddressResponse",
+                "members": {
+                    "sequencer_address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxInfo": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxInfo",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxInfoRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxInfoRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxInfoResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxInfoResponse",
+                "members": {
+                    "tx_info": {
+                        "cairo_type": "starkware.starknet.common.syscalls.TxInfo*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxSignature": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxSignature",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+                        "offset": 1
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxSignatureRequest": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxSignatureRequest",
+                "members": {
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.GetTxSignatureResponse": {
+                "full_name": "starkware.starknet.common.syscalls.GetTxSignatureResponse",
+                "members": {
+                    "signature": {
+                        "cairo_type": "felt*",
+                        "offset": 1
+                    },
+                    "signature_len": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.LIBRARY_CALL_L1_HANDLER_SELECTOR": {
+                "type": "const",
+                "value": 436233452754198157705746250789557519228244616562
+            },
+            "starkware.starknet.common.syscalls.LIBRARY_CALL_SELECTOR": {
+                "type": "const",
+                "value": 92376026794327011772951660
+            },
+            "starkware.starknet.common.syscalls.LibraryCall": {
+                "full_name": "starkware.starknet.common.syscalls.LibraryCall",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.LibraryCallRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.CallContractResponse",
+                        "offset": 5
+                    }
+                },
+                "size": 7,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.LibraryCallRequest": {
+                "full_name": "starkware.starknet.common.syscalls.LibraryCallRequest",
+                "members": {
+                    "calldata": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "calldata_size": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "class_hash": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "function_selector": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 5,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.SEND_MESSAGE_TO_L1_SELECTOR": {
+                "type": "const",
+                "value": 433017908768303439907196859243777073
+            },
+            "starkware.starknet.common.syscalls.STORAGE_READ_SELECTOR": {
+                "type": "const",
+                "value": 100890693370601760042082660
+            },
+            "starkware.starknet.common.syscalls.STORAGE_WRITE_SELECTOR": {
+                "type": "const",
+                "value": 25828017502874050592466629733
+            },
+            "starkware.starknet.common.syscalls.SendMessageToL1SysCall": {
+                "full_name": "starkware.starknet.common.syscalls.SendMessageToL1SysCall",
+                "members": {
+                    "payload_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 3
+                    },
+                    "payload_size": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "to_address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 4,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageRead": {
+                "full_name": "starkware.starknet.common.syscalls.StorageRead",
+                "members": {
+                    "request": {
+                        "cairo_type": "starkware.starknet.common.syscalls.StorageReadRequest",
+                        "offset": 0
+                    },
+                    "response": {
+                        "cairo_type": "starkware.starknet.common.syscalls.StorageReadResponse",
+                        "offset": 2
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageReadRequest": {
+                "full_name": "starkware.starknet.common.syscalls.StorageReadRequest",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageReadResponse": {
+                "full_name": "starkware.starknet.common.syscalls.StorageReadResponse",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.StorageWrite": {
+                "full_name": "starkware.starknet.common.syscalls.StorageWrite",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "selector": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    }
+                },
+                "size": 3,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.TxInfo": {
+                "full_name": "starkware.starknet.common.syscalls.TxInfo",
+                "members": {
+                    "account_contract_address": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    },
+                    "chain_id": {
+                        "cairo_type": "felt",
+                        "offset": 6
+                    },
+                    "max_fee": {
+                        "cairo_type": "felt",
+                        "offset": 2
+                    },
+                    "nonce": {
+                        "cairo_type": "felt",
+                        "offset": 7
+                    },
+                    "signature": {
+                        "cairo_type": "felt*",
+                        "offset": 4
+                    },
+                    "signature_len": {
+                        "cairo_type": "felt",
+                        "offset": 3
+                    },
+                    "transaction_hash": {
+                        "cairo_type": "felt",
+                        "offset": 5
+                    },
+                    "version": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 8,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_read": {
+                "decorators": [],
+                "pc": 15,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.storage_read.Args": {
+                "full_name": "starkware.starknet.common.syscalls.storage_read.Args",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_read.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.storage_read.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_read.Return": {
+                "cairo_type": "(value: felt)",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.storage_read.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.storage_read.__temp1": {
+                "cairo_type": "felt",
+                "full_name": "starkware.starknet.common.syscalls.storage_read.__temp1",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 1
+                        },
+                        "pc": 17,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_read.address": {
+                "cairo_type": "felt",
+                "full_name": "starkware.starknet.common.syscalls.storage_read.address",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 0
+                        },
+                        "pc": 15,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_read.response": {
+                "cairo_type": "starkware.starknet.common.syscalls.StorageReadResponse",
+                "full_name": "starkware.starknet.common.syscalls.storage_read.response",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 1
+                        },
+                        "pc": 19,
+                        "value": "[cast([fp + (-4)] + 2, starkware.starknet.common.syscalls.StorageReadResponse*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_read.syscall": {
+                "cairo_type": "starkware.starknet.common.syscalls.StorageRead",
+                "full_name": "starkware.starknet.common.syscalls.storage_read.syscall",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 0
+                        },
+                        "pc": 15,
+                        "value": "[cast([fp + (-4)], starkware.starknet.common.syscalls.StorageRead*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_read.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.storage_read.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 0
+                        },
+                        "pc": 15,
+                        "value": "[cast(fp + (-4), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 1,
+                            "offset": 1
+                        },
+                        "pc": 19,
+                        "value": "cast([fp + (-4)] + 3, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_write": {
+                "decorators": [],
+                "pc": 23,
+                "type": "function"
+            },
+            "starkware.starknet.common.syscalls.storage_write.Args": {
+                "full_name": "starkware.starknet.common.syscalls.storage_write.Args",
+                "members": {
+                    "address": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_write.ImplicitArgs": {
+                "full_name": "starkware.starknet.common.syscalls.storage_write.ImplicitArgs",
+                "members": {
+                    "syscall_ptr": {
+                        "cairo_type": "felt*",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.starknet.common.syscalls.storage_write.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "starkware.starknet.common.syscalls.storage_write.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.starknet.common.syscalls.storage_write.__temp2": {
+                "cairo_type": "felt",
+                "full_name": "starkware.starknet.common.syscalls.storage_write.__temp2",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 2,
+                            "offset": 1
+                        },
+                        "pc": 25,
+                        "value": "[cast(ap + (-1), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_write.address": {
+                "cairo_type": "felt",
+                "full_name": "starkware.starknet.common.syscalls.storage_write.address",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 2,
+                            "offset": 0
+                        },
+                        "pc": 23,
+                        "value": "[cast(fp + (-4), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_write.syscall_ptr": {
+                "cairo_type": "felt*",
+                "full_name": "starkware.starknet.common.syscalls.storage_write.syscall_ptr",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 2,
+                            "offset": 0
+                        },
+                        "pc": 23,
+                        "value": "[cast(fp + (-5), felt**)]"
+                    },
+                    {
+                        "ap_tracking_data": {
+                            "group": 2,
+                            "offset": 1
+                        },
+                        "pc": 28,
+                        "value": "cast([fp + (-5)] + 3, felt*)"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.starknet.common.syscalls.storage_write.value": {
+                "cairo_type": "felt",
+                "full_name": "starkware.starknet.common.syscalls.storage_write.value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 2,
+                            "offset": 0
+                        },
+                        "pc": 23,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            }
+        },
+        "main_scope": "__main__",
+        "prime": "0x800000000000011000000000000000000000000000000000000000000000001",
+        "reference_manager": {
+            "references": [
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 0
+                    },
+                    "pc": 0,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "pc": 5,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.memcpy.memcpy.LoopFrame*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 2
+                    },
+                    "pc": 5,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.memcpy.memcpy.LoopFrame*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "pc": 6,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "pc": 7,
+                    "value": "[cast(ap, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 0,
+                        "offset": 3
+                    },
+                    "pc": 7,
+                    "value": "cast(ap + 1, starkware.cairo.common.memcpy.memcpy.LoopFrame*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 15,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 15,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 0
+                    },
+                    "pc": 15,
+                    "value": "[cast([fp + (-4)], starkware.starknet.common.syscalls.StorageRead*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "pc": 17,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "pc": 19,
+                    "value": "[cast([fp + (-4)] + 2, starkware.starknet.common.syscalls.StorageReadResponse*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 1,
+                        "offset": 1
+                    },
+                    "pc": 19,
+                    "value": "cast([fp + (-4)] + 3, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 23,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 23,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 0
+                    },
+                    "pc": 23,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "pc": 25,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 2,
+                        "offset": 1
+                    },
+                    "pc": 28,
+                    "value": "cast([fp + (-5)] + 3, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 31,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 31,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 3,
+                        "offset": 0
+                    },
+                    "pc": 31,
+                    "value": "cast(916907772491729262376534102982219947830828984996257231353398618781993312401, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 36,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 36,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 0
+                    },
+                    "pc": 36,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 7
+                    },
+                    "pc": 40,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 7
+                    },
+                    "pc": 40,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 7
+                    },
+                    "pc": 40,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 14
+                    },
+                    "pc": 44,
+                    "value": "[cast(ap + (-2), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 14
+                    },
+                    "pc": 44,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 15
+                    },
+                    "pc": 45,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 16
+                    },
+                    "pc": 46,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 17
+                    },
+                    "pc": 47,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 4,
+                        "offset": 18
+                    },
+                    "pc": 48,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-6), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 0
+                    },
+                    "pc": 49,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 7
+                    },
+                    "pc": 53,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 7
+                    },
+                    "pc": 53,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 7
+                    },
+                    "pc": 53,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 5,
+                        "offset": 14
+                    },
+                    "pc": 58,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 61,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 61,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 6,
+                        "offset": 0
+                    },
+                    "pc": 61,
+                    "value": "cast(1104701650050787127621698902278859233491966253026387283937380535844150150743, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 66,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 66,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 0
+                    },
+                    "pc": 66,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 7
+                    },
+                    "pc": 70,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 7
+                    },
+                    "pc": 70,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 7
+                    },
+                    "pc": 70,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 14
+                    },
+                    "pc": 74,
+                    "value": "[cast(ap + (-2), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 14
+                    },
+                    "pc": 74,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 15
+                    },
+                    "pc": 75,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 16
+                    },
+                    "pc": 76,
+                    "value": "[cast(ap + (-1), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 17
+                    },
+                    "pc": 77,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 7,
+                        "offset": 18
+                    },
+                    "pc": 78,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 79,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 79,
+                    "value": "[cast(fp + (-6), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 79,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 0
+                    },
+                    "pc": 79,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 7
+                    },
+                    "pc": 83,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 7
+                    },
+                    "pc": 83,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 7
+                    },
+                    "pc": 83,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 8,
+                        "offset": 14
+                    },
+                    "pc": 88,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 91,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 91,
+                    "value": "[cast(fp + (-6), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 91,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 0
+                    },
+                    "pc": 91,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 22
+                    },
+                    "pc": 97,
+                    "value": "[cast(ap + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 22
+                    },
+                    "pc": 97,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 9,
+                        "offset": 22
+                    },
+                    "pc": 97,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 98,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 98,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 98,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 98,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 98,
+                    "value": "[cast([fp + (-3)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 98,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 0
+                    },
+                    "pc": 98,
+                    "value": "cast([fp + (-3)] + 1 - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 1
+                    },
+                    "pc": 100,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 29
+                    },
+                    "pc": 107,
+                    "value": "[cast(ap + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 29
+                    },
+                    "pc": 107,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 29
+                    },
+                    "pc": 107,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 29
+                    },
+                    "pc": 107,
+                    "value": "[cast(ap + 0, ()*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 30
+                    },
+                    "pc": 109,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 10,
+                        "offset": 30
+                    },
+                    "pc": 109,
+                    "value": "cast(0, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 0
+                    },
+                    "pc": 116,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 0
+                    },
+                    "pc": 116,
+                    "value": "[cast(fp + (-6), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 0
+                    },
+                    "pc": 116,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 0
+                    },
+                    "pc": 116,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 23
+                    },
+                    "pc": 121,
+                    "value": "[cast(ap + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 23
+                    },
+                    "pc": 121,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 23
+                    },
+                    "pc": 121,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 23
+                    },
+                    "pc": 121,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 45
+                    },
+                    "pc": 127,
+                    "value": "[cast(ap + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 45
+                    },
+                    "pc": 127,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 11,
+                        "offset": 45
+                    },
+                    "pc": 127,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 128,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 128,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 128,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 128,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 128,
+                    "value": "[cast([fp + (-3)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 128,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 0
+                    },
+                    "pc": 128,
+                    "value": "cast([fp + (-3)] + 1 - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 1
+                    },
+                    "pc": 130,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 52
+                    },
+                    "pc": 137,
+                    "value": "[cast(ap + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 52
+                    },
+                    "pc": 137,
+                    "value": "[cast(ap + (-2), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 52
+                    },
+                    "pc": 137,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 52
+                    },
+                    "pc": 137,
+                    "value": "[cast(ap + 0, ()*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 53
+                    },
+                    "pc": 139,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 12,
+                        "offset": 53
+                    },
+                    "pc": 139,
+                    "value": "cast(0, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 146,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 146,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 146,
+                    "value": "[cast(fp + (-7), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 146,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 13,
+                        "offset": 0
+                    },
+                    "pc": 146,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "pc": 152,
+                    "value": "[cast(fp + (-5), (b_len: felt, b: felt*)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 0
+                    },
+                    "pc": 152,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 3
+                    },
+                    "pc": 154,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 3
+                    },
+                    "pc": 154,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 3
+                    },
+                    "pc": 155,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 3
+                    },
+                    "pc": 158,
+                    "value": "[cast(fp + 1, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 3
+                    },
+                    "pc": 158,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 4
+                    },
+                    "pc": 160,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 14,
+                        "offset": 4
+                    },
+                    "pc": 161,
+                    "value": "[cast(fp + 2, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 2
+                    },
+                    "pc": 173,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 2
+                    },
+                    "pc": 173,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 2
+                    },
+                    "pc": 173,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 2
+                    },
+                    "pc": 173,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 2
+                    },
+                    "pc": 173,
+                    "value": "[cast([fp + (-3)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 2
+                    },
+                    "pc": 173,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 3
+                    },
+                    "pc": 174,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 4
+                    },
+                    "pc": 175,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 4
+                    },
+                    "pc": 176,
+                    "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 4
+                    },
+                    "pc": 176,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 5
+                    },
+                    "pc": 178,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 6
+                    },
+                    "pc": 179,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 7
+                    },
+                    "pc": 180,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 7
+                    },
+                    "pc": 180,
+                    "value": "cast([ap + (-1)] - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 8
+                    },
+                    "pc": 182,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 20
+                    },
+                    "pc": 191,
+                    "value": "[cast(ap + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 20
+                    },
+                    "pc": 191,
+                    "value": "[cast(ap + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 20
+                    },
+                    "pc": 191,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 20
+                    },
+                    "pc": 191,
+                    "value": "[cast(ap + (-2), (b_len: felt, b: felt*)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 20
+                    },
+                    "pc": 192,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 16,
+                        "offset": 20
+                    },
+                    "pc": 193,
+                    "value": "[cast(fp + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 17,
+                        "offset": 0
+                    },
+                    "pc": 196,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 17,
+                        "offset": 0
+                    },
+                    "pc": 196,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 17,
+                        "offset": 0
+                    },
+                    "pc": 196,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 0
+                    },
+                    "pc": 202,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 0
+                    },
+                    "pc": 202,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 0
+                    },
+                    "pc": 202,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 23
+                    },
+                    "pc": 207,
+                    "value": "[cast(ap + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 23
+                    },
+                    "pc": 207,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 23
+                    },
+                    "pc": 207,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 18,
+                        "offset": 23
+                    },
+                    "pc": 207,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 0
+                    },
+                    "pc": 208,
+                    "value": "[cast(fp + (-4), (balance: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 0
+                    },
+                    "pc": 208,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 1
+                    },
+                    "pc": 210,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 1
+                    },
+                    "pc": 210,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 1
+                    },
+                    "pc": 211,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 19,
+                        "offset": 2
+                    },
+                    "pc": 213,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "pc": 217,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "pc": 217,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "pc": 217,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "pc": 217,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 0
+                    },
+                    "pc": 217,
+                    "value": "cast([fp + (-3)] - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 28
+                    },
+                    "pc": 223,
+                    "value": "[cast(ap + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 28
+                    },
+                    "pc": 223,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 28
+                    },
+                    "pc": 223,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 28
+                    },
+                    "pc": 223,
+                    "value": "[cast(ap + (-1), (balance: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 36
+                    },
+                    "pc": 226,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 36
+                    },
+                    "pc": 226,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 20,
+                        "offset": 36
+                    },
+                    "pc": 226,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 0
+                    },
+                    "pc": 232,
+                    "value": "[cast(fp + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 0
+                    },
+                    "pc": 232,
+                    "value": "[cast(fp + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 0
+                    },
+                    "pc": 232,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 23
+                    },
+                    "pc": 237,
+                    "value": "[cast(ap + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 23
+                    },
+                    "pc": 237,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 23
+                    },
+                    "pc": 237,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 21,
+                        "offset": 23
+                    },
+                    "pc": 237,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 0
+                    },
+                    "pc": 238,
+                    "value": "[cast(fp + (-4), (answer: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 0
+                    },
+                    "pc": 238,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 1
+                    },
+                    "pc": 240,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 1
+                    },
+                    "pc": 240,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 1
+                    },
+                    "pc": 241,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 2
+                    },
+                    "pc": 243,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 247,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 247,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 247,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 247,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 247,
+                    "value": "cast([fp + (-3)] - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 28
+                    },
+                    "pc": 253,
+                    "value": "[cast(ap + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 28
+                    },
+                    "pc": 253,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 28
+                    },
+                    "pc": 253,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 28
+                    },
+                    "pc": 253,
+                    "value": "[cast(ap + (-1), (answer: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 36
+                    },
+                    "pc": 256,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 36
+                    },
+                    "pc": 256,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 36
+                    },
+                    "pc": 256,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "[cast(fp + (-7), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 262,
+                    "value": "cast([fp + (-4)] + [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 0
+                    },
+                    "pc": 267,
+                    "value": "[cast(fp + (-4), (sum: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 0
+                    },
+                    "pc": 267,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 1
+                    },
+                    "pc": 269,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 1
+                    },
+                    "pc": 269,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 1
+                    },
+                    "pc": 270,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 25,
+                        "offset": 2
+                    },
+                    "pc": 272,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "[cast([fp + (-3)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "[cast([fp + (-3)] + 1, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "cast([fp + (-3)] + 2, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 0
+                    },
+                    "pc": 276,
+                    "value": "cast([fp + (-3)] + 2 - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 1
+                    },
+                    "pc": 278,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 12
+                    },
+                    "pc": 286,
+                    "value": "[cast(ap + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 12
+                    },
+                    "pc": 286,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 12
+                    },
+                    "pc": 286,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 12
+                    },
+                    "pc": 286,
+                    "value": "[cast(ap + (-1), (sum: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 20
+                    },
+                    "pc": 289,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 20
+                    },
+                    "pc": 289,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 26,
+                        "offset": 20
+                    },
+                    "pc": 289,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "pc": 295,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "pc": 295,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "pc": 295,
+                    "value": "[cast(fp + (-7), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "pc": 295,
+                    "value": "[cast(fp + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 27,
+                        "offset": 0
+                    },
+                    "pc": 295,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 0
+                    },
+                    "pc": 301,
+                    "value": "[cast(fp + (-5), (b_len: felt, b: felt*)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 0
+                    },
+                    "pc": 301,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 3
+                    },
+                    "pc": 303,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 3
+                    },
+                    "pc": 303,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 3
+                    },
+                    "pc": 304,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 3
+                    },
+                    "pc": 307,
+                    "value": "[cast(fp + 1, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 3
+                    },
+                    "pc": 307,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 4
+                    },
+                    "pc": 309,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 28,
+                        "offset": 4
+                    },
+                    "pc": 310,
+                    "value": "[cast(fp + 2, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 2
+                    },
+                    "pc": 322,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 2
+                    },
+                    "pc": 322,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 2
+                    },
+                    "pc": 322,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 2
+                    },
+                    "pc": 322,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 2
+                    },
+                    "pc": 322,
+                    "value": "[cast([fp + (-3)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 2
+                    },
+                    "pc": 322,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 3
+                    },
+                    "pc": 323,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 4
+                    },
+                    "pc": 324,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 4
+                    },
+                    "pc": 325,
+                    "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 4
+                    },
+                    "pc": 325,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 5
+                    },
+                    "pc": 327,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 6
+                    },
+                    "pc": 328,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 7
+                    },
+                    "pc": 329,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 7
+                    },
+                    "pc": 329,
+                    "value": "cast([ap + (-1)] - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 8
+                    },
+                    "pc": 331,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 20
+                    },
+                    "pc": 340,
+                    "value": "[cast(ap + (-5), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 20
+                    },
+                    "pc": 340,
+                    "value": "[cast(ap + (-4), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 20
+                    },
+                    "pc": 340,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 20
+                    },
+                    "pc": 340,
+                    "value": "[cast(ap + (-2), (b_len: felt, b: felt*)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 20
+                    },
+                    "pc": 341,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 20
+                    },
+                    "pc": 342,
+                    "value": "[cast(fp + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 31,
+                        "offset": 0
+                    },
+                    "pc": 345,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 31,
+                        "offset": 0
+                    },
+                    "pc": 345,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 31,
+                        "offset": 0
+                    },
+                    "pc": 345,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "[cast(fp + (-6), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "[cast(fp + (-5), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "[cast(fp + (-4), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "cast((1, 0), starkware.cairo.common.uint256.Uint256)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "cast(((1, 0), [fp + (-3)]), __main__.MyAccount)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "cast((1000, 0), starkware.cairo.common.uint256.Uint256)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 32,
+                        "offset": 0
+                    },
+                    "pc": 351,
+                    "value": "cast([fp + (-3)] + 1, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 0
+                    },
+                    "pc": 366,
+                    "value": "[cast(fp + (-9), (account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 0
+                    },
+                    "pc": 366,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 1
+                    },
+                    "pc": 368,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 1
+                    },
+                    "pc": 368,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 1
+                    },
+                    "pc": 368,
+                    "value": "cast(fp + (-9), felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 1
+                    },
+                    "pc": 371,
+                    "value": "cast([fp] + 3, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 1
+                    },
+                    "pc": 371,
+                    "value": "cast(fp + (-6), felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 1
+                    },
+                    "pc": 373,
+                    "value": "cast([fp] + 5, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 1
+                    },
+                    "pc": 374,
+                    "value": "cast([fp] + 6, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 33,
+                        "offset": 2
+                    },
+                    "pc": 376,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 0
+                    },
+                    "pc": 380,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 0
+                    },
+                    "pc": 380,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 0
+                    },
+                    "pc": 380,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 0
+                    },
+                    "pc": 380,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 0
+                    },
+                    "pc": 380,
+                    "value": "[cast([fp + (-3)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 0
+                    },
+                    "pc": 380,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 0
+                    },
+                    "pc": 380,
+                    "value": "cast([fp + (-3)] + 1 - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 1
+                    },
+                    "pc": 382,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 16
+                    },
+                    "pc": 389,
+                    "value": "[cast(ap + (-9), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 16
+                    },
+                    "pc": 389,
+                    "value": "[cast(ap + (-8), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 16
+                    },
+                    "pc": 389,
+                    "value": "[cast(ap + (-7), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 16
+                    },
+                    "pc": 389,
+                    "value": "[cast(ap + (-6), (account: __main__.MyAccount, total: starkware.cairo.common.uint256.Uint256, ref: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 24
+                    },
+                    "pc": 392,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 24
+                    },
+                    "pc": 392,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 34,
+                        "offset": 24
+                    },
+                    "pc": 392,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 0
+                    },
+                    "pc": 398,
+                    "value": "[cast(fp + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 0
+                    },
+                    "pc": 398,
+                    "value": "[cast(fp + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 0
+                    },
+                    "pc": 398,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 0
+                    },
+                    "pc": 398,
+                    "value": "[cast(fp + (-8), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 0
+                    },
+                    "pc": 398,
+                    "value": "[cast(fp + (-7), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 0
+                    },
+                    "pc": 398,
+                    "value": "[cast(fp + (-6), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 23
+                    },
+                    "pc": 403,
+                    "value": "[cast(ap + (-4), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 23
+                    },
+                    "pc": 403,
+                    "value": "[cast(ap + (-3), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 23
+                    },
+                    "pc": 403,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 35,
+                        "offset": 23
+                    },
+                    "pc": 403,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 0
+                    },
+                    "pc": 411,
+                    "value": "[cast(fp + (-7), (id: felt, b_len: felt, b: felt*, answer: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 0
+                    },
+                    "pc": 411,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 3
+                    },
+                    "pc": 413,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 3
+                    },
+                    "pc": 413,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 3
+                    },
+                    "pc": 414,
+                    "value": "cast([fp] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 3
+                    },
+                    "pc": 415,
+                    "value": "cast([fp] + 2, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 3
+                    },
+                    "pc": 418,
+                    "value": "[cast(fp + 1, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 3
+                    },
+                    "pc": 418,
+                    "value": "cast([fp] + 2, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 4
+                    },
+                    "pc": 420,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 36,
+                        "offset": 4
+                    },
+                    "pc": 421,
+                    "value": "[cast(fp + 2, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 37,
+                        "offset": 0
+                    },
+                    "pc": 428,
+                    "value": "cast([fp + 2] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 37,
+                        "offset": 1
+                    },
+                    "pc": 430,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 2
+                    },
+                    "pc": 436,
+                    "value": "[cast([fp + (-5)], felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 2
+                    },
+                    "pc": 436,
+                    "value": "[cast([fp + (-5)] + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 2
+                    },
+                    "pc": 436,
+                    "value": "[cast([fp + (-5)] + 2, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 2
+                    },
+                    "pc": 436,
+                    "value": "[cast(fp + (-3), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 2
+                    },
+                    "pc": 436,
+                    "value": "[cast([fp + (-3)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 2
+                    },
+                    "pc": 436,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 3
+                    },
+                    "pc": 437,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 4
+                    },
+                    "pc": 438,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 4
+                    },
+                    "pc": 439,
+                    "value": "cast([[fp + (-5)] + 2] + 1, felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 4
+                    },
+                    "pc": 439,
+                    "value": "cast([fp + (-3)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 5
+                    },
+                    "pc": 441,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 6
+                    },
+                    "pc": 442,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 7
+                    },
+                    "pc": 443,
+                    "value": "[cast(ap + (-1), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 7
+                    },
+                    "pc": 443,
+                    "value": "[cast([ap + (-1)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 7
+                    },
+                    "pc": 443,
+                    "value": "cast([ap + (-1)] + 1, felt*)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 7
+                    },
+                    "pc": 443,
+                    "value": "cast([ap + (-1)] + 1 - [fp + (-3)], felt)"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 8
+                    },
+                    "pc": 445,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 9
+                    },
+                    "pc": 447,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 47
+                    },
+                    "pc": 457,
+                    "value": "[cast(ap + (-7), felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 47
+                    },
+                    "pc": 457,
+                    "value": "[cast(ap + (-6), starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 47
+                    },
+                    "pc": 457,
+                    "value": "[cast(ap + (-5), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 47
+                    },
+                    "pc": 457,
+                    "value": "[cast(ap + (-4), (id: felt, b_len: felt, b: felt*, answer: felt)*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 47
+                    },
+                    "pc": 458,
+                    "value": "[cast(fp, felt**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 38,
+                        "offset": 47
+                    },
+                    "pc": 459,
+                    "value": "[cast(fp + 1, starkware.cairo.common.cairo_builtins.HashBuiltin**)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 39,
+                        "offset": 0
+                    },
+                    "pc": 462,
+                    "value": "[cast(ap + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 39,
+                        "offset": 0
+                    },
+                    "pc": 462,
+                    "value": "[cast(ap + (-2), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 39,
+                        "offset": 0
+                    },
+                    "pc": 462,
+                    "value": "[cast(ap + (-1), felt**)]"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This PR add support to declare V1 transaction.
I have added a unit test similar to the declare V2 transaction one but I'm not sure if this test is enough.

Closes: #385 