### PR TITLE
chore() remove unused SequencerError

### DIFF
--- a/crates/katana/core/src/sequencer_error.rs
+++ b/crates/katana/core/src/sequencer_error.rs
@@ -40,6 +40,4 @@ pub enum SequencerError {
     DataUnavailable,
     #[error("Failed to decode state")]
     FailedToDecodeStateDump,
-    #[error("Failed to set storage")]
-    FailedToSetStorage,
 }


### PR DESCRIPTION
WRT #703
I was typing the PR message but the PR was accepted 3 minutes before the message was all typed in.

https://github.com/dojoengine/dojo/pull/703#issue-1834017517

> New Sequencer error
> ```rs
> #[error("Failed to set storage")]
> FailedToSetStorage,
> ```
> `UPDATE` Ended up using StateNotFound, will remove this.