### PR TITLE
fix: adding "events" package to react-example

### DIFF
--- a/packages/examples/react-example/package.json
+++ b/packages/examples/react-example/package.json
@@ -13,6 +13,7 @@
     "@latticexyz/recs": "^1.43.0",
     "@latticexyz/utils": "^1.43.0",
     "ethers": "^5.7.2",
+    "events": "^3.3.0",
     "mobx": "^6.9.0",
     "proxy-deep": "^3.1.1",
     "react": "^18.2.0",

--- a/packages/examples/react-example/yarn.lock
+++ b/packages/examples/react-example/yarn.lock
@@ -1376,6 +1376,11 @@ ethers@^5.7.2:
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"


### PR DESCRIPTION
To fix "provider.js:2 Uncaught TypeError: Class extends value undefined is not a constructor or null at provider.js:2:31"