### PR TITLE
Add linebreaks to sozo component outputs

### DIFF
--- a/crates/sozo/src/ops/component.rs
+++ b/crates/sozo/src/ops/component.rs
@@ -56,7 +56,7 @@ pub async fn execute(command: ComponentCommands, env_metadata: Option<Value>) ->
 
             println!(
                 "{}",
-                entity.iter().map(|f| format!("{f:#x}")).collect::<Vec<String>>().join(" ")
+                entity.iter().map(|f| format!("{f:#x}")).collect::<Vec<String>>().join("\n")
             )
         }
     }


### PR DESCRIPTION
Easier to read with line breaks

```bash 
> sozo component entity Game
0x3ee9e18edc71a6df30ac3aca2e0b02a198fbce19b7480a63a0d71cbd76652e0
0x33c627a3e5213790e246a917770ce23d7e562baa5b4d2917c23b1be6d91961c
0x3ee9e18edc71a6df30ac3aca2e0b02a198fbce19b7480a63a0d71cbd76652e0
0x0
0x0
```