### PR TITLE
feat(katana): shutdown state dump

### DIFF
--- a/crates/katana/src/args.rs
+++ b/crates/katana/src/args.rs
@@ -29,7 +29,6 @@ pub struct KatanaArgs {
     pub block_time: Option<u64>,
 
     #[arg(long)]
-    #[arg(hide = true)]
     #[arg(value_name = "PATH")]
     #[arg(help = "Dump the state of chain on exit to the given file.")]
     #[arg(long_help = "Dump the state of chain on exit to the given file. \


### PR DESCRIPTION
resolves #700

* Awaits until `Ctrl` + `C`
* Calls `shutdown_handler`
* If `config.dump_state` is set, dumps the state to path.