### PR TITLE
feat(torii): expose entity field as component member

### DIFF
--- a/crates/torii/src/graphql/object/component_state.rs
+++ b/crates/torii/src/graphql/object/component_state.rs
@@ -97,7 +97,6 @@ fn add_arguments(field: Field, field_type_mapping: TypeMapping) -> Field {
     field_type_mapping
         .into_iter()
         .fold(field, |field, (name, ty)| {
-
             // omit entity id as argument
             match name.as_str() {
                 ENTITY_ID => field,
@@ -173,7 +172,6 @@ fn value_mapping_from_row(row: &SqliteRow, fields: &TypeMapping) -> sqlx::Result
     fields
         .iter()
         .map(|(name, ty)| {
-
             // handle entity_id separately since it's not a component member
             match name.as_str() {
                 ENTITY_ID => Ok((Name::new(name), fetch_string(row, name)?)),

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use sqlx::pool::PoolConnection;
 use sqlx::{FromRow, Pool, QueryBuilder, Result, Sqlite};
 
-use super::component_state::{component_state_by_id, type_mapping_from};
+use super::component_state::{component_state_by_entity_id, type_mapping_from};
 use super::query::{query_by_id, ID};
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::graphql::constants::DEFAULT_LIMIT;
@@ -85,9 +85,13 @@ impl ObjectTrait for EntityObject {
                 for component_name in components {
                     let table_name = component_name.to_lowercase();
                     let field_type_mapping = type_mapping_from(&mut conn, &table_name).await?;
-                    let state =
-                        component_state_by_id(&mut conn, &table_name, &id, &field_type_mapping)
-                            .await?;
+                    let state = component_state_by_entity_id(
+                        &mut conn,
+                        &table_name,
+                        &id,
+                        &field_type_mapping,
+                    )
+                    .await?;
                     results
                         .push(FieldValue::with_type(FieldValue::owned_any(state), component_name));
                 }

--- a/crates/torii/src/state/sql.rs
+++ b/crates/torii/src/state/sql.rs
@@ -163,8 +163,8 @@ impl State for Sql {
         )];
 
         let mut component_table_query = format!(
-            "CREATE TABLE IF NOT EXISTS external_{} (id TEXT NOT NULL PRIMARY KEY, partition TEXT \
-             NOT NULL, ",
+            "CREATE TABLE IF NOT EXISTS external_{} (entity_id TEXT NOT NULL PRIMARY KEY, \
+             partition TEXT NOT NULL, ",
             component.name.to_lowercase()
         );
 
@@ -175,7 +175,7 @@ impl State for Sql {
 
         component_table_query.push_str(
             "created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (id) REFERENCES entities(id));",
+        FOREIGN KEY (entity_id) REFERENCES entities(id));",
         );
         queries.push(component_table_query);
 
@@ -236,7 +236,8 @@ impl State for Sql {
             entity_id, partition, keys_str, component_names
         );
         let insert_components = format!(
-            "INSERT OR REPLACE INTO external_{} (id, partition, {}) VALUES ('{}', '{:#x}', {})",
+            "INSERT OR REPLACE INTO external_{} (entity_id, partition, {}) VALUES ('{}', '{:#x}', \
+             {})",
             component.to_lowercase(),
             names_str,
             entity_id,

--- a/crates/torii/src/tests/common/mod.rs
+++ b/crates/torii/src/tests/common/mod.rs
@@ -1,4 +1,5 @@
 use camino::Utf8PathBuf;
+use serde::Deserialize;
 use serde_json::Value;
 use sqlx::SqlitePool;
 use starknet::core::types::FieldElement;
@@ -6,6 +7,26 @@ use starknet::core::types::FieldElement;
 use crate::graphql::schema::build_schema;
 use crate::state::sql::{Executable, Sql};
 use crate::state::State;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Entity {
+    pub component_names: String,
+    pub keys: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct Moves {
+    pub __typename: String,
+    pub remaining: u32,
+}
+
+#[derive(Deserialize)]
+pub struct Position {
+    pub __typename: String,
+    pub x: u32,
+    pub y: u32,
+}
 
 #[allow(dead_code)]
 pub async fn run_graphql_query(pool: &SqlitePool, query: &str) -> Value {

--- a/crates/torii/src/tests/entities_test.rs
+++ b/crates/torii/src/tests/entities_test.rs
@@ -1,30 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use serde::Deserialize;
     use sqlx::SqlitePool;
     use starknet_crypto::{poseidon_hash_many, FieldElement};
 
-    use crate::tests::common::{entity_fixtures, run_graphql_query};
-
-    #[derive(Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    pub struct Entity {
-        pub component_names: String,
-        pub keys: Option<String>,
-    }
-
-    #[derive(Deserialize)]
-    struct Moves {
-        __typename: String,
-        remaining: u32,
-    }
-
-    #[derive(Deserialize)]
-    struct Position {
-        __typename: String,
-        x: u32,
-        y: u32,
-    }
+    use crate::tests::common::{entity_fixtures, run_graphql_query, Entity, Moves, Position};
 
     #[sqlx::test(migrations = "./migrations")]
     async fn test_entity(pool: SqlitePool) {


### PR DESCRIPTION
For all component queries, parent entity field is exposed as member

```
positionComponents {
    __typename
    x
    y
    entity {
        id
        keys
        ...
    }
}
```