### PR TITLE
feat(torii): sql register component use proper type

### DIFF
--- a/crates/torii/src/graphql/mod.rs
+++ b/crates/torii/src/graphql/mod.rs
@@ -2,5 +2,5 @@ mod constants;
 mod object;
 pub mod schema;
 pub mod server;
-mod types;
+pub mod types;
 mod utils;

--- a/crates/torii/src/graphql/object/component.rs
+++ b/crates/torii/src/graphql/object/component.rs
@@ -46,9 +46,9 @@ impl ComponentObject {
             field_type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
                 (Name::new("name"), TypeRef::STRING.to_string()),
-                (Name::new("classHash"), ScalarType::FELT252.to_string()),
-                (Name::new("transactionHash"), ScalarType::FELT252.to_string()),
-                (Name::new("createdAt"), ScalarType::DATE_TIME.to_string()),
+                (Name::new("classHash"), ScalarType::Felt252.to_string()),
+                (Name::new("transactionHash"), ScalarType::Felt252.to_string()),
+                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
             ]),
             storage_names,
         }

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -31,10 +31,10 @@ impl EntityObject {
         Self {
             field_type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
-                (Name::new("partition"), ScalarType::FELT252.to_string()),
+                (Name::new("partition"), ScalarType::Felt252.to_string()),
                 (Name::new("keys"), TypeRef::STRING.to_string()),
-                (Name::new("transactionHash"), ScalarType::FELT252.to_string()),
-                (Name::new("createdAt"), ScalarType::DATE_TIME.to_string()),
+                (Name::new("transactionHash"), ScalarType::Felt252.to_string()),
+                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
             ]),
         }
     }
@@ -105,7 +105,10 @@ impl ObjectTrait for EntityObject {
                     Ok(Some(FieldValue::list(entities.into_iter().map(FieldValue::owned_any))))
                 })
             })
-            .argument(InputValue::new("partition", TypeRef::named_nn(ScalarType::FELT252)))
+            .argument(InputValue::new(
+                "partition",
+                TypeRef::named_nn(ScalarType::Felt252.to_string()),
+            ))
             .argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING)))
             .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
         ]

--- a/crates/torii/src/graphql/object/event.rs
+++ b/crates/torii/src/graphql/object/event.rs
@@ -35,7 +35,7 @@ impl EventObject {
                 (Name::new("keys"), TypeRef::STRING.to_string()),
                 (Name::new("data"), TypeRef::STRING.to_string()),
                 (Name::new("systemCallId"), TypeRef::INT.to_string()),
-                (Name::new("createdAt"), ScalarType::DATE_TIME.to_string()),
+                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
             ]),
         }
     }

--- a/crates/torii/src/graphql/object/system.rs
+++ b/crates/torii/src/graphql/object/system.rs
@@ -34,10 +34,10 @@ impl SystemObject {
             field_type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
                 (Name::new("name"), TypeRef::STRING.to_string()),
-                (Name::new("address"), ScalarType::ADDRESS.to_string()),
-                (Name::new("classHash"), ScalarType::FELT252.to_string()),
-                (Name::new("transactionHash"), ScalarType::FELT252.to_string()),
-                (Name::new("createdAt"), ScalarType::DATE_TIME.to_string()),
+                (Name::new("address"), ScalarType::Address.to_string()),
+                (Name::new("classHash"), ScalarType::Felt252.to_string()),
+                (Name::new("transactionHash"), ScalarType::Felt252.to_string()),
+                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
             ]),
         }
     }

--- a/crates/torii/src/graphql/object/system_call.rs
+++ b/crates/torii/src/graphql/object/system_call.rs
@@ -34,7 +34,7 @@ impl SystemCallObject {
                 (Name::new("transactionHash"), TypeRef::STRING.to_string()),
                 (Name::new("data"), TypeRef::STRING.to_string()),
                 (Name::new("systemId"), TypeRef::ID.to_string()),
-                (Name::new("createdAt"), ScalarType::DATE_TIME.to_string()),
+                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
             ]),
         }
     }

