### PR TITLE
fix: export not found

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,5 +2,5 @@ import * as Providers from './provider';
 import * as Account from './account'
 import * as Utils from './utils'
 import { SyncWorker } from './network/SyncWorker';
-import { Query } from './types';
+import type { Query } from './types';
 export { Providers, Account, Utils, Query, SyncWorker };


### PR DESCRIPTION
When linking core directly from a react project (git subtree of dojo in @/lib), I get the error `Uncaught SyntaxError: The requested module '/****/lib/dojo/packages/core/src/types/index.ts' does not provide an export named 'Query'`

This https://stackoverflow.com/questions/65721426/typescript-export-was-not-found hinted for the fix which seems to work and not break the build.