### PR TITLE
Add support for multi-object graphql queries

### DIFF
--- a/crates/torii/src/graphql/constants.rs
+++ b/crates/torii/src/graphql/constants.rs
@@ -1,1 +1,1 @@
-pub const _DEFAULT_LIMIT: usize = 10;
+pub const DEFAULT_LIMIT: u64 = 10;

--- a/crates/torii/src/graphql/object/mod.rs
+++ b/crates/torii/src/graphql/object/mod.rs
@@ -1,6 +1,7 @@
 pub mod component;
 pub mod entity;
 pub mod event;
+mod query;
 pub mod storage;
 pub mod system;
 pub mod system_call;

--- a/crates/torii/src/graphql/object/query.rs
+++ b/crates/torii/src/graphql/object/query.rs
@@ -1,0 +1,38 @@
+use sqlx::pool::PoolConnection;
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, QueryBuilder, Result, Sqlite};
+
+pub enum ID {
+    Str(String),
+    I64(i64),
+}
+
+pub async fn query_by_id<T>(
+    conn: &mut PoolConnection<Sqlite>,
+    table_name: &str,
+    id: ID,
+) -> Result<T>
+where
+    T: Send + Unpin + for<'a> FromRow<'a, SqliteRow>,
+{
+    let query = format!("SELECT * FROM {} WHERE id = ?", table_name);
+    let result = match id {
+        ID::Str(id) => sqlx::query_as::<_, T>(&query).bind(id).fetch_one(conn).await?,
+        ID::I64(id) => sqlx::query_as::<_, T>(&query).bind(id).fetch_one(conn).await?,
+    };
+    Ok(result)
+}
+
+pub async fn query_all<T>(
+    conn: &mut PoolConnection<Sqlite>,
+    table_name: &str,
+    limit: u64,
+) -> Result<Vec<T>>
+where
+    T: Send + Unpin + for<'a> FromRow<'a, SqliteRow>,
+{
+    let mut builder: QueryBuilder<'_, Sqlite> = QueryBuilder::new("SELECT * FROM ");
+    builder.push(table_name).push(" ORDER BY created_at DESC LIMIT ").push(limit);
+    let results: Vec<T> = builder.build_query_as().fetch_all(conn).await?;
+    Ok(results)
+}

--- a/crates/torii/src/graphql/object/storage.rs
+++ b/crates/torii/src/graphql/object/storage.rs
@@ -57,7 +57,7 @@ pub async fn storage_by_name(
     name: &str,
     fields: &TypeMapping,
 ) -> Result<ValueMapping> {
-    let query = format!("SELECT * FROM {}", name);
+    let query = format!("SELECT * FROM {} ORDER BY created_at DESC LIMIT 1", name);
     let storage = sqlx::query(&query).fetch_one(conn).await?;
     let result = value_mapping_from_row(&storage, fields)?;
     Ok(result)

--- a/crates/torii/src/graphql/object/system_call.rs
+++ b/crates/torii/src/graphql/object/system_call.rs
@@ -6,8 +6,10 @@ use serde::Deserialize;
 use sqlx::pool::PoolConnection;
 use sqlx::{FromRow, Pool, Result, Sqlite};
 
-use super::system::system_by_id;
+use super::query::{query_all, query_by_id, ID};
+use super::system::SystemObject;
 use super::{ObjectTrait, TypeMapping, ValueMapping};
+use crate::graphql::constants::DEFAULT_LIMIT;
 use crate::graphql::types::ScalarType;
 use crate::graphql::utils::extract_value::extract;
 
@@ -36,6 +38,21 @@ impl SystemCallObject {
             ]),
         }
     }
+
+    pub fn value_mapping(system_call: SystemCall) -> ValueMapping {
+        IndexMap::from([
+            (Name::new("id"), Value::from(system_call.id.to_string())),
+            (Name::new("transactionHash"), Value::from(system_call.transaction_hash)),
+            (Name::new("data"), Value::from(system_call.data)),
+            (Name::new("systemId"), Value::from(system_call.system_id)),
+            (
+                Name::new("createdAt"),
+                Value::from(
+                    system_call.created_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                ),
+            ),
+        ])
+    }
 }
 
 impl ObjectTrait for SystemCallObject {
@@ -57,11 +74,32 @@ impl ObjectTrait for SystemCallObject {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
                     let id = ctx.args.try_get("id")?.i64()?;
-                    let syscall_values = system_call_by_id(&mut conn, id).await?;
-                    Ok(Some(FieldValue::owned_any(syscall_values)))
+                    let system_call = query_by_id(&mut conn, "system_calls", ID::I64(id)).await?;
+                    let result = SystemCallObject::value_mapping(system_call);
+                    Ok(Some(FieldValue::owned_any(result)))
                 })
             })
             .argument(InputValue::new("id", TypeRef::named_nn(TypeRef::INT))),
