### PR TITLE
[Katana] Fix l1 messages output parsing and populate transaction_outputs

### DIFF
--- a/crates/katana/core/src/starknet/block.rs
+++ b/crates/katana/core/src/starknet/block.rs
@@ -60,6 +60,10 @@ impl StarknetBlock {
         self.inner.body.transactions.push(transaction);
     }
 
+    pub fn insert_transaction_output(&mut self, output: TransactionOutput) {
+        self.inner.body.transaction_outputs.push(output);
+    }
+
     pub fn transactions(&self) -> &[Transaction] {
         &self.inner.body.transactions
     }

--- a/crates/katana/core/src/starknet/mod.rs
+++ b/crates/katana/core/src/starknet/mod.rs
@@ -149,12 +149,14 @@ impl StarknetWrapper {
                     None,
                 );
 
-                //  append successful tx to pending block
-                self.blocks
+                let pending_block = self.blocks
                     .pending_block
                     .as_mut()
-                    .expect("no pending block")
-                    .insert_transaction(api_tx);
+                    .expect("no pending block");
+
+                // Append successful tx and it's output to pending block.
+                pending_block.insert_transaction(api_tx);
+                pending_block.insert_transaction_output(starknet_tx.output());
 
                 self.store_transaction(starknet_tx);
 

--- a/crates/katana/core/src/starknet/mod.rs
+++ b/crates/katana/core/src/starknet/mod.rs
@@ -149,10 +149,7 @@ impl StarknetWrapper {
                     None,
                 );
 
-                let pending_block = self.blocks
-                    .pending_block
-                    .as_mut()
-                    .expect("no pending block");
+                let pending_block = self.blocks.pending_block.as_mut().expect("no pending block");
 
                 // Append successful tx and it's output to pending block.
                 pending_block.insert_transaction(api_tx);

--- a/crates/katana/core/src/starknet/transaction.rs
+++ b/crates/katana/core/src/starknet/transaction.rs
@@ -143,7 +143,6 @@ impl StarknetTransaction {
         messages
     }
 
-
     pub(crate) fn output(&self) -> TransactionOutput {
         let actual_fee = self.actual_fee();
         let events = self.emitted_events();

--- a/crates/katana/core/src/starknet/transaction.rs
+++ b/crates/katana/core/src/starknet/transaction.rs
@@ -108,38 +108,43 @@ impl StarknetTransaction {
     pub fn l2_to_l1_messages(&self) -> Vec<MessageToL1> {
         let mut messages: Vec<MessageToL1> = vec![];
 
+        fn get_messages_recursively(info: &CallInfo) -> Vec<MessageToL1> {
+            let mut messages: Vec<MessageToL1> = vec![];
+
+            messages.extend(info.execution.l2_to_l1_messages.iter().map(|m| MessageToL1 {
+                to_address: m.message.to_address,
+                payload: m.message.payload.clone(),
+                from_address: info.call.caller_address,
+            }));
+
+            info.inner_calls.iter().for_each(|call| {
+                messages.extend(get_messages_recursively(call));
+            });
+
+            messages
+        }
+
         let Some(ref execution_info) = self.execution_info else {
             return messages;
         };
 
         if let Some(ref info) = execution_info.validate_call_info {
-            messages.extend(info.execution.l2_to_l1_messages.iter().map(|m| MessageToL1 {
-                to_address: m.message.to_address,
-                payload: m.message.payload.clone(),
-                from_address: info.call.caller_address,
-            }))
+            messages.extend(get_messages_recursively(info));
         }
 
         if let Some(ref info) = execution_info.execute_call_info {
-            messages.extend(info.execution.l2_to_l1_messages.iter().map(|m| MessageToL1 {
-                to_address: m.message.to_address,
-                payload: m.message.payload.clone(),
-                from_address: info.call.caller_address,
-            }))
+            messages.extend(get_messages_recursively(info));
         }
 
         if let Some(ref info) = execution_info.fee_transfer_call_info {
-            messages.extend(info.execution.l2_to_l1_messages.iter().map(|m| MessageToL1 {
-                to_address: m.message.to_address,
-                payload: m.message.payload.clone(),
-                from_address: info.call.caller_address,
-            }))
+            messages.extend(get_messages_recursively(info));
         }
 
         messages
     }
 
-    fn output(&self) -> TransactionOutput {
+
+    pub(crate) fn output(&self) -> TransactionOutput {
         let actual_fee = self.actual_fee();
         let events = self.emitted_events();
         let messages_sent = self.l2_to_l1_messages();


### PR DESCRIPTION
This PR has two modifications:

1. The `l2_to_l1_messages` were only parsed at the first level of `CallInfo`. But as events, messages can be nested into `inner_calls`.

I implemented the same recursion made for events.

2. A block has `transaction_outputs` field, which is handy to get all events of messages of the block without having to iterate on all transactions receipts.

Now after each successful transaction, it's output is added to the block transactions outputs.