### PR TITLE
Use dojo packable trait for pack / unpack

### DIFF
--- a/crates/dojo-core/src/lib.cairo
+++ b/crates/dojo-core/src/lib.cairo
@@ -1,6 +1,8 @@
 mod executor;
 mod interfaces;
 mod database;
+mod packable;
+use packable::Packable;
 mod world;
 mod world_factory;
 

--- a/crates/dojo-core/src/packable.cairo
+++ b/crates/dojo-core/src/packable.cairo
@@ -1,0 +1,179 @@
+use starknet::{ClassHash, ContractAddress};
+use array::ArrayTrait;
+
+trait Packable<T> {
+    fn pack(self: @T, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>);
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<T>);
+    fn size() -> usize;
+}
+
+// impl TPackable<T, impl TSerde: Serde<T>, impl TPackable: Packable<T>> of Packable<T> {
+//     fn pack(self: @T, ref packed: Array<felt252>) {
+//         TSerde::serialize(self, ref packed);
+//     }
+//     fn unpack(ref packed: Span<felt252>) -> Option<T> {
+//         TSerde::deserialize(ref packed)
+//     }
+//     fn size() -> usize {
+//         TPackable::size()
+//     }
+// }
+
+impl PackableFelt252 of Packable<felt252> {
+    #[inline(always)]
+    fn pack(self: @felt252, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<felt252>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        252
+    }
+}
+
+impl PackableBool of Packable<bool> {
+    #[inline(always)]
+    fn pack(self: @bool, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<bool>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        1
+    }
+}
+
+impl PackableU8 of Packable<u8> {
+    #[inline(always)]
+    fn pack(self: @u8, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u8>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        8
+    }
+}
+
+impl PackableU16 of Packable<u16> {
+    #[inline(always)]
+    fn pack(self: @u16, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u16>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        16
+    }
+}
+
+impl PackableU32 of Packable<u32> {
+    #[inline(always)]
+    fn pack(self: @u32, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u32>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        32
+    }
+}
+
+impl PackableU64 of Packable<u64> {
+    #[inline(always)]
+    fn pack(self: @u64, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u64>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        64
+    }
+}
+
+impl PackableU128 of Packable<u128> {
+    #[inline(always)]
+    fn pack(self: @u128, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u128>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        128
+    }
+}
+
+impl PackableContractAddress of Packable<ContractAddress> {
+    #[inline(always)]
+    fn pack(self: @ContractAddress, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<ContractAddress>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        252
+    }
+}
+
+impl PackableClassHash of Packable<ClassHash> {
+    #[inline(always)]
+    fn pack(self: @ClassHash, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<ClassHash>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        252
+    }
+}
+
+/// Pack the proposal fields into a single felt252.
+fn pack(self: @felt252, size: u8, ref packing: felt252, mut packing_offset: u8, ref packed: Array<felt252>) -> u8 {
+    let remaining_bits = 252 - packing_offset;
+
+    if remaining_bits < size {
+        let first_part = self & ((1 << remaining_bits) - 1);
+        let second_part = self >> remaining_bits;
+
+        // Pack the first part into the current felt
+        packing = packing | (first_part << packing_offset);
+        packed.append(packing);
+
+        // Start a new felt and pack the second part into it
+        packing = second_part;
+        packing_offset = size - remaining_bits;
+    } else {
+        // Pack the data into the current felt
+        packing = packing | (self << packing_offset);
+        packing_offset = packing_offset + size;
+    }
+
+    packing_offset
+}

