### PR TITLE
[torii] feat: Added a way to filter entities by component name in torii

### DIFF
--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -135,22 +135,35 @@ fn resolve_many(name: &str, type_name: &str) -> Field {
             let limit =
                 ctx.args.try_get("limit").and_then(|limit| limit.u64()).unwrap_or(DEFAULT_LIMIT);
 
-            let entities = entities_by_sk(&mut conn, keys, limit).await?;
+            let component_name = ctx.args.try_get("componentName")? // Add the component name argument
+                .string()
+                .ok()
+                .map(|name| name.to_lowercase());
+
+            let entities = entities_by_sk(&mut conn, keys, component_name, limit).await?;
             Ok(Some(FieldValue::list(entities.into_iter().map(FieldValue::owned_any))))
         })
     })
     .argument(InputValue::new("keys", TypeRef::named_nn_list_nn(TypeRef::STRING)))
     .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT)))
+    .argument(InputValue::new("componentName", TypeRef::named(TypeRef::STRING)))
 }
 
 async fn entities_by_sk(
     conn: &mut PoolConnection<Sqlite>,
     keys: Vec<String>,
+    component_name: Option<String>, // Add the filter parameter
     limit: u64,
 ) -> Result<Vec<ValueMapping>> {
     let mut builder: QueryBuilder<'_, Sqlite> = QueryBuilder::new("SELECT * FROM entities");
     let keys_str = format!("{},%", keys.join(","));
     builder.push(" WHERE keys LIKE ").push_bind(keys_str);
+
+    if let Some(name) = component_name {
+        let name_str = format!("%{}%", name);
+        builder.push(" AND component_names LIKE ").push_bind(name_str);
+    }
+
     builder.push(" ORDER BY created_at DESC LIMIT ").push(limit);
 
     let entities: Vec<Entity> = builder.build_query_as().fetch_all(conn).await?;

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -135,10 +135,8 @@ fn resolve_many(name: &str, type_name: &str) -> Field {
             let limit =
                 ctx.args.try_get("limit").and_then(|limit| limit.u64()).unwrap_or(DEFAULT_LIMIT);
 
-            let component_name = ctx.args.try_get("componentName")? // Add the component name argument
-                .string()
-                .ok()
-                .map(|name| name.to_lowercase());
+            let component_name = ctx.args.try_get("componentName") // Add the component name argument
+                .and_then(|name| name.string().map(|s| s.to_lowercase())).ok();
 
             let entities = entities_by_sk(&mut conn, keys, component_name, limit).await?;
             Ok(Some(FieldValue::list(entities.into_iter().map(FieldValue::owned_any))))

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -164,7 +164,7 @@ async fn entities_by_sk(
             .push_bind(name.clone())
             .push(" OR ")
             .push("component_names LIKE ")
-            .push_bind(format!("{},%", name.clone()))
+            .push_bind(format!("{},%", name))
             .push(" OR ")
             .push("component_names LIKE ")
             .push_bind(format!("%,{}", name))

--- a/crates/torii/src/tests/entities_test.rs
+++ b/crates/torii/src/tests/entities_test.rs
@@ -89,16 +89,15 @@ mod tests {
     async fn test_entities_without_component_filters(pool: SqlitePool) {
         entity_fixtures(&pool).await;
 
-        let query = format!(
-            "
-                {{
-                    entities (keys: [\"%%\"]) {{
-                        keys
-                    }}
-                }}
-            ",
-        );
-        let value = run_graphql_query(&pool, &query).await;
+        let query = "
+        {
+            entities (keys: [\"%%\"]) {
+                keys
+                componentNames
+            }
+        }
+        ";
+        let value = run_graphql_query(&pool, query).await;
 
         let entities = value.get("entities").ok_or("entities not found").unwrap();
         let entities: Vec<Entity> = serde_json::from_value(entities.clone()).unwrap();
@@ -111,16 +110,15 @@ mod tests {
     async fn test_entities_with_component_filters(pool: SqlitePool) {
         entity_fixtures(&pool).await;
 
-        let query = format!(
-            "
-                {{
-                    entities (keys: [\"%%\"], componentName:\"Moves\") {{
-                        keys
-                    }}
-                }}
-            ",
-        );
-        let value = run_graphql_query(&pool, &query).await;
+        let query = "
+        {
+            entities (keys: [\"%%\"], componentName:\"Moves\") {
+                keys
+                componentNames
+            }
+        }
+        ";
+        let value = run_graphql_query(&pool, query).await;
 
         let entities = value.get("entities").ok_or("entities not found").unwrap();
         let entities: Vec<Entity> = serde_json::from_value(entities.clone()).unwrap();


### PR DESCRIPTION
## Features
- be able to filter entities by component name in Torii

example of a query:
```
query {
  entities(keys: ["%"], limit: 30, componentName: "Movable") {
    id
    keys
    componentNames
  }
}
```
This would return all entities that have component Movable