### PR TITLE
feat(sozo): `events` subcommand to retrive events

### DIFF
--- a/crates/sozo/src/args.rs
+++ b/crates/sozo/src/args.rs
@@ -9,6 +9,7 @@ use tracing_log::AsTrace;
 
 use crate::commands::build::BuildArgs;
 use crate::commands::component::ComponentArgs;
+use crate::commands::events::EventsArgs;
 use crate::commands::execute::ExecuteArgs;
 use crate::commands::init::InitArgs;
 use crate::commands::migrate::MigrateArgs;
@@ -58,6 +59,8 @@ pub enum Commands {
     System(SystemArgs),
     #[command(about = "Register new systems and components")]
     Register(RegisterArgs),
+    #[command(about = "Queries world events")]
+    Events(EventsArgs),
 }
 
 impl SozoArgs {

--- a/crates/sozo/src/commands/events.rs
+++ b/crates/sozo/src/commands/events.rs
@@ -1,29 +1,29 @@
-use crate::ops::events;
-
-use super::options::{
-    dojo_metadata_from_workspace, starknet::StarknetOptions, world::WorldOptions,
-};
 use anyhow::Result;
-use clap::Args;
+use clap::Parser;
 use scarb::core::Config;
 
-#[derive(Args, Debug)]
-pub struct EventsArgs {
-    #[clap(short, long)]
-    #[clap(help = "idk yet")]
-    pub chunk_size: u64,
+use super::options::dojo_metadata_from_workspace;
+use super::options::starknet::StarknetOptions;
+use super::options::world::WorldOptions;
+use crate::ops::events;
 
-    #[clap(short, long)]
-    #[clap(help = "Block number from where to look for events")]
+#[derive(Parser, Debug)]
+pub struct EventsArgs {
+    #[arg(help = "List of specific events to be filtered")]
+    #[arg(value_delimiter = ',')]
+    pub events: Option<Vec<String>>,
+
+    #[arg(short, long)]
+    #[arg(help = "Block number from where to look for events")]
     pub from_block: Option<u64>,
 
-    #[clap(short, long)]
-    #[clap(help = "Block number until where to look for events")]
+    #[arg(short, long)]
+    #[arg(help = "Block number until where to look for events")]
     pub to_block: Option<u64>,
 
-    #[clap(short, long)]
-    #[clap(help = "List of specific events to be filtered")]
-    pub events: Option<Vec<String>>,
+    #[arg(short, long)]
+    #[arg(help = "Number of events to return per page")]
+    pub chunk_size: u64,
 
     #[command(flatten)]
     pub world: WorldOptions,
@@ -47,5 +47,18 @@ impl EventsArgs {
             None
         };
         config.tokio_handle().block_on(events::execute(self, env_metadata))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn events_are_parsed_correctly() {
+        let arg = EventsArgs::parse_from(["event", "Event1,Event2", "--chunk-size", "1"]);
+        assert!(arg.events.unwrap().len() == 2);
+        assert!(arg.from_block.is_none());
+        assert!(arg.to_block.is_none());
+        assert!(arg.chunk_size == 1);
     }
 }

--- a/crates/sozo/src/commands/events.rs
+++ b/crates/sozo/src/commands/events.rs
@@ -1,6 +1,8 @@
 use crate::ops::events;
 
-use super::options::{dojo_metadata_from_workspace, starknet::StarknetOptions};
+use super::options::{
+    dojo_metadata_from_workspace, starknet::StarknetOptions, world::WorldOptions,
+};
 use anyhow::Result;
 use clap::Args;
 use scarb::core::Config;
@@ -10,6 +12,21 @@ pub struct EventsArgs {
     #[clap(short, long)]
     #[clap(help = "idk yet")]
     pub chunk_size: u64,
+
+    #[clap(short, long)]
+    #[clap(help = "Block number from where to look for events")]
+    pub from_block: Option<u64>,
+
+    #[clap(short, long)]
+    #[clap(help = "Block number until where to look for events")]
+    pub to_block: Option<u64>,
+
+    #[clap(short, long)]
+    #[clap(help = "List of specific events to be filtered")]
+    pub events: Option<Vec<String>>,
+
+    #[command(flatten)]
+    pub world: WorldOptions,
 
     #[command(flatten)]
     pub starknet: StarknetOptions,

--- a/crates/sozo/src/commands/events.rs
+++ b/crates/sozo/src/commands/events.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use clap::Args;
+use scarb::core::Config;
+
+#[derive(Args, Debug)]
+pub struct EventsArgs {
+    #[clap(short, long)]
+    #[clap(help = "idk yet")]
+    chunk_size: usize,
+}
+
+impl EventsArgs {
+    pub fn run(self, _config: &Config) -> Result<()> {
+        Ok(())
+    }
+}

--- a/crates/sozo/src/commands/events.rs
+++ b/crates/sozo/src/commands/events.rs
@@ -1,3 +1,6 @@
+use crate::ops::events;
+
+use super::options::{dojo_metadata_from_workspace, starknet::StarknetOptions};
 use anyhow::Result;
 use clap::Args;
 use scarb::core::Config;
@@ -6,11 +9,26 @@ use scarb::core::Config;
 pub struct EventsArgs {
     #[clap(short, long)]
     #[clap(help = "idk yet")]
-    chunk_size: usize,
+    pub chunk_size: u64,
+
+    #[command(flatten)]
+    pub starknet: StarknetOptions,
 }
 
 impl EventsArgs {
-    pub fn run(self, _config: &Config) -> Result<()> {
-        Ok(())
+    pub fn run(self, config: &Config) -> Result<()> {
+        let env_metadata = if config.manifest_path().exists() {
+            let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
+            let env_metadata = dojo_metadata_from_workspace(&ws)
+                .and_then(|dojo_metadata| dojo_metadata.get("env").cloned());
+
+            env_metadata
+                .as_ref()
+                .and_then(|env_metadata| env_metadata.get(ws.config().profile().as_str()).cloned())
+                .or(env_metadata)
+        } else {
+            None
+        };
+        config.tokio_handle().block_on(events::execute(self, env_metadata))
     }
 }

--- a/crates/sozo/src/commands/migrate.rs
+++ b/crates/sozo/src/commands/migrate.rs
@@ -13,8 +13,8 @@ use crate::ops::migration;
 
 #[derive(Args)]
 pub struct MigrateArgs {
-    #[clap(short, long)]
-    #[clap(help = "Perform a dry run and outputs the plan to be executed")]
+    #[arg(short, long)]
+    #[arg(help = "Perform a dry run and outputs the plan to be executed")]
     plan: bool,
 
     #[command(flatten)]

--- a/crates/sozo/src/commands/mod.rs
+++ b/crates/sozo/src/commands/mod.rs
@@ -5,6 +5,7 @@ use crate::args::Commands;
 
 pub(crate) mod build;
 pub(crate) mod component;
+pub(crate) mod events;
 pub(crate) mod execute;
 pub(crate) mod init;
 pub(crate) mod migrate;
@@ -24,5 +25,6 @@ pub fn run(command: Commands, config: &Config) -> Result<()> {
         Commands::Component(args) => args.run(config),
         Commands::System(args) => args.run(config),
         Commands::Register(args) => args.run(config),
+        Commands::Events(args) => args.run(config),
     }
 }

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -1,25 +1,20 @@
-use starknet::{
-    core::types::{BlockId, EventFilter},
-    core::utils::starknet_keccak,
-    providers::Provider,
-};
+use anyhow::Result;
+use starknet::core::types::{BlockId, EventFilter};
+use starknet::core::utils::starknet_keccak;
+use starknet::providers::Provider;
 use toml::Value;
 
 use crate::commands::events::EventsArgs;
-use anyhow::Result;
 
 pub async fn execute(args: EventsArgs, env_metadata: Option<Value>) -> Result<()> {
     let EventsArgs { chunk_size, starknet, world, from_block, to_block, events } = args;
 
-    let from_block = from_block.map(|num| BlockId::Number(num));
-    let to_block = to_block.map(|num| BlockId::Number(num));
-    let keys = events.map(|e| {
-        let mut ret = vec![];
-        for event in e {
-            ret.push(vec![starknet_keccak(event.as_bytes())]);
-        }
-        ret
-    });
+    let from_block = from_block.map(BlockId::Number);
+    let to_block = to_block.map(BlockId::Number);
+    // Currently dojo doesn't use custom keys for events. In future if custom keys are used this
+    // needs to be updated for granular queries.
+    let keys =
+        events.map(|e| vec![e.iter().map(|event| starknet_keccak(event.as_bytes())).collect()]);
 
     let provider = starknet.provider(env_metadata.as_ref())?;
     let event_filter = EventFilter { from_block, to_block, address: world.world_address, keys };

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -24,8 +24,9 @@ pub async fn execute(args: EventsArgs, env_metadata: Option<Value>) -> Result<()
     let provider = starknet.provider(env_metadata.as_ref())?;
     let event_filter = EventFilter { from_block, to_block, address: world.world_address, keys };
 
-    let res = provider.get_events(event_filter, None, chunk_size).await;
+    let res = provider.get_events(event_filter, None, chunk_size).await?;
 
-    println!("{res:#?}");
+    let value = serde_json::to_value(res)?;
+    println!("{}", serde_json::to_string_pretty(&value)?);
     Ok(())
 }

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -1,13 +1,29 @@
-use starknet::{core::types::EventFilter, providers::Provider};
+use starknet::{
+    core::types::{BlockId, EventFilter},
+    core::utils::starknet_keccak,
+    providers::Provider,
+};
 use toml::Value;
 
 use crate::commands::events::EventsArgs;
 use anyhow::Result;
 
 pub async fn execute(args: EventsArgs, env_metadata: Option<Value>) -> Result<()> {
-    let EventsArgs { chunk_size, starknet } = args;
+    let EventsArgs { chunk_size, starknet, world, from_block, to_block, events } = args;
+
+    let from_block = from_block.map(|num| BlockId::Number(num));
+    let to_block = to_block.map(|num| BlockId::Number(num));
+    let keys = events.map(|e| {
+        let mut ret = vec![];
+        for event in e {
+            ret.push(vec![starknet_keccak(event.as_bytes())]);
+        }
+        ret
+    });
+
     let provider = starknet.provider(env_metadata.as_ref())?;
-    let event_filter = EventFilter { from_block: None, to_block: None, address: None, keys: None };
+    let event_filter = EventFilter { from_block, to_block, address: world.world_address, keys };
+
     let res = provider.get_events(event_filter, None, chunk_size).await;
 
     println!("{res:#?}");

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -1,0 +1,15 @@
+use starknet::{core::types::EventFilter, providers::Provider};
+use toml::Value;
+
+use crate::commands::events::EventsArgs;
+use anyhow::Result;
+
+pub async fn execute(args: EventsArgs, env_metadata: Option<Value>) -> Result<()> {
+    let EventsArgs { chunk_size, starknet } = args;
+    let provider = starknet.provider(env_metadata.as_ref())?;
+    let event_filter = EventFilter { from_block: None, to_block: None, address: None, keys: None };
+    let res = provider.get_events(event_filter, None, chunk_size).await;
+
+    println!("{res:#?}");
+    Ok(())
+}

--- a/crates/sozo/src/ops/mod.rs
+++ b/crates/sozo/src/ops/mod.rs
@@ -1,4 +1,5 @@
 pub mod component;
+pub mod events;
 pub mod execute;
 pub mod migration;
 pub mod register;


### PR DESCRIPTION
Fixes: #475 
<details>
<summary>This is what help command looks like (click to expand)</summary>

```
Queries world events

Usage: sozo events [OPTIONS] --chunk-size <CHUNK_SIZE> [EVENTS]...

Arguments:
  [EVENTS]...  List of specific events to be filtered

Options:
  -f, --from-block <FROM_BLOCK>  Block number from where to look for events
  -t, --to-block <TO_BLOCK>      Block number until where to look for events
  -c, --chunk-size <CHUNK_SIZE>  Number of events to return per page
  -v, --verbose...               More output per occurrence
  -q, --quiet...                 Less output per occurrence
  -h, --help                     Print help (see more with '--help')
  -V, --version                  Print version

World options:
      --world <WORLD_ADDRESS>  The address of the World contract.

Starknet options:
      --rpc-url <URL>  The Starknet RPC endpoint.
```

</details>



To query events of specific types within a block range:
```
sozo events -c 1 --rpc-url http://localhost:5050  --from-block 1 --to-block 10 ComponentRegistered,PlayerJoined
```

currently for simplicity we only handle the case where events don't specify custom keys like [(which we don't atm)](https://github.com/dojoengine/dojo/blob/efb3cf6841b679fd94204ace10147a8e84c5fc8a/crates/dojo-core/src/world.cairo#L68C1-L108):
```rust
#[derive(starknet::Event)]
struct Approve {
   #[key]
   owner: ContractAddress,
   #[key]
   spender: ContractAddress,
   amount: u256
}
```
to know more about how events are filtered see: https://community.starknet.io/t/cairo-1-contract-syntax-is-evolving/94794?u=feedthefed#events-10

---

Currently `--chunk-size` and `--world` doesn't work properly due to RPC bug so i have opened a separate issue for it #592 (but i have checked that those values are being passed properly in `EventFilter` so it shouldn't block this PR)

Also I think we should set a default value for `chunk-size` and `rpc-url` so we don't need to pass it everytime. What should be a good default value for `chunk-size`? for `rpc-url` we can use default used by katana.