### PR TITLE
Implement dojo Packable trait for storage packing

### DIFF
--- a/crates/dojo-core/src/lib.cairo
+++ b/crates/dojo-core/src/lib.cairo
@@ -1,6 +1,8 @@
 mod executor;
 mod interfaces;
 mod database;
+mod packable;
+use packable::Packable;
 mod world;
 mod world_factory;
 

--- a/crates/dojo-core/src/packable.cairo
+++ b/crates/dojo-core/src/packable.cairo
@@ -6,7 +6,7 @@ use option::OptionTrait;
 
 
 /// Pack the proposal fields into a single felt252.
-fn pack_util(self: @felt252, size: u8, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+fn pack(self: @felt252, size: u8, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
     // Easier to work on u256 rather than felt252.
     let self_256: u256 = (*self).into();
 
@@ -36,7 +36,7 @@ fn pack_util(self: @felt252, size: u8, ref packing: felt252, ref packing_offset:
     }
 }
 
-fn unpack_util(size: u8, ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<felt252> {
+fn unpack(size: u8, ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<felt252> {
     let remaining_bits: u8 = (251 - unpacking_offset).into();
 
     let mut unpacking_256: u256 = unpacking.into();
@@ -90,7 +90,7 @@ trait Packable<T> {
 impl PackableFelt252 of Packable<felt252> {
     #[inline(always)]
     fn pack(self: @felt252, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack_util(
+        pack(
             self, 
             Packable::<felt252>::size().try_into().unwrap(), 
             ref packing, ref packing_offset, ref packed
@@ -98,7 +98,7 @@ impl PackableFelt252 of Packable<felt252> {
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<felt252> {
-        unpack_util(
+        unpack(
             Packable::<felt252>::size().try_into().unwrap(), 
             ref packed, ref unpacking, ref unpacking_offset
         )
@@ -119,14 +119,14 @@ impl PackableBool of Packable<bool> {
                 0_felt252
             }
         };
-        pack_util(
+        pack(
             @self_felt252, Packable::<bool>::size().try_into().unwrap(), 
             ref packing, ref packing_offset, ref packed
         )
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<bool> {
-        match unpack_util(
+        match unpack(
             Packable::<bool>::size().try_into().unwrap(), 
             ref packed, ref unpacking, ref unpacking_offset
         ){
@@ -151,14 +151,14 @@ impl PackableBool of Packable<bool> {
 impl PackableU8 of Packable<u8> {
     #[inline(always)]
     fn pack(self: @u8, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack_util(
+        pack(
             @(*self).into(), Packable::<u8>::size().try_into().unwrap(), 
             ref packing, ref packing_offset, ref packed
         )
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u8> {
-        match unpack_util(Packable::<u8>::size().try_into().unwrap(), ref packed, ref unpacking, ref unpacking_offset){
+        match unpack(Packable::<u8>::size().try_into().unwrap(), ref packed, ref unpacking, ref unpacking_offset){
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
@@ -172,7 +172,7 @@ impl PackableU8 of Packable<u8> {
 impl PackableU16 of Packable<u16> {
     #[inline(always)]
     fn pack(self: @u16, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack_util(
+        pack(
             @(*self).into(), 
             Packable::<u16>::size().try_into().unwrap(), 
             ref packing, ref packing_offset, ref packed
@@ -180,7 +180,7 @@ impl PackableU16 of Packable<u16> {
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u16> {
-        match unpack_util(
+        match unpack(
             Packable::<u16>::size().try_into().unwrap(), 
             ref packed, ref unpacking, ref unpacking_offset
         ){
@@ -197,7 +197,7 @@ impl PackableU16 of Packable<u16> {
 impl PackableU32 of Packable<u32> {
     #[inline(always)]
     fn pack(self: @u32, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack_util(
+        pack(
             @(*self).into(), 
             Packable::<u32>::size().try_into().unwrap(), 
             ref packing, ref packing_offset, ref packed
@@ -205,7 +205,7 @@ impl PackableU32 of Packable<u32> {
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u32> {
-        match unpack_util(
+        match unpack(
             Packable::<u32>::size().try_into().unwrap(), 
             ref packed, ref unpacking, ref unpacking_offset
         ) {
@@ -222,7 +222,7 @@ impl PackableU32 of Packable<u32> {
 impl PackableU64 of Packable<u64> {
     #[inline(always)]
     fn pack(self: @u64, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack_util(
+        pack(
             @(*self).into(), 
             Packable::<u64>::size().try_into().unwrap(), 
             ref packing, ref packing_offset, ref packed
@@ -230,7 +230,7 @@ impl PackableU64 of Packable<u64> {
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u64> {
-        match unpack_util(
+        match unpack(
             Packable::<u64>::size().try_into().unwrap(), 
             ref packed, ref unpacking, ref unpacking_offset
         ) {
@@ -247,7 +247,7 @@ impl PackableU64 of Packable<u64> {
 impl PackableU128 of Packable<u128> {
     #[inline(always)]
     fn pack(self: @u128, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack_util(
+        pack(
             @(*self).into(), 
             Packable::<u128>::size().try_into().unwrap(), 
             ref packing, ref packing_offset, ref packed
@@ -255,7 +255,7 @@ impl PackableU128 of Packable<u128> {
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u128> {
-        match unpack_util(
+        match unpack(
             Packable::<u128>::size().try_into().unwrap(), 
             ref packed, ref unpacking, ref unpacking_offset
         ) {

--- a/crates/dojo-core/src/packable.cairo
+++ b/crates/dojo-core/src/packable.cairo
@@ -89,9 +89,9 @@ impl PackableFelt252 of Packable<felt252> {
     fn pack(
         self: @felt252, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
     ) {
-        if packing_offset == 0 {
-            return packed.append(*self);
-        }
+        // if packing_offset == 0 {
+        //     return packed.append(*self);
+        // }
 
         return pack(self, 252, ref packing, ref packing_offset, ref packed);
     }
@@ -99,9 +99,9 @@ impl PackableFelt252 of Packable<felt252> {
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<felt252> {
-        if unpacking_offset == 0 {
-            return Option::Some(*packed.pop_front()?);
-        }
+        // if unpacking_offset == 0 {
+        //     return Option::Some(*packed.pop_front()?);
+        // }
 
         return unpack(252, ref packed, ref unpacking, ref unpacking_offset);
     }

--- a/crates/dojo-core/src/packable.cairo
+++ b/crates/dojo-core/src/packable.cairo
@@ -4,7 +4,6 @@ use traits::{Into, TryInto};
 use integer::{U256BitAnd, U256BitOr, U256BitXor, upcast, downcast, BoundedInt};
 use option::OptionTrait;
 
-
 /// Pack the proposal fields into a single felt252.
 fn pack(
     self: @felt252,
@@ -90,24 +89,21 @@ impl PackableFelt252 of Packable<felt252> {
     fn pack(
         self: @felt252, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
     ) {
-        pack(
-            self,
-            252,
-            ref packing,
-            ref packing_offset,
-            ref packed
-        )
+        if packing_offset == 0 {
+            return packed.append(*self);
+        }
+
+        return pack(self, 252, ref packing, ref packing_offset, ref packed);
     }
     #[inline(always)]
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<felt252> {
-        unpack(
-            252,
-            ref packed,
-            ref unpacking,
-            ref unpacking_offset
-        )
+        if unpacking_offset == 0 {
+            return Option::Some(*packed.pop_front()?);
+        }
+
+        return unpack(252, ref packed, ref unpacking, ref unpacking_offset);
     }
     #[inline(always)]
     fn size(self: @felt252) -> usize {
@@ -125,24 +121,13 @@ impl PackableBool of Packable<bool> {
                 0_felt252
             }
         };
-        pack(
-            @self_felt252,
-            1,
-            ref packing,
-            ref packing_offset,
-            ref packed
-        )
+        pack(@self_felt252, 1, ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<bool> {
-        match unpack(
-            1,
-            ref packed,
-            ref unpacking,
-            ref unpacking_offset
-        ) {
+        match unpack(1, ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => {
                 if val == 0_felt252 {
                     Option::Some(false)
@@ -164,24 +149,13 @@ impl PackableBool of Packable<bool> {
 impl PackableU8 of Packable<u8> {
     #[inline(always)]
     fn pack(self: @u8, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack(
-            @(*self).into(),
-            8,
-            ref packing,
-            ref packing_offset,
-            ref packed
-        )
+        pack(@(*self).into(), 8, ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<u8> {
-        match unpack(
-            8,
-            ref packed,
-            ref unpacking,
-            ref unpacking_offset
-        ) {
+        match unpack(8, ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
@@ -195,24 +169,13 @@ impl PackableU8 of Packable<u8> {
 impl PackableU16 of Packable<u16> {
     #[inline(always)]
     fn pack(self: @u16, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack(
-            @(*self).into(),
-            16,
-            ref packing,
-            ref packing_offset,
-            ref packed
-        )
+        pack(@(*self).into(), 16, ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<u16> {
-        match unpack(
-            16,
-            ref packed,
-            ref unpacking,
-            ref unpacking_offset
-        ) {
+        match unpack(16, ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
@@ -226,24 +189,13 @@ impl PackableU16 of Packable<u16> {
 impl PackableU32 of Packable<u32> {
     #[inline(always)]
     fn pack(self: @u32, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack(
-            @(*self).into(),
-            32,
-            ref packing,
-            ref packing_offset,
-            ref packed
-        )
+        pack(@(*self).into(), 32, ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<u32> {
-        match unpack(
-            32,
-            ref packed,
-            ref unpacking,
-            ref unpacking_offset
-        ) {
+        match unpack(32, ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
@@ -257,24 +209,13 @@ impl PackableU32 of Packable<u32> {
 impl PackableU64 of Packable<u64> {
     #[inline(always)]
     fn pack(self: @u64, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack(
-            @(*self).into(),
-            64,
-            ref packing,
-            ref packing_offset,
-            ref packed
-        )
+        pack(@(*self).into(), 64, ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<u64> {
-        match unpack(
-            64,
-            ref packed,
-            ref unpacking,
-            ref unpacking_offset
-        ) {
+        match unpack(64, ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
@@ -288,24 +229,13 @@ impl PackableU64 of Packable<u64> {
 impl PackableU128 of Packable<u128> {
     #[inline(always)]
     fn pack(self: @u128, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        pack(
-            @(*self).into(),
-            128,
-            ref packing,
-            ref packing_offset,
-            ref packed
-        )
+        pack(@(*self).into(), 128, ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
     fn unpack(
         ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
     ) -> Option<u128> {
-        match unpack(
-            128,
-            ref packed,
-            ref unpacking,
-            ref unpacking_offset
-        ) {
+        match unpack(128, ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }

--- a/crates/dojo-core/src/packable.cairo
+++ b/crates/dojo-core/src/packable.cairo
@@ -1,0 +1,179 @@
+use starknet::{ClassHash, ContractAddress};
+use array::ArrayTrait;
+
+trait Packable<T> {
+    fn pack(self: @T, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>);
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<T>);
+    fn size() -> usize;
+}
+
+// impl TPackable<T, impl TSerde: Serde<T>, impl TPackable: Packable<T>> of Packable<T> {
+//     fn pack(self: @T, ref packed: Array<felt252>) {
+//         TSerde::serialize(self, ref packed);
+//     }
+//     fn unpack(ref packed: Span<felt252>) -> Option<T> {
+//         TSerde::deserialize(ref packed)
+//     }
+//     fn size() -> usize {
+//         TPackable::size()
+//     }
+// }
+
+impl PackableFelt252 of Packable<felt252> {
+    #[inline(always)]
+    fn pack(self: @felt252, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<felt252>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        252
+    }
+}
+
+impl PackableBool of Packable<bool> {
+    #[inline(always)]
+    fn pack(self: @bool, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<bool>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        1
+    }
+}
+
+impl PackableU8 of Packable<u8> {
+    #[inline(always)]
+    fn pack(self: @u8, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u8>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        8
+    }
+}
+
+impl PackableU16 of Packable<u16> {
+    #[inline(always)]
+    fn pack(self: @u16, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u16>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        16
+    }
+}
+
+impl PackableU32 of Packable<u32> {
+    #[inline(always)]
+    fn pack(self: @u32, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u32>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        32
+    }
+}
+
+impl PackableU64 of Packable<u64> {
+    #[inline(always)]
+    fn pack(self: @u64, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u64>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        64
+    }
+}
+
+impl PackableU128 of Packable<u128> {
+    #[inline(always)]
+    fn pack(self: @u128, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<u128>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        128
+    }
+}
+
+impl PackableContractAddress of Packable<ContractAddress> {
+    #[inline(always)]
+    fn pack(self: @ContractAddress, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<ContractAddress>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        252
+    }
+}
+
+impl PackableClassHash of Packable<ClassHash> {
+    #[inline(always)]
+    fn pack(self: @ClassHash, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>) {
+        
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<ClassHash>) {
+
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        252
+    }
+}
+
+/// Pack the proposal fields into a single felt252.
+fn pack(self: @felt252, size: u8, ref packing: felt252, mut packing_offset: u8, ref packed: Array<felt252>) -> u8 {
+    let remaining_bits = 252 - packing_offset;
+
+    if remaining_bits < size {
+        let first_part = self & ((1 << remaining_bits) - 1);
+        let second_part = self >> remaining_bits;
+
+        // Pack the first part into the current felt
+        packing = packing | (first_part << packing_offset);
+        packed.append(packing);
+
+        // Start a new felt and pack the second part into it
+        packing = second_part;
+        packing_offset = size - remaining_bits;
+    } else {
+        // Pack the data into the current felt
+        packing = packing | (self << packing_offset);
+        packing_offset = packing_offset + size;
+    }
+
+    packing_offset
+}

--- a/crates/dojo-core/src/packable.cairo
+++ b/crates/dojo-core/src/packable.cairo
@@ -6,7 +6,13 @@ use option::OptionTrait;
 
 
 /// Pack the proposal fields into a single felt252.
-fn pack(self: @felt252, size: u8, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+fn pack(
+    self: @felt252,
+    size: u8,
+    ref packing: felt252,
+    ref packing_offset: u8,
+    ref packed: Array<felt252>
+) {
     // Easier to work on u256 rather than felt252.
     let self_256: u256 = (*self).into();
 
@@ -36,7 +42,9 @@ fn pack(self: @felt252, size: u8, ref packing: felt252, ref packing_offset: u8, 
     }
 }
 
-fn unpack(size: u8, ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<felt252> {
+fn unpack(
+    size: u8, ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+) -> Option<felt252> {
     let remaining_bits: u8 = (251 - unpacking_offset).into();
 
     let mut unpacking_256: u256 = unpacking.into();
@@ -71,40 +79,38 @@ fn unpack(size: u8, ref packed: Span<felt252>, ref unpacking: felt252, ref unpac
 
 trait Packable<T> {
     fn pack(self: @T, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>);
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<T>;
-    fn size() -> usize;
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<T>;
+    fn size(self: @T) -> usize;
 }
-
-// impl TPackable<T, impl TSerde: Serde<T>, impl TPackable: Packable<T>> of Packable<T> {
-//     fn pack(self: @T, ref packed: Array<felt252>) {
-//         TSerde::serialize(self, ref packed);
-//     }
-//     fn unpack(ref packed: Span<felt252>) -> Option<T> {
-//         TSerde::deserialize(ref packed)
-//     }
-//     fn size() -> usize {
-//         TPackable::size()
-//     }
-// }
 
 impl PackableFelt252 of Packable<felt252> {
     #[inline(always)]
-    fn pack(self: @felt252, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+    fn pack(
+        self: @felt252, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
+    ) {
         pack(
-            self, 
-            Packable::<felt252>::size().try_into().unwrap(), 
-            ref packing, ref packing_offset, ref packed
+            self,
+            252,
+            ref packing,
+            ref packing_offset,
+            ref packed
         )
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<felt252> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<felt252> {
         unpack(
-            Packable::<felt252>::size().try_into().unwrap(), 
-            ref packed, ref unpacking, ref unpacking_offset
+            252,
+            ref packed,
+            ref unpacking,
+            ref unpacking_offset
         )
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @felt252) -> usize {
         252
     }
 }
@@ -120,16 +126,23 @@ impl PackableBool of Packable<bool> {
             }
         };
         pack(
-            @self_felt252, Packable::<bool>::size().try_into().unwrap(), 
-            ref packing, ref packing_offset, ref packed
+            @self_felt252,
+            1,
+            ref packing,
+            ref packing_offset,
+            ref packed
         )
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<bool> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<bool> {
         match unpack(
-            Packable::<bool>::size().try_into().unwrap(), 
-            ref packed, ref unpacking, ref unpacking_offset
-        ){
+            1,
+            ref packed,
+            ref unpacking,
+            ref unpacking_offset
+        ) {
             Option::Some(val) => {
                 if val == 0_felt252 {
                     Option::Some(false)
@@ -143,7 +156,7 @@ impl PackableBool of Packable<bool> {
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @bool) -> usize {
         1
     }
 }
@@ -152,19 +165,29 @@ impl PackableU8 of Packable<u8> {
     #[inline(always)]
     fn pack(self: @u8, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
         pack(
-            @(*self).into(), Packable::<u8>::size().try_into().unwrap(), 
-            ref packing, ref packing_offset, ref packed
+            @(*self).into(),
+            8,
+            ref packing,
+            ref packing_offset,
+            ref packed
         )
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u8> {
-        match unpack(Packable::<u8>::size().try_into().unwrap(), ref packed, ref unpacking, ref unpacking_offset){
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<u8> {
+        match unpack(
+            8,
+            ref packed,
+            ref unpacking,
+            ref unpacking_offset
+        ) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @u8) -> usize {
         8
     }
 }
@@ -173,23 +196,29 @@ impl PackableU16 of Packable<u16> {
     #[inline(always)]
     fn pack(self: @u16, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
         pack(
-            @(*self).into(), 
-            Packable::<u16>::size().try_into().unwrap(), 
-            ref packing, ref packing_offset, ref packed
+            @(*self).into(),
+            16,
+            ref packing,
+            ref packing_offset,
+            ref packed
         )
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u16> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<u16> {
         match unpack(
-            Packable::<u16>::size().try_into().unwrap(), 
-            ref packed, ref unpacking, ref unpacking_offset
-        ){
+            16,
+            ref packed,
+            ref unpacking,
+            ref unpacking_offset
+        ) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @u16) -> usize {
         16
     }
 }
@@ -198,23 +227,29 @@ impl PackableU32 of Packable<u32> {
     #[inline(always)]
     fn pack(self: @u32, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
         pack(
-            @(*self).into(), 
-            Packable::<u32>::size().try_into().unwrap(), 
-            ref packing, ref packing_offset, ref packed
+            @(*self).into(),
+            32,
+            ref packing,
+            ref packing_offset,
+            ref packed
         )
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u32> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<u32> {
         match unpack(
-            Packable::<u32>::size().try_into().unwrap(), 
-            ref packed, ref unpacking, ref unpacking_offset
+            32,
+            ref packed,
+            ref unpacking,
+            ref unpacking_offset
         ) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @u32) -> usize {
         32
     }
 }
@@ -223,23 +258,29 @@ impl PackableU64 of Packable<u64> {
     #[inline(always)]
     fn pack(self: @u64, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
         pack(
-            @(*self).into(), 
-            Packable::<u64>::size().try_into().unwrap(), 
-            ref packing, ref packing_offset, ref packed
+            @(*self).into(),
+            64,
+            ref packing,
+            ref packing_offset,
+            ref packed
         )
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u64> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<u64> {
         match unpack(
-            Packable::<u64>::size().try_into().unwrap(), 
-            ref packed, ref unpacking, ref unpacking_offset
+            64,
+            ref packed,
+            ref unpacking,
+            ref unpacking_offset
         ) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @u64) -> usize {
         64
     }
 }
@@ -248,73 +289,95 @@ impl PackableU128 of Packable<u128> {
     #[inline(always)]
     fn pack(self: @u128, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
         pack(
-            @(*self).into(), 
-            Packable::<u128>::size().try_into().unwrap(), 
-            ref packing, ref packing_offset, ref packed
+            @(*self).into(),
+            128,
+            ref packing,
+            ref packing_offset,
+            ref packed
         )
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<u128> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<u128> {
         match unpack(
-            Packable::<u128>::size().try_into().unwrap(), 
-            ref packed, ref unpacking, ref unpacking_offset
+            128,
+            ref packed,
+            ref unpacking,
+            ref unpacking_offset
         ) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @u128) -> usize {
         128
     }
 }
 
 impl PackableContractAddress of Packable<ContractAddress> {
     #[inline(always)]
-    fn pack(self: @ContractAddress, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+    fn pack(
+        self: @ContractAddress,
+        ref packing: felt252,
+        ref packing_offset: u8,
+        ref packed: Array<felt252>
+    ) {
         let self_felt252: felt252 = (*self).into();
         self_felt252.pack(ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<ContractAddress> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<ContractAddress> {
         match Packable::<felt252>::unpack(ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @ContractAddress) -> usize {
         252
     }
 }
 
 impl PackableClassHash of Packable<ClassHash> {
     #[inline(always)]
-    fn pack(self: @ClassHash, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+    fn pack(
+        self: @ClassHash, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
+    ) {
         let self_felt252: felt252 = (*self).into();
         self_felt252.pack(ref packing, ref packing_offset, ref packed)
     }
     #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<ClassHash> {
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<ClassHash> {
         match Packable::<felt252>::unpack(ref packed, ref unpacking, ref unpacking_offset) {
             Option::Some(val) => val.try_into(),
             Option::None(()) => Option::None(()),
         }
     }
     #[inline(always)]
-    fn size() -> usize {
+    fn size(self: @ClassHash) -> usize {
         252
     }
 }
 
 fn fpow(x: u256, n: u8) -> u256 {
     let y = x;
-    if n == 0 { return 1; } 
-    if n == 1 { return x; }
+    if n == 0 {
+        return 1;
+    }
+    if n == 1 {
+        return x;
+    }
     let double = fpow(y * x, n / 2);
-    if (n % 2) == 1 { return x * double; } 
+    if (n % 2) == 1 {
+        return x * double;
+    }
     return double;
-    
 }
 
 fn shl(x: u256, n: u8) -> u256 {

--- a/crates/dojo-core/tests/src/lib.cairo
+++ b/crates/dojo-core/tests/src/lib.cairo
@@ -1,11 +1,10 @@
-// #[cfg(test)]
-// mod executor;
-// #[cfg(test)]
-// mod database;
-// #[cfg(test)]
-// mod world;
-// #[cfg(test)]
-// mod world_factory;
-
+#[cfg(test)]
+mod executor;
+#[cfg(test)]
+mod database;
+#[cfg(test)]
+mod world;
+#[cfg(test)]
+mod world_factory;
 #[cfg(test)]
 mod packable;

--- a/crates/dojo-core/tests/src/lib.cairo
+++ b/crates/dojo-core/tests/src/lib.cairo
@@ -1,8 +1,11 @@
+// #[cfg(test)]
+// mod executor;
+// #[cfg(test)]
+// mod database;
+// #[cfg(test)]
+// mod world;
+// #[cfg(test)]
+// mod world_factory;
+
 #[cfg(test)]
-mod executor;
-#[cfg(test)]
-mod database;
-#[cfg(test)]
-mod world;
-#[cfg(test)]
-mod world_factory;
+mod packable;

--- a/crates/dojo-core/tests/src/packable.cairo
+++ b/crates/dojo-core/tests/src/packable.cairo
@@ -1,4 +1,5 @@
 use array::{ArrayTrait, SpanTrait};
+use starknet::{ClassHash, ContractAddress, Felt252TryIntoContractAddress, Felt252TryIntoClassHash};
 use dojo::packable::{
     Packable, 
     PackableU8, 
@@ -143,6 +144,12 @@ fn test_pack_unpack_types() {
     53_u128.pack(ref packing, ref offset, ref packed);   
     58_felt252.pack(ref packing, ref offset, ref packed); 
     false.pack(ref packing, ref offset, ref packed);  
+    
+    let contract_address = Felt252TryIntoContractAddress::try_into(0).unwrap();
+    contract_address.pack(ref packing, ref offset, ref packed);  
+    let class_hash = Felt252TryIntoClassHash::try_into(0).unwrap();
+    class_hash.pack(ref packing, ref offset, ref packed);  
+    
     packed.append(packing);
 
     let mut unpacking: felt252 = packed.pop_front().unwrap();
@@ -183,5 +190,15 @@ fn test_pack_unpack_types() {
         Packable::<bool>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
         == false, 
         'Types bool'
+    );
+    assert(
+        Packable::<ContractAddress>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == contract_address, 
+        'Types ContractAddress'
+    );
+    assert(
+        Packable::<ClassHash>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == class_hash, 
+        'Types ClassHash'
     );
 }

--- a/crates/dojo-core/tests/src/packable.cairo
+++ b/crates/dojo-core/tests/src/packable.cairo
@@ -1,20 +1,187 @@
 use array::{ArrayTrait, SpanTrait};
-use dojo::packable::{Packable, PackableU8, PackableU32};
+use dojo::packable::{
+    Packable, 
+    PackableU8, 
+    PackableU16, 
+    PackableU32, 
+    PackableU64, 
+    PackableU128, 
+    PackableFelt252,
+    PackableBool, 
+    shl, shr, fpow
+};
+use integer::U256BitAnd;
 use option::OptionTrait;
 use debug::PrintTrait;
+use traits::{Into, TryInto};
 
 #[test]
-#[available_gas(2000000)]
-fn test_basic_package() {
+#[available_gas(9000000)]
+fn test_bit_fpow() {
+    assert(fpow(2, 250) == 1809251394333065553493296640760748560207343510400633813116524750123642650624_u256, '')
+}
+
+#[test]
+#[available_gas(9000000)]
+fn test_bit_shift() {
+    assert(1 == shl(1, 0), 'left == right');
+    assert(1 == shr(1, 0), 'left == right');
+
+    assert(16 == shl(1, 4), 'left == right');
+    assert(1 == shr(16, 4), 'left == right');
+
+    assert(shr(shl(1, 251), 251) == 1, 'left == right')
+}
+
+
+
+#[test]
+#[available_gas(9000000)]
+fn test_pack_unpack_single() {
     let mut packed = array::ArrayTrait::new();
     let mut packing: felt252 = 0;
     let mut offset = 0;
     18_u8.pack(ref packing, ref offset, ref packed);
-    let mut unpacking: felt252 = 0;
+    packed.append(packing);
+
+    assert(*packed.at(0) == 18_felt252, 'Packing single value');
+
+    let mut unpacking: felt252 = packed.pop_front().unwrap();
     let mut un_offset = 0;
     let mut packed_span = packed.span();
 
     let result = Packable::<u8>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap();
-    result.print();
-    assert(result == 18_u8, 'Expect equal');
+    assert(result == 18_u8, 'Unpacked equals packed');
+}
+
+#[test]
+#[available_gas(100000000)]
+fn test_pack_multiple() {
+    let mut packed = array::ArrayTrait::new();
+    let mut packing: felt252 = 0;
+    let mut offset = 0;
+
+    let mut i: u32 = 0;
+    loop {
+        if i >= 20 {
+            break;
+        }
+        i.pack(ref packing, ref offset, ref packed);
+        i += 1;
+    };    
+    packed.append(packing);
+
+    assert(
+        *packed.at(0) == 188719626707717088982296698380167795313645871959412740063448560304128_felt252, 
+        'Packed multiple 0'
+    );
+    assert(
+        *packed.at(1) == 12940774403044448679501384905228180427841125450824163620418038790095104_felt252, 
+        'Packed multiple 1'
+    );
+    assert(
+        *packed.at(2) == 1541463130217537339061372343828480_felt252, 
+        'Packed multiple 2'
+    );
+}
+
+#[test]
+#[available_gas(500000000)]
+fn test_pack_unpack_multiple() {
+    let mut packed = array::ArrayTrait::new();
+    let mut packing: felt252 = 0;
+    let mut offset = 0;
+
+    let mut i: u8 = 0;
+    loop {
+        if i >= 40 {
+            break;
+        }
+        let mut j: u32 = i.into();
+        j = (j + 3) * j;
+
+        i.pack(ref packing, ref offset, ref packed);
+        j.pack(ref packing, ref offset, ref packed);
+
+        i += 1;
+    }; 
+    packed.append(packing);
+
+    let mut unpacking: felt252 = packed.pop_front().unwrap();
+    let mut un_offset = 0;
+    let mut packed_span = packed.span();
+
+    i = 0;
+    loop {
+        if i >= 40 {
+            break;
+        }
+        let result_i = Packable::<u8>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap();
+        let result_j = Packable::<u32>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap();
+
+        let mut j: u32 = i.into();
+        j = (j + 3) * j;
+
+        assert(result_i == i, 'Unpacked equals packed');
+        assert(result_j == j, 'Unpacked equals packed');
+        i += 1;
+    };
+}
+
+#[test]
+#[available_gas(500000000)]
+fn test_pack_unpack_types() {
+    let mut packed = array::ArrayTrait::new();
+    let mut packing: felt252 = 0;
+    let mut offset = 0;
+
+    let mut i: u8 = 0;
+    3_u8.pack(ref packing, ref offset, ref packed);   
+    14_u16.pack(ref packing, ref offset, ref packed);   
+    59_u32.pack(ref packing, ref offset, ref packed);   
+    26_u64.pack(ref packing, ref offset, ref packed);   
+    53_u128.pack(ref packing, ref offset, ref packed);   
+    58_felt252.pack(ref packing, ref offset, ref packed); 
+    false.pack(ref packing, ref offset, ref packed);  
+    packed.append(packing);
+
+    let mut unpacking: felt252 = packed.pop_front().unwrap();
+    let mut un_offset = 0;
+    let mut packed_span = packed.span();
+
+    assert(
+        Packable::<u8>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 3_u8, 
+        'Types u8'
+    );
+    assert(
+        Packable::<u16>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 14_u16, 
+        'Types u16'
+    );
+    assert(
+        Packable::<u32>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 59_u32, 
+        'Types u32'
+    );
+    assert(
+        Packable::<u64>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 26_u64, 
+        'Types u64'
+    );
+    assert(
+        Packable::<u128>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 53_u128, 
+        'Types u128'
+    );
+    assert(
+        Packable::<felt252>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 58_felt252, 
+        'Types felt252'
+    );
+    assert(
+        Packable::<bool>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == false, 
+        'Types bool'
+    );
 }

--- a/crates/dojo-core/tests/src/packable.cairo
+++ b/crates/dojo-core/tests/src/packable.cairo
@@ -145,9 +145,9 @@ fn test_pack_unpack_types() {
     58_felt252.pack(ref packing, ref offset, ref packed); 
     false.pack(ref packing, ref offset, ref packed);  
     
-    let contract_address = Felt252TryIntoContractAddress::try_into(0).unwrap();
+    let contract_address = Felt252TryIntoContractAddress::try_into(3).unwrap();
     contract_address.pack(ref packing, ref offset, ref packed);  
-    let class_hash = Felt252TryIntoClassHash::try_into(0).unwrap();
+    let class_hash = Felt252TryIntoClassHash::try_into(1337).unwrap();
     class_hash.pack(ref packing, ref offset, ref packed);  
     
     packed.append(packing);

--- a/crates/dojo-core/tests/src/packable.cairo
+++ b/crates/dojo-core/tests/src/packable.cairo
@@ -55,6 +55,33 @@ fn test_pack_unpack_single() {
     assert(result == 18_u8, 'Unpacked equals packed');
 }
 
+
+#[test]
+#[available_gas(9000000)]
+fn test_pack_unpack_felt252_u128() {
+    let mut packed = array::ArrayTrait::new();
+    let mut packing: felt252 = 0;
+    let mut offset = 0;
+    420_felt252.pack(ref packing, ref offset, ref packed);
+    1337_u128.pack(ref packing, ref offset, ref packed);
+    packed.append(packing);
+
+    let mut unpacking: felt252 = packed.pop_front().unwrap();
+    let mut un_offset = 0;
+    let mut packed_span = packed.span();
+
+    assert(
+        Packable::<felt252>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 420_felt252, 
+        'Types u8'
+    );
+    assert(
+        Packable::<u128>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap() 
+        == 1337_u128, 
+        'Types u8'
+    );
+}
+
 #[test]
 #[available_gas(100000000)]
 fn test_pack_multiple() {

--- a/crates/dojo-core/tests/src/packable.cairo
+++ b/crates/dojo-core/tests/src/packable.cairo
@@ -1,0 +1,20 @@
+use array::{ArrayTrait, SpanTrait};
+use dojo::packable::{Packable, PackableU8, PackableU32};
+use option::OptionTrait;
+use debug::PrintTrait;
+
+#[test]
+#[available_gas(2000000)]
+fn test_basic_package() {
+    let mut packed = array::ArrayTrait::new();
+    let mut packing: felt252 = 0;
+    let mut offset = 0;
+    18_u8.pack(ref packing, ref offset, ref packed);
+    let mut unpacking: felt252 = 0;
+    let mut un_offset = 0;
+    let mut packed_span = packed.span();
+
+    let result = Packable::<u8>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap();
+    result.print();
+    assert(result == 18_u8, 'Expect equal');
+}

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -29,7 +29,7 @@ impl PackableFoo of Packable<Foo> {
     #[inline(always)]
     fn pack(self: @Foo, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
         self.a.pack(ref packing, ref packing_offset, ref packed);
-        self.b.pack(ref packing, ref packing_offset, ref packed)
+        self.b.pack(ref packing, ref packing_offset, ref packed);
     }
     #[inline(always)]
     fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<Foo> {

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -181,11 +181,12 @@ fn test_set_entity_admin() {
     data.append(1337);
     world.execute('bar'.into(), data.span());
 
-    let foo = world.entity('Foo'.into(), alice.into(), 0, 0);
-    (*foo[0]).print();
-    (*foo[1]).print();
-    assert(*foo[0] == 420, 'data not stored');
-    assert(*foo[1] == 1337, 'data not stored');
+    let mut packed_span = world.entity('Foo'.into(), alice.into(), 0, 0);
+    let mut unpacking: felt252 = *packed_span.pop_front().unwrap();
+    let mut un_offset = 0;
+    let foo = Packable::<Foo>::unpack(ref packed_span, ref unpacking, ref un_offset).unwrap();
+    assert(foo.a == 420, 'data not stored');
+    assert(foo.b == 1337, 'data not stored');
 }
 
 #[test]

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -39,8 +39,8 @@ impl PackableFoo of Packable<Foo> {
         })
     }
     #[inline(always)]
-    fn size() -> usize {
-        Packable::<felt252>::size() + Packable::<u128>::size()
+    fn size(self: @Foo) -> usize {
+        Packable::<felt252>::size(self.a) + Packable::<u128>::size(self.b)
     }
 }
 
@@ -61,8 +61,8 @@ impl PackableFizz of Packable<Fizz> {
         })
     }
     #[inline(always)]
-    fn size() -> usize {
-        Packable::<felt252>::size()
+    fn size(self: @Fizz) -> usize {
+        Packable::<felt252>::size(self.a)
     }
 }
 

--- a/crates/dojo-core/tests/src/world.cairo
+++ b/crates/dojo-core/tests/src/world.cairo
@@ -182,6 +182,8 @@ fn test_set_entity_admin() {
     world.execute('bar'.into(), data.span());
 
     let foo = world.entity('Foo'.into(), alice.into(), 0, 0);
+    (*foo[0]).print();
+    (*foo[1]).print();
     assert(*foo[0] == 420, 'data not stored');
     assert(*foo[1] == 1337, 'data not stored');
 }

--- a/crates/dojo-lang/src/commands/find.rs
+++ b/crates/dojo-lang/src/commands/find.rs
@@ -126,7 +126,7 @@ impl CommandMacroTrait for FindCommand {
                                     match raw_entities.pop_front() {
                                         Option::Some(raw) => {
                                             let mut raw = *raw;
-                                            let e = serde::Serde::<$component$>::deserialize(ref \
+                                            let e = dojo::Packable::<$component$>::unpack(ref \
                          raw).expect('$deser_err_msg$');
                                             entities.append(e);
                                         },

--- a/crates/dojo-lang/src/commands/find.rs
+++ b/crates/dojo-lang/src/commands/find.rs
@@ -125,9 +125,11 @@ impl CommandMacroTrait for FindCommand {
                                 loop {
                                     match raw_entities.pop_front() {
                                         Option::Some(raw) => {
+                                            let mut unpacking: felt252 = 0;
+                                            let mut offset = 0;
                                             let mut raw = *raw;
-                                            let e = dojo::Packable::<$component$>::unpack(ref \
-                         raw).expect('$deser_err_msg$');
+                                            let e = dojo::Packable::<$component$>::unpack(ref raw, \
+                         ref unpacking, ref offset).expect('$deser_err_msg$');
                                             entities.append(e);
                                         },
                                         Option::None(_) => {

--- a/crates/dojo-lang/src/commands/get.rs
+++ b/crates/dojo-lang/src/commands/get.rs
@@ -111,7 +111,7 @@ impl GetCommand {
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
                 "
                     let mut __$query_id$_$query_subtype$_raw = $world$.entity('$component$', \
-                        $query$, 0_u8, 0_usize);
+                 $query$, 0_u8, 0_usize);
 
                     assert(__$query_id$_$query_subtype$_raw.len() > 0_usize, '$lookup_err_msg$');
 
@@ -169,9 +169,9 @@ impl GetCommand {
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
                 "
                     let mut __$query_id$_$query_subtype$_raw = $world$.entity('$component$', \
-                        $query$, 0_u8, 0_usize);
+                 $query$, 0_u8, 0_usize);
                     let __$query_id$_$query_subtype$ = match \
-                        __$query_id$_$query_subtype$_raw.len() > 0_usize {
+                 __$query_id$_$query_subtype$_raw.len() > 0_usize {
                         bool::False(()) => {
                             Option::None(())
                         },

--- a/crates/dojo-lang/src/commands/get.rs
+++ b/crates/dojo-lang/src/commands/get.rs
@@ -113,7 +113,7 @@ impl GetCommand {
                     let mut __$query_id$_$query_subtype$_raw = $world$.entity('$component$', \
                  $query$, 0_u8, 0_usize);
                     assert(__$query_id$_$query_subtype$_raw.len() > 0_usize, '$lookup_err_msg$');
-                    let __$query_id$_$query_subtype$ = serde::Serde::<$component$>::deserialize(
+                    let __$query_id$_$query_subtype$ = dojo::Packable::<$component$>::unpack(
                         ref __$query_id$_$query_subtype$_raw
                     ).expect('$deser_err_msg$');
                     ",
@@ -156,7 +156,7 @@ impl GetCommand {
         part_names: Vec<String>,
     ) {
         for component in components.iter() {
-            let mut deser_err_msg = format!("{} failed to deserialize", component.to_string());
+            let mut deser_err_msg = format!("{} failed to unpack", component.to_string());
             deser_err_msg.truncate(CAIRO_ERR_MSG_LEN);
 
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
@@ -169,7 +169,7 @@ impl GetCommand {
                             Option::None(())
                         },
                         bool::True(()) => {
-                            Option::Some(serde::Serde::<$component$>::deserialize(
+                            Option::Some(dojo::Packable::<$component$>::unpack(
                                 ref __$query_id$_$query_subtype$_raw
                             ).expect('$deser_err_msg$'))
                         }

--- a/crates/dojo-lang/src/commands/get.rs
+++ b/crates/dojo-lang/src/commands/get.rs
@@ -111,12 +111,19 @@ impl GetCommand {
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
                 "
                     let mut __$query_id$_$query_subtype$_raw = $world$.entity('$component$', \
-                 $query$, 0_u8, 0_usize);
+                        $query$, 0_u8, 0_usize);
+
                     assert(__$query_id$_$query_subtype$_raw.len() > 0_usize, '$lookup_err_msg$');
+
+                    let mut unpacking: felt252 = 0;
+                    let mut offset = 0;
+
                     let __$query_id$_$query_subtype$ = dojo::Packable::<$component$>::unpack(
-                        ref __$query_id$_$query_subtype$_raw
+                        ref __$query_id$_$query_subtype$_raw,
+                        ref unpacking,
+                        ref offset
                     ).expect('$deser_err_msg$');
-                    ",
+                ",
                 UnorderedHashMap::from([
                     ("world".to_string(), RewriteNode::new_trimmed(world.as_syntax_node())),
                     ("component".to_string(), RewriteNode::Text(component.to_string())),

--- a/crates/dojo-lang/src/commands/get.rs
+++ b/crates/dojo-lang/src/commands/get.rs
@@ -169,15 +169,20 @@ impl GetCommand {
             self.data.rewrite_nodes.push(RewriteNode::interpolate_patched(
                 "
                     let mut __$query_id$_$query_subtype$_raw = $world$.entity('$component$', \
-                 $query$, 0_u8, 0_usize);
+                        $query$, 0_u8, 0_usize);
                     let __$query_id$_$query_subtype$ = match \
-                 __$query_id$_$query_subtype$_raw.len() > 0_usize {
+                        __$query_id$_$query_subtype$_raw.len() > 0_usize {
                         bool::False(()) => {
                             Option::None(())
                         },
                         bool::True(()) => {
+                            let mut unpacking: felt252 = 0;
+                            let mut offset = 0;
+
                             Option::Some(dojo::Packable::<$component$>::unpack(
-                                ref __$query_id$_$query_subtype$_raw
+                                ref __$query_id$_$query_subtype$_raw,
+                                ref unpacking,
+                                ref offset
                             ).expect('$deser_err_msg$'))
                         }
                     };

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -35,7 +35,8 @@ impl SetCommand {
                     {
                         let mut calldata = array::ArrayTrait::new();
                         let mut packing: felt252 = 0;
-                        dojo::Packable::pack(@$ctor$, ref packing, 0, ref calldata);
+                        let mut offset = 0;
+                        dojo::Packable::pack(@$ctor$, ref packing, ref offset, ref calldata);
                         $world$.set_entity('$component$', $query$, 0_u8, \
                             array::ArrayTrait::span(@calldata));
                     }

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -34,7 +34,7 @@ impl SetCommand {
                     "
                     {
                         let mut calldata = array::ArrayTrait::new();
-                        serde::Serde::serialize(@$ctor$, ref calldata);
+                        dojo::Packable::pack(@$ctor$, ref calldata);
                         $world$.set_entity('$component$', $query$, 0_u8, \
                      array::ArrayTrait::span(@calldata));
                     }

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -39,7 +39,7 @@ impl SetCommand {
                         dojo::Packable::pack(@$ctor$, ref packing, ref offset, ref calldata);
                         array::ArrayTrait::append(ref calldata, packing);
                         $world$.set_entity('$component$', $query$, 0_u8, \
-                            array::ArrayTrait::span(@calldata));
+                     array::ArrayTrait::span(@calldata));
                     }
                     ",
                     UnorderedHashMap::from([

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -37,6 +37,7 @@ impl SetCommand {
                         let mut packing: felt252 = 0;
                         let mut offset = 0;
                         dojo::Packable::pack(@$ctor$, ref packing, ref offset, ref calldata);
+                        array::ArrayTrait::append(ref calldata, packing);
                         $world$.set_entity('$component$', $query$, 0_u8, \
                             array::ArrayTrait::span(@calldata));
                     }

--- a/crates/dojo-lang/src/commands/set.rs
+++ b/crates/dojo-lang/src/commands/set.rs
@@ -34,9 +34,10 @@ impl SetCommand {
                     "
                     {
                         let mut calldata = array::ArrayTrait::new();
-                        dojo::Packable::pack(@$ctor$, ref calldata);
+                        let mut packing: felt252 = 0;
+                        dojo::Packable::pack(@$ctor$, ref packing, 0, ref calldata);
                         $world$.set_entity('$component$', $query$, 0_u8, \
-                     array::ArrayTrait::span(@calldata));
+                            array::ArrayTrait::span(@calldata));
                     }
                     ",
                     UnorderedHashMap::from([

--- a/crates/dojo-lang/src/lib.rs
+++ b/crates/dojo-lang/src/lib.rs
@@ -8,5 +8,6 @@ pub mod compiler;
 pub mod component;
 pub mod db;
 mod manifest;
+mod packable;
 pub mod plugin;
 pub mod system;

--- a/crates/dojo-lang/src/packable.rs
+++ b/crates/dojo-lang/src/packable.rs
@@ -1,0 +1,108 @@
+use cairo_lang_semantic::patcher::RewriteNode;
+use cairo_lang_syntax::node::ast::ItemStruct;
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode};
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
+use itertools::Itertools;
+
+/// A handler for Dojo code that modifies a packable struct.
+/// Parameters:
+/// * db: The semantic database.
+/// * struct_ast: The AST of the packable struct.
+/// Returns:
+/// * A RewriteNode containing the generated code.
+pub fn handle_packable_struct(db: &dyn SyntaxGroup, struct_ast: ItemStruct) -> RewriteNode {
+    RewriteNode::interpolate_patched(
+        "
+        impl Packable$name$ of dojo::Packable<$type$> {
+            #[inline(always)]
+            fn pack(self: @$type$, ref packing: felt252, ref packing_offset: u8, ref packed: \
+         Array<felt252>) {
+                $pack_members$
+            }
+            #[inline(always)]
+            fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) \
+         -> Option<$type$> {
+                option::Option::Some($type$ {
+                    $unpack_members$
+                })
+            }
+            #[inline(always)]
+            fn size(self: @$type$) -> usize {
+                $size_members$
+            }
+        }
+        ",
+        UnorderedHashMap::from([
+            ("name".to_string(), RewriteNode::new_trimmed(struct_ast.name(db).as_syntax_node())),
+            ("type".to_string(), RewriteNode::new_trimmed(struct_ast.name(db).as_syntax_node())),
+            (
+                "pack_members".to_string(),
+                RewriteNode::new_modified(
+                    struct_ast
+                        .members(db)
+                        .elements(db)
+                        .iter()
+                        .map(|member| {
+                            RewriteNode::interpolate_patched(
+                                "
+                                dojo::Packable::pack(self.$name$, ref packing, ref packing_offset, \
+                                 ref packed);",
+                                UnorderedHashMap::from([(
+                                    "name".to_string(),
+                                    RewriteNode::new_trimmed(member.name(db).as_syntax_node()),
+                                )]),
+                            )
+                        })
+                        .collect(),
+                ),
+            ),
+            (
+                "unpack_members".to_string(),
+                RewriteNode::new_modified(
+                    struct_ast
+                        .members(db)
+                        .elements(db)
+                        .iter()
+                        .map(|member| {
+                            RewriteNode::interpolate_patched(
+                                "
+                                $name$: \
+                                 option::OptionTrait::unwrap(dojo::Packable::<$type$>::unpack(
+                                    ref packed,
+                                    ref unpacking,
+                                    ref unpacking_offset
+                                )),",
+                                UnorderedHashMap::from([
+                                    (
+                                        "type".to_string(),
+                                        RewriteNode::new_trimmed(
+                                            member.type_clause(db).ty(db).as_syntax_node(),
+                                        ),
+                                    ),
+                                    (
+                                        "name".to_string(),
+                                        RewriteNode::new_trimmed(member.name(db).as_syntax_node()),
+                                    ),
+                                ]),
+                            )
+                        })
+                        .collect(),
+                ),
+            ),
+            (
+                "size_members".to_string(),
+                RewriteNode::Text(
+                    struct_ast
+                        .members(db)
+                        .elements(db)
+                        .iter()
+                        .map(|member| {
+                            format!("dojo::Packable::size(self.{})", member.name(db).text(db))
+                        })
+                        .join(" + "),
+                ),
+            ),
+        ]),
+    )
+}

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -28,6 +28,7 @@ use smol_str::SmolStr;
 use url::Url;
 
 use crate::component::handle_component_struct;
+use crate::packable::handle_packable_struct;
 use crate::system::System;
 
 const SYSTEM_ATTR: &str = "system";
@@ -153,6 +154,9 @@ impl MacroPlugin for DojoPlugin {
                                     &mut aux_data,
                                     struct_ast.clone(),
                                 ));
+                            }
+                            "Packable" => {
+                                rewrite_nodes.push(handle_packable_struct(db, struct_ast.clone()));
                             }
                             _ => continue,
                         }

--- a/crates/dojo-lang/src/plugin_test_data/component
+++ b/crates/dojo-lang/src/plugin_test_data/component
@@ -6,7 +6,7 @@ ExpandContractTestRunner
 //! > cairo_code
 use serde::Serde;
 
-#[derive(Component, Copy, Drop, Serde)]
+#[derive(Component, Copy, Drop, Serde, Packable)]
 struct Position {
     x: felt252,
     y: felt252
@@ -30,12 +30,7 @@ impl PositionImpl of PositionTrait {
     }
 }
 
-#[derive(Component, Serde)]
-struct Roles {
-    role_ids: Array<u8>
-}
-
-#[derive(Component, Copy, Drop, Serde)]
+#[derive(Component, Copy, Drop, Serde, Packable)]
 struct Player {
     name: felt252, 
 }
@@ -105,45 +100,36 @@ mod position {
     }
 }
 
-struct Roles {
-    role_ids: Array<u8>
-}
-
-#[starknet::interface]
-trait IRoles<T> {
-    fn name(self: @T) -> felt252;
-    fn len(self: @T) -> u8;
-}
-
-#[starknet::contract]
-mod roles {
-    use super::Roles;
-
-    #[storage]
-    struct Storage {}
-
-    #[external(v0)]
-    fn schema(self: @ContractState) -> Array<(felt252, felt252, usize, u8)> {
-        let mut arr = array::ArrayTrait::new();
-        array::ArrayTrait::append(ref arr, ('role_ids', 'Array<u8>', 0, 0));
-
-        arr
+impl PackablePosition of dojo::Packable<Position> {
+    #[inline(always)]
+    fn pack(
+        self: @Position, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
+    ) {
+        dojo::Packable::pack(self.x, ref packing, ref packing_offset, ref packed);
+        dojo::Packable::pack(self.y, ref packing, ref packing_offset, ref packed);
     }
-
-
-    #[external(v0)]
-    fn name(self: @ContractState) -> felt252 {
-        'Roles'
+    #[inline(always)]
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<Position> {
+        option::Option::Some(
+            Position {
+                x: option::OptionTrait::unwrap(
+                    dojo::Packable::<felt252>::unpack(
+                        ref packed, ref unpacking, ref unpacking_offset
+                    )
+                ),
+                y: option::OptionTrait::unwrap(
+                    dojo::Packable::<felt252>::unpack(
+                        ref packed, ref unpacking, ref unpacking_offset
+                    )
+                ),
+            }
+        )
     }
-
-    #[external(v0)]
-    fn len(self: @ContractState) -> usize {
-        1_usize
-    }
-
-    #[external(v0)]
-    fn is_indexed(self: @ContractState) -> bool {
-        bool::False(())
+    #[inline(always)]
+    fn size(self: @Position) -> usize {
+        dojo::Packable::size(self.x) + dojo::Packable::size(self.y)
     }
 }
 
@@ -186,6 +172,33 @@ mod player {
     #[external(v0)]
     fn is_indexed(self: @ContractState) -> bool {
         bool::False(())
+    }
+}
+
+impl PackablePlayer of dojo::Packable<Player> {
+    #[inline(always)]
+    fn pack(
+        self: @Player, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
+    ) {
+        dojo::Packable::pack(self.name, ref packing, ref packing_offset, ref packed);
+    }
+    #[inline(always)]
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<Player> {
+        option::Option::Some(
+            Player {
+                name: option::OptionTrait::unwrap(
+                    dojo::Packable::<felt252>::unpack(
+                        ref packed, ref unpacking, ref unpacking_offset
+                    )
+                ),
+            }
+        )
+    }
+    #[inline(always)]
+    fn size(self: @Player) -> usize {
+        dojo::Packable::size(self.name)
     }
 }
 

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -7,13 +7,13 @@ ExpandContractTestRunner
 use array::ArrayTrait;
 use serde::Serde;
 
-#[derive(Component, Copy, Drop, Serde)]
+#[derive(Component, Copy, Drop, Serde, Packable)]
 struct Position {
     x: felt252,
     y: felt252,
 }
 
-#[derive(Component, Copy, Drop, Serde)]
+#[derive(Component, Copy, Drop, Serde, Packable)]
 #[component(indexed: true)]
 struct Player {
     name: felt252, 
@@ -217,6 +217,39 @@ mod position {
     }
 }
 
+impl PackablePosition of dojo::Packable<Position> {
+    #[inline(always)]
+    fn pack(
+        self: @Position, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
+    ) {
+        dojo::Packable::pack(self.x, ref packing, ref packing_offset, ref packed);
+        dojo::Packable::pack(self.y, ref packing, ref packing_offset, ref packed);
+    }
+    #[inline(always)]
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<Position> {
+        option::Option::Some(
+            Position {
+                x: option::OptionTrait::unwrap(
+                    dojo::Packable::<felt252>::unpack(
+                        ref packed, ref unpacking, ref unpacking_offset
+                    )
+                ),
+                y: option::OptionTrait::unwrap(
+                    dojo::Packable::<felt252>::unpack(
+                        ref packed, ref unpacking, ref unpacking_offset
+                    )
+                ),
+            }
+        )
+    }
+    #[inline(always)]
+    fn size(self: @Position) -> usize {
+        dojo::Packable::size(self.x) + dojo::Packable::size(self.y)
+    }
+}
+
 struct Player {
     name: felt252, 
 }
@@ -256,6 +289,33 @@ mod player {
     #[external(v0)]
     fn is_indexed(self: @ContractState) -> bool {
         bool::True(())
+    }
+}
+
+impl PackablePlayer of dojo::Packable<Player> {
+    #[inline(always)]
+    fn pack(
+        self: @Player, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>
+    ) {
+        dojo::Packable::pack(self.name, ref packing, ref packing_offset, ref packed);
+    }
+    #[inline(always)]
+    fn unpack(
+        ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8
+    ) -> Option<Player> {
+        option::Option::Some(
+            Player {
+                name: option::OptionTrait::unwrap(
+                    dojo::Packable::<felt252>::unpack(
+                        ref packed, ref unpacking, ref unpacking_offset
+                    )
+                ),
+            }
+        )
+    }
+    #[inline(always)]
+    fn size(self: @Player) -> usize {
+        dojo::Packable::size(self.name)
     }
 }
 
@@ -1153,13 +1213,3 @@ error: Plugin diagnostic: Unexpected argument type. Expected: "dojo::database::q
  --> lib.cairo:50:26
         set !(ctx.world, (0, 0, 0, 0, 0), (
                          ^*************^
-
-error: Trait has no implementation in context: dojo::packable::Packable::<test::Player>
- --> spawn:48:41
-                        dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
-                                        ^**^
-
-error: Trait has no implementation in context: dojo::packable::Packable::<test::Position>
- --> move:76:81
-                                            let e = dojo::Packable::<Position>::unpack(ref raw, ref unpacking, ref offset).expect('Position failed to deserialize');
-                                                                                ^****^

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -302,7 +302,10 @@ mod spawn {
     fn execute(self: @ContractState, ctx: Context, name: felt252) {
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Player { name: name }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx
                 .world
                 .set_entity(
@@ -315,7 +318,10 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx
                 .world
                 .set_entity(
@@ -328,25 +334,37 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Player { name: name }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx.world.set_entity('Player', 420.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx.world.set_entity('Position', 420.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Player { name: name }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx.world.set_entity('Player', 120.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx.world.set_entity('Position', 120.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
@@ -354,7 +372,10 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Player { name: name }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx
                 .world
                 .set_entity('Player', player_id.into(), 0_u8, array::ArrayTrait::span(@calldata));
@@ -362,7 +383,10 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx
                 .world
                 .set_entity('Position', player_id.into(), 0_u8, array::ArrayTrait::span(@calldata));
@@ -370,7 +394,10 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Player { name: name }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx
                 .world
                 .set_entity('Player', (0, 0, 0, 0, 0), 0_u8, array::ArrayTrait::span(@calldata));
@@ -378,7 +405,10 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx
                 .world
                 .set_entity('Position', (0, 0, 0, 0, 0), 0_u8, array::ArrayTrait::span(@calldata));
@@ -386,13 +416,19 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Player { name: name }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx.world.set_entity('Player', 1337.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
+            let mut packing: felt252 = 0;
+            let mut offset = 0;
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref packing, ref offset, ref calldata);
+            array::ArrayTrait::append(ref calldata, packing);
             ctx.world.set_entity('Position', 1337.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
         return ();
@@ -471,8 +507,12 @@ mod move {
                 loop {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
+                            let mut unpacking: felt252 = 0;
+                            let mut offset = 0;
                             let mut raw = *raw;
-                            let e = dojo::Packable::<Position>::unpack(ref raw)
+                            let e = dojo::Packable::<Position>::unpack(
+                                ref raw, ref unpacking, ref offset
+                            )
                                 .expect('Position failed to deserialize');
                             entities.append(e);
                         },
@@ -495,8 +535,12 @@ mod move {
                 loop {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
+                            let mut unpacking: felt252 = 0;
+                            let mut offset = 0;
                             let mut raw = *raw;
-                            let e = dojo::Packable::<Player>::unpack(ref raw)
+                            let e = dojo::Packable::<Player>::unpack(
+                                ref raw, ref unpacking, ref offset
+                            )
                                 .expect('Player failed to deserialize');
                             entities.append(e);
                         },
@@ -534,8 +578,12 @@ mod move {
                 loop {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
+                            let mut unpacking: felt252 = 0;
+                            let mut offset = 0;
                             let mut raw = *raw;
-                            let e = dojo::Packable::<Player>::unpack(ref raw)
+                            let e = dojo::Packable::<Player>::unpack(
+                                ref raw, ref unpacking, ref offset
+                            )
                                 .expect('Player failed to deserialize');
                             entities.append(e);
                         },
@@ -554,26 +602,43 @@ mod move {
         let players_query = (__players);
 
         let mut __player_player_raw = ctx.world.entity('Player', player_id.into(), 0_u8, 0_usize);
+
         assert(__player_player_raw.len() > 0_usize, 'Player not found');
-        let __player_player = dojo::Packable::<Player>::unpack(ref __player_player_raw)
+
+        let mut unpacking: felt252 = 0;
+        let mut offset = 0;
+
+        let __player_player = dojo::Packable::<Player>::unpack(
+            ref __player_player_raw, ref unpacking, ref offset
+        )
             .expect('Player failed to deserialize');
         let player = __player_player;
 
         let mut __player_position_position_raw = ctx
             .world
             .entity('Position', player_id.into(), 0_u8, 0_usize);
+
         assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
+
+        let mut unpacking: felt252 = 0;
+        let mut offset = 0;
+
         let __player_position_position = dojo::Packable::<Position>::unpack(
-            ref __player_position_position_raw
+            ref __player_position_position_raw, ref unpacking, ref offset
         )
             .expect('Position failed to deserialize');
 
         let mut __player_position_player_raw = ctx
             .world
             .entity('Player', player_id.into(), 0_u8, 0_usize);
+
         assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
+
+        let mut unpacking: felt252 = 0;
+        let mut offset = 0;
+
         let __player_position_player = dojo::Packable::<Player>::unpack(
-            ref __player_position_player_raw
+            ref __player_position_player_raw, ref unpacking, ref offset
         )
             .expect('Player failed to deserialize');
         let player_position = (__player_position_position, __player_position_player);
@@ -585,18 +650,28 @@ mod move {
             let mut __player_position_position_raw = ctx
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_position = dojo::Packable::<Position>::unpack(
-                ref __player_position_position_raw
+                ref __player_position_position_raw, ref unpacking, ref offset
             )
                 .expect('Position failed to deserialize');
 
             let mut __player_position_player_raw = ctx
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_player = dojo::Packable::<Player>::unpack(
-                ref __player_position_player_raw
+                ref __player_position_player_raw, ref unpacking, ref offset
             )
                 .expect('Player failed to deserialize');
             let player_position = (__player_position_position, __player_position_player);
@@ -628,8 +703,12 @@ mod move {
                         loop {
                             match raw_entities.pop_front() {
                                 Option::Some(raw) => {
+                                    let mut unpacking: felt252 = 0;
+                                    let mut offset = 0;
                                     let mut raw = *raw;
-                                    let e = dojo::Packable::<Position>::unpack(ref raw)
+                                    let e = dojo::Packable::<Position>::unpack(
+                                        ref raw, ref unpacking, ref offset
+                                    )
                                         .expect('Position failed to deserialize');
                                     entities.append(e);
                                 },
@@ -652,8 +731,12 @@ mod move {
                         loop {
                             match raw_entities.pop_front() {
                                 Option::Some(raw) => {
+                                    let mut unpacking: felt252 = 0;
+                                    let mut offset = 0;
                                     let mut raw = *raw;
-                                    let e = dojo::Packable::<Player>::unpack(ref raw)
+                                    let e = dojo::Packable::<Player>::unpack(
+                                        ref raw, ref unpacking, ref offset
+                                    )
                                         .expect('Player failed to deserialize');
                                     entities.append(e);
                                 },
@@ -680,8 +763,13 @@ mod move {
                     Option::None(())
                 },
                 bool::True(()) => {
+                    let mut unpacking: felt252 = 0;
+                    let mut offset = 0;
+
                     Option::Some(
-                        dojo::Packable::<Player>::unpack(ref __maybe_player_player_raw)
+                        dojo::Packable::<Player>::unpack(
+                            ref __maybe_player_player_raw, ref unpacking, ref offset
+                        )
                             .expect('Player failed to unpack')
                     )
                 }
@@ -702,8 +790,13 @@ mod move {
                     Option::None(())
                 },
                 bool::True(()) => {
+                    let mut unpacking: felt252 = 0;
+                    let mut offset = 0;
+
                     Option::Some(
-                        dojo::Packable::<Position>::unpack(ref __positions_query_position_raw)
+                        dojo::Packable::<Position>::unpack(
+                            ref __positions_query_position_raw, ref unpacking, ref offset
+                        )
                             .expect('Position failed to unpack')
                     )
                 }
@@ -717,8 +810,13 @@ mod move {
                     Option::None(())
                 },
                 bool::True(()) => {
+                    let mut unpacking: felt252 = 0;
+                    let mut offset = 0;
+
                     Option::Some(
-                        dojo::Packable::<Player>::unpack(ref __positions_query_player_raw)
+                        dojo::Packable::<Player>::unpack(
+                            ref __positions_query_player_raw, ref unpacking, ref offset
+                        )
                             .expect('Player failed to unpack')
                     )
                 }
@@ -739,18 +837,28 @@ mod move {
             let mut __player_position_position_raw = ctx
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_position = dojo::Packable::<Position>::unpack(
-                ref __player_position_position_raw
+                ref __player_position_position_raw, ref unpacking, ref offset
             )
                 .expect('Position failed to deserialize');
 
             let mut __player_position_player_raw = ctx
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_player = dojo::Packable::<Player>::unpack(
-                ref __player_position_player_raw
+                ref __player_position_player_raw, ref unpacking, ref offset
             )
                 .expect('Player failed to deserialize');
             let player_position = (__player_position_position, __player_position_player);
@@ -759,18 +867,28 @@ mod move {
             let mut __player_position_position_raw = ctx
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_position = dojo::Packable::<Position>::unpack(
-                ref __player_position_position_raw
+                ref __player_position_position_raw, ref unpacking, ref offset
             )
                 .expect('Position failed to deserialize');
 
             let mut __player_position_player_raw = ctx
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_player = dojo::Packable::<Player>::unpack(
-                ref __player_position_player_raw
+                ref __player_position_player_raw, ref unpacking, ref offset
             )
                 .expect('Player failed to deserialize');
             let player_position = (__player_position_position, __player_position_player);
@@ -783,18 +901,28 @@ mod move {
                 let mut __player_position_position_raw = ctx
                     .world
                     .entity('Position', player_id.into(), 0_u8, 0_usize);
+
                 assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
+
+                let mut unpacking: felt252 = 0;
+                let mut offset = 0;
+
                 let __player_position_position = dojo::Packable::<Position>::unpack(
-                    ref __player_position_position_raw
+                    ref __player_position_position_raw, ref unpacking, ref offset
                 )
                     .expect('Position failed to deserialize');
 
                 let mut __player_position_player_raw = ctx
                     .world
                     .entity('Player', player_id.into(), 0_u8, 0_usize);
+
                 assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
+
+                let mut unpacking: felt252 = 0;
+                let mut offset = 0;
+
                 let __player_position_player = dojo::Packable::<Player>::unpack(
-                    ref __player_position_player_raw
+                    ref __player_position_player_raw, ref unpacking, ref offset
                 )
                     .expect('Player failed to deserialize');
                 let player_position = (__player_position_position, __player_position_player);
@@ -827,8 +955,12 @@ mod move {
                             loop {
                                 match raw_entities.pop_front() {
                                     Option::Some(raw) => {
+                                        let mut unpacking: felt252 = 0;
+                                        let mut offset = 0;
                                         let mut raw = *raw;
-                                        let e = dojo::Packable::<Position>::unpack(ref raw)
+                                        let e = dojo::Packable::<Position>::unpack(
+                                            ref raw, ref unpacking, ref offset
+                                        )
                                             .expect('Position failed to deserialize');
                                         entities.append(e);
                                     },
@@ -851,8 +983,12 @@ mod move {
                             loop {
                                 match raw_entities.pop_front() {
                                     Option::Some(raw) => {
+                                        let mut unpacking: felt252 = 0;
+                                        let mut offset = 0;
                                         let mut raw = *raw;
-                                        let e = dojo::Packable::<Player>::unpack(ref raw)
+                                        let e = dojo::Packable::<Player>::unpack(
+                                            ref raw, ref unpacking, ref offset
+                                        )
                                             .expect('Player failed to deserialize');
                                         entities.append(e);
                                     },
@@ -875,18 +1011,28 @@ mod move {
                 let mut __player_position_position_raw = ctx
                     .world
                     .entity('Position', player_id.into(), 0_u8, 0_usize);
+
                 assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
+
+                let mut unpacking: felt252 = 0;
+                let mut offset = 0;
+
                 let __player_position_position = dojo::Packable::<Position>::unpack(
-                    ref __player_position_position_raw
+                    ref __player_position_position_raw, ref unpacking, ref offset
                 )
                     .expect('Position failed to deserialize');
 
                 let mut __player_position_player_raw = ctx
                     .world
                     .entity('Player', player_id.into(), 0_u8, 0_usize);
+
                 assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
+
+                let mut unpacking: felt252 = 0;
+                let mut offset = 0;
+
                 let __player_position_player = dojo::Packable::<Player>::unpack(
-                    ref __player_position_player_raw
+                    ref __player_position_player_raw, ref unpacking, ref offset
                 )
                     .expect('Player failed to deserialize');
                 let player_position = (__player_position_position, __player_position_player);
@@ -911,18 +1057,28 @@ mod move {
             let mut __player_position_position_raw = ctx
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_position = dojo::Packable::<Position>::unpack(
-                ref __player_position_position_raw
+                ref __player_position_position_raw, ref unpacking, ref offset
             )
                 .expect('Position failed to deserialize');
 
             let mut __player_position_player_raw = ctx
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
+
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
+
+            let mut unpacking: felt252 = 0;
+            let mut offset = 0;
+
             let __player_position_player = dojo::Packable::<Player>::unpack(
-                ref __player_position_player_raw
+                ref __player_position_player_raw, ref unpacking, ref offset
             )
                 .expect('Player failed to deserialize');
             let player_position = (__player_position_position, __player_position_player);
@@ -988,12 +1144,22 @@ error: Plugin diagnostic: Component types cannot be empty
         let err = get!(ctx.world, player_id.into(), ());
                   ^***********************************^
 
-error: Plugin diagnostic: Unexpected argument type. Expected: "dojo::database::query::Query", found: "(?78, ?79, ?80, ?81, ?82)".
+error: Plugin diagnostic: Unexpected argument type. Expected: "dojo::database::query::Query", found: "(?105, ?106, ?107, ?108, ?109)".
  --> lib.cairo:50:26
         set !(ctx.world, (0, 0, 0, 0, 0), (
                          ^*************^
 
-error: Plugin diagnostic: Unexpected argument type. Expected: "dojo::database::query::Query", found: "(?90, ?91, ?92, ?93, ?94)".
+error: Plugin diagnostic: Unexpected argument type. Expected: "dojo::database::query::Query", found: "(?120, ?121, ?122, ?123, ?124)".
  --> lib.cairo:50:26
         set !(ctx.world, (0, 0, 0, 0, 0), (
                          ^*************^
+
+error: Trait has no implementation in context: dojo::packable::Packable::<test::Player>
+ --> spawn:48:41
+                        dojo::Packable::pack(@Player { name: name }, ref packing, ref offset, ref calldata);
+                                        ^**^
+
+error: Trait has no implementation in context: dojo::packable::Packable::<test::Position>
+ --> move:76:81
+                                            let e = dojo::Packable::<Position>::unpack(ref raw, ref unpacking, ref offset).expect('Position failed to deserialize');
+                                                                                ^****^

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -302,7 +302,7 @@ mod spawn {
     fn execute(self: @ContractState, ctx: Context, name: felt252) {
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx
                 .world
                 .set_entity(
@@ -315,7 +315,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx
                 .world
                 .set_entity(
@@ -328,25 +328,25 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx.world.set_entity('Player', 420.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx.world.set_entity('Position', 420.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx.world.set_entity('Player', 120.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx.world.set_entity('Position', 120.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
@@ -354,7 +354,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx
                 .world
                 .set_entity('Player', player_id.into(), 0_u8, array::ArrayTrait::span(@calldata));
@@ -362,7 +362,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx
                 .world
                 .set_entity('Position', player_id.into(), 0_u8, array::ArrayTrait::span(@calldata));
@@ -370,7 +370,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx
                 .world
                 .set_entity('Player', (0, 0, 0, 0, 0), 0_u8, array::ArrayTrait::span(@calldata));
@@ -378,7 +378,7 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx
                 .world
                 .set_entity('Position', (0, 0, 0, 0, 0), 0_u8, array::ArrayTrait::span(@calldata));
@@ -386,13 +386,13 @@ mod spawn {
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Player { name: name }, ref calldata);
+            dojo::Packable::pack(@Player { name: name }, ref calldata);
             ctx.world.set_entity('Player', 1337.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
 
         {
             let mut calldata = array::ArrayTrait::new();
-            serde::Serde::serialize(@Position { x: 0, y: 0 }, ref calldata);
+            dojo::Packable::pack(@Position { x: 0, y: 0 }, ref calldata);
             ctx.world.set_entity('Position', 1337.into(), 0_u8, array::ArrayTrait::span(@calldata));
         }
         return ();
@@ -472,7 +472,7 @@ mod move {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
                             let mut raw = *raw;
-                            let e = serde::Serde::<Position>::deserialize(ref raw)
+                            let e = dojo::Packable::<Position>::unpack(ref raw)
                                 .expect('Position failed to deserialize');
                             entities.append(e);
                         },
@@ -496,7 +496,7 @@ mod move {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
                             let mut raw = *raw;
-                            let e = serde::Serde::<Player>::deserialize(ref raw)
+                            let e = dojo::Packable::<Player>::unpack(ref raw)
                                 .expect('Player failed to deserialize');
                             entities.append(e);
                         },
@@ -535,7 +535,7 @@ mod move {
                     match raw_entities.pop_front() {
                         Option::Some(raw) => {
                             let mut raw = *raw;
-                            let e = serde::Serde::<Player>::deserialize(ref raw)
+                            let e = dojo::Packable::<Player>::unpack(ref raw)
                                 .expect('Player failed to deserialize');
                             entities.append(e);
                         },
@@ -555,7 +555,7 @@ mod move {
 
         let mut __player_player_raw = ctx.world.entity('Player', player_id.into(), 0_u8, 0_usize);
         assert(__player_player_raw.len() > 0_usize, 'Player not found');
-        let __player_player = serde::Serde::<Player>::deserialize(ref __player_player_raw)
+        let __player_player = dojo::Packable::<Player>::unpack(ref __player_player_raw)
             .expect('Player failed to deserialize');
         let player = __player_player;
 
@@ -563,7 +563,7 @@ mod move {
             .world
             .entity('Position', player_id.into(), 0_u8, 0_usize);
         assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-        let __player_position_position = serde::Serde::<Position>::deserialize(
+        let __player_position_position = dojo::Packable::<Position>::unpack(
             ref __player_position_position_raw
         )
             .expect('Position failed to deserialize');
@@ -572,7 +572,7 @@ mod move {
             .world
             .entity('Player', player_id.into(), 0_u8, 0_usize);
         assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-        let __player_position_player = serde::Serde::<Player>::deserialize(
+        let __player_position_player = dojo::Packable::<Player>::unpack(
             ref __player_position_player_raw
         )
             .expect('Player failed to deserialize');
@@ -586,7 +586,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -595,7 +595,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');
@@ -629,7 +629,7 @@ mod move {
                             match raw_entities.pop_front() {
                                 Option::Some(raw) => {
                                     let mut raw = *raw;
-                                    let e = serde::Serde::<Position>::deserialize(ref raw)
+                                    let e = dojo::Packable::<Position>::unpack(ref raw)
                                         .expect('Position failed to deserialize');
                                     entities.append(e);
                                 },
@@ -653,7 +653,7 @@ mod move {
                             match raw_entities.pop_front() {
                                 Option::Some(raw) => {
                                     let mut raw = *raw;
-                                    let e = serde::Serde::<Player>::deserialize(ref raw)
+                                    let e = dojo::Packable::<Player>::unpack(ref raw)
                                         .expect('Player failed to deserialize');
                                     entities.append(e);
                                 },
@@ -681,8 +681,8 @@ mod move {
                 },
                 bool::True(()) => {
                     Option::Some(
-                        serde::Serde::<Player>::deserialize(ref __maybe_player_player_raw)
-                            .expect('Player failed to deserialize')
+                        dojo::Packable::<Player>::unpack(ref __maybe_player_player_raw)
+                            .expect('Player failed to unpack')
                     )
                 }
             };
@@ -703,8 +703,8 @@ mod move {
                 },
                 bool::True(()) => {
                     Option::Some(
-                        serde::Serde::<Position>::deserialize(ref __positions_query_position_raw)
-                            .expect('Position failed to deserialize')
+                        dojo::Packable::<Position>::unpack(ref __positions_query_position_raw)
+                            .expect('Position failed to unpack')
                     )
                 }
             };
@@ -718,8 +718,8 @@ mod move {
                 },
                 bool::True(()) => {
                     Option::Some(
-                        serde::Serde::<Player>::deserialize(ref __positions_query_player_raw)
-                            .expect('Player failed to deserialize')
+                        dojo::Packable::<Player>::unpack(ref __positions_query_player_raw)
+                            .expect('Player failed to unpack')
                     )
                 }
             };
@@ -740,7 +740,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -749,7 +749,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');
@@ -760,7 +760,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -769,7 +769,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');
@@ -784,7 +784,7 @@ mod move {
                     .world
                     .entity('Position', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-                let __player_position_position = serde::Serde::<Position>::deserialize(
+                let __player_position_position = dojo::Packable::<Position>::unpack(
                     ref __player_position_position_raw
                 )
                     .expect('Position failed to deserialize');
@@ -793,7 +793,7 @@ mod move {
                     .world
                     .entity('Player', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-                let __player_position_player = serde::Serde::<Player>::deserialize(
+                let __player_position_player = dojo::Packable::<Player>::unpack(
                     ref __player_position_player_raw
                 )
                     .expect('Player failed to deserialize');
@@ -828,7 +828,7 @@ mod move {
                                 match raw_entities.pop_front() {
                                     Option::Some(raw) => {
                                         let mut raw = *raw;
-                                        let e = serde::Serde::<Position>::deserialize(ref raw)
+                                        let e = dojo::Packable::<Position>::unpack(ref raw)
                                             .expect('Position failed to deserialize');
                                         entities.append(e);
                                     },
@@ -852,7 +852,7 @@ mod move {
                                 match raw_entities.pop_front() {
                                     Option::Some(raw) => {
                                         let mut raw = *raw;
-                                        let e = serde::Serde::<Player>::deserialize(ref raw)
+                                        let e = dojo::Packable::<Player>::unpack(ref raw)
                                             .expect('Player failed to deserialize');
                                         entities.append(e);
                                     },
@@ -876,7 +876,7 @@ mod move {
                     .world
                     .entity('Position', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-                let __player_position_position = serde::Serde::<Position>::deserialize(
+                let __player_position_position = dojo::Packable::<Position>::unpack(
                     ref __player_position_position_raw
                 )
                     .expect('Position failed to deserialize');
@@ -885,7 +885,7 @@ mod move {
                     .world
                     .entity('Player', player_id.into(), 0_u8, 0_usize);
                 assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-                let __player_position_player = serde::Serde::<Player>::deserialize(
+                let __player_position_player = dojo::Packable::<Player>::unpack(
                     ref __player_position_player_raw
                 )
                     .expect('Player failed to deserialize');
@@ -912,7 +912,7 @@ mod move {
                 .world
                 .entity('Position', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_position_raw.len() > 0_usize, 'Position not found');
-            let __player_position_position = serde::Serde::<Position>::deserialize(
+            let __player_position_position = dojo::Packable::<Position>::unpack(
                 ref __player_position_position_raw
             )
                 .expect('Position failed to deserialize');
@@ -921,7 +921,7 @@ mod move {
                 .world
                 .entity('Player', player_id.into(), 0_u8, 0_usize);
             assert(__player_position_player_raw.len() > 0_usize, 'Player not found');
-            let __player_position_player = serde::Serde::<Player>::deserialize(
+            let __player_position_player = dojo::Packable::<Player>::unpack(
                 ref __player_position_player_raw
             )
                 .expect('Player failed to deserialize');

--- a/examples/ecs/src/components.cairo
+++ b/examples/ecs/src/components.cairo
@@ -1,13 +1,12 @@
 use array::{ArrayTrait, SpanTrait};
-use dojo::packable::{Packable, PackableU8, PackableU32};
 use option::OptionTrait;
 
-#[derive(Component, Copy, Drop, Serde)]
+#[derive(Component, Copy, Drop, Serde, Packable)]
 struct Moves {
     remaining: u8, 
 }
 
-#[derive(Component, Copy, Drop, Serde)]
+#[derive(Component, Copy, Drop, Serde, Packable)]
 struct Position {
     x: u32,
     y: u32
@@ -28,40 +27,6 @@ impl PositionImpl of PositionTrait {
 
     fn is_equal(self: Position, b: Position) -> bool {
         self.x == b.x && self.y == b.y
-    }
-}
-
-impl PackableMoves of Packable<Moves> {
-    #[inline(always)]
-    fn pack(self: @Moves, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        self.remaining.pack(ref packing, ref packing_offset, ref packed)
-    }
-    #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<Moves> {
-        Option::Some(Moves { remaining: Packable::<u8>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap()})
-    }
-    #[inline(always)]
-    fn size() -> usize {
-        Packable::<u8>::size()
-    }
-}
-
-impl PackablePosition of Packable<Position> {
-    #[inline(always)]
-    fn pack(self: @Position, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
-        self.x.pack(ref packing, ref packing_offset, ref packed);
-        self.y.pack(ref packing, ref packing_offset, ref packed)
-    }
-    #[inline(always)]
-    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<Position> {
-        Option::Some(Position { 
-            x: Packable::<u32>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap(),
-            y: Packable::<u32>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap()
-        })
-    }
-    #[inline(always)]
-    fn size() -> usize {
-        Packable::<u32>::size() + Packable::<u32>::size()
     }
 }
 

--- a/examples/ecs/src/components.cairo
+++ b/examples/ecs/src/components.cairo
@@ -1,4 +1,6 @@
-use array::ArrayTrait;
+use array::{ArrayTrait, SpanTrait};
+use dojo::packable::{Packable, PackableU8, PackableU32};
+use option::OptionTrait;
 
 #[derive(Component, Copy, Drop, Serde)]
 struct Moves {
@@ -26,6 +28,40 @@ impl PositionImpl of PositionTrait {
 
     fn is_equal(self: Position, b: Position) -> bool {
         self.x == b.x && self.y == b.y
+    }
+}
+
+impl PackableMoves of Packable<Moves> {
+    #[inline(always)]
+    fn pack(self: @Moves, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+        self.remaining.pack(ref packing, ref packing_offset, ref packed)
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<Moves> {
+        Option::Some(Moves { remaining: Packable::<u8>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap()})
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        Packable::<u8>::size()
+    }
+}
+
+impl PackablePosition of Packable<Position> {
+    #[inline(always)]
+    fn pack(self: @Position, ref packing: felt252, ref packing_offset: u8, ref packed: Array<felt252>) {
+        self.x.pack(ref packing, ref packing_offset, ref packed);
+        self.y.pack(ref packing, ref packing_offset, ref packed)
+    }
+    #[inline(always)]
+    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, ref unpacking_offset: u8) -> Option<Position> {
+        Option::Some(Position { 
+            x: Packable::<u32>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap(),
+            y: Packable::<u32>::unpack(ref packed, ref unpacking, ref unpacking_offset).unwrap()
+        })
+    }
+    #[inline(always)]
+    fn size() -> usize {
+        Packable::<u32>::size() + Packable::<u32>::size()
     }
 }
 

--- a/examples/ecs/src/systems.cairo
+++ b/examples/ecs/src/systems.cairo
@@ -1,7 +1,5 @@
 #[system]
 mod spawn {
-    use array::ArrayTrait;
-    use box::BoxTrait;
     use traits::Into;
     use dojo::world::Context;
 
@@ -18,8 +16,6 @@ mod spawn {
 
 #[system]
 mod move {
-    use array::ArrayTrait;
-    use box::BoxTrait;
     use traits::Into;
     use dojo::world::Context;
 


### PR DESCRIPTION
Introduces a Packable trait to support struct packing for world state.

```cairo
trait Packable<T> {
    fn pack(self: @T, ref packing: felt252, packing_offset: u8, ref packed: Array<felt252>);
    fn unpack(ref packed: Span<felt252>, ref unpacking: felt252, unpacking_offset: u8, ref unpacked: Array<felt252>);
    fn size() -> usize;
}
```
Dojo core implements the native types which can then be used to derive packed representations for high user defined structs.

The interface is designed to minimize allocations, it provides a packing struct which represents a partially packed / unpacked felt, once it has been consumed, the packed / unpacked type is appended to the output.

Opening here to show the general idea but impl still needs more work.