### PR TITLE
refactor(sozo): make `--manifest-path` a global option

### DIFF
--- a/crates/sozo/src/args.rs
+++ b/crates/sozo/src/args.rs
@@ -21,6 +21,7 @@ use crate::commands::test::TestArgs;
 #[command(propagate_version = true)]
 pub struct SozoArgs {
     #[arg(long)]
+    #[arg(global = true)]
     #[arg(hide_short_help = true)]
     #[arg(env = "DOJO_MANIFEST_PATH")]
     #[arg(help = "Override path to a directory containing a Scarb.toml file.")]


### PR DESCRIPTION
Currently, to use `--manifest-path` option, user must specify it ONLY before the `sozo` subcommand they are using, for example, `sozo --manifest-path path/to/Scarb.toml build`.

This change will allow `--manifest-path` to be used anywhere (after `sozo`) within a command. E.g. `sozo build --manifest-path path/to/Scarb.toml`. 