+            Field::new("systemCalls", TypeRef::named_list(self.type_name()), |ctx| {
+                FieldFuture::new(async move {
+                    let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
+                    let limit = ctx
+                        .args
+                        .try_get("limit")
+                        .and_then(|limit| limit.u64())
+                        .unwrap_or(DEFAULT_LIMIT);
+
+                    let system_calls: Vec<SystemCall> =
+                        query_all(&mut conn, "system_calls", limit).await?;
+                    let result: Vec<FieldValue<'_>> = system_calls
+                        .into_iter()
+                        .map(SystemCallObject::value_mapping)
+                        .map(FieldValue::owned_any)
+                        .collect();
+
+                    Ok(Some(FieldValue::list(result)))
+                })
+            }),
         ]
     }
 
@@ -70,21 +108,13 @@ impl ObjectTrait for SystemCallObject {
             FieldFuture::new(async move {
                 let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
                 let syscall_values = ctx.parent_value.try_downcast_ref::<ValueMapping>()?;
-
-                let system_id = extract::<String>(syscall_values, "system_id")?;
-                let system_call = system_by_id(&mut conn, &system_id).await?;
-
-                Ok(Some(FieldValue::owned_any(system_call)))
+                let system_id = extract::<String>(syscall_values, "systemId")?;
+                let system = query_by_id(&mut conn, "systems", ID::Str(system_id)).await?;
+                let result = SystemObject::value_mapping(system);
+                Ok(Some(FieldValue::owned_any(result)))
             })
         })])
     }
