### PR TITLE
Inlinemacros

### DIFF
--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -105,5 +105,6 @@ fn test_compiler() {
     let config = build_test_config("../../examples/ecs/Scarb.toml").unwrap();
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    ops::compile(vec![], &ws).unwrap_or_else(|op| panic!("Error compiling: {op:?}"))
+    let packages = ws.members().map(|p| p.id).collect();
+    ops::compile(packages, &ws).unwrap_or_else(|op| panic!("Error compiling: {op:?}"))
 }

--- a/crates/dojo-test-utils/build.rs
+++ b/crates/dojo-test-utils/build.rs
@@ -11,7 +11,7 @@ fn main() {
     use scarb::ui::Verbosity;
 
     let target_path = Utf8PathBuf::from_path_buf("../../examples/ecs/target".into()).unwrap();
-    if !target_path.exists() {
+    if target_path.exists() {
         return;
     }
 

--- a/crates/dojo-test-utils/build.rs
+++ b/crates/dojo-test-utils/build.rs
@@ -35,7 +35,8 @@ fn main() {
         .unwrap();
 
     let ws = ops::read_workspace(config.manifest_path(), &config).unwrap();
-    ops::compile(vec![], &ws).unwrap();
+    let packages = ws.members().map(|p| p.id).collect();
+    ops::compile(packages, &ws).unwrap();
 }
 
 #[cfg(not(feature = "build-examples"))]

--- a/crates/sozo/src/commands/build.rs
+++ b/crates/sozo/src/commands/build.rs
@@ -9,6 +9,7 @@ pub struct BuildArgs;
 impl BuildArgs {
     pub fn run(self, config: &Config) -> Result<()> {
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
-        ops::compile(vec![], &ws)
+        let packages = ws.members().map(|p| p.id).collect();
+        ops::compile(packages, &ws)
     }
 }

--- a/crates/sozo/src/commands/migrate.rs
+++ b/crates/sozo/src/commands/migrate.rs
@@ -38,7 +38,8 @@ impl MigrateArgs {
         let target_dir = target_dir.join(ws.config().profile().as_str());
 
         if !target_dir.join("manifest.json").exists() {
-            scarb::ops::compile(vec![], &ws)?;
+            let packages = ws.members().map(|p| p.id).collect();
+            scarb::ops::compile(packages, &ws)?;
         }
 
         let mut env_metadata = dojo_metadata_from_workspace(&ws)


### PR DESCRIPTION
Two issues addressed,
1. Return when the target path already exists https://github.com/dojoengine/dojo/commit/c77cb831e3181d8ab4a3d421125ac01e480ac49c
2. Pass `packages` `vec` to `scarb::ops::compile`
  - This is fixed for all `scarb::ops::compile` calls in code.