--- a/crates/torii/src/graphql/schema.rs
+++ b/crates/torii/src/graphql/schema.rs
@@ -33,7 +33,7 @@ pub async fn build_schema(pool: &SqlitePool) -> Result<Schema> {
 
     // register custom scalars
     for scalar_type in ScalarType::types().iter() {
-        schema_builder = schema_builder.register(Scalar::new(*scalar_type));
+        schema_builder = schema_builder.register(Scalar::new(scalar_type.to_string()));
     }
 
     // register gql objects and union

--- a/crates/torii/src/graphql/types.rs
+++ b/crates/torii/src/graphql/types.rs
@@ -1,36 +1,111 @@
 use std::collections::HashSet;
+use std::fmt;
 
-pub struct ScalarType;
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum ScalarType {
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    USize,
+    Bool,
+    Cursor,
+    Address,
+    DateTime,
+    Felt252,
+}
 
-// Custom scalar types
+impl fmt::Display for ScalarType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ScalarType::U8 => write!(f, "u8"),
+            ScalarType::U16 => write!(f, "u16"),
+            ScalarType::U32 => write!(f, "u32"),
+            ScalarType::U64 => write!(f, "u64"),
+            ScalarType::U128 => write!(f, "u128"),
+            ScalarType::U256 => write!(f, "u256"),
+            ScalarType::USize => write!(f, "usize"),
+            ScalarType::Bool => write!(f, "bool"),
+            ScalarType::Cursor => write!(f, "Cursor"),
+            ScalarType::Address => write!(f, "Address"),
+            ScalarType::DateTime => write!(f, "DateTime"),
+            ScalarType::Felt252 => write!(f, "felt252"),
+        }
+    }
+}
+
 impl ScalarType {
-    pub const U8: &'static str = "u8";
-    pub const U16: &'static str = "u16";
-    pub const U32: &'static str = "u32";
-    pub const U64: &'static str = "u64";
-    pub const U128: &'static str = "u128";
-    pub const U256: &'static str = "u256";
-    pub const USIZE: &'static str = "usize";
-    pub const BOOL: &'static str = "bool";
-    pub const CURSOR: &'static str = "Cursor";
-    pub const ADDRESS: &'static str = "Address";
-    pub const DATE_TIME: &'static str = "DateTime";
-    pub const FELT252: &'static str = "felt252";
-
-    pub fn types() -> HashSet<&'static str> {
-        HashSet::from([
+    pub fn types() -> HashSet<ScalarType> {
+        vec![
             ScalarType::U8,
             ScalarType::U16,
             ScalarType::U32,
             ScalarType::U64,
             ScalarType::U128,
             ScalarType::U256,
-            ScalarType::USIZE,
-            ScalarType::BOOL,
-            ScalarType::CURSOR,
-            ScalarType::ADDRESS,
-            ScalarType::DATE_TIME,
-            ScalarType::FELT252,
-        ])
+            ScalarType::USize,
+            ScalarType::Bool,
+            ScalarType::Cursor,
+            ScalarType::Address,
+            ScalarType::DateTime,
+            ScalarType::Felt252,
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    pub fn numeric_types() -> HashSet<ScalarType> {
+        vec![
+            ScalarType::U8,
+            ScalarType::U16,
+            ScalarType::U32,
+            ScalarType::U64,
+            ScalarType::USize,
+            ScalarType::Bool,
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    // u128 and u256 are non numeric here due to
+    // sqlite constraint on integer columns
+    pub fn _non_numeric_types() -> HashSet<ScalarType> {
+        vec![
+            ScalarType::U128,
+            ScalarType::U256,
+            ScalarType::Cursor,
+            ScalarType::Address,
+            ScalarType::DateTime,
+            ScalarType::Felt252,
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    pub fn is_numeric_type(&self) -> bool {
+        ScalarType::numeric_types().contains(self)
+    }
+
+    pub fn from_str<S: AsRef<str>>(s: S) -> Result<ScalarType, anyhow::Error> {
+        match s.as_ref() {
+            "u8" => Ok(ScalarType::U8),
+            "u16" => Ok(ScalarType::U16),
+            "u32" => Ok(ScalarType::U32),
+            "u64" => Ok(ScalarType::U64),
+            "u128" => Ok(ScalarType::U128),
+            "usize" => Ok(ScalarType::USize),
+            "bool" => Ok(ScalarType::Bool),
+            "Cursor" => Ok(ScalarType::Cursor),
+            "Address" => Ok(ScalarType::Address),
+            "DateTime" => Ok(ScalarType::DateTime),
+            "felt252" => Ok(ScalarType::Felt252),
+            _ => Err(anyhow::anyhow!("Unknown type {}", s.as_ref().to_string())),
+        }
+    }
+
+    pub fn as_sql_type(&self) -> &'static str {
+        if self.is_numeric_type() { "INTEGER" } else { "TEXT" }
     }
 }

--- a/crates/torii/src/tests/components_test.rs
+++ b/crates/torii/src/tests/components_test.rs
@@ -13,14 +13,14 @@ mod tests {
     #[derive(Deserialize)]
     struct Moves {
         __typename: String,
-        remaining: String,
+        remaining: u32,
     }
 
     #[derive(Deserialize)]
     struct Position {
         __typename: String,
-        x: String,
-        y: String,
+        x: u32,
+        y: u32,
     }
 
     #[derive(Deserialize)]
@@ -68,9 +68,9 @@ mod tests {
         let position = value.get("position").ok_or("no position found").unwrap();
         let position: Position = serde_json::from_value(position.clone()).unwrap();
 
-        assert_eq!(moves.remaining, "0xa");
-        assert_eq!(position.x, "0x2a");
-        assert_eq!(position.y, "0x45");
+        assert_eq!(moves.remaining, 10);
+        assert_eq!(position.x, 42);
+        assert_eq!(position.y, 69);
     }
 
     #[sqlx::test(migrations = "./migrations")]


### PR DESCRIPTION
Currently, all component members are treated as strings in db, this PR includes type parsing for component members, allowing each member to be stored with its proper type (almost).

Due to sqlite constraint on integer, members are stored as:
* u8, u16, u32, u64, usize, bool stored as INTEGER
* u128, u256, felt252 stored as TEXT
