### PR TITLE
refactor(katana-rpc): rename api server traits

### DIFF
--- a/crates/katana/rpc/src/katana.rs
+++ b/crates/katana/rpc/src/katana.rs
@@ -6,18 +6,18 @@ use katana_core::sequencer::Sequencer;
 
 use crate::api::katana::{KatanaApiError, KatanaApiServer};
 
-pub struct KatanaRpc<S> {
+pub struct KatanaApi<S> {
     sequencer: Arc<S>,
 }
 
-impl<S: Sequencer + Send + Sync + 'static> KatanaRpc<S> {
+impl<S: Sequencer + Send + Sync + 'static> KatanaApi<S> {
     pub fn new(sequencer: Arc<S>) -> Self {
         Self { sequencer }
     }
 }
 
 #[async_trait]
-impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaRpc<S> {
+impl<S: Sequencer + Send + Sync + 'static> KatanaApiServer for KatanaApi<S> {
     async fn generate_block(&self) -> Result<(), Error> {
         let mut starknet = self.sequencer.mut_starknet().await;
         starknet.generate_latest_block();

--- a/crates/katana/rpc/src/lib.rs
+++ b/crates/katana/rpc/src/lib.rs
@@ -16,8 +16,8 @@ use tower_http::cors::{Any, CorsLayer};
 
 use crate::api::katana::KatanaApiServer;
 use crate::api::starknet::StarknetApiServer;
-use crate::katana::KatanaRpc;
-use crate::starknet::StarknetRpc;
+use crate::katana::KatanaApi;
+use crate::starknet::StarknetApi;
 
 #[derive(Debug, Clone)]
 pub struct KatanaNodeRpc<S> {
@@ -34,8 +34,8 @@ where
     }
 
     pub async fn run(self) -> Result<(SocketAddr, ServerHandle)> {
-        let mut methods = KatanaRpc::new(self.sequencer.clone()).into_rpc();
-        methods.merge(StarknetRpc::new(self.sequencer.clone()).into_rpc())?;
+        let mut methods = KatanaApi::new(self.sequencer.clone()).into_rpc();
+        methods.merge(StarknetApi::new(self.sequencer.clone()).into_rpc())?;
 
         let cors = CorsLayer::new()
             // Allow `POST` when accessing the resource

--- a/crates/katana/rpc/src/starknet.rs
+++ b/crates/katana/rpc/src/starknet.rs
@@ -46,17 +46,17 @@ use crate::utils::contract::{
     legacy_inner_to_rpc_class, legacy_rpc_to_inner_class, rpc_to_inner_class,
 };
 
-pub struct StarknetRpc<S> {
+pub struct StarknetApi<S> {
     sequencer: Arc<S>,
 }
 
-impl<S: Sequencer + Send + Sync + 'static> StarknetRpc<S> {
+impl<S: Sequencer + Send + Sync + 'static> StarknetApi<S> {
     pub fn new(sequencer: Arc<S>) -> Self {
         Self { sequencer }
     }
 }
 #[async_trait]
-impl<S: Sequencer + Send + Sync + 'static> StarknetApiServer for StarknetRpc<S> {
+impl<S: Sequencer + Send + Sync + 'static> StarknetApiServer for StarknetApi<S> {
     async fn chain_id(&self) -> Result<String, Error> {
         Ok(self.sequencer.chain_id().await.as_hex())
     }


### PR DESCRIPTION
**Stack**:
- #604
- #603
- #602
- #601 ⬅
- #600
- #599


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*