### PR TITLE
Use dojo packable trait for pack / unpack

### DIFF
--- a/crates/dojo-core/tests/src/lib.cairo
+++ b/crates/dojo-core/tests/src/lib.cairo
@@ -1,8 +1,11 @@
+// #[cfg(test)]
+// mod executor;
+// #[cfg(test)]
+// mod database;
+// #[cfg(test)]
+// mod world;
+// #[cfg(test)]
+// mod world_factory;
+
 #[cfg(test)]
-mod executor;
-#[cfg(test)]
-mod database;
-#[cfg(test)]
-mod world;
-#[cfg(test)]
-mod world_factory;
+mod packable;

--- a/crates/dojo-core/tests/src/packable.cairo
+++ b/crates/dojo-core/tests/src/packable.cairo
@@ -1,0 +1,20 @@
+use array::{ArrayTrait, SpanTrait};
+use dojo::packable::{Packable, PackableU8, PackableU32};
+use option::OptionTrait;
+use debug::PrintTrait;
+
+#[test]
+#[available_gas(2000000)]
+fn test_basic_package() {
+    let mut packed = array::ArrayTrait::new();
+    let mut packing: felt252 = 0;
+    let mut offset = 0;
+    18_u8.pack(ref packing, ref offset, ref packed);
+    let mut unpacking: felt252 = 0;
+    let mut un_offset = 0;
+    let mut packed_span = packed.span();
+
+    let result = Packable::<u8>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap();
+    result.print();
+    assert(result == 18_u8, 'Expect equal');
+}

--- a/crates/dojo-lang/src/commands/get.rs
+++ b/crates/dojo-lang/src/commands/get.rs
@@ -111,12 +111,19 @@ impl GetCommand {
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
                 "
                     let mut __$query_id$_$query_subtype$_raw = $world$.entity('$component$', \
-                 $query$, 0_u8, 0_usize);
+                        $query$, 0_u8, 0_usize);
+
                     assert(__$query_id$_$query_subtype$_raw.len() > 0_usize, '$lookup_err_msg$');
+
+                    let mut unpacking: felt252 = 0;
+                    let mut offset = 0;
+
                     let __$query_id$_$query_subtype$ = dojo::Packable::<$component$>::unpack(
-                        ref __$query_id$_$query_subtype$_raw
+                        ref __$query_id$_$query_subtype$_raw,
+                        ref unpacking,
+                        ref offset
                     ).expect('$deser_err_msg$');
-                    ",
+                ",
                 UnorderedHashMap::from([
                     ("world".to_string(), RewriteNode::new_trimmed(world.as_syntax_node())),
                     ("component".to_string(), RewriteNode::Text(component.to_string())),

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -35,7 +35,8 @@ impl SetCommand {
                     {
                         let mut calldata = array::ArrayTrait::new();
                         let mut packing: felt252 = 0;
-                        dojo::Packable::pack(@$ctor$, ref packing, 0, ref calldata);
+                        let mut offset = 0;
+                        dojo::Packable::pack(@$ctor$, ref packing, ref offset, ref calldata);
                         $world$.set_entity('$component$', $query$, 0_u8, \
                             array::ArrayTrait::span(@calldata));
                     }

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -34,9 +34,10 @@ impl SetCommand {
                     "
                     {
                         let mut calldata = array::ArrayTrait::new();
-                        dojo::Packable::pack(@$ctor$, ref calldata);
+                        let mut packing: felt252 = 0;
+                        dojo::Packable::pack(@$ctor$, ref packing, 0, ref calldata);
                         $world$.set_entity('$component$', $query$, 0_u8, \
-                     array::ArrayTrait::span(@calldata));
+                            array::ArrayTrait::span(@calldata));
                     }
                     ",
                     UnorderedHashMap::from([

--- a/examples/ecs/src/components.cairo
+++ b/examples/ecs/src/components.cairo
@@ -1,4 +1,6 @@
-use array::ArrayTrait;
+use array::{ArrayTrait, SpanTrait};
+use dojo::packable::{Packable, PackableU8, PackableU32};
+use option::OptionTrait;
 
 #[derive(Component, Copy, Drop, Serde)]
 struct Moves {
@@ -26,6 +28,40 @@ impl PositionImpl of PositionTrait {
 
     fn is_equal(self: Position, b: Position) -> bool {
         self.x == b.x && self.y == b.y
+    }
+}
+
+impl PackableMoves of Packable<Moves> {
+    #[inline(always)]
+    fn pack(self: @Moves, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+        self.remaining.pack(ref packing, ref packing_offset, ref packed)
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<Moves> {
+        Option::Some(Moves { remaining: Packable::<u8>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap()})
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        Packable::<u8>::size()
+    }
+}
+
+impl PackablePosition of Packable<Position> {
+    #[inline(always)]
+    fn pack(self: @Position, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+        self.x.pack(ref packing, ref packing_offset, ref packed);
+        self.y.pack(ref packing, ref packing_offset, ref packed)
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<Position> {
+        Option::Some(Position { 
+            x: Packable::<u32>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap(),
+            y: Packable::<u32>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap()
+        })
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        Packable::<u32>::size() + Packable::<u32>::size()
     }
 }
 


### PR DESCRIPTION
Introduces a Packable trait to support struct packing for world state.

```cairo
trait Packable<T> {
    fn pack(self: @T, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>);
    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<felt252>);
    fn size() -> usize;
}
```
Dojo core implements the native types which can then be used to derive packed representations for high user defined structs.

The interface is designed to minimize allocations, it provides a packing struct which represents a partially packed / unpacked felt, once it has been consumed, the packed / unpacked type is appended to the output.

Opening here to show the general idea but impl still needs more work.