### PR TITLE
fix(torii): only parse events from world address

### DIFF
--- a/crates/torii/src/cli.rs
+++ b/crates/torii/src/cli.rs
@@ -34,7 +34,7 @@ mod tests;
 #[command(author, version, about, long_about = None)]
 struct Args {
     /// The world to index
-    #[arg(short, long, default_value = "0x420")]
+    #[arg(short, long)]
     world_address: FieldElement,
     /// The rpc endpoint to use
     #[arg(long, default_value = "http://localhost:5050")]
@@ -95,7 +95,8 @@ async fn main() -> anyhow::Result<()> {
         ..Processors::default()
     };
 
-    let indexer = Indexer::new(&state, &provider, processors, manifest, args.start_block);
+    let indexer =
+        Indexer::new(&state, &provider, processors, manifest, args.world_address, args.start_block);
     let graphql = start_graphql(&pool);
 
     tokio::select! {

--- a/crates/torii/src/cli.rs
+++ b/crates/torii/src/cli.rs
@@ -46,8 +46,8 @@ struct Args {
     #[arg(short, long)]
     manifest: Option<Utf8PathBuf>,
     /// Specify a block to start indexing from, ignored if stored head exists
-    #[arg(short, long)]
-    start_block: Option<u64>,
+    #[arg(short, long, default_value = "0")]
+    start_block: u64,
 }
 
 #[tokio::main]

--- a/crates/torii/src/indexer.rs
+++ b/crates/torii/src/indexer.rs
@@ -24,15 +24,13 @@ impl<'a, S: State + Executable, T: JsonRpcTransport + Sync + Send> Indexer<'a, S
         processors: Processors<S, T>,
         manifest: Manifest,
         world_address: FieldElement,
-        start_block: Option<u64>,
+        start_block: u64,
     ) -> Self {
         let engine = Engine::new(
             storage,
             provider,
             processors,
-            world_address,
-            start_block,
-            EngineConfig::default(),
+            EngineConfig { world_address, start_block, ..Default::default() },
         );
         Self { storage, provider, engine, manifest }
     }

--- a/crates/torii/src/indexer.rs
+++ b/crates/torii/src/indexer.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 
 use dojo_world::manifest::Manifest;
 use starknet::providers::jsonrpc::{JsonRpcClient, JsonRpcTransport};
+use starknet_crypto::FieldElement;
 use tracing::info;
 
 use crate::engine::{Engine, EngineConfig, Processors};
@@ -22,10 +23,17 @@ impl<'a, S: State + Executable, T: JsonRpcTransport + Sync + Send> Indexer<'a, S
         provider: &'a JsonRpcClient<T>,
         processors: Processors<S, T>,
         manifest: Manifest,
+        world_address: FieldElement,
         start_block: Option<u64>,
     ) -> Self {
-        let engine =
-            Engine::new(storage, provider, processors, start_block, EngineConfig::default());
+        let engine = Engine::new(
+            storage,
+            provider,
+            processors,
+            world_address,
+            start_block,
+            EngineConfig::default(),
+        );
         Self { storage, provider, engine, manifest }
     }
 


### PR DESCRIPTION
Resolves https://github.com/dojoengine/dojo/issues/686.

It makes world_address required for now when starting torii. For world explorer, we can refactor and have a more generic event parser.