### PR TITLE
fix(katana/rpc): `starknet_getEvents` filtering by address

### DIFF
--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -452,7 +452,7 @@ impl Sequencer for KatanaSequencer {
                         .filter(|event| {
                             // Check the address condition
                             let address_condition = match &address {
-                                Some(a) => a != event.from_address.0.key(),
+                                Some(a) => a == event.from_address.0.key(),
                                 None => true,
                             };
 


### PR DESCRIPTION
Fixes: #593 

To verify re-run the process linked in the issue and see now returned events are only from address `CONTRACT_ADDRESS`