### PR TITLE
Add `dojo-types` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,6 +2007,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "dojo-test-utils",
+ "dojo-types",
  "dojo-world",
  "starknet",
  "starknet-crypto",
@@ -2038,6 +2039,7 @@ dependencies = [
  "camino",
  "convert_case 0.6.0",
  "dojo-test-utils",
+ "dojo-types",
  "dojo-world",
  "env_logger 0.10.0",
  "itertools 0.10.5",
@@ -2115,6 +2117,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dojo-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "starknet",
+]
+
+[[package]]
 name = "dojo-world"
 version = "0.1.0"
 dependencies = [
@@ -2128,6 +2138,7 @@ dependencies = [
  "convert_case 0.6.0",
  "dojo-lang",
  "dojo-test-utils",
+ "dojo-types",
  "reqwest",
  "serde",
  "serde_json",
@@ -6633,6 +6644,7 @@ dependencies = [
  "chrono",
  "clap",
  "ctrlc",
+ "dojo-types",
  "dojo-world",
  "indexmap 1.9.3",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "crates/dojo-language-server",
   "crates/dojo-signers",
   "crates/dojo-test-utils",
+  "crates/dojo-types",
   "crates/dojo-world",
   "crates/katana",
   "crates/katana/core",

--- a/crates/dojo-client/Cargo.toml
+++ b/crates/dojo-client/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dojo-types = { path = "../dojo-types" }
 dojo-world = { path = "../dojo-world" }
 starknet-crypto.workspace = true
 starknet.workspace = true

--- a/crates/dojo-client/src/contract/component.rs
+++ b/crates/dojo-client/src/contract/component.rs
@@ -1,6 +1,6 @@
 use std::vec;
 
-use dojo_world::manifest::Member;
+use dojo_types::component::Member;
 use starknet::core::types::{BlockId, FieldElement, FunctionCall};
 use starknet::core::utils::{
     cairo_short_string_to_felt, get_selector_from_name, parse_cairo_short_string,

--- a/crates/dojo-client/src/contract/component_test.rs
+++ b/crates/dojo-client/src/contract/component_test.rs
@@ -1,6 +1,6 @@
 use camino::Utf8PathBuf;
 use dojo_test_utils::sequencer::TestSequencer;
-use dojo_world::manifest::Member;
+use dojo_types::component::Member;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, BlockTag, FieldElement};
 

--- a/crates/dojo-client/src/contract/system.rs
+++ b/crates/dojo-client/src/contract/system.rs
@@ -1,4 +1,4 @@
-use dojo_world::manifest::Dependency;
+use dojo_types::system::Dependency;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, FieldElement, FunctionCall, InvokeTransactionResult};
 use starknet::core::utils::{
@@ -175,8 +175,7 @@ impl<'a, P: Provider + Sync> SystemReader<'a, P> {
 
             dependencies.push(Dependency {
                 name: parse_cairo_short_string(&chunk[0])
-                    .map_err(SystemReaderError::ParseCairoShortStringError)?
-                    .into(),
+                    .map_err(SystemReaderError::ParseCairoShortStringError)?,
                 read: !is_write,
                 write: is_write,
             });

--- a/crates/dojo-client/src/contract/system_test.rs
+++ b/crates/dojo-client/src/contract/system_test.rs
@@ -1,6 +1,6 @@
 use camino::Utf8PathBuf;
 use dojo_test_utils::sequencer::TestSequencer;
-use dojo_world::manifest::Dependency;
+use dojo_types::system::Dependency;
 use starknet::accounts::Account;
 use starknet::core::types::{BlockId, BlockTag};
 use starknet_crypto::FieldElement;

--- a/crates/dojo-lang/Cargo.toml
+++ b/crates/dojo-lang/Cargo.toml
@@ -27,6 +27,7 @@ cairo-lang-syntax.workspace = true
 cairo-lang-starknet.workspace = true
 cairo-lang-utils.workspace = true
 convert_case.workspace = true
+dojo-types = { path = "../dojo-types" }
 dojo-world = { path = "../dojo-world" }
 itertools.workspace = true
 scarb.workspace = true

--- a/crates/dojo-lang/src/commands/find.rs
+++ b/crates/dojo-lang/src/commands/find.rs
@@ -3,7 +3,7 @@ use cairo_lang_semantic::patcher::RewriteNode;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
-use dojo_world::manifest::Dependency;
+use dojo_types::system::Dependency;
 use sanitizer::StringSanitizer;
 use smol_str::SmolStr;
 
@@ -91,7 +91,7 @@ impl CommandMacroTrait for FindCommand {
 
         command.component_deps = components
             .iter()
-            .map(|c| Dependency { name: c.clone(), read: true, write: false })
+            .map(|c| Dependency { name: c.to_string(), read: true, write: false })
             .collect();
 
         command.data.rewrite_nodes.push(RewriteNode::interpolate_patched(

--- a/crates/dojo-lang/src/commands/get.rs
+++ b/crates/dojo-lang/src/commands/get.rs
@@ -4,7 +4,7 @@ use cairo_lang_syntax::node::ast::Arg;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, TypedSyntaxNode};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
-use dojo_world::manifest::Dependency;
+use dojo_types::system::Dependency;
 use itertools::Itertools;
 use sanitizer::StringSanitizer;
 use smol_str::SmolStr;
@@ -64,7 +64,7 @@ impl CommandMacroTrait for GetCommand {
 
         command.component_deps = components
             .iter()
-            .map(|c| Dependency { name: c.clone(), read: true, write: false })
+            .map(|c| Dependency { name: c.to_string(), read: true, write: false })
             .collect();
 
         let part_names = components

--- a/crates/dojo-lang/src/commands/mod.rs
+++ b/crates/dojo-lang/src/commands/mod.rs
@@ -2,7 +2,7 @@ use cairo_lang_defs::plugin::PluginDiagnostic;
 use cairo_lang_semantic::patcher::RewriteNode;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, Terminal};
-use dojo_world::manifest::Dependency;
+use dojo_types::system::Dependency;
 
 use self::execute::ExecuteCommand;
 use self::find::FindCommand;

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -3,7 +3,7 @@ use cairo_lang_semantic::patcher::RewriteNode;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
-use dojo_world::manifest::Dependency;
+use dojo_types::system::Dependency;
 
 use super::{Command, CommandData, CommandMacroTrait};
 
@@ -26,7 +26,7 @@ impl SetCommand {
                 let component_name = segment.ident(db).text(db);
 
                 self.component_deps.push(Dependency {
-                    name: component_name.clone(),
+                    name: component_name.to_string(),
                     write: true,
                     read: false,
                 });

--- a/crates/dojo-lang/src/component.rs
+++ b/crates/dojo-lang/src/component.rs
@@ -8,7 +8,7 @@ use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use convert_case::{Case, Casing};
-use dojo_world::manifest::Member;
+use dojo_types::component::Member;
 
 use crate::plugin::{Component, DojoAuxData};
 

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -19,7 +19,8 @@ use cairo_lang_syntax::attribute::structured::{
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{ast, Terminal};
-use dojo_world::manifest::{Dependency, Member};
+use dojo_types::component::Member;
+use dojo_types::system::Dependency;
 use scarb::compiler::plugin::builtin::BuiltinSemanticCairoPlugin;
 use scarb::core::{PackageId, PackageName, SourceId};
 use semver::Version;

--- a/crates/dojo-lang/src/system.rs
+++ b/crates/dojo-lang/src/system.rs
@@ -10,8 +10,9 @@ use cairo_lang_syntax::node::ast::OptionReturnTypeClause::ReturnTypeClause;
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
-use dojo_world::manifest::Dependency;
+use dojo_types::system::Dependency;
 use itertools::Itertools;
+use smol_str::SmolStr;
 
 use crate::commands::Command;
 use crate::plugin::{DojoAuxData, SystemAuxData};
@@ -364,12 +365,12 @@ impl System {
     }
 
     fn update_deps(&mut self, deps: Vec<Dependency>) {
-        for dep in deps.iter() {
-            if let Some(existing) = self.dependencies.get(&dep.name) {
+        for dep in deps {
+            if let Some(existing) = self.dependencies.get(&SmolStr::from(dep.name.as_str())) {
                 self.dependencies
-                    .insert(dep.name.clone(), merge_deps(dep.clone(), existing.clone()));
+                    .insert(dep.name.clone().into(), merge_deps(dep.clone(), existing.clone()));
             } else {
-                self.dependencies.insert(dep.name.clone(), dep.clone());
+                self.dependencies.insert(dep.name.clone().into(), dep.clone());
             }
         }
     }

--- a/crates/dojo-types/Cargo.toml
+++ b/crates/dojo-types/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+edition = "2021"
+name = "dojo-types"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde.workspace = true
+starknet.workspace = true

--- a/crates/dojo-types/src/component.rs
+++ b/crates/dojo-types/src/component.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents a component member.
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Member {
+    /// Name of the member.
+    pub name: String,
+    /// Type of the member.
+    #[serde(rename = "type")]
+    pub ty: String,
+    pub slot: u64,
+    pub offset: u8,
+}

--- a/crates/dojo-types/src/event.rs
+++ b/crates/dojo-types/src/event.rs
@@ -1,0 +1,38 @@
+use starknet::core::types::FieldElement;
+
+/// The event emitted when a World is spawned.
+#[derive(Clone, Debug)]
+pub struct WorldSpawned {
+    pub address: FieldElement,
+    pub caller: FieldElement,
+}
+
+/// The event emitted when a system is registered to a World.
+#[derive(Clone, Debug)]
+pub struct SystemRegistered {
+    pub name: String,
+    pub class_hash: FieldElement,
+}
+
+/// The event emitted when a component is registered to a World.
+#[derive(Clone, Debug)]
+pub struct ComponentRegistered {
+    pub name: String,
+    pub class_hash: FieldElement,
+}
+
+/// The event emmitted when a component value of an entity is set.
+#[derive(Clone, Debug)]
+pub struct StoreSetRecord {
+    pub table_id: FieldElement,
+    pub keys: Vec<FieldElement>,
+    pub offset: u8,
+    pub value: Vec<FieldElement>,
+}
+
+/// The event emmitted when a component is deleted from an entity.
+#[derive(Clone, Debug)]
+pub struct StoreDelRecord {
+    pub table_id: FieldElement,
+    pub keys: Vec<FieldElement>,
+}

--- a/crates/dojo-types/src/lib.rs
+++ b/crates/dojo-types/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod component;
+pub mod event;
+pub mod storage;
+pub mod system;

--- a/crates/dojo-types/src/storage.rs
+++ b/crates/dojo-types/src/storage.rs
@@ -1,0 +1,8 @@
+use starknet::core::types::FieldElement;
+
+#[derive(Clone, Debug)]
+pub struct Query {
+    pub address_domain: u32,
+    pub partition: FieldElement,
+    pub keys: Vec<FieldElement>,
+}

--- a/crates/dojo-types/src/system.rs
+++ b/crates/dojo-types/src/system.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+/// Represents a system's component dependency.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Dependency {
+    /// Name of the component.
+    pub name: String,
+    pub read: bool,
+    pub write: bool,
+}

--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -14,6 +14,7 @@ cairo-lang-project.workspace = true
 cairo-lang-starknet.workspace = true
 camino.workspace = true
 convert_case.workspace = true
+dojo-types = { path = "../dojo-types" }
 reqwest = { version = "0.11.18", default-features = false, features = [
     "rustls-tls",
 ] }

--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 
 use ::serde::{Deserialize, Serialize};
 use anyhow::{anyhow, Result};
+use dojo_types::component::Member;
+use dojo_types::system::Dependency;
 use serde_with::serde_as;
 use smol_str::SmolStr;
 use starknet::core::serde::unsigned_field_element::UfeHex;
@@ -34,16 +36,6 @@ pub enum ManifestError<E> {
     Provider(ProviderError<E>),
 }
 
-/// Component member.
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
-pub struct Member {
-    pub name: String,
-    #[serde(rename = "type")]
-    pub ty: String,
-    pub slot: u64,
-    pub offset: u8,
-}
-
 /// Represents a declaration of a component.
 #[serde_as]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
@@ -67,13 +59,6 @@ pub struct Input {
 pub struct Output {
     #[serde(rename = "type")]
     pub ty: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Dependency {
-    pub name: SmolStr,
-    pub read: bool,
-    pub write: bool,
 }
 
 /// Represents a declaration of a system.

--- a/crates/torii/Cargo.toml
+++ b/crates/torii/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 camino.workspace = true
+dojo-types = { path = "../dojo-types" }
 dojo-world = { path = "../dojo-world" }
 async-trait.workspace = true
 anyhow.workspace = true

--- a/crates/torii/src/state/sql_test.rs
+++ b/crates/torii/src/state/sql_test.rs
@@ -1,5 +1,6 @@
 use camino::Utf8PathBuf;
-use dojo_world::manifest::{Component, Member, System};
+use dojo_types::component::Member;
+use dojo_world::manifest::{Component, System};
 use sqlx::sqlite::SqlitePool;
 use starknet::core::types::FieldElement;
 


### PR DESCRIPTION
Moves all related types that are used across Dojo to this crate. Also include types from the world contracts.

motivation:
- makes it easy to manage types that can be reused across many crates. 
- also for convenience, by having all types grouped together in a crate strictly for types only