### PR TITLE
feat: Use DOJO_WORLD_ADDRESS env

### DIFF
--- a/crates/sozo/src/commands/options/world.rs
+++ b/crates/sozo/src/commands/options/world.rs
@@ -25,8 +25,9 @@ impl WorldOptions {
             Ok(FieldElement::from_str(&world_address)?)
         } else {
             Err(anyhow!(
-            "Could not find World address. Please specify it with --world or in the world config."
-        ))
+                "Could not find World address. Please specify it with --world or in the world \
+                 config."
+            ))
         }
     }
 }

--- a/crates/sozo/src/commands/options/world.rs
+++ b/crates/sozo/src/commands/options/world.rs
@@ -16,18 +16,17 @@ pub struct WorldOptions {
 impl WorldOptions {
     pub fn address(&self, env_metadata: Option<&Value>) -> Result<FieldElement> {
         if let Some(world_address) = self.world_address {
-            return Ok(world_address);
-        } else if let Some(dojo_metadata) = env_metadata {
-            if let Some(world_address) = dojo_metadata.get("world_address") {
-                if let Some(world_address) = world_address.as_str() {
-                    let world_address = FieldElement::from_str(world_address)?;
-                    return Ok(world_address);
-                }
-            }
-        }
-
-        Err(anyhow!(
+            Ok(world_address)
+        } else if let Some(world_address) = env_metadata.and_then(|env| {
+            env.get("world_address")
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .or(std::env::var("DOJO_WORLD_ADDRESS").ok())
+        }) {
+            Ok(FieldElement::from_str(&world_address)?)
+        } else {
+            Err(anyhow!(
             "Could not find World address. Please specify it with --world or in the world config."
         ))
+        }
     }
 }


### PR DESCRIPTION
This pr allows the world address to be retrieved as environment variable or from manifest

### environment variable
<img width="700" alt="image" src="https://github.com/dojoengine/dojo/assets/35031356/748c6ce5-1a65-4b0a-aa6f-69f2d76b79fd">

### manifest
```Rust
[tool.dojo.env]
world_address = "0x716a65f8a54091434f0ae34929c28bd8c67d3d1320c3e2ab54436f4458e215"
```
<img width="700" alt="image" src="https://github.com/dojoengine/dojo/assets/35031356/978be252-b490-46e7-b094-75ea068d71cd">



Fix #474 