### PR TITLE
refactor(sozo-migrate): deploy world with seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,6 +2137,7 @@ dependencies = [
  "serde_with",
  "smol_str",
  "starknet",
+ "starknet-crypto 0.5.1",
  "thiserror",
  "tokio",
  "tracing",

--- a/crates/dojo-client/src/contract/world_test.rs
+++ b/crates/dojo-client/src/contract/world_test.rs
@@ -37,7 +37,13 @@ pub async fn deploy_world(
     let world = WorldDiff::compute(manifest.clone(), None);
     let account = sequencer.account();
 
-    let strategy = prepare_for_migration(None, Some("seed".into()), path, world).unwrap();
+    let strategy = prepare_for_migration(
+        None,
+        Some(FieldElement::from_hex_be("0x12345").unwrap()),
+        path,
+        world,
+    )
+    .unwrap();
     let executor_address = strategy
         .executor
         .unwrap()

--- a/crates/dojo-client/src/contract/world_test.rs
+++ b/crates/dojo-client/src/contract/world_test.rs
@@ -37,7 +37,7 @@ pub async fn deploy_world(
     let world = WorldDiff::compute(manifest.clone(), None);
     let account = sequencer.account();
 
-    let strategy = prepare_for_migration(None, path, world).unwrap();
+    let strategy = prepare_for_migration(None, Some("seed".into()), path, world).unwrap();
     let executor_address = strategy
         .executor
         .unwrap()

--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -24,6 +24,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 smol_str.workspace = true
 starknet.workspace = true
+starknet-crypto.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tokio.workspace = true

--- a/crates/dojo-world/src/migration/contract.rs
+++ b/crates/dojo-world/src/migration/contract.rs
@@ -14,7 +14,6 @@ pub struct ContractDiff {
     pub name: String,
     pub local: FieldElement,
     pub remote: Option<FieldElement>,
-    pub address: FieldElement,
 }
 
 impl StateDiff for ContractDiff {
@@ -30,7 +29,6 @@ impl StateDiff for ContractDiff {
 impl Display for ContractDiff {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}:", self.name)?;
-        writeln!(f, "   Address: {:#x}", self.address)?;
         writeln!(f, "   Local: {:#x}", self.local)?;
 
         if let Some(remote) = self.remote {
@@ -41,7 +39,6 @@ impl Display for ContractDiff {
     }
 }
 
-// TODO: evaluate the contract address when building the migration plan
 // Represents a contract that needs to be migrated to the remote state
 #[derive(Debug, Default)]
 pub struct ContractMigration {
@@ -72,4 +69,8 @@ impl Declarable for ContractMigration {
 }
 
 #[async_trait]
-impl Deployable for ContractMigration {}
+impl Deployable for ContractMigration {
+    fn salt(&self) -> FieldElement {
+        self.salt
+    }
+}

--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -115,7 +115,6 @@ pub trait Declarable {
     fn artifact_path(&self) -> &PathBuf;
 }
 
-// TODO: Remove `mut` once we can calculate the contract address before sending the tx
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Deployable: Declarable + Sync {
@@ -142,7 +141,7 @@ pub trait Deployable: Declarable + Sync {
         let calldata = [
             vec![
                 class_hash,                                     // class hash
-                FieldElement::ZERO,                             // salt
+                self.salt(),                                    // salt
                 FieldElement::ZERO,                             // unique
                 FieldElement::from(constructor_calldata.len()), // constructor calldata len
             ],
@@ -151,7 +150,7 @@ pub trait Deployable: Declarable + Sync {
         .concat();
 
         let contract_address = get_contract_address(
-            FieldElement::ZERO,
+            self.salt(),
             class_hash,
             &constructor_calldata,
             FieldElement::ZERO,
@@ -188,6 +187,8 @@ pub trait Deployable: Declarable + Sync {
 
         Ok(DeployOutput { transaction_hash, contract_address, declare })
     }
+
+    fn salt(&self) -> FieldElement;
 }
 
 fn prepare_contract_declaration_params(

--- a/crates/dojo-world/src/migration/world.rs
+++ b/crates/dojo-world/src/migration/world.rs
@@ -1,8 +1,5 @@
 use std::fmt::Display;
 
-use starknet::core::types::FieldElement;
-use starknet::core::utils::get_contract_address;
-
 use super::class::ClassDiff;
 use super::contract::ContractDiff;
 use super::StateDiff;
@@ -13,7 +10,7 @@ use crate::manifest::{Manifest, EXECUTOR_CONTRACT_NAME, WORLD_CONTRACT_NAME};
 mod tests;
 
 /// Represents the state differences between the local and remote worlds.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WorldDiff {
     pub world: ContractDiff,
     pub executor: ContractDiff,
@@ -62,34 +59,14 @@ impl WorldDiff {
             })
             .collect::<Vec<_>>();
 
-        let local_executor_contract_address = get_contract_address(
-            FieldElement::ZERO,
-            local.executor.class_hash,
-            &[],
-            FieldElement::ZERO,
-        );
         let executor = ContractDiff {
             name: EXECUTOR_CONTRACT_NAME.into(),
-            address: remote
-                .as_ref()
-                .and_then(|m| m.executor.address)
-                .unwrap_or(local_executor_contract_address),
             local: local.executor.class_hash,
             remote: remote.as_ref().map(|m| m.executor.class_hash),
         };
 
-        let local_world_contract_address = get_contract_address(
-            FieldElement::ZERO,
-            local.world.class_hash,
-            &[executor.address],
-            FieldElement::ZERO,
-        );
         let world = ContractDiff {
             name: WORLD_CONTRACT_NAME.into(),
-            address: remote
-                .as_ref()
-                .and_then(|m| m.world.address)
-                .unwrap_or(local_world_contract_address),
             local: local.world.class_hash,
             remote: remote.map(|m| m.world.class_hash),
         };

--- a/crates/dojo-world/src/migration/world.rs
+++ b/crates/dojo-world/src/migration/world.rs
@@ -8,6 +8,10 @@ use super::contract::ContractDiff;
 use super::StateDiff;
 use crate::manifest::{Manifest, EXECUTOR_CONTRACT_NAME, WORLD_CONTRACT_NAME};
 
+#[cfg(test)]
+#[path = "world_test.rs"]
+mod tests;
+
 /// Represents the state differences between the local and remote worlds.
 #[derive(Debug)]
 pub struct WorldDiff {

--- a/crates/dojo-world/src/migration/world_test.rs
+++ b/crates/dojo-world/src/migration/world_test.rs
@@ -1,0 +1,74 @@
+use super::*;
+use crate::manifest::{Component, Contract, Manifest, System};
+
+#[test]
+fn no_diff_when_local_and_remote_are_equal() {
+    let world_contract = Contract {
+        address: Some(77_u32.into()),
+        class_hash: 66_u32.into(),
+        name: WORLD_CONTRACT_NAME.into(),
+    };
+
+    let executor_contract = Contract {
+        address: Some(88_u32.into()),
+        class_hash: 99_u32.into(),
+        name: EXECUTOR_CONTRACT_NAME.into(),
+    };
+
+    let components =
+        vec![Component { members: vec![], name: "Component".into(), class_hash: 11_u32.into() }];
+
+    let systems =
+        vec![System { name: "System".into(), class_hash: 22_u32.into(), ..Default::default() }];
+
+    let local = Manifest {
+        components,
+        world: world_contract,
+        executor: executor_contract,
+        systems,
+        ..Default::default()
+    };
+    let remote = local.clone();
+
+    let diff = WorldDiff::compute(local, Some(remote));
+
+    assert_eq!(diff.count_diffs(), 0);
+}
+
+#[test]
+fn diff_when_local_and_remote_are_different() {
+    let world_contract = Contract {
+        class_hash: 66_u32.into(),
+        name: WORLD_CONTRACT_NAME.into(),
+        ..Default::default()
+    };
+
+    let executor_contract = Contract {
+        class_hash: 99_u32.into(),
+        name: EXECUTOR_CONTRACT_NAME.into(),
+        ..Default::default()
+    };
+
+    let components =
+        vec![Component { members: vec![], name: "Component".into(), class_hash: 11_u32.into() }];
+
+    let systems =
+        vec![System { name: "System".into(), class_hash: 22_u32.into(), ..Default::default() }];
+
+    let local = Manifest {
+        components,
+        world: world_contract,
+        executor: executor_contract,
+        systems,
+        ..Default::default()
+    };
+
+    let mut remote = local.clone();
+    remote.world.class_hash = 44_u32.into();
+    remote.executor.class_hash = 55_u32.into();
+    remote.components[0].class_hash = 33_u32.into();
+
+    let diff = WorldDiff::compute(local, Some(remote));
+
+    assert_eq!(diff.count_diffs(), 3);
+}

--- a/crates/sozo/src/commands/migrate.rs
+++ b/crates/sozo/src/commands/migrate.rs
@@ -17,7 +17,7 @@ pub struct MigrateArgs {
     #[arg(long)]
     #[arg(help = "Name of the World.")]
     #[arg(
-        long_help = "Name of the World. It will be used as the salt when deploying the contract to avoid address conflicts."
+        long_help = "Name of the World. It's hash will be used as a salt when deploying the contract to avoid address conflicts."
     )]
     pub name: Option<String>,
 

--- a/crates/sozo/src/commands/migrate.rs
+++ b/crates/sozo/src/commands/migrate.rs
@@ -11,8 +11,15 @@ use crate::ops::migration;
 #[derive(Args)]
 pub struct MigrateArgs {
     #[arg(short, long)]
-    #[arg(help = "Perform a dry run and outputs the plan to be executed")]
+    #[arg(help = "Perform a dry run and outputs the plan to be executed.")]
     pub plan: bool,
+
+    #[arg(long)]
+    #[arg(help = "Name of the World.")]
+    #[arg(
+        long_help = "Name of the World. It will be used as the salt when deploying the contract to avoid address conflicts."
+    )]
+    pub name: Option<String>,
 
     #[command(flatten)]
     pub world: WorldOptions,
@@ -45,9 +52,12 @@ impl MigrateArgs {
             .and_then(|env_metadata| env_metadata.get(ws.config().profile().as_str()).cloned())
             .or(env_metadata);
 
-        ws.config().tokio_handle().block_on(async {
-            migration::execute(self, env_metadata, target_dir, ws.config()).await
-        })?;
+        ws.config().tokio_handle().block_on(migration::execute(
+            self,
+            env_metadata,
+            target_dir,
+            ws.config(),
+        ))?;
 
         Ok(())
     }

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -5,7 +5,7 @@ use dojo_client::contract::world::WorldContract;
 use dojo_world::manifest::{Manifest, ManifestError};
 use dojo_world::migration::strategy::{prepare_for_migration, MigrationStrategy};
 use dojo_world::migration::world::WorldDiff;
-use dojo_world::migration::{Declarable, Deployable, MigrationError, RegisterOutput};
+use dojo_world::migration::{Declarable, Deployable, MigrationError, RegisterOutput, StateDiff};
 use dojo_world::utils::TransactionWaiter;
 use scarb::core::Config;
 use starknet::accounts::{Account, ConnectedAccount, SingleOwnerAccount};
@@ -40,41 +40,39 @@ pub async fn execute<U>(
 where
     U: AsRef<Path>,
 {
-    let MigrateArgs { account, starknet, world, .. } = args;
+    let MigrateArgs { account, starknet, world, name, .. } = args;
+
+    // Setup account for migration and fetch world address if it exists.
 
     let (world_address, account) =
         setup_env(account, starknet, world, env_metadata, config).await?;
 
+    // Load local and remote World manifests.
+
     let (local_manifest, remote_manifest) =
         load_world_manifests(&target_dir, world_address, &account, config).await?;
 
-    config.ui().print_step(2, "🧰", "Evaluating Worlds diff...");
+    // Calculate diff between local and remote World manifests.
 
+    config.ui().print_step(2, "🧰", "Evaluating Worlds diff...");
     let diff = WorldDiff::compute(local_manifest, remote_manifest);
     let total_diffs = diff.count_diffs();
-
     config.ui().print_sub(format!("Total diffs found: {total_diffs}"));
 
     if total_diffs == 0 {
         config.ui().print("\n✨ No changes to be made. Remote World is already up to date!")
     } else {
-        config.ui().print_step(3, "📦", "Preparing for migration...");
+        // Prepare migration strategy based on the diff.
 
-        let mut migration = prepare_for_migration(world_address, target_dir, diff)
-            .with_context(|| "Problem preparing for migration.")?;
+        if name.is_none() && !diff.world.is_same() {
+            bail!("World name is required when attempting to migrate the World contract. Please provide it using the `--name`.");
+        }
 
-        let info = migration.info();
-
-        config.ui().print_sub(format!(
-            "Total items to be migrated ({}): New {} Update {}",
-            info.new + info.update,
-            info.new,
-            info.update
-        ));
+        let strategy = prepare_migration(target_dir, diff, name, world_address, config)?;
 
         println!("  ");
 
-        execute_strategy(&mut migration, account, config)
+        execute_strategy(&strategy, &account, config)
             .await
             .map_err(|e| anyhow!(e))
             .with_context(|| "Problem trying to migrate.")?;
@@ -83,7 +81,7 @@ where
             "\n🎉 Successfully migrated World at address {}",
             bold_message(format!(
                 "{:#x}",
-                migration.world_address().expect("world address must exist")
+                strategy.world_address().expect("world address must exist")
             ))
         ));
     }
@@ -162,10 +160,36 @@ where
     Ok((local_manifest, remote_manifest))
 }
 
-// TODO: display migration type (either new or update)
+fn prepare_migration<U>(
+    target_dir: U,
+    diff: WorldDiff,
+    seed: Option<String>,
+    world_address: Option<FieldElement>,
+    config: &Config,
+) -> Result<MigrationStrategy>
+where
+    U: AsRef<Path>,
+{
+    config.ui().print_step(3, "📦", "Preparing for migration...");
+
+    let migration = prepare_for_migration(world_address, seed, target_dir, diff)
+        .with_context(|| "Problem preparing for migration.")?;
+
+    let info = migration.info();
+
+    config.ui().print_sub(format!(
+        "Total items to be migrated ({}): New {} Update {}",
+        info.new + info.update,
+        info.new,
+        info.update
+    ));
+
+    Ok(migration)
+}
+
 async fn execute_strategy<P, S>(
-    strategy: &mut MigrationStrategy,
-    migrator: SingleOwnerAccount<P, S>,
+    strategy: &MigrationStrategy,
+    migrator: &SingleOwnerAccount<P, S>,
     ws_config: &Config,
 ) -> Result<()>
 where
@@ -176,7 +200,7 @@ where
         Some(executor) => {
             ws_config.ui().print_header("# Executor");
 
-            match executor.deploy(executor.diff.local, vec![], &migrator).await {
+            match executor.deploy(executor.diff.local, vec![], migrator).await {
                 Ok(val) => {
                     if let Some(declare) = val.clone().declare {
                         ws_config.ui().print_hidden_sub(format!(
@@ -215,7 +239,7 @@ where
         None => {}
     };
 
-    match &mut strategy.world {
+    match &strategy.world {
         Some(world) => {
             ws_config.ui().print_header("# World");
 
@@ -223,14 +247,14 @@ where
                 .deploy(
                     world.diff.local,
                     vec![strategy.executor.as_ref().unwrap().contract_address],
-                    &migrator,
+                    migrator,
                 )
                 .await
             {
                 Ok(val) => {
                     if let Some(declare) = val.clone().declare {
                         ws_config.ui().print_hidden_sub(format!(
-                            "declare transaction: {:#x}",
+                            "Declare transaction: {:#x}",
                             declare.transaction_hash
                         ));
                     }
@@ -242,7 +266,11 @@ where
 
                     Ok(())
                 }
-                Err(MigrationError::ContractAlreadyDeployed) => Ok(()),
+                Err(MigrationError::ContractAlreadyDeployed) => Err(anyhow!(
+                    "Attempting to deploy World at address {:#x} but a World already exists there. Try \
+                     using a different World name using `--name`.",
+                    world.contract_address
+                )),
                 Err(e) => Err(anyhow!("Failed to migrate world: {:?}", e)),
             }?;
 
@@ -251,8 +279,8 @@ where
         None => {}
     };
 
-    register_components(strategy, &migrator, ws_config).await?;
-    register_systems(strategy, &migrator, ws_config).await?;
+    register_components(strategy, migrator, ws_config).await?;
+    register_systems(strategy, migrator, ws_config).await?;
 
     Ok(())
 }


### PR DESCRIPTION
`sozo migrate` now expects a new option `--name` which will be used as the salt value for World contract deployment. This is to avoid having address conflicts.