### PR TITLE
refactor(katana): display default accounts seed

### DIFF
--- a/crates/katana/src/args.rs
+++ b/crates/katana/src/args.rs
@@ -48,8 +48,9 @@ pub struct ServerOptions {
 #[derive(Debug, Args, Clone)]
 pub struct StarknetOptions {
     #[arg(long)]
+    #[arg(default_value = "0")]
     #[arg(help = "Specify the seed for randomness of accounts to be predeployed.")]
-    pub seed: Option<String>,
+    pub seed: String,
 
     #[arg(long = "accounts")]
     #[arg(value_name = "NUM")]
@@ -100,7 +101,7 @@ impl KatanaArgs {
     pub fn starknet_config(&self) -> StarknetConfig {
         StarknetConfig {
             total_accounts: self.starknet.total_accounts,
-            seed: parse_seed(self.starknet.seed.clone()),
+            seed: parse_seed(&self.starknet.seed),
             account_path: self.starknet.account_path.clone(),
             allow_zero_max_fee: self.starknet.allow_zero_max_fee,
             auto_mine: self.block_time.is_none() && !self.no_mining,
@@ -112,19 +113,16 @@ impl KatanaArgs {
     }
 }
 
-fn parse_seed(seed: Option<String>) -> [u8; 32] {
-    seed.map(|seed| {
-        let seed = seed.as_bytes();
+fn parse_seed(seed: &str) -> [u8; 32] {
+    let seed = seed.as_bytes();
 
-        if seed.len() >= 32 {
-            unsafe { *(seed[..32].as_ptr() as *const [u8; 32]) }
-        } else {
-            let mut actual_seed = [0u8; 32];
-            seed.iter().enumerate().for_each(|(i, b)| actual_seed[i] = *b);
-            actual_seed
-        }
-    })
-    .unwrap_or_default()
+    if seed.len() >= 32 {
+        unsafe { *(seed[..32].as_ptr() as *const [u8; 32]) }
+    } else {
+        let mut actual_seed = [0u8; 32];
+        seed.iter().enumerate().for_each(|(i, b)| actual_seed[i] = *b);
+        actual_seed
+    }
 }
 
 #[cfg(test)]

--- a/crates/katana/src/main.rs
+++ b/crates/katana/src/main.rs
@@ -49,7 +49,7 @@ async fn main() {
     };
 }
 
-fn print_intro(accounts: String, seed: Option<String>, address: String) {
+fn print_intro(accounts: String, seed: String, address: String) {
     println!(
         "{}",
         Paint::red(
@@ -75,15 +75,13 @@ PREFUNDED ACCOUNTS
     "
     );
 
-    if let Some(seed) = seed {
-        println!(
-            r"
+    println!(
+        r"
 ACCOUNTS SEED
 =============
 {seed}
     "
-        );
-    }
+    );
 
     println!("\n{address}\n\n");
 }

--- a/examples/rpc/starknet/starknet_call.hurl
+++ b/examples/rpc/starknet/starknet_call.hurl
@@ -8,7 +8,7 @@ Content-Type: application/json
 			"contract_address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
 			"entry_point_selector": "0x2e4263afad30923c891518314c3c95dbe830a16874e8abc5777a9a20b54c76e",
 			"calldata": [
-				"0x049c7a9c0d35fc7af43743e288974b99bb5393496282ec560180ab77120f44a2"
+				"0x05b92948371346d0df1d3c2d7568573364497f6cba65f4734ecd54ed0a0dbd11"
 			]
 		},
 		"pending"

--- a/examples/rpc/starknet/starknet_getClassHashAt.hurl
+++ b/examples/rpc/starknet/starknet_getClassHashAt.hurl
@@ -5,7 +5,7 @@ Content-Type: application/json
   "method": "starknet_getClassHashAt",
   "params": [
     "pending",
-    "0x049c7a9c0d35fc7af43743e288974b99bb5393496282ec560180ab77120f44a2"
+    "0x05b92948371346d0df1d3c2d7568573364497f6cba65f4734ecd54ed0a0dbd11"
   ],
   "id": 1
 }

--- a/examples/rpc/starknet/starknet_getEstimateFee.hurl
+++ b/examples/rpc/starknet/starknet_getEstimateFee.hurl
@@ -13,7 +13,7 @@ Content-Type: application/json
 				"signature": [
 				
 				],
-				"sender_address": "0x049c7a9c0d35fc7af43743e288974b99bb5393496282ec560180ab77120f44a2",
+				"sender_address": "0x05b92948371346d0df1d3c2d7568573364497f6cba65f4734ecd54ed0a0dbd11",
 				"calldata": [
 					"0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
 					"0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
@@ -31,7 +31,7 @@ Content-Type: application/json
 				"signature": [
 				
 				],
-				"sender_address": "0x049c7a9c0d35fc7af43743e288974b99bb5393496282ec560180ab77120f44a2",
+				"sender_address": "0x05b92948371346d0df1d3c2d7568573364497f6cba65f4734ecd54ed0a0dbd11",
 				"calldata": [
 					"0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
 					"0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",

--- a/examples/rpc/starknet/starknet_getNonce.hurl
+++ b/examples/rpc/starknet/starknet_getNonce.hurl
@@ -5,7 +5,7 @@ Content-Type: application/json
     "method": "starknet_getNonce",
     "params": [
         "latest",
-        "0x03fc02daad5e6fbe732a214d0e44cc7029701004c679dd18f0cc1b8e5276a306"
+        "0x05b92948371346d0df1d3c2d7568573364497f6cba65f4734ecd54ed0a0dbd11"
     ],
     "id":1
 }


### PR DESCRIPTION
It's better to be explicit of the default seed value used when `--seed` option is not set.