-}
-
-pub async fn system_call_by_id(conn: &mut PoolConnection<Sqlite>, id: i64) -> Result<ValueMapping> {
-    let system_call: SystemCall =
-        sqlx::query_as("SELECT * FROM system_calls WHERE id = $1").bind(id).fetch_one(conn).await?;
-
-    Ok(value_mapping(system_call))
 }
 
 pub async fn system_calls_by_system_id(
@@ -97,18 +127,5 @@ pub async fn system_calls_by_system_id(
             .fetch_all(conn)
             .await?;
 
-    Ok(system_calls.into_iter().map(value_mapping).collect())
-}
-
-fn value_mapping(system_call: SystemCall) -> ValueMapping {
-    IndexMap::from([
-        (Name::new("id"), Value::from(system_call.id.to_string())),
-        (Name::new("transactionHash"), Value::from(system_call.transaction_hash)),
-        (Name::new("data"), Value::from(system_call.data)),
-        (Name::new("systemId"), Value::from(system_call.system_id)),
-        (
-            Name::new("createdAt"),
-            Value::from(system_call.created_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
-        ),
-    ])
+    Ok(system_calls.into_iter().map(SystemCallObject::value_mapping).collect())
 }

--- a/crates/torii/src/tests/fixtures/seed.sql
+++ b/crates/torii/src/tests/fixtures/seed.sql
@@ -2,18 +2,15 @@
 INSERT INTO indexer (head) VALUES (0);
 
 /* register components and systems */ 
-INSERT INTO components (id, name, address, class_hash, transaction_hash, storage_definition)
-VALUES ('component_1', 'Game', '0x0', '0x0', '0x0', 
-    '[{"name":"name","type":"FieldElement","slot":0,"offset":0},{"name":"is_finished","type":"Boolean","slot":0,"offset":0}]');
-INSERT INTO components (id, name, address, class_hash, transaction_hash, storage_definition)
-VALUES ('component_2', 'Stats', '0x0', '0x0', '0x0', 
-    '[{"name":"health","type":"u8","slot":0,"offset":0},{"name":"mana","type":"u8","slot":0,"offset":0}]');
-INSERT INTO components (id, name, address, class_hash, transaction_hash, storage_definition)
-VALUES ('component_3', 'Cash', '0x0', '0x0', '0x0', 
-    '[{"name":"amount","type":"u32","slot":0,"offset":0}]');
-INSERT INTO systems (id, name, address, class_hash, transaction_hash) VALUES ('system_1', 'SpawnGame', '0x0', '0x0', '0x0');
-INSERT INTO systems (id, name, address, class_hash, transaction_hash) VALUES ('system_2', 'SpawnPlayer', '0x0', '0x0', '0x0');
-INSERT INTO systems (id, name, address, class_hash, transaction_hash) VALUES ('system_3', 'SpawnPlayer', '0x0', '0x0', '0x0');
+INSERT INTO components (id, name, class_hash, transaction_hash)
+VALUES ('component_1', 'Game', '0x0', '0x0');
+INSERT INTO components (id, name, class_hash, transaction_hash)
+VALUES ('component_2', 'Stats', '0x0', '0x0');
+INSERT INTO components (id, name, class_hash, transaction_hash)
+VALUES ('component_3', 'Cash', '0x0', '0x0');
+INSERT INTO systems (id, name, class_hash, transaction_hash) VALUES ('system_1', 'SpawnGame', '0x0', '0x0');
+INSERT INTO systems (id, name, class_hash, transaction_hash) VALUES ('system_2', 'SpawnPlayer', '0x0', '0x0');
+INSERT INTO systems (id, name, class_hash, transaction_hash) VALUES ('system_3', 'SpawnPlayer', '0x0', '0x0');
 
 /* system calls to spawn game and player */
 INSERT INTO system_calls (id, system_id, transaction_hash, data) VALUES (1, 'system_1', '0x0', 'game_data');
@@ -41,46 +38,33 @@ INSERT INTO entities (id, name, partition_id, keys, transaction_hash, created_at
 VALUES ( 'entity_3', 'Player', 'game_1', 'player_2', '0x0', '2023-05-19T21:08:12Z');
 
 /* tables for component storage, created at runtime by processor */
-CREATE TABLE storage_game (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
+CREATE TABLE game (
+    id TEXT NOT NULL,
+    partition TEXT NOT NULL,
     is_finished BOOLEAN NOT NULL,
-    version TEXT NOT NULL,
-    entity_id TEXT NOT NULL,
-    component_id TEXT NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (entity_id) REFERENCES entities(id),
-    FOREIGN KEY (component_id) REFERENCES components(id)
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE storage_stats (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
+CREATE TABLE stats (
+    id TEXT NOT NULL,
+    partition TEXT NOT NULL,
     health INTEGER NOT NULL,
     mana INTEGER NOT NULL,
-    version TEXT NOT NULL,
-    entity_id TEXT NOT NULL,
-    component_id TEXT NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (entity_id) REFERENCES entities(id),
-    FOREIGN KEY (component_id) REFERENCES components(id)
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
-CREATE TABLE storage_cash (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
+CREATE TABLE cash (
+    id TEXT NOT NULL,
+    partition TEXT NOT NULL,
     amount INTEGER NOT NULL,
-    version TEXT NOT NULL,
-    entity_id TEXT NOT NULL,
-    component_id TEXT NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (entity_id) REFERENCES entities(id),
-    FOREIGN KEY (component_id) REFERENCES components(id)
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
-INSERT INTO storage_game (id, name, is_finished, version, entity_id, component_id, created_at)
-VALUES (1, '0x594F4C4F', 0, '0.0.0', 'entity_1', 'component_1', '2023-05-19T21:04:04Z');
-INSERT INTO storage_stats (id, health, mana, version, entity_id, component_id, created_at)
-VALUES (1, 100, 100, '0.0.0', 'entity_2', 'component_2', '2023-05-19T21:05:44Z');
-INSERT INTO storage_stats (id, health, mana, version, entity_id, component_id, created_at)
-VALUES (2, 50, 50, '0.0.0', 'entity_3', 'component_2', '2023-05-19T21:08:12Z');
-INSERT INTO storage_cash (id, amount, version, entity_id, component_id, created_at)
-VALUES (1, 77, '0.0.0', 'entity_2', 'component_3', '2023-05-19T21:05:44Z');
-INSERT INTO storage_cash (id, amount, version, entity_id, component_id, created_at)
-VALUES (2, 88, '0.0.0', 'entity_3', 'component_3', '2023-05-19T21:08:12Z');
+INSERT INTO game (id, partition, is_finished, created_at)
+VALUES ('1', 'game_partition', 0, '2023-05-19T21:04:04Z');
+INSERT INTO stats (id, partition, health, mana, created_at)
+VALUES ('2', 'game_partition', '69', '42', '2023-05-19T21:05:44Z');
+INSERT INTO stats (id, partition, health, mana, created_at)
+VALUES ('3', 'game_partition', '42', '69', '2023-05-19T21:08:12Z');
+INSERT INTO cash (id, partition, amount, created_at)
+VALUES ('2', 'game_partition', '88', '2023-05-19T21:05:44Z');
+INSERT INTO cash (id, partition, amount, created_at)
+VALUES ('3', 'game_partition', '66', '2023-05-19T21:08:12Z');


### PR DESCRIPTION
For dynamic async-graphql, we won't be able to use the Connection Relay type from their base crate, we'll most likely need to implement this ourselves to support pagination. For now, this PR enables querying multi objects with a simple limit param.