### PR TITLE
make build step for dojo-test-utils opt-outable via feature flag

### DIFF
--- a/crates/dojo-test-utils/Cargo.toml
+++ b/crates/dojo-test-utils/Cargo.toml
@@ -35,3 +35,6 @@ assert_fs = "1.0.9"
 camino.workspace = true
 dojo-lang = { path = "../dojo-lang" }
 scarb.workspace = true
+
+[features]
+skip-build = []

--- a/crates/dojo-test-utils/build.rs
+++ b/crates/dojo-test-utils/build.rs
@@ -9,6 +9,12 @@ use scarb::ops;
 use scarb::ui::Verbosity;
 
 fn main() {
+
+     #[cfg(feature = "skip-build")]
+    {
+        return;
+    }
+    
     let mut compilers = CompilerRepository::empty();
     compilers.add(Box::new(DojoCompiler)).unwrap();
 

--- a/crates/dojo-test-utils/build.rs
+++ b/crates/dojo-test-utils/build.rs
@@ -8,13 +8,12 @@ use scarb::core::Config;
 use scarb::ops;
 use scarb::ui::Verbosity;
 
+#[allow(unreachable_code)]
 fn main() {
-
-     #[cfg(feature = "skip-build")]
+    #[cfg(feature = "skip-build")]
     {
         return;
     }
-    
     let mut compilers = CompilerRepository::empty();
     compilers.add(Box::new(DojoCompiler)).unwrap();
 


### PR DESCRIPTION
We have dojo-test-utils as a dependency and I am seeing this when we are trying to build a fresh repo:

```
Caused by:
  process didn't exit successfully: `/Users/jmsb/exps/internet-computers/starknet/kakarot-rpc/target/debug/build/dojo-test-utils-8d04fd8f9703d93f/build-script-build` (exit status: 101)
  --- stdout
      Updating git repository https://github.com/dojoengine/dojo
       Running git fetch --verbose --force --update-head-ok https://github.com/dojoengine/dojo +HEAD:refs/remotes/origin/HEAD
       Running git clone --local --verbose --config core.autocrlf=false --recurse-submodules /var/folders/y0/j_bkhbr12tq5v0nk52l7snyr0000gn/T/.tmpYsNZlh/registry/git/db/dojo-dvdc4757v8eai.git /var/folders/y0/j_bkhbr12tq5v0nk52l7snyr0000gn/T/.tmpYsNZlh/registry/git/checkouts/dojo-dvdc4757v8eai/540dd55
       Running git reset --hard 540dd5592fe83729396889b6dd79d1972cc704e5
     Compiling dojo_examples v0.1.0 (/Users/jmsb/.cargo/git/checkouts/dojo-d75623fc398b98a6/3aa23a2/examples/ecs/Scarb.toml
```

Not 100% sure whats going on, but I thought it might be useful to have the build step be opt-outable via a feature flag. 

Example usage:

```
dojo-test-utils = { git = 'https://github.com/dojoengine/dojo', rev = "<rev-here>", features = ["skip-build"] }
```

