### PR TITLE
fix(sozo-migrate): poll transaction status before progressing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,6 +2120,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_fs",
+ "assert_matches",
  "async-trait",
  "cairo-lang-filesystem",
  "cairo-lang-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "dojo-lang",
  "dojo-test-utils",
  "dojo-types",
+ "futures",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/dojo-client/src/contract/component_test.rs
+++ b/crates/dojo-client/src/contract/component_test.rs
@@ -1,5 +1,5 @@
 use camino::Utf8PathBuf;
-use dojo_test_utils::sequencer::TestSequencer;
+use dojo_test_utils::sequencer::{SequencerConfig, TestSequencer};
 use dojo_types::component::Member;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, BlockTag, FieldElement};
@@ -9,7 +9,7 @@ use crate::contract::world::WorldContractReader;
 
 #[tokio::test]
 async fn test_component() {
-    let sequencer = TestSequencer::start().await;
+    let sequencer = TestSequencer::start(SequencerConfig::default()).await;
     let account = sequencer.account();
     let provider = account.provider();
     let (world_address, _) = deploy_world(

--- a/crates/dojo-client/src/contract/system_test.rs
+++ b/crates/dojo-client/src/contract/system_test.rs
@@ -1,5 +1,5 @@
 use camino::Utf8PathBuf;
-use dojo_test_utils::sequencer::TestSequencer;
+use dojo_test_utils::sequencer::{SequencerConfig, TestSequencer};
 use dojo_types::system::Dependency;
 use starknet::accounts::Account;
 use starknet::core::types::{BlockId, BlockTag};
@@ -10,7 +10,7 @@ use crate::contract::world::WorldContract;
 
 #[tokio::test]
 async fn test_system() {
-    let sequencer = TestSequencer::start().await;
+    let sequencer = TestSequencer::start(SequencerConfig::default()).await;
     let account = sequencer.account();
     let (world_address, _) = deploy_world(
         &sequencer,

--- a/crates/dojo-client/src/contract/world_test.rs
+++ b/crates/dojo-client/src/contract/world_test.rs
@@ -1,5 +1,5 @@
 use camino::Utf8PathBuf;
-use dojo_test_utils::sequencer::TestSequencer;
+use dojo_test_utils::sequencer::{SequencerConfig, TestSequencer};
 use dojo_world::manifest::Manifest;
 use dojo_world::migration::strategy::prepare_for_migration;
 use dojo_world::migration::world::WorldDiff;
@@ -11,7 +11,7 @@ use super::{WorldContract, WorldContractReader};
 
 #[tokio::test]
 async fn test_world_contract_reader() {
-    let sequencer = TestSequencer::start().await;
+    let sequencer = TestSequencer::start(SequencerConfig::default()).await;
     let account = sequencer.account();
     let provider = account.provider();
     let (world_address, executor_address) = deploy_world(

--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use jsonrpsee::core::Error;
-use katana_core::sequencer::{KatanaSequencer, SequencerConfig};
+use katana_core::sequencer::KatanaSequencer;
 use katana_core::starknet::config::{Environment, StarknetConfig};
 use katana_rpc::config::ServerConfig;
 use katana_rpc::{spawn, KatanaApi, NodeHandle, StarknetApi};
@@ -12,6 +12,8 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet::signers::{LocalWallet, SigningKey};
 use url::Url;
+
+pub use katana_core::sequencer::SequencerConfig;
 
 pub struct TestAccount {
     pub private_key: FieldElement,
@@ -27,9 +29,9 @@ pub struct TestSequencer {
 }
 
 impl TestSequencer {
-    pub async fn start() -> Self {
+    pub async fn start(config: SequencerConfig) -> Self {
         let sequencer = Arc::new(KatanaSequencer::new(
-            SequencerConfig::default(),
+            config,
             StarknetConfig {
                 allow_zero_max_fee: true,
                 env: Environment { chain_id: "SN_GOERLI".into(), ..Default::default() },

--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use jsonrpsee::core::Error;
 use katana_core::sequencer::KatanaSequencer;
+pub use katana_core::sequencer::SequencerConfig;
 use katana_core::starknet::config::{Environment, StarknetConfig};
 use katana_rpc::config::ServerConfig;
 use katana_rpc::{spawn, KatanaApi, NodeHandle, StarknetApi};
@@ -12,8 +13,6 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet::signers::{LocalWallet, SigningKey};
 use url::Url;
-
-pub use katana_core::sequencer::SequencerConfig;
 
 pub struct TestAccount {
     pub private_key: FieldElement,

--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -31,6 +31,8 @@ url = "2.2.2"
 
 [dev-dependencies]
 assert_fs = "1.0.9"
+assert_matches = "1.5.0"
 dojo-test-utils = { path = "../dojo-test-utils" }
 dojo-lang = { path = "../dojo-lang" }
 tokio = { version = "1.28.0", features = ["full"] }
+

--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -15,6 +15,7 @@ cairo-lang-starknet.workspace = true
 camino.workspace = true
 convert_case.workspace = true
 dojo-types = { path = "../dojo-types" }
+futures = "0.3.28"
 reqwest = { version = "0.11.18", default-features = false, features = [
     "rustls-tls",
 ] }
@@ -25,6 +26,7 @@ smol_str.workspace = true
 starknet.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+tokio.workspace = true
 url = "2.2.2"
 
 [dev-dependencies]

--- a/crates/dojo-world/src/lib.rs
+++ b/crates/dojo-world/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod manifest;
 pub mod migration;
+pub mod utils;

--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -6,7 +6,8 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::ContractClass;
-use starknet::accounts::{AccountError, Call, ConnectedAccount};
+use starknet::accounts::Account;
+use starknet::accounts::{AccountError, Call, ConnectedAccount, SingleOwnerAccount};
 use starknet::core::types::contract::{CompiledClass, SierraClass};
 use starknet::core::types::{
     BlockId, BlockTag, DeclareTransactionResult, FieldElement, FlattenedSierraClass,
@@ -16,6 +17,7 @@ use starknet::core::utils::{
     get_contract_address, get_selector_from_name, CairoShortStringToFeltError,
 };
 use starknet::providers::{Provider, ProviderError};
+use starknet::signers::Signer;
 use thiserror::Error;
 
 use crate::utils::{TransactionWaiter, TransactionWaitingError};
@@ -75,12 +77,16 @@ pub trait StateDiff {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Declarable {
-    async fn declare<A>(
+    async fn declare<P, S>(
         &self,
-        account: &A,
-    ) -> Result<DeclareOutput, MigrationError<A::SignError, <A::Provider as Provider>::Error>>
+        account: &SingleOwnerAccount<P, S>,
+    ) -> Result<
+        DeclareOutput,
+        MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError, <P as Provider>::Error>,
+    >
     where
-        A: ConnectedAccount + Sync,
+        P: Provider + Sync + Send,
+        S: Signer + Sync + Send,
     {
         let (flattened_class, casm_class_hash) =
             prepare_contract_declaration_params(self.artifact_path()).unwrap();
@@ -102,11 +108,7 @@ pub trait Declarable {
             .await
             .map_err(MigrationError::Migrator)?;
 
-        let receipt = TransactionWaiter::new(transaction_hash, account.provider())
-            .await
-            .map_err(MigrationError::WaitingError)?;
-
-        println!("receipt for {transaction_hash:#x} : {:?}", receipt);
+        let _ = TransactionWaiter::new(transaction_hash, account.provider()).await.unwrap();
 
         return Ok(DeclareOutput { transaction_hash, class_hash });
     }
@@ -118,14 +120,18 @@ pub trait Declarable {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Deployable: Declarable + Sync {
-    async fn deploy<A>(
+    async fn deploy<P, S>(
         &mut self,
         class_hash: FieldElement,
         constructor_calldata: Vec<FieldElement>,
-        account: &A,
-    ) -> Result<DeployOutput, MigrationError<A::SignError, <A::Provider as Provider>::Error>>
+        account: &SingleOwnerAccount<P, S>,
+    ) -> Result<
+        DeployOutput,
+        MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError, <P as Provider>::Error>,
+    >
     where
-        A: ConnectedAccount + Sync,
+        P: Provider + Sync + Send,
+        S: Signer + Sync + Send,
     {
         let declare = match self.declare(account).await {
             Ok(res) => Some(res),
@@ -179,11 +185,9 @@ pub trait Deployable: Declarable + Sync {
             .await
             .map_err(MigrationError::Migrator)?;
 
-        let receipt = TransactionWaiter::new(transaction_hash, account.provider())
+        let _ = TransactionWaiter::new(transaction_hash, account.provider())
             .await
             .map_err(MigrationError::WaitingError)?;
-
-        println!("receipt for {transaction_hash:#x} : {:?}", receipt);
 
         Ok(DeployOutput { transaction_hash, contract_address, declare })
     }

--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -6,8 +6,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::ContractClass;
-use starknet::accounts::Account;
-use starknet::accounts::{AccountError, Call, ConnectedAccount, SingleOwnerAccount};
+use starknet::accounts::{Account, AccountError, Call, ConnectedAccount, SingleOwnerAccount};
 use starknet::core::types::contract::{CompiledClass, SierraClass};
 use starknet::core::types::{
     BlockId, BlockTag, DeclareTransactionResult, FieldElement, FlattenedSierraClass,

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -1,0 +1,186 @@
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::thread;
+use std::time::Duration;
+
+use futures::FutureExt;
+use starknet::core::types::{
+    FieldElement, MaybePendingTransactionReceipt, TransactionReceipt, TransactionStatus,
+};
+use starknet::providers::{Provider, ProviderError};
+use tokio::time::{Instant, Interval};
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransactionWaitingError<E> {
+    #[error("request timed out")]
+    Timeout,
+    #[error("transaction was rejected")]
+    TransactionRejected,
+    #[error(transparent)]
+    Provider(ProviderError<E>),
+}
+
+/// A type that waits for a transaction to achieve `status` status. The transaction will be polled
+/// for every `interval` miliseconds. If the transaction does not achieved `status` status within
+/// `timeout` miliseconds, an error will be returned. An error is also returned if the transaction
+/// is rejected ( i.e., the transaction returns a `REJECTED` status ).
+///
+///
+/// # Arguments
+///
+/// * `tx_hash` - The hash of the transaction to wait for.
+/// * `status` - The status to wait for. Defaults to `TransactionStatus::AcceptedOnL2`.
+/// * `interval` - Poll the transaction every `interval` miliseconds. Miliseconds are used so that
+///   we can be more precise with the polling interval. Defaults to 1 second.
+/// * `timeout` - The maximum amount of time to wait for the transaction to achieve `status` status.
+///   Defaults to 60 seconds.
+/// * `provider` - The provider to use for polling the transaction.
+///
+///
+///  # Examples
+///
+/// ```
+/// let provider = JsonRpcClient::new(HttpTransport::new("http://localhost:5000").unwrap());
+/// let tx_hash = FieldElement::from_hex_str("0x1234").unwrap();
+/// TransactionWaiter::new(tx_hash, provider).await;
+/// ```
+pub struct TransactionWaiter<'a, P>
+where
+    P: Provider,
+{
+    tx_hash: FieldElement,
+    status: TransactionStatus,
+    interval: Interval,
+    timeout: Duration,
+    provider: &'a P,
+    /// The future that polls for the transaction receipt.
+    future: Option<
+        Pin<
+            Box<
+                dyn Future<Output = Result<bool, TransactionWaitingError<<P as Provider>::Error>>>
+                    + 'a,
+            >,
+        >,
+    >,
+    phantom: PhantomData<&'a P>,
+}
+
+impl<'a, P> TransactionWaiter<'a, P>
+where
+    P: Provider + 'a,
+{
+    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+    const DEFAULT_INTERVAL: Duration = Duration::from_millis(100);
+    const DEFAULT_STATUS: TransactionStatus = TransactionStatus::AcceptedOnL2;
+
+    pub fn new(tx: FieldElement, provider: &'a P) -> Self {
+        Self {
+            provider,
+            tx_hash: tx,
+            future: None,
+            status: Self::DEFAULT_STATUS,
+            timeout: Self::DEFAULT_TIMEOUT,
+            interval: tokio::time::interval_at(
+                Instant::now() + Self::DEFAULT_INTERVAL,
+                Self::DEFAULT_INTERVAL,
+            ),
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn with_interval(mut self, milisecond: u64) -> Self {
+        let interval = Duration::from_millis(milisecond);
+        self.interval = tokio::time::interval_at(Instant::now() + interval, interval);
+        self
+    }
+
+    pub fn with_status(mut self, status: TransactionStatus) -> Self {
+        self.status = status;
+        self
+    }
+
+    async fn check_transaction_status(
+        transaction_hash: FieldElement,
+        expected_status: TransactionStatus,
+        provider: &'a P,
+    ) -> Result<bool, TransactionWaitingError<P::Error>> {
+        match provider
+            .get_transaction_receipt(transaction_hash)
+            .await
+            .map_err(TransactionWaitingError::Provider)?
+        {
+            MaybePendingTransactionReceipt::Receipt(receipt) => {
+                match transaction_status_from_receipt(&receipt) {
+                    TransactionStatus::Rejected => {
+                        Err(TransactionWaitingError::TransactionRejected)
+                    }
+
+                    status if status == expected_status => Ok(true),
+
+                    // TODO: handle case where the status is 'higher' than the one we are
+                    // waiting for.
+                    _ => Ok(false),
+                }
+            }
+
+            // Transaction is still pending.
+            _ => Ok(false),
+        }
+    }
+}
+
+impl<'a, P> Future for TransactionWaiter<'a, P>
+where
+    P: Provider + Unpin + 'a,
+{
+    type Output = Result<TransactionReceipt, TransactionWaitingError<P::Error>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let elapsed = Instant::now();
+
+        loop {
+            println!("polling");
+
+            if elapsed.elapsed() > this.timeout {
+                return Poll::Ready(Err(TransactionWaitingError::Timeout));
+            }
+
+            loop {
+                if let Some(mut flush) = this.future.take() {
+                    match flush.poll_unpin(cx) {
+                        Poll::Ready(_) => {
+                            this.interval.reset();
+                        }
+                        Poll::Pending => {
+                            this.future = Some(flush);
+                            return Poll::Pending;
+                        }
+                    }
+                }
+
+                if this.interval.poll_tick(cx).is_ready() {
+                    this.future = Some(Box::pin(TransactionWaiter::check_transaction_status(
+                        this.tx_hash,
+                        this.status,
+                        this.provider,
+                    )));
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn transaction_status_from_receipt(receipt: &TransactionReceipt) -> TransactionStatus {
+    match receipt {
+        TransactionReceipt::Invoke(receipt) => receipt.status,
+        TransactionReceipt::Deploy(receipt) => receipt.status,
+        TransactionReceipt::Declare(receipt) => receipt.status,
+        TransactionReceipt::L1Handler(receipt) => receipt.status,
+        TransactionReceipt::DeployAccount(receipt) => receipt.status,
+    }
+}

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -32,7 +32,7 @@ pub enum TransactionWaitingError<E> {
 /// * `tx_hash` - The hash of the transaction to wait for.
 /// * `status` - The status to wait for. Defaults to `TransactionStatus::AcceptedOnL2`.
 /// * `interval` - Poll the transaction every `interval` miliseconds. Miliseconds are used so that
-///   we can be more precise with the polling interval. Defaults to 1 second.
+///   we can be more precise with the polling interval. Defaults to 250ms.
 /// * `timeout` - The maximum amount of time to wait for the transaction to achieve `status` status.
 ///   Defaults to 60 seconds.
 /// * `provider` - The provider to use for polling the transaction.
@@ -75,7 +75,7 @@ where
     P: Provider + Send,
 {
     const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
-    const DEFAULT_INTERVAL: Duration = Duration::from_millis(200);
+    const DEFAULT_INTERVAL: Duration = Duration::from_millis(250);
     const DEFAULT_STATUS: TransactionStatus = TransactionStatus::AcceptedOnL2;
 
     pub fn new(tx: FieldElement, provider: &'a P) -> Self {

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -32,10 +32,10 @@ pub enum TransactionWaitingError<E> {
 ///  # Examples
 ///
 /// ```no_run
-/// use starknet::providers::JsonRpcClient;
-/// use starknet::providers::jsonrpc::HttpTransport;
-/// use starknet::core::types::FieldElement;
 /// use dojo_world::utils::TransactionWaiter;
+/// use starknet::core::types::FieldElement;
+/// use starknet::providers::jsonrpc::HttpTransport;
+/// use starknet::providers::JsonRpcClient;
 ///
 /// let provider = JsonRpcClient::new(HttpTransport::new("http://localhost:5000").unwrap());
 /// let tx_hash = FieldElement::from_hex_str("0x1234").unwrap();

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -28,19 +28,6 @@ pub enum TransactionWaitingError<E> {
 /// for every `interval` miliseconds. If the transaction does not achieved `status` status within
 /// `timeout` miliseconds, an error will be returned. An error is also returned if the transaction
 /// is rejected ( i.e., the transaction returns a `REJECTED` status ).
-///
-///  # Examples
-///
-/// ```no_run
-/// use dojo_world::utils::TransactionWaiter;
-/// use starknet::core::types::FieldElement;
-/// use starknet::providers::jsonrpc::HttpTransport;
-/// use starknet::providers::JsonRpcClient;
-///
-/// let provider = JsonRpcClient::new(HttpTransport::new("http://localhost:5000").unwrap());
-/// let tx_hash = FieldElement::from_hex_str("0x1234").unwrap();
-/// TransactionWaiter::new(tx_hash, provider).await;
-/// ```
 pub struct TransactionWaiter<'a, P>
 where
     P: Provider,

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -178,13 +178,13 @@ fn transaction_status_from_receipt(receipt: &TransactionReceipt) -> TransactionS
 
 #[cfg(test)]
 mod tests {
-    use super::{Duration, TransactionWaiter};
-
     use assert_matches::assert_matches;
     use dojo_test_utils::sequencer::{SequencerConfig, TestSequencer};
     use starknet::core::types::FieldElement;
     use starknet::providers::jsonrpc::HttpTransport;
     use starknet::providers::JsonRpcClient;
+
+    use super::{Duration, TransactionWaiter};
 
     #[tokio::test]
     async fn should_timeout_on_nonexistant_transaction() {

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -31,7 +31,12 @@ pub enum TransactionWaitingError<E> {
 ///
 ///  # Examples
 ///
-/// ```
+/// ```no_run
+/// use starknet::providers::JsonRpcClient;
+/// use starknet::providers::jsonrpc::HttpTransport;
+/// use starknet::core::types::FieldElement;
+/// use dojo_world::utils::TransactionWaiter;
+///
 /// let provider = JsonRpcClient::new(HttpTransport::new("http://localhost:5000").unwrap());
 /// let tx_hash = FieldElement::from_hex_str("0x1234").unwrap();
 /// TransactionWaiter::new(tx_hash, provider).await;

--- a/crates/katana/core/src/starknet/mod.rs
+++ b/crates/katana/core/src/starknet/mod.rs
@@ -136,7 +136,7 @@ impl StarknetWrapper {
                     // TODO: change the status to `Reverted` status once the variant is implemented.
                     TransactionStatus::Rejected
                 } else {
-                    TransactionStatus::AcceptedOnL2
+                    TransactionStatus::Pending
                 };
 
                 let starknet_tx = StarknetTransaction::new(

--- a/crates/katana/rpc/tests/starknet.rs
+++ b/crates/katana/rpc/tests/starknet.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use cairo_lang_starknet::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet::contract_class::ContractClass;
 use dojo_test_utils::sequencer::TestSequencer;
+use katana_core::sequencer::SequencerConfig;
 use starknet::accounts::{Account, Call, ConnectedAccount};
 use starknet::core::types::contract::legacy::LegacyContractClass;
 use starknet::core::types::contract::{CompiledClass, SierraClass};
@@ -18,7 +19,7 @@ use starknet::providers::Provider;
 
 #[tokio::test]
 async fn test_send_declare_and_deploy_contract() {
-    let sequencer = TestSequencer::start().await;
+    let sequencer = TestSequencer::start(SequencerConfig::default()).await;
     let account = sequencer.account();
 
     let path: PathBuf = PathBuf::from("tests/test_data/cairo1_contract.json");
@@ -87,7 +88,7 @@ async fn test_send_declare_and_deploy_contract() {
 
 #[tokio::test]
 async fn test_send_declare_and_deploy_legcay_contract() {
-    let sequencer = TestSequencer::start().await;
+    let sequencer = TestSequencer::start(SequencerConfig::default()).await;
     let account = sequencer.account();
 
     let path = PathBuf::from("tests/test_data/cairo0_contract.json");


### PR DESCRIPTION
Resolves #608 

- Create a type `TransactionWaiter` that when awaited, will poll for the specified transaction until it return `ACCEPTED_ON_L2` status (can be configured to poll for different status).
- Will poll for every 250ms by default.
- Had to explicitly specify account type as `SingleOwnerAccount` because `ConnectedAccount::Provider` doesn't enforce `Send`.