### PR TITLE
feat(katana,sozo): add subcommand completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3848,6 +3857,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "clap",
+ "clap_complete",
  "env_logger 0.10.0",
  "katana-core",
  "katana-rpc",
@@ -5745,6 +5755,7 @@ dependencies = [
  "camino",
  "clap",
  "clap-verbosity-flag",
+ "clap_complete",
  "console",
  "dojo-client",
  "dojo-lang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ cairo-vm = "0.6.0"
 camino = { version = "1.1.2", features = [ "serde1" ] }
 chrono = { version = "0.4.24", features = [ "serde" ] }
 clap = { version = "4.2", features = [ "derive" ] }
+clap_complete = "4.3"
 colored = "2"
 console = "0.15.7"
 convert_case = "0.6.0"

--- a/crates/katana/Cargo.toml
+++ b/crates/katana/Cargo.toml
@@ -8,6 +8,7 @@ description = "A fast and lightweight local Starknet development sequencer."
 
 [dependencies]
 clap.workspace = true
+clap_complete.workspace = true
 env_logger.workspace = true
 log.workspace = true
 tokio.workspace = true
@@ -15,7 +16,6 @@ katana-core = { path = "core" }
 katana-rpc = { path = "rpc" }
 starknet_api.workspace = true
 yansi.workspace = true
-clap_complete = "4.3.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/katana/Cargo.toml
+++ b/crates/katana/Cargo.toml
@@ -15,6 +15,7 @@ katana-core = { path = "core" }
 katana-rpc = { path = "rpc" }
 starknet_api.workspace = true
 yansi.workspace = true
+clap_complete = "4.3.2"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/crates/katana/src/args.rs
+++ b/crates/katana/src/args.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser};
+use clap::{Args, Parser, Subcommand};
+use clap_complete::Shell;
 use katana_core::backend::config::{Environment, StarknetConfig};
 use katana_core::constants::{
     DEFAULT_GAS_PRICE, DEFAULT_INVOKE_MAX_STEPS, DEFAULT_VALIDATE_MAX_STEPS,
@@ -33,6 +34,15 @@ pub struct KatanaArgs {
     #[command(flatten)]
     #[command(next_help_heading = "Starknet options")]
     pub starknet: StarknetOptions,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    #[command(about = "Generate shell completion file for specified shell")]
+    Completions { shell: Shell },
 }
 
 #[derive(Debug, Args, Clone)]

--- a/crates/katana/src/main.rs
+++ b/crates/katana/src/main.rs
@@ -1,7 +1,8 @@
-use std::process::exit;
 use std::sync::Arc;
+use std::{io, process::exit};
 
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::{generate, Shell};
 use env_logger::Env;
 use katana_core::sequencer::KatanaSequencer;
 use katana_rpc::{spawn, KatanaApi, NodeHandle, StarknetApi};
@@ -10,7 +11,7 @@ use yansi::Paint;
 
 mod args;
 
-use args::KatanaArgs;
+use args::{Commands::Completions, KatanaArgs};
 
 #[tokio::main]
 async fn main() {
@@ -20,6 +21,14 @@ async fn main() {
     .init();
 
     let config = KatanaArgs::parse();
+    if let Some(command) = config.command {
+        match command {
+            Completions { shell } => {
+                print_completion(shell);
+                return;
+            }
+        }
+    }
 
     let server_config = config.server_config();
     let sequencer_config = config.sequencer_config();
@@ -49,6 +58,12 @@ async fn main() {
             exit(1);
         }
     };
+}
+
+fn print_completion(shell: Shell) {
+    let mut command = KatanaArgs::command();
+    let name = command.get_name().to_string();
+    generate(shell, &mut command, name, &mut io::stdout());
 }
 
 fn print_intro(accounts: String, seed: String, address: String) {

--- a/crates/sozo/Cargo.toml
+++ b/crates/sozo/Cargo.toml
@@ -37,6 +37,7 @@ clap-verbosity-flag = "2.0.1"
 yansi.workspace = true
 tracing.workspace = true
 tracing-log = "0.1.3"
+clap_complete = "4.3.2"
 
 [dev-dependencies]
 assert_fs = "1.0.10"

--- a/crates/sozo/Cargo.toml
+++ b/crates/sozo/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 camino.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 dojo-client = { path = "../dojo-client" }
 dojo-lang = { path = "../dojo-lang" }
 dojo-world = { path = "../dojo-world" }
@@ -37,7 +38,6 @@ clap-verbosity-flag = "2.0.1"
 yansi.workspace = true
 tracing.workspace = true
 tracing-log = "0.1.3"
-clap_complete = "4.3.2"
 
 [dev-dependencies]
 assert_fs = "1.0.10"

--- a/crates/sozo/src/args.rs
+++ b/crates/sozo/src/args.rs
@@ -9,6 +9,7 @@ use tracing_log::AsTrace;
 
 use crate::commands::auth::AuthArgs;
 use crate::commands::build::BuildArgs;
+use crate::commands::completions::CompletionsArgs;
 use crate::commands::component::ComponentArgs;
 use crate::commands::events::EventsArgs;
 use crate::commands::execute::ExecuteArgs;
@@ -64,6 +65,8 @@ pub enum Commands {
     Events(EventsArgs),
     #[command(about = "Manage world authorization")]
     Auth(AuthArgs),
+    #[command(about = "Generate shell completion file for specified shell")]
+    Completions(CompletionsArgs),
 }
 
 impl SozoArgs {

--- a/crates/sozo/src/commands/completions.rs
+++ b/crates/sozo/src/commands/completions.rs
@@ -1,0 +1,20 @@
+use std::io;
+
+use crate::SozoArgs;
+use anyhow::Result;
+use clap::{Args, CommandFactory};
+use clap_complete::{generate, Shell};
+
+#[derive(Args, Debug)]
+pub struct CompletionsArgs {
+    shell: Shell,
+}
+
+impl CompletionsArgs {
+    pub fn run(self) -> Result<()> {
+        let mut command = SozoArgs::command();
+        let name = command.get_name().to_string();
+        generate(self.shell, &mut command, name, &mut io::stdout());
+        Ok(())
+    }
+}

--- a/crates/sozo/src/commands/mod.rs
+++ b/crates/sozo/src/commands/mod.rs
@@ -5,6 +5,7 @@ use crate::args::Commands;
 
 pub(crate) mod auth;
 pub(crate) mod build;
+pub(crate) mod completions;
 pub(crate) mod component;
 pub(crate) mod events;
 pub(crate) mod execute;
@@ -28,5 +29,6 @@ pub fn run(command: Commands, config: &Config) -> Result<()> {
         Commands::System(args) => args.run(config),
         Commands::Register(args) => args.run(config),
         Commands::Events(args) => args.run(config),
+        Commands::Completions(args) => args.run(),
     }
 }


### PR DESCRIPTION
Fixes: #694 

adds a subcommand to katana and sozo which prints the completion file of specified shell to stdout.

usage:
> katana completions fish > katana.fish

now can copy this file to folder where fish looks for completion files.