### PR TITLE
fix: param name in starknet_addDeclareTransaction

### DIFF
--- a/crates/katana-rpc/src/starknet/api.rs
+++ b/crates/katana-rpc/src/starknet/api.rs
@@ -166,7 +166,7 @@ pub trait StarknetApi {
     #[method(name = "addDeclareTransaction")]
     async fn add_declare_transaction(
         &self,
-        transaction: BroadcastedDeclareTransaction,
+        declare_transaction: BroadcastedDeclareTransaction,
     ) -> Result<DeclareTransactionResult, Error>;
 
     #[method(name = "addInvokeTransaction")]

--- a/crates/katana-rpc/src/starknet/rpc.rs
+++ b/crates/katana-rpc/src/starknet/rpc.rs
@@ -857,11 +857,11 @@ impl<S: Sequencer + Send + Sync + 'static> StarknetApiServer for StarknetRpc<S> 
 
     async fn add_declare_transaction(
         &self,
-        transaction: BroadcastedDeclareTransaction,
+        declare_transaction: BroadcastedDeclareTransaction,
     ) -> Result<DeclareTransactionResult, Error> {
         let chain_id = FieldElement::from_hex_be(&self.sequencer.chain_id().await.as_hex())
             .map_err(|_| Error::from(StarknetApiError::InternalServerError))?;
-        let (transaction_hash, class_hash, transaction) = match transaction {
+        let (transaction_hash, class_hash, transaction) = match declare_transaction {
             BroadcastedDeclareTransaction::V1(tx) => {
                 let raw_class_str = serde_json::to_string(&tx.contract_class)
                     .map_err(|_| Error::from(StarknetApiError::InvalidContractClass))?;


### PR DESCRIPTION
The param name should be `declare_transaction` instead of `transaction`. This affects applications that send params as object instead of array.