--- a/crates/dojo-lang/src/commands/find.rs
+++ b/crates/dojo-lang/src/commands/find.rs
@@ -126,7 +126,7 @@ impl CommandMacroTrait for FindCommand {
                                     match raw_entities.pop_front() {
                                         Option::Some(raw) => {
                                             let mut raw = *raw;
-                                            let e = serde::Serde::<$component$>::deserialize(ref \
+                                            let e = dojo::Packable::<$component$>::unpack(ref \
                          raw).expect('$deser_err_msg$');
                                             entities.append(e);
                                         },

--- a/crates/dojo-lang/src/commands/get.rs
+++ b/crates/dojo-lang/src/commands/get.rs
@@ -113,7 +113,7 @@ impl GetCommand {
                     let mut __$query_id$_$query_subtype$_raw = $world$.entity('$component$', \
                  $query$, 0_u8, 0_usize);
                     assert(__$query_id$_$query_subtype$_raw.len() > 0_usize, '$lookup_err_msg$');
-                    let __$query_id$_$query_subtype$ = serde::Serde::<$component$>::deserialize(
+                    let __$query_id$_$query_subtype$ = dojo::Packable::<$component$>::unpack(
                         ref __$query_id$_$query_subtype$_raw
                     ).expect('$deser_err_msg$');
                     ",
@@ -156,7 +156,7 @@ impl GetCommand {
         part_names: Vec<String>,
     ) {
         for component in components.iter() {
-            let mut deser_err_msg = format!("{} failed to deserialize", component.to_string());
+            let mut deser_err_msg = format!("{} failed to unpack", component.to_string());
             deser_err_msg.truncate(CAIRO_ERR_MSG_LEN);
 
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
@@ -169,7 +169,7 @@ impl GetCommand {
                             Option::None(())
                         },
                         bool::True(()) => {
-                            Option::Some(serde::Serde::<$component$>::deserialize(
+                            Option::Some(dojo::Packable::<$component$>::unpack(
                                 ref __$query_id$_$query_subtype$_raw
                             ).expect('$deser_err_msg$'))
                         }

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -34,7 +34,7 @@ impl SetCommand {
                     "
                     {
                         let mut calldata = array::ArrayTrait::new();
-                        serde::Serde::serialize(@$ctor$, ref calldata);
+                        dojo::Packable::pack(@$ctor$, ref calldata);
                         $world$.set_entity('$component$', $query$, 0_u8, \
                      array::ArrayTrait::span(@calldata));
                     }

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -302,7 +302,7 @@ mod spawn {
     fn execute(self: @ContractState, ctx: Context, name: felt252) {
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx
                 .world
                 .set_entity(
@@ -315,7 +315,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx
                 .world
                 .set_entity(
@@ -328,25 +328,25 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx.world.set_entity('Player', 420.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx.world.set_entity('Position', 420.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx.world.set_entity('Player', 120.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx.world.set_entity('Position', 120.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
@@ -354,7 +354,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx
                 .world
                 .set_entity('Player', player_id.into(), 0_u8, array::ArrayTrait::span(@calldata));
@@ -362,7 +362,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx
                 .world
                 .set_entity('Position', player_id.into(), 0_u8, array::ArrayTrait::span(@calldata));
@@ -370,7 +370,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx
                 .world
                 .set_entity('Player', (0, 0, 0, 0, 0), 0_u8, array::ArrayTrait::span(@calldata));
@@ -378,7 +378,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx
                 .world
                 .set_entity('Position', (0, 0, 0, 0, 0), 0_u8, array::ArrayTrait::span(@calldata));
@@ -386,13 +386,13 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx.world.set_entity('Player', 1337.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx.world.set_entity('Position', 1337.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
         return ();
@@ -472,7 +472,7 @@ mod move {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
                             let mut raw = *raw;
-                            let e = serde::Serde::<Position>::deserialize(ref raw)
+                            let e = dojo::Packable::<Position>::unpack(ref raw)
                                 .expect('Position failed to deserialize');
                             entities.append(e);
                         },
@@ -496,7 +496,7 @@ mod move {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
                             let mut raw = *raw;
-                            let e = serde::Serde::<Player>::deserialize(ref raw)
+                            let e = dojo::Packable::<Player>::unpack(ref raw)
                                 .expect('Player failed to deserialize');
                             entities.append(e);
                         },
@@ -535,7 +535,7 @@ mod move {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
                             let mut raw = *raw;
-                            let e = serde::Serde::<Player>::deserialize(ref raw)
+                            let e = dojo::Packable::<Player>::unpack(ref raw)
                                 .expect('Player failed to deserialize');
                             entities.append(e);
                         },
@@ -555,7 +555,7 @@ mod move {
 
         let mut __player_player_raw = ctx.world.entity('Player', player_id.into(), 0_u8, 0_usize);
         assert(__player_player_raw.len() > 0_usize, 'Player not found');
-        let __player_player = serde::Serde::<Player>::deserialize(ref __player_player_raw)
+        let __player_player = dojo::Packable::<Player>::unpack(ref __player_player_raw)
             .expect('Player failed to deserialize');
         let player = __player_player;
 
@@ -563,7 +563,7 @@ mod move {
             .world
             .entity('Position', player_id.into(), 0_u8, 0_usize);
         assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-        let __player_position_position = serde::Serde::<Position>::deserialize(
+        let __player_position_position = dojo::Packable::<Position>::unpack(
             ref __player_position_position_raw
         )
             .expect('Position failed to deserialize');
@@ -572,7 +572,7 @@ mod move {
             .world
             .entity('Player', player_id.into(), 0_u8, 0_usize);
         assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-        let __player_position_player = serde::Serde::<Player>::deserialize(
+        let __player_position_player = dojo::Packable::<Player>::unpack(
             ref __player_position_player_raw
         )
             .expect('Player failed to deserialize');
@@ -586,7 +586,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -595,7 +595,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');
@@ -629,7 +629,7 @@ mod move {
                             match raw_entities.pop_front() {
                                 Option::Some(raw) => {
                                     let mut raw = *raw;
-                                    let e = serde::Serde::<Position>::deserialize(ref raw)
+                                    let e = dojo::Packable::<Position>::unpack(ref raw)
                                         .expect('Position failed to deserialize');
                                     entities.append(e);
                                 },
@@ -653,7 +653,7 @@ mod move {
                             match raw_entities.pop_front() {
                                 Option::Some(raw) => {
                                     let mut raw = *raw;
-                                    let e = serde::Serde::<Player>::deserialize(ref raw)
+                                    let e = dojo::Packable::<Player>::unpack(ref raw)
                                         .expect('Player failed to deserialize');
                                     entities.append(e);
                                 },
@@ -681,8 +681,8 @@ mod move {
                 },
                 bool::True(()) => {
                     Option::Some(
-                        serde::Serde::<Player>::deserialize(ref __maybe_player_player_raw)
-                            .expect('Player failed to deserialize')
+                        dojo::Packable::<Player>::unpack(ref __maybe_player_player_raw)
+                            .expect('Player failed to unpack')
                     )
                 }
             };
@@ -703,8 +703,8 @@ mod move {
                 },
                 bool::True(()) => {
                     Option::Some(
-                        serde::Serde::<Position>::deserialize(ref __positions_query_position_raw)
-                            .expect('Position failed to deserialize')
+                        dojo::Packable::<Position>::unpack(ref __positions_query_position_raw)
+                            .expect('Position failed to unpack')
                     )
                 }
             };
@@ -718,8 +718,8 @@ mod move {
                 },
                 bool::True(()) => {
                     Option::Some(
-                        serde::Serde::<Player>::deserialize(ref __positions_query_player_raw)
-                            .expect('Player failed to deserialize')
+                        dojo::Packable::<Player>::unpack(ref __positions_query_player_raw)
+                            .expect('Player failed to unpack')
                     )
                 }
             };
@@ -740,7 +740,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -749,7 +749,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');
@@ -760,7 +760,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -769,7 +769,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');
@@ -784,7 +784,7 @@ mod move {
                     .world
                     .entity('Position', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-                let __player_position_position = serde::Serde::<Position>::deserialize(
+                let __player_position_position = dojo::Packable::<Position>::unpack(
                     ref __player_position_position_raw
                 )
                     .expect('Position failed to deserialize');
@@ -793,7 +793,7 @@ mod move {
                     .world
                     .entity('Player', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-                let __player_position_player = serde::Serde::<Player>::deserialize(
+                let __player_position_player = dojo::Packable::<Player>::unpack(
                     ref __player_position_player_raw
                 )
                     .expect('Player failed to deserialize');
@@ -828,7 +828,7 @@ mod move {
                                 match raw_entities.pop_front() {
                                     Option::Some(raw) => {
                                         let mut raw = *raw;
-                                        let e = serde::Serde::<Position>::deserialize(ref raw)
+                                        let e = dojo::Packable::<Position>::unpack(ref raw)
                                             .expect('Position failed to deserialize');
                                         entities.append(e);
                                     },
@@ -852,7 +852,7 @@ mod move {
                                 match raw_entities.pop_front() {
                                     Option::Some(raw) => {
                                         let mut raw = *raw;
-                                        let e = serde::Serde::<Player>::deserialize(ref raw)
+                                        let e = dojo::Packable::<Player>::unpack(ref raw)
                                             .expect('Player failed to deserialize');
                                         entities.append(e);
                                     },
@@ -876,7 +876,7 @@ mod move {
                     .world
                     .entity('Position', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-                let __player_position_position = serde::Serde::<Position>::deserialize(
+                let __player_position_position = dojo::Packable::<Position>::unpack(
                     ref __player_position_position_raw
                 )
                     .expect('Position failed to deserialize');
@@ -885,7 +885,7 @@ mod move {
                     .world
                     .entity('Player', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-                let __player_position_player = serde::Serde::<Player>::deserialize(
+                let __player_position_player = dojo::Packable::<Player>::unpack(
                     ref __player_position_player_raw
                 )
                     .expect('Player failed to deserialize');
@@ -912,7 +912,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -921,7 +921,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');


### PR DESCRIPTION
Introduces a `Packable` trait to support struct packing for world state.

```
trait Packable<T> {
    fn pack(self: @T, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>);
    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<felt252>);
    fn size() -> usize;
}
```

Dojo core implements the native types which can then be used to derive packed representations for high user defined structs.

The interface is designed to minimize allocations, it provides a `packing` struct which represents a partially packed / unpacked felt, once it has been consumed, the packed / unpacked type is appended to the output.

Opening here to show the general idea but impl still needs more work