### PR TITLE
feat: assume role validation

### DIFF
--- a/crates/dojo-core/src/auth/systems.cairo
+++ b/crates/dojo-core/src/auth/systems.cairo
@@ -44,13 +44,14 @@ mod IsAccountAdmin {
     use traits::Into;
     use box::BoxTrait;
     use dojo_core::{auth::components::{AuthStatus, AuthRole}, integer::u250};
+    use dojo_core::world::World;
 
     fn execute(ctx: Context) -> bool {
         // Get calling account contract address
         let caller = ctx.caller_account;
         let role = commands::<AuthRole>::entity(caller.into());
         // Authorize if role is Admin
-        role.id.into() == 'Admin'
+        role.id.into() == World::ADMIN
     }
 }
 
@@ -58,7 +59,7 @@ mod IsAccountAdmin {
 mod IsAuthorized {
     use traits::Into;
     use dojo_core::{auth::components::{AuthStatus, AuthRole}, integer::u250};
-
+    use dojo_core::world::World;
 
     fn execute(ctx: Context, target_id: u250, resource_id: u250) -> bool {
         // Check if execution role is not set
@@ -96,8 +97,8 @@ mod IsAuthorized {
         let role = commands::<AuthRole>::entity(target_id.into());
 
         // Check if system's role is Admin and executed by an Admin
-        if role.id.into() == 'Admin' {
-            assert(ctx.execution_role.id.into() == 'Admin', 'Unauthorized Admin call');
+        if role.id.into() == World::ADMIN {
+            assert(ctx.execution_role.id.into() == World::ADMIN, 'Unauthorized Admin call');
             true
         } else {
             false

--- a/crates/dojo-core/src/auth/systems.cairo
+++ b/crates/dojo-core/src/auth/systems.cairo
@@ -95,8 +95,13 @@ mod IsAuthorized {
         // If system is not authorized, get World level role
         let role = commands::<AuthRole>::entity(target_id.into());
 
-        // Check if system's role is Admin
-        role.id.into() == 'Admin'
+        // Check if system's role is Admin and executed by an Admin
+        if role.id.into() == 'Admin' {
+            assert(ctx.execution_role.id.into() == 'Admin', 'Unauthorized Admin call');
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/crates/dojo-core/src/interfaces.cairo
+++ b/crates/dojo-core/src/interfaces.cairo
@@ -28,9 +28,10 @@ trait IWorld {
     fn is_authorized(system: ShortString, component: ShortString, execution_role: AuthRole) -> bool;
     fn is_account_admin() -> bool;
     fn delete_entity(context: Context, component: ShortString, query: Query);
-    fn assume_role(role_id: u250, components: Array<ShortString>);
+    fn assume_role(role_id: u250, systems: Array<ShortString>);
     fn is_role_authorized(role_id: u250, component: ShortString) -> bool;
     fn execution_role() -> u250;
+    fn system_components(system: ShortString) -> Array<(ShortString, bool)>;
 }
 
 // TODO: Remove once Serde is derivable for dispatchers
@@ -61,6 +62,7 @@ trait IComponent {
 #[abi]
 trait ISystem {
     fn name() -> ShortString;
+    fn dependencies() -> Array<(ShortString, bool)>;
 }
 
 #[abi]

--- a/crates/dojo-core/src/interfaces.cairo
+++ b/crates/dojo-core/src/interfaces.cairo
@@ -27,8 +27,10 @@ trait IWorld {
     fn set_executor(contract_address: ContractAddress);
     fn is_authorized(system: ShortString, component: ShortString, execution_role: AuthRole) -> bool;
     fn is_account_admin() -> bool;
+    fn is_system_for_execution(system: ShortString) -> bool;
     fn delete_entity(context: Context, component: ShortString, query: Query);
     fn assume_role(role_id: u250, systems: Array<ShortString>);
+    fn clear_role(systems: Array<ShortString>);
     fn execution_role() -> u250;
     fn system_components(system: ShortString) -> Array<(ShortString, bool)>;
 }

--- a/crates/dojo-core/src/interfaces.cairo
+++ b/crates/dojo-core/src/interfaces.cairo
@@ -28,7 +28,8 @@ trait IWorld {
     fn is_authorized(system: ShortString, component: ShortString, execution_role: AuthRole) -> bool;
     fn is_account_admin() -> bool;
     fn delete_entity(context: Context, component: ShortString, query: Query);
-    fn set_execution_role(role_id: u250);
+    fn assume_role(role_id: u250, components: Array<ShortString>);
+    fn is_role_authorized(role_id: u250, component: ShortString) -> bool;
     fn execution_role() -> u250;
 }
 

--- a/crates/dojo-core/src/interfaces.cairo
+++ b/crates/dojo-core/src/interfaces.cairo
@@ -29,7 +29,6 @@ trait IWorld {
     fn is_account_admin() -> bool;
     fn delete_entity(context: Context, component: ShortString, query: Query);
     fn assume_role(role_id: u250, systems: Array<ShortString>);
-    fn is_role_authorized(role_id: u250, component: ShortString) -> bool;
     fn execution_role() -> u250;
     fn system_components(system: ShortString) -> Array<(ShortString, bool)>;
 }

--- a/crates/dojo-core/src/test_utils.cairo
+++ b/crates/dojo-core/src/test_utils.cairo
@@ -59,7 +59,7 @@ fn spawn_test_world(
     let mut grant_role_calldata: Array<felt252> = ArrayTrait::new();
 
     grant_role_calldata.append(caller.into()); // target_id
-    grant_role_calldata.append('Admin'); // role_id
+    grant_role_calldata.append(World::ADMIN); // role_id
     world.execute('GrantAuthRole'.into(), grant_role_calldata.span());
 
     // register components

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -9,7 +9,7 @@ mod World {
         get_caller_address, get_contract_address, get_tx_info,
         contract_address::ContractAddressIntoFelt252, ClassHash, Zeroable, ContractAddress
     };
-    use debug::PrintTrait;
+
     use dojo_core::storage::{db::Database, query::{Query, QueryTrait}};
     use dojo_core::execution_context::Context;
     use dojo_core::auth::components::AuthRole;

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -38,6 +38,8 @@ mod World {
         nonce: usize,
     }
 
+    const ADMIN: felt252 = 'Admin';
+
     #[constructor]
     fn constructor(executor: ContractAddress) {
         executor_dispatcher::write(IExecutorDispatcher { contract_address: executor });
@@ -85,7 +87,7 @@ mod World {
 
             // Call RouteAuth system via executor with the serialized route
             executor_dispatcher::read()
-                .execute(route_auth_class_hash, AuthRole { id: 'Admin'.into() }, calldata.span());
+                .execute(route_auth_class_hash, AuthRole { id: ADMIN.into() }, calldata.span());
 
             index += 1;
         };
@@ -147,7 +149,7 @@ mod World {
         // Call IsAccountAdmin system via executor
         let mut calldata = ArrayTrait::new();
         let res = executor_dispatcher::read()
-            .execute(is_account_admin_class_hash, AuthRole { id: 'Admin'.into() }, calldata.span());
+            .execute(is_account_admin_class_hash, AuthRole { id: ADMIN.into() }, calldata.span());
         (*res[0]).is_non_zero()
     }
 
@@ -382,7 +384,7 @@ mod World {
     #[external]
     fn assume_role(role_id: u250, components: Array<ShortString>) {
         // Only Admin can set Admin role 
-        if role_id == 'Admin'.into() {
+        if role_id == ADMIN.into() {
             assert(is_account_admin(), 'only admin can set Admin role');
         } else {
 
@@ -433,10 +435,10 @@ mod World {
         let is_authorized_class_hash = system_registry::read('IsAuthorized'.into());
 
         let mut calldata = ArrayTrait::<felt252>::new();
-        calldata.append(0); // target_id
+        calldata.append(role_id.into()); // target_id
         calldata.append(component.into()); // resource_id
         let res = executor_dispatcher::read()
-            .execute(is_authorized_class_hash, AuthRole { id: role_id }, calldata.span());
+            .execute(is_authorized_class_hash, AuthRole { id: ADMIN.into() }, calldata.span());
         (*res[0]).is_non_zero()
     }
 }

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -39,7 +39,7 @@ mod World {
         nonce: usize,
     }
 
-    const ADMIN: felt252 = 'Admin';
+    const ADMIN: felt252 = 'Demiurge';
 
     #[constructor]
     fn constructor(executor: ContractAddress) {

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -275,11 +275,15 @@ mod World {
         // Get execution role
         let role = execution_role();
 
-        // Validate the calling system has permission to write to the component
-        assert(
-            is_authorized(context.caller_system, component, AuthRole { id: role }),
-            'system not authorized'
-        );
+        // Validate authorization if role is not set
+        // Otherwise, proceed with the write
+        if role.into() == 0 {
+            // Validate the calling system has permission to write to the component
+            assert(
+                is_authorized(context.caller_system, component, AuthRole { id: role }),
+                'system not authorized'
+            );
+        };
 
         // Set the entity
         let table = query.table(component);
@@ -306,11 +310,15 @@ mod World {
         // Get execution role
         let role = execution_role();
 
-        // Validate the calling system has permission to write to the component
-        assert(
-            is_authorized(context.caller_system, component, AuthRole { id: role }),
-            'system not authorized'
-        );
+        // Validate authorization if role is not set
+        // Otherwise, proceed with the write
+        if role.into() == 0 {
+            // Validate the calling system has permission to write to the component
+            assert(
+                is_authorized(context.caller_system, component, AuthRole { id: role }),
+                'system not authorized'
+            );
+        };
 
         // Delete the entity
         let table = query.table(component);
@@ -387,7 +395,6 @@ mod World {
         if role_id == ADMIN.into() {
             assert(is_account_admin(), 'only admin can set Admin role');
         } else {
-
             let mut index = 0;
             let len = components.len();
 
@@ -435,10 +442,11 @@ mod World {
         let is_authorized_class_hash = system_registry::read('IsAuthorized'.into());
 
         let mut calldata = ArrayTrait::<felt252>::new();
-        calldata.append(role_id.into()); // target_id
+        let caller = get_tx_info().unbox().account_contract_address;
+        calldata.append(caller.into()); // target_id
         calldata.append(component.into()); // resource_id
         let res = executor_dispatcher::read()
-            .execute(is_authorized_class_hash, AuthRole { id: ADMIN.into() }, calldata.span());
+            .execute(is_authorized_class_hash, AuthRole { id: role_id.into() }, calldata.span());
         (*res[0]).is_non_zero()
     }
 }

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -39,7 +39,7 @@ mod World {
         nonce: usize,
     }
 
-    const ADMIN: felt252 = 'Demiurge';
+    const ADMIN: felt252 = 'sudo';
 
     #[constructor]
     fn constructor(executor: ContractAddress) {

--- a/crates/dojo-core/src/world_factory.cairo
+++ b/crates/dojo-core/src/world_factory.cairo
@@ -62,9 +62,7 @@ mod WorldFactory {
 
     #[external]
     fn spawn(
-        components: Array<ClassHash>,
-        systems: Array<ClassHash>,
-        routes: Array<Route>,
+        components: Array<ClassHash>, systems: Array<ClassHash>, routes: Array<Route>, 
     ) -> ContractAddress {
         // deploy world
         let mut world_constructor_calldata: Array<felt252> = ArrayTrait::new();

--- a/crates/dojo-core/src/world_factory.cairo
+++ b/crates/dojo-core/src/world_factory.cairo
@@ -83,7 +83,7 @@ mod WorldFactory {
         let mut grant_role_calldata: Array<felt252> = ArrayTrait::new();
 
         grant_role_calldata.append(caller.into()); // target_id
-        grant_role_calldata.append('Admin'); // role_id
+        grant_role_calldata.append(dojo_core::world::World::ADMIN); // role_id
         world.execute('GrantAuthRole'.into(), grant_role_calldata.span());
 
         // register components

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -174,6 +174,28 @@ fn test_assume_role() {
 
 #[test]
 #[available_gas(9000000)]
+#[should_panic]
+fn test_assume_unauthorized_role() {
+    // Spawn empty world
+    let world = spawn_empty_world();
+
+    world.register_system(Bar::TEST_CLASS_HASH.try_into().unwrap());
+    world.register_component(FooComponent::TEST_CLASS_HASH.try_into().unwrap());
+
+    // No route
+    let mut route = ArrayTrait::new();
+
+    // Initialize world
+    world.initialize(route);
+
+    // Assume FooWriter role
+    let mut systems = ArrayTrait::new();
+    systems.append('Bar'.into());
+    world.assume_role('FooWriter'.into(), systems);
+}
+
+#[test]
+#[available_gas(9000000)]
 fn test_clear_role() {
     // Spawn empty world
     let world = spawn_empty_world();

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -169,7 +169,7 @@ fn test_assume_role() {
     // Admin assumes Admin role
     let mut systems = ArrayTrait::new();
     systems.append('Bar'.into());
-    world.assume_role('Admin'.into(), systems);
+    world.assume_role(World::ADMIN.into(), systems);
 }
 
 #[test]
@@ -399,9 +399,9 @@ fn test_admin_system_but_non_admin_caller() {
     // Admin caller grants Admin role to Bar system
     let mut grant_role_calldata: Array<felt252> = ArrayTrait::new();
     grant_role_calldata.append('Bar'); // target_id
-    grant_role_calldata.append('Admin'); // role_id
+    grant_role_calldata.append(World::ADMIN); // role_id
     let systems = ArrayTrait::new();
-    world.assume_role('Admin'.into(), systems);
+    world.assume_role(World::ADMIN.into(), systems);
     world.execute('GrantAuthRole'.into(), grant_role_calldata.span());
 
     // Admin revokes its Admin role

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -185,7 +185,7 @@ fn test_set_entity_admin() {
     // Admin caller grants Admin role to Bar system
     let mut grant_role_calldata: Array<felt252> = ArrayTrait::new();
     grant_role_calldata.append('Bar'); // target_id
-    grant_role_calldata.append('Admin'); // role_id
+    grant_role_calldata.append(World::ADMIN); // role_id
     world.execute('GrantAuthRole'.into(), grant_role_calldata.span());
 
     // Call Bar system
@@ -495,7 +495,7 @@ fn spawn_empty_world() -> IWorldDispatcher {
     let mut grant_role_calldata: Array<felt252> = ArrayTrait::new();
 
     grant_role_calldata.append(caller.into()); // target_id
-    grant_role_calldata.append('Admin'); // role_id
+    grant_role_calldata.append(World::ADMIN); // role_id
     world.execute('GrantAuthRole'.into(), grant_role_calldata.span());
 
     world

--- a/crates/dojo-core/tests/src/world_factory.cairo
+++ b/crates/dojo-core/tests/src/world_factory.cairo
@@ -101,7 +101,7 @@ fn test_spawn_world() {
     // Check Admin role is set
     let caller = get_caller_address();
     let role = world.entity('AuthRole'.into(), caller.into(), 0, 0);
-    assert(*role[0] == 'Admin', 'admin role not set');
+    assert(*role[0] == World::ADMIN, 'admin role not set');
 
     // Check AuthRole component and GrantAuthRole system are registered
     let role_hash = world.component('AuthRole'.into());

--- a/crates/dojo-core/tests/src/world_factory.cairo
+++ b/crates/dojo-core/tests/src/world_factory.cairo
@@ -63,7 +63,7 @@ fn test_constructor() {
 }
 
 #[test]
-#[available_gas(100000000)]
+#[available_gas(90000000)]
 fn test_spawn_world() {
     // Deploy Executor
     let constructor_calldata = array::ArrayTrait::new();


### PR DESCRIPTION
This pr does the following:

- update authorization checking during role assumption (`assume_role`)
- fallback check on the default resource-scoped role for when role is not set
- `assume_role` uses `dependencies` to check which systems access to write components
- add `clear_role` and checking if executed systems are part of the checking during role assumption
- update admin role to `sudo`
-  resolves #452 