### PR TITLE
fix(katana): range iterating on blocks for events

### DIFF
--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -423,7 +423,7 @@ impl Sequencer for KatanaSequencer {
             .ok_or(SequencerError::BlockNotFound(to_block))?;
 
         let mut events = Vec::new();
-        for i in from_block.0..to_block.0 {
+        for i in from_block.0..to_block.0 + 1 {
             let block = self
                 .starknet
                 .read()

--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -423,7 +423,7 @@ impl Sequencer for KatanaSequencer {
             .ok_or(SequencerError::BlockNotFound(to_block))?;
 
         let mut events = Vec::new();
-        for i in from_block.0..to_block.0 + 1 {
+        for i in from_block.0..=to_block.0 {
             let block = self
                 .starknet
                 .read()


### PR DESCRIPTION
Little fix to ensure that events from the latest block are actually retrieved.