### PR TITLE
feat(torii): graphql relay connection support

### DIFF
--- a/crates/katana/README.md
+++ b/crates/katana/README.md
@@ -40,9 +40,9 @@ cargo install --path ./crates/katana --locked --force
 | starknet_getTransactionByHash            | :white_check_mark: |
 | starknet_getTransactionByBlockIdAndIndex | :white_check_mark: |
 | starknet_getTransactionReceipt           | :white_check_mark: |
-| starknet_getClass                        | :construction:     |
+| starknet_getClass                        | :white_check_mark: |
 | starknet_getClassHashAt                  | :white_check_mark: |
-| starknet_getClassAt                      | :construction:     |
+| starknet_getClassAt                      | :white_check_mark: |
 | starknet_getBlockTransactionCount        | :white_check_mark: |
 | starknet_call                            | :white_check_mark: |
 | starknet_estimateFee                     | :white_check_mark: |
@@ -51,7 +51,7 @@ cargo install --path ./crates/katana --locked --force
 | starknet_chainId                         | :white_check_mark: |
 | starknet_pendingTransactions             | :white_check_mark: |
 | starknet_syncing                         | :construction:     |
-| starknet_getEvents                       | :construction:     |
+| starknet_getEvents                       | :white_check_mark: |
 | starknet_getNonce                        | :white_check_mark: |
 | **Trace**                                |
 | starknet_traceTransaction                | :construction:     |
@@ -80,48 +80,55 @@ cargo install --path ./crates/katana --locked --force
 PREFUNDED ACCOUNTS
 ==================
 
-| Account address |  0x06f62894bfd81d2e396ce266b2ad0f21e0668d604e5bb1077337b6d570a54aea
-| Private key     |  0x07230b49615d175307d580c33d6fda61fc7b9aec91df0f5c1a5ebe3b8cbfee02
-| Public key      |  0x078e6e3e4a50285be0f6e8d0b8a61044033e24023df6eb95979ae4073f159ae6
+| Account address |  0x03ee9e18edc71a6df30ac3aca2e0b02a198fbce19b7480a63a0d71cbd76652e0
+| Private key     |  0x0300001800000000300000180000000000030000000000003006001800006600
+| Public key      |  0x01b7b37a580d91bc3ad4f9933ed61f3a395e0e51c9dd5553323b8ca3942bb44e
 
-| Account address |  0x04b352538f61697825af242c9c451df02a40cca99391a47054489dee82138008
-| Private key     |  0x0326b6d921c2d9c9b76bb641c433c94b030cf57d48803dc742729704ffdd0fc6
-| Public key      |  0x0564a13ba4d4cf95a60f78ca05fc04ff6845736e2f04b3c6703283cdf65e2615
+| Account address |  0x033c627a3e5213790e246a917770ce23d7e562baa5b4d2917c23b1be6d91961c
+| Private key     |  0x0333803103001800039980190300d206608b0070db0012135bd1fb5f6282170b
+| Public key      |  0x04486e2308ef3513531042acb8ead377b887af16bd4cdd8149812dfef1ba924d
 
-| Account address |  0x045d22a493ddf200def65fe3bdaba1d2d5b20fe303cc2ed902ad5722d6834af1
-| Private key     |  0x041a7efcede848dae4eecae96e5bdc2d91ae589aee3f1b8b23d2cfccf9972a27
-| Public key      |  0x07ffd0e1b598190fab7a2df22b0b6292f05f82b80af015c60f226bf435544c95
+| Account address |  0x01d98d835e43b032254ffbef0f150c5606fa9c5c9310b1fae370ab956a7919f5
+| Private key     |  0x07ca856005bee0329def368d34a6711b2d95b09ef9740ebf2c7c7e3b16c1ca9c
+| Public key      |  0x07006c42b1cfc8bd45710646a0bb3534b182e83c313c7bc88ecf33b53ba4bcbc
 
-| Account address |  0x021edaaa14de3294311307153e3e39b25418f4948d17ff7b3f586c784e0a69a0
-| Private key     |  0x07d3fe0fe48f2d4e4552378b80ab97bdd459f7ff4a9fe761f34fa01af8496eb3
-| Public key      |  0x020758daea09b807c5702bc3ec8f8b0490363bc7d5eee47d295c437de9cf885b
+| Account address |  0x0697aaeb6fb12665ced647f7efa57c8f466dc3048556dd265e4774c546caa059
+| Private key     |  0x009f6d7a28c0aec0bb42b11600b2fdc4f20042ab6adeac0ca9e6696aabc5bc95
+| Public key      |  0x076e247c83b961e3ac33082406498a8629a51c1c9e465f4302018565ec1841ff
 
-| Account address |  0x056f373dc91d2ee0a0e9b47c33bf90c02ea97760c8dc56a86431469981d60f37
-| Private key     |  0x00a0ff8c75df423c4814fc0f0dcac1fee74dcd5a8452e3065c060ff877f79264
-| Public key      |  0x0440432421c64944841875b480ba3e930f562835b57cb0b642d46d2a6a58d2d2
+| Account address |  0x021b8eb1d455d5a1ef836a8dae16bfa61fbf7aaa252384ab4732603d12d684d2
+| Private key     |  0x05d4184feb2ba1aa1274885dd88c8a670a806066dda7684aa562390441224483
+| Public key      |  0x04e8b088e35962a3912054065682b0546921a96f0b63418484c824ed67729ba3
 
-| Account address |  0x04622d0936e6e5acefbccd62dda1a53a129033a175f2cd6fcbddab56f46307ed
-| Private key     |  0x010a50bbc86605b34edc100418400353faa3074eb03843bf7f877e9d1a37f53d
-| Public key      |  0x02c4bcb9c416c1efc84e0cfc8a104471582939c8f06279253602404509de8bc9
+| Account address |  0x018e623c4ee9f3cf93b06784606f5bc1e86070e8ee6459308c9482554e265367
+| Private key     |  0x01c62fa406d5cac0f365e20ae9c365548f793196e40536c8c118130255a0ac54
+| Public key      |  0x04796fb56fc9e44bf543c56625527c04e0a6c51b76b00fc95d8b18749f051077
 
-| Account address |  0x001546cd0b387da3548fb25917cb11edd0b622bcaac9d76df55348f7914269e8
-| Private key     |  0x0787c87b11ceb1a4cffd12511ca16bb242c9b0eb132b12c685c78202a2ceeac6
-| Public key      |  0x06a359a89d9890ea8cda2110fe9cd7f0050bd0b5f50bffe7b86a8c8ada768c0b
+| Account address |  0x01a0a8e7c3a71a44d2e43fec473d7517fd4f20c6ea054e33be3f98ef82e449df
+| Private key     |  0x07813a0576f69d6e2e90d6d5d861f029fa34e528ba418ebb8e335dbc1ed18505
+| Public key      |  0x04fa2c2e826b04cdf46625c4e80a6e24c8c1e629ccedcbed7dcbe2cf2dd0a6da
 
-| Account address |  0x07b502625694e1fd1937cd4422f5c63f3ec1ab58ceca7f83d41048b1bf13abca
-| Private key     |  0x0455fec1b8f370fe457a4408f3c9dbef183d21e9f2b6a41046a15e71de396c22
-| Public key      |  0x0111cc1d9b04a362844eff62e10f477baf6eeb1f2e4112779ce815255b29c634
+| Account address |  0x006a933941976911cbf6917010aae47ef7a54bb32846a3d890c1985d879807aa
+| Private key     |  0x0092f44f50c2fe38cdd00c59a8ab796238982426341f0ee9ebcaa7fd8b1ac939
+| Public key      |  0x03aa57dec32a26b97ab2542da41ca2512cfc5e3ffc3feca2d21664e2eeeb3836
 
-| Account address |  0x03d2bc8ca262f5eb9ce5c74ac4726fb77efae0a9c7f71e19b82f4eef7f8d570f
-| Private key     |  0x01c30ee733a20acac5212c4eb47822da9ddf9a0eb284db5db9349bfb13fa4414
-| Public key      |  0x00043d3160509684bd8a4eb6c71ee6254f2242bd98bb24458ec73c03e1f32807
+| Account address |  0x03c00d7cda80f89cb59c147d897acb1647f9e33228579674afeea08f6f57e418
+| Private key     |  0x04f5adc57e9025a7c5d1424972354fd83ace8b60ff7d46251512b3ea69b81434
+| Public key      |  0x03839dd0e4e8e664f659b580a9d04de2984914a86e055f46ad2abd687bf4225d
 
-| Account address |  0x0359538c9aa342ce7d97009969657f802cc6ba3df88133d4d1715f73cc49d78e
-| Private key     |  0x00ea7dc42ff7fbed5a64adecfaa7fd340075f76c931190571d0f52cc1d4b9002
-| Public key      |  0x0369073d60190de294bb56e07b8e65ebbe44f70c7e7818e80a48268d79a90d8f
+| Account address |  0x04514dd4ce4762369fc108297f45771f5160aeb7c864d5209e5047a48ab90b52
+| Private key     |  0x04929b5202c17d1bf1329e0f3b1deac313252a007cfd925d703e716f790c5726
+| Public key      |  0x0250a4e65d6d55cbb2a643585a92891b3950c841f30c79ab8b3ee5ee2c3f4194
 
 
-🚀 JSON-RPC server started: http://127.0.0.1:5050
+ACCOUNTS SEED
+=============
+0
+
+
+🚀 JSON-RPC server started: http://0.0.0.0:5050
 
 
 ```
+
+Check out the [`katana Reference`](https://book.dojoengine.org/reference/katana/index.html) section of the Dojo book to learn about all the available RPC methods and options.

--- a/crates/torii/src/graphql/object/component.rs
+++ b/crates/torii/src/graphql/object/component.rs
@@ -5,7 +5,8 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 use sqlx::{FromRow, Pool, Sqlite};
 
-use super::query::{query_all, query_by_id, ID};
+use super::connection::connection_output;
+use super::query::{query_all, query_by_id, query_total_count, ID};
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::graphql::constants::DEFAULT_LIMIT;
 use crate::graphql::types::ScalarType;
@@ -75,7 +76,7 @@ impl ObjectTrait for ComponentObject {
                     let id = ctx.args.try_get("id")?.string()?.to_string();
                     let component = query_by_id(&mut conn, "components", ID::Str(id)).await?;
                     let result = ComponentObject::value_mapping(component);
-                    Ok(Some(FieldValue::owned_any(result)))
+                    Ok(Some(Value::Object(result)))
                 })
             })
             .argument(InputValue::new("id", TypeRef::named_nn(TypeRef::ID))),
@@ -83,28 +84,21 @@ impl ObjectTrait for ComponentObject {
     }
 
     fn resolve_many(&self) -> Option<Field> {
-        Some(
-            Field::new("components", TypeRef::named_list(self.type_name()), |ctx| {
+        Some(Field::new(
+            "components",
+            TypeRef::named(format!("{}Connection", self.type_name())),
+            |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
-                    let limit = ctx
-                        .args
-                        .try_get("limit")
-                        .and_then(|limit| limit.u64())
-                        .unwrap_or(DEFAULT_LIMIT);
+                    let total_count = query_total_count(&mut conn, "components").await?;
+                    let data: Vec<Component> =
+                        query_all(&mut conn, "components", DEFAULT_LIMIT).await?;
+                    let components: Vec<ValueMapping> =
+                        data.into_iter().map(ComponentObject::value_mapping).collect();
 
-                    let components: Vec<Component> =
-                        query_all(&mut conn, "components", limit).await?;
-                    let result: Vec<FieldValue<'_>> = components
-                        .into_iter()
-                        .map(ComponentObject::value_mapping)
-                        .map(FieldValue::owned_any)
-                        .collect();
-
-                    Ok(Some(FieldValue::list(result)))
+                    Ok(Some(Value::Object(connection_output(&components, "id", total_count))))
                 })
-            })
-            .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
-        )
+            },
+        ))
     }
 }

--- a/crates/torii/src/graphql/object/component.rs
+++ b/crates/torii/src/graphql/object/component.rs
@@ -30,11 +30,11 @@ impl ComponentObject {
     pub fn _new() -> Self {
         Self {
             type_mapping: IndexMap::from([
-                (Name::new("id"), TypeRef::ID.to_string()),
-                (Name::new("name"), TypeRef::STRING.to_string()),
-                (Name::new("classHash"), ScalarType::Felt252.to_string()),
-                (Name::new("transactionHash"), ScalarType::Felt252.to_string()),
-                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
+                (Name::new("id"), TypeRef::named(TypeRef::ID)),
+                (Name::new("name"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("classHash"), TypeRef::named(ScalarType::Felt252.to_string())),
+                (Name::new("transactionHash"), TypeRef::named(ScalarType::Felt252.to_string())),
+                (Name::new("createdAt"), TypeRef::named(ScalarType::DateTime.to_string())),
             ]),
         }
     }

--- a/crates/torii/src/graphql/object/component.rs
+++ b/crates/torii/src/graphql/object/component.rs
@@ -22,14 +22,14 @@ pub struct Component {
 }
 
 pub struct ComponentObject {
-    pub field_type_mapping: TypeMapping,
+    pub type_mapping: TypeMapping,
 }
 
 impl ComponentObject {
     // Not used currently, eventually used for component metadata
     pub fn _new() -> Self {
         Self {
-            field_type_mapping: IndexMap::from([
+            type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
                 (Name::new("name"), TypeRef::STRING.to_string()),
                 (Name::new("classHash"), ScalarType::Felt252.to_string()),
@@ -64,8 +64,8 @@ impl ObjectTrait for ComponentObject {
         "Component"
     }
 
-    fn field_type_mapping(&self) -> &TypeMapping {
-        &self.field_type_mapping
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
     }
 
     fn resolvers(&self) -> Vec<Field> {

--- a/crates/torii/src/graphql/object/component.rs
+++ b/crates/torii/src/graphql/object/component.rs
@@ -9,7 +9,6 @@ use super::query::{query_all, query_by_id, ID};
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::graphql::constants::DEFAULT_LIMIT;
 use crate::graphql::types::ScalarType;
-use crate::graphql::utils::remove_quotes;
 
 #[derive(FromRow, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -73,7 +72,7 @@ impl ObjectTrait for ComponentObject {
             Field::new(self.name(), TypeRef::named_nn(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
-                    let id = remove_quotes(ctx.args.try_get("id")?.string()?);
+                    let id = ctx.args.try_get("id")?.string()?.to_string();
                     let component = query_by_id(&mut conn, "components", ID::Str(id)).await?;
                     let result = ComponentObject::value_mapping(component);
                     Ok(Some(FieldValue::owned_any(result)))

--- a/crates/torii/src/graphql/object/component.rs
+++ b/crates/torii/src/graphql/object/component.rs
@@ -68,8 +68,8 @@ impl ObjectTrait for ComponentObject {
         &self.type_mapping
     }
 
-    fn resolvers(&self) -> Vec<Field> {
-        vec![
+    fn resolve_one(&self) -> Option<Field> {
+        Some(
             Field::new(self.name(), TypeRef::named_nn(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -80,6 +80,11 @@ impl ObjectTrait for ComponentObject {
                 })
             })
             .argument(InputValue::new("id", TypeRef::named_nn(TypeRef::ID))),
+        )
+    }
+
+    fn resolve_many(&self) -> Option<Field> {
+        Some(
             Field::new("components", TypeRef::named_list(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -101,6 +106,6 @@ impl ObjectTrait for ComponentObject {
                 })
             })
             .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
-        ]
+        )
     }
 }

--- a/crates/torii/src/graphql/object/connection/edge.rs
+++ b/crates/torii/src/graphql/object/connection/edge.rs
@@ -1,0 +1,42 @@
+use async_graphql::{dynamic::TypeRef, Name};
+use indexmap::IndexMap;
+
+use crate::graphql::{
+    object::{ObjectTrait, TypeMapping},
+    types::ScalarType,
+};
+
+pub struct EdgeObject {
+    pub name: String,
+    pub type_name: String,
+    pub type_mapping: TypeMapping,
+}
+
+impl EdgeObject {
+    pub fn new(name: String, type_name: String) -> Self {
+        let type_mapping = IndexMap::from([
+            (Name::new("node"), TypeRef::named(type_name.clone())),
+            (Name::new("cursor"), TypeRef::named_nn(ScalarType::Cursor.to_string())),
+        ]);
+
+        Self {
+            name: format!("{}Edge", name),
+            type_name: format!("{}Edge", type_name),
+            type_mapping,
+        }
+    }
+}
+
+impl ObjectTrait for EdgeObject {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn type_name(&self) -> &str {
+        &self.type_name
+    }
+
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
+    }
+}

--- a/crates/torii/src/graphql/object/connection/mod.rs
+++ b/crates/torii/src/graphql/object/connection/mod.rs
@@ -1,7 +1,7 @@
 use async_graphql::dynamic::{Field, InputValue, ResolverContext, TypeRef};
-use async_graphql::Name;
+use async_graphql::{Error, Name, Value};
 use indexmap::IndexMap;
-use sqlx::Value;
+use serde_json::Number;
 
 use crate::graphql::types::ScalarType;
 
@@ -12,8 +12,8 @@ pub mod page_info;
 
 #[derive(Debug)]
 pub struct InputArguments {
-    pub first: u64,
-    pub last: u64,
+    pub first: Option<u64>,
+    pub last: Option<u64>,
     pub after: Option<String>,
     pub before: Option<String>,
 }
@@ -45,14 +45,6 @@ impl ConnectionObject {
             type_mapping,
         }
     }
-
-    pub fn arguments(field: Field) -> Field {
-        field
-            .argument(InputValue::new("first", TypeRef::named(TypeRef::INT)))
-            .argument(InputValue::new("last", TypeRef::named(TypeRef::INT)))
-            .argument(InputValue::new("before", TypeRef::named(ScalarType::Cursor.to_string())))
-            .argument(InputValue::new("after", TypeRef::named(ScalarType::Cursor.to_string())))
-    }
 }
 
 impl ObjectTrait for ConnectionObject {
@@ -69,9 +61,50 @@ impl ObjectTrait for ConnectionObject {
     }
 }
 
-pub fn parse_arguments(ctx: &ResolverContext<'_>) -> InputArguments {
-    let first = ctx.args.try_get("first").and_then(|first| first.u64()).unwrap_or(0);
-    let last = ctx.args.try_get("last").and_then(|last| last.u64()).unwrap_or(0);
+pub fn parse_arguments(ctx: &ResolverContext<'_>) -> Result<InputArguments, Error> {
+    let first = ctx.args.try_get("first").and_then(|first| first.u64()).ok();
+    let last = ctx.args.try_get("last").and_then(|last| last.u64()).ok();
+    let after = ctx.args.try_get("after").and_then(|after| Ok(after.string()?.to_string())).ok();
+    let before =
+        ctx.args.try_get("before").and_then(|before| Ok(before.string()?.to_string())).ok();
 
-    InputArguments { first, last, after: None, before: None }
+    if first.is_some() && last.is_some() {
+        return Err(
+            "Passing both `first` and `last` to paginate a connection is not supported.".into()
+        );
+    }
+
+    Ok(InputArguments { first, last, after, before })
+}
+
+pub fn connection_input(field: Field) -> Field {
+    field
+        .argument(InputValue::new("first", TypeRef::named(TypeRef::INT)))
+        .argument(InputValue::new("last", TypeRef::named(TypeRef::INT)))
+        .argument(InputValue::new("before", TypeRef::named(ScalarType::Cursor.to_string())))
+        .argument(InputValue::new("after", TypeRef::named(ScalarType::Cursor.to_string())))
+}
+
+pub fn connection_output(
+    data: &Vec<ValueMapping>,
+    cursor_field: &str,
+    total_count: i64,
+) -> ValueMapping {
+    let edges: Vec<Value> = data
+        .into_iter()
+        .map(|v| {
+            // TODO: based64 encode cursor
+            let cursor = v.get(cursor_field).expect("invalid cursor field");
+            let mut edge = ValueMapping::new();
+            edge.insert(Name::new("node"), Value::Object(v.clone()));
+            edge.insert(Name::new("cursor"), cursor.clone());
+
+            Value::Object(edge)
+        })
+        .collect();
+
+    ValueMapping::from([
+        (Name::new("totalCount"), Value::Number(Number::from(total_count))),
+        (Name::new("edges"), Value::List(edges)),
+    ])
 }

--- a/crates/torii/src/graphql/object/connection/mod.rs
+++ b/crates/torii/src/graphql/object/connection/mod.rs
@@ -1,0 +1,77 @@
+use async_graphql::dynamic::{Field, InputValue, ResolverContext, TypeRef};
+use async_graphql::Name;
+use indexmap::IndexMap;
+use sqlx::Value;
+
+use crate::graphql::types::ScalarType;
+
+use super::{ObjectTrait, TypeMapping, ValueMapping};
+
+pub mod edge;
+pub mod page_info;
+
+#[derive(Debug)]
+pub struct InputArguments {
+    pub first: u64,
+    pub last: u64,
+    pub after: Option<String>,
+    pub before: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ConnectionData {
+    pub edges: Vec<ValueMapping>,
+    // pageInfo: PageInfo,
+    pub total_count: u64,
+}
+
+pub struct ConnectionObject {
+    pub name: String,
+    pub type_name: String,
+    pub type_mapping: TypeMapping,
+}
+
+impl ConnectionObject {
+    pub fn new(name: String, type_name: String) -> Self {
+        let type_mapping = IndexMap::from([
+            (Name::new("edges"), TypeRef::named_list(format!("{}Edge", type_name))),
+            (Name::new("pageInfo"), TypeRef::named_nn("PageInfo")),
+            (Name::new("totalCount"), TypeRef::named_nn(TypeRef::INT)),
+        ]);
+
+        Self {
+            name: format!("{}Connection", name),
+            type_name: format!("{}Connection", type_name),
+            type_mapping,
+        }
+    }
+
+    pub fn arguments(field: Field) -> Field {
+        field
+            .argument(InputValue::new("first", TypeRef::named(TypeRef::INT)))
+            .argument(InputValue::new("last", TypeRef::named(TypeRef::INT)))
+            .argument(InputValue::new("before", TypeRef::named(ScalarType::Cursor.to_string())))
+            .argument(InputValue::new("after", TypeRef::named(ScalarType::Cursor.to_string())))
+    }
+}
+
+impl ObjectTrait for ConnectionObject {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn type_name(&self) -> &str {
+        &self.type_name
+    }
+
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
+    }
+}
+
+pub fn parse_arguments(ctx: &ResolverContext<'_>) -> InputArguments {
+    let first = ctx.args.try_get("first").and_then(|first| first.u64()).unwrap_or(0);
+    let last = ctx.args.try_get("last").and_then(|last| last.u64()).unwrap_or(0);
+
+    InputArguments { first, last, after: None, before: None }
+}

--- a/crates/torii/src/graphql/object/connection/page_info.rs
+++ b/crates/torii/src/graphql/object/connection/page_info.rs
@@ -1,0 +1,39 @@
+use async_graphql::dynamic::TypeRef;
+use async_graphql::Name;
+use indexmap::IndexMap;
+
+use crate::graphql::{
+    object::{ObjectTrait, TypeMapping},
+    types::ScalarType,
+};
+
+pub struct PageInfoObject {
+    pub type_mapping: TypeMapping,
+}
+
+impl PageInfoObject {
+    pub fn new() -> Self {
+        Self {
+            type_mapping: IndexMap::from([
+                (Name::new("hasPreviousPage"), TypeRef::named(TypeRef::BOOLEAN)),
+                (Name::new("hasNextPage"), TypeRef::named(TypeRef::BOOLEAN)),
+                (Name::new("startCursor"), TypeRef::named(ScalarType::Cursor.to_string())),
+                (Name::new("endCursor"), TypeRef::named(ScalarType::Cursor.to_string())),
+            ]),
+        }
+    }
+}
+
+impl ObjectTrait for PageInfoObject {
+    fn name(&self) -> &str {
+        "pageInfo"
+    }
+
+    fn type_name(&self) -> &str {
+        "PageInfo"
+    }
+
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
+    }
+}

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -143,16 +143,12 @@ impl ObjectTrait for EntityObject {
                         .and_then(|limit| limit.u64())
                         .unwrap_or(DEFAULT_LIMIT);
 
-                    let component_name = ctx.args.try_get("componentName") // Add the component name argument
-                    .and_then(|name| name.string().map(|s| s.to_string())).ok();
-
-                    let entities = entities_by_sk(&mut conn, keys, component_name, limit).await?;
+                    let entities = entities_by_sk(&mut conn, keys, limit).await?;
                     Ok(Some(FieldValue::list(entities.into_iter().map(FieldValue::owned_any))))
                 })
             })
             .argument(InputValue::new("keys", TypeRef::named_nn_list_nn(TypeRef::STRING)))
-            .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT)))
-            .argument(InputValue::new("componentName", TypeRef::named(TypeRef::STRING))),
+            .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
         )
     }
 }
@@ -160,30 +156,11 @@ impl ObjectTrait for EntityObject {
 async fn entities_by_sk(
     conn: &mut PoolConnection<Sqlite>,
     keys: Vec<String>,
-    component_name: Option<String>, // Add the filter parameter
     limit: u64,
 ) -> Result<Vec<ValueMapping>> {
     let mut builder: QueryBuilder<'_, Sqlite> = QueryBuilder::new("SELECT * FROM entities");
     let keys_str = format!("{},%", keys.join(","));
     builder.push(" WHERE keys LIKE ").push_bind(keys_str);
-
-    if let Some(name) = component_name {
-        builder
-            .push(" AND (")
-            .push("component_names = ")
-            .push_bind(name.clone())
-            .push(" OR ")
-            .push("component_names LIKE ")
-            .push_bind(format!("{},%", name))
-            .push(" OR ")
-            .push("component_names LIKE ")
-            .push_bind(format!("%,{}", name))
-            .push(" OR ")
-            .push("component_names LIKE ")
-            .push_bind(format!("%,{},%", name))
-            .push(")");
-    }
-
     builder.push(" ORDER BY created_at DESC LIMIT ").push(limit);
 
     let entities: Vec<Entity> = builder.build_query_as().fetch_all(conn).await?;

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -26,13 +26,13 @@ pub struct Entity {
 }
 
 pub struct EntityObject {
-    pub field_type_mapping: TypeMapping,
+    pub type_mapping: TypeMapping,
 }
 
 impl EntityObject {
     pub fn new() -> Self {
         Self {
-            field_type_mapping: IndexMap::from([
+            type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
                 (Name::new("keys"), TypeRef::STRING.to_string()),
                 (Name::new("componentNames"), TypeRef::STRING.to_string()),
@@ -68,8 +68,8 @@ impl ObjectTrait for EntityObject {
         "Entity"
     }
 
-    fn field_type_mapping(&self) -> &TypeMapping {
-        &self.field_type_mapping
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
     }
 
     fn nested_fields(&self) -> Option<Vec<Field>> {
@@ -84,12 +84,12 @@ impl ObjectTrait for EntityObject {
                 let mut results: Vec<FieldValue<'_>> = Vec::new();
                 for component_name in components {
                     let table_name = component_name.to_lowercase();
-                    let field_type_mapping = type_mapping_from(&mut conn, &table_name).await?;
+                    let type_mapping = type_mapping_from(&mut conn, &table_name).await?;
                     let state = component_state_by_entity_id(
                         &mut conn,
                         &table_name,
                         &id,
-                        &field_type_mapping,
+                        &type_mapping,
                     )
                     .await?;
                     results

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -33,11 +33,11 @@ impl EntityObject {
     pub fn new() -> Self {
         Self {
             type_mapping: IndexMap::from([
-                (Name::new("id"), TypeRef::ID.to_string()),
-                (Name::new("keys"), TypeRef::STRING.to_string()),
-                (Name::new("componentNames"), TypeRef::STRING.to_string()),
-                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
-                (Name::new("updatedAt"), ScalarType::DateTime.to_string()),
+                (Name::new("id"), TypeRef::named(TypeRef::ID)),
+                (Name::new("keys"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("componentNames"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("createdAt"), TypeRef::named(ScalarType::DateTime.to_string())),
+                (Name::new("updatedAt"), TypeRef::named(ScalarType::DateTime.to_string())),
             ]),
         }
     }

--- a/crates/torii/src/graphql/object/entity.rs
+++ b/crates/torii/src/graphql/object/entity.rs
@@ -7,6 +7,7 @@ use sqlx::pool::PoolConnection;
 use sqlx::{FromRow, Pool, QueryBuilder, Result, Sqlite};
 
 use super::component_state::{component_state_by_entity_id, type_mapping_from};
+use super::connection::connection_output;
 use super::query::{query_by_id, ID};
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::graphql::constants::DEFAULT_LIMIT;
@@ -124,31 +125,29 @@ impl ObjectTrait for EntityObject {
 
     fn resolve_many(&self) -> Option<Field> {
         Some(
-            Field::new("entities", TypeRef::named_list(self.type_name()), |ctx| {
-                FieldFuture::new(async move {
-                    let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
+            Field::new(
+                "entities",
+                TypeRef::named(format!("{}Connection", self.type_name())),
+                |ctx| {
+                    FieldFuture::new(async move {
+                        let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
+                        let total_count = 100;
+                        let keys_value = ctx.args.try_get("keys")?;
+                        let keys = keys_value
+                            .list()?
+                            .iter()
+                            .map(
+                                |val| val.string().unwrap().to_string(), // safe unwrap
+                            )
+                            .collect();
 
-                    let keys_value = ctx.args.try_get("keys")?;
-                    let keys = keys_value
-                        .list()?
-                        .iter()
-                        .map(
-                            |val| val.string().unwrap().to_string(), // safe unwrap
-                        )
-                        .collect();
+                        let entities = entities_by_sk(&mut conn, keys, DEFAULT_LIMIT).await?;
 
-                    let limit = ctx
-                        .args
-                        .try_get("limit")
-                        .and_then(|limit| limit.u64())
-                        .unwrap_or(DEFAULT_LIMIT);
-
-                    let entities = entities_by_sk(&mut conn, keys, limit).await?;
-                    Ok(Some(FieldValue::list(entities.into_iter().map(FieldValue::owned_any))))
-                })
-            })
-            .argument(InputValue::new("keys", TypeRef::named_nn_list_nn(TypeRef::STRING)))
-            .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
+                        Ok(Some(Value::Object(connection_output(&entities, "id", total_count))))
+                    })
+                },
+            )
+            .argument(InputValue::new("keys", TypeRef::named_nn_list_nn(TypeRef::STRING))),
         )
     }
 }

--- a/crates/torii/src/graphql/object/event.rs
+++ b/crates/torii/src/graphql/object/event.rs
@@ -11,7 +11,6 @@ use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::graphql::constants::DEFAULT_LIMIT;
 use crate::graphql::types::ScalarType;
 use crate::graphql::utils::extract_value::extract;
-use crate::graphql::utils::remove_quotes;
 
 #[derive(FromRow, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -72,7 +71,7 @@ impl ObjectTrait for EventObject {
             Field::new(self.name(), TypeRef::named_nn(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
-                    let id = remove_quotes(ctx.args.try_get("id")?.string()?);
+                    let id = ctx.args.try_get("id")?.string()?.to_string();
                     let event = query_by_id(&mut conn, "events", ID::Str(id)).await?;
                     let result = EventObject::value_mapping(event);
                     Ok(Some(FieldValue::owned_any(result)))

--- a/crates/torii/src/graphql/object/event.rs
+++ b/crates/torii/src/graphql/object/event.rs
@@ -67,8 +67,8 @@ impl ObjectTrait for EventObject {
         &self.type_mapping
     }
 
-    fn resolvers(&self) -> Vec<Field> {
-        vec![
+    fn resolve_one(&self) -> Option<Field> {
+        Some(
             Field::new(self.name(), TypeRef::named_nn(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -79,6 +79,11 @@ impl ObjectTrait for EventObject {
                 })
             })
             .argument(InputValue::new("id", TypeRef::named_nn(TypeRef::ID))),
+        )
+    }
+
+    fn resolve_many(&self) -> Option<Field> {
+        Some(
             Field::new("events", TypeRef::named_list(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -99,7 +104,7 @@ impl ObjectTrait for EventObject {
                 })
             })
             .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
-        ]
+        )
     }
 
     fn nested_fields(&self) -> Option<Vec<Field>> {

--- a/crates/torii/src/graphql/object/event.rs
+++ b/crates/torii/src/graphql/object/event.rs
@@ -24,13 +24,13 @@ pub struct Event {
 }
 
 pub struct EventObject {
-    pub field_type_mapping: TypeMapping,
+    pub type_mapping: TypeMapping,
 }
 
 impl EventObject {
     pub fn new() -> Self {
         Self {
-            field_type_mapping: IndexMap::from([
+            type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
                 (Name::new("keys"), TypeRef::STRING.to_string()),
                 (Name::new("data"), TypeRef::STRING.to_string()),
@@ -63,8 +63,8 @@ impl ObjectTrait for EventObject {
         "Event"
     }
 
-    fn field_type_mapping(&self) -> &TypeMapping {
-        &self.field_type_mapping
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
     }
 
     fn resolvers(&self) -> Vec<Field> {

--- a/crates/torii/src/graphql/object/event.rs
+++ b/crates/torii/src/graphql/object/event.rs
@@ -31,11 +31,11 @@ impl EventObject {
     pub fn new() -> Self {
         Self {
             type_mapping: IndexMap::from([
-                (Name::new("id"), TypeRef::ID.to_string()),
-                (Name::new("keys"), TypeRef::STRING.to_string()),
-                (Name::new("data"), TypeRef::STRING.to_string()),
-                (Name::new("systemCallId"), TypeRef::INT.to_string()),
-                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
+                (Name::new("id"), TypeRef::named(TypeRef::ID)),
+                (Name::new("keys"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("data"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("systemCallId"), TypeRef::named(TypeRef::INT)),
+                (Name::new("createdAt"), TypeRef::named(ScalarType::DateTime.to_string())),
             ]),
         }
     }

--- a/crates/torii/src/graphql/object/mod.rs
+++ b/crates/torii/src/graphql/object/mod.rs
@@ -1,67 +1,91 @@
 pub mod component;
 pub mod component_state;
+pub mod connection;
 pub mod entity;
 pub mod event;
 mod query;
 pub mod system;
 pub mod system_call;
 
-use async_graphql::dynamic::{Field, FieldFuture, Object, TypeRef};
-use async_graphql::{Name, Value};
+use async_graphql::dynamic::{Field, FieldFuture, FieldValue, Object, TypeRef};
+use async_graphql::{Error, Name, Value};
 use indexmap::IndexMap;
+
+use self::connection::edge::EdgeObject;
+use self::connection::ConnectionObject;
 
 // Type aliases for GraphQL fields
 pub type TypeMapping = IndexMap<Name, TypeRef>;
 pub type ValueMapping = IndexMap<Name, Value>;
 
 pub trait ObjectTrait {
-    // Name of the graphql object (eg "person")
+    // Name of the graphql object (eg "player")
     fn name(&self) -> &str;
 
-    // Type name of the graphql object (eg "Person")
+    // Type name of the graphql object (eg "Player")
     fn type_name(&self) -> &str;
 
-    // Type mapping defines the fields of the graphql object and their corresponding scalar type
+    // Type mapping defines the fields of the graphql object and their corresponding type
     fn type_mapping(&self) -> &TypeMapping;
-
-    // Resolves single object queries, returns current object of type type_name
-    fn resolve_one(&self) -> Option<Field> {
-        None
-    }
-
-    // Resolves plural object queries, returns type of {type_name}Connection (eg "PersonConnection")
-    // https://relay.dev/graphql/connections.htm
-    fn resolve_many(&self) -> Option<Field> {
-        None
-    }
 
     // Related graphql objects
     fn nested_fields(&self) -> Option<Vec<Field>> {
         None
     }
 
-    // Create a new GraphQL object
+    // Resolves single object queries, returns current object of type type_name (eg "Player")
+    fn resolve_one(&self) -> Option<Field> {
+        None
+    }
+
+    // Resolves plural object queries, returns type of {type_name}Connection (eg "PlayerConnection")
+    fn resolve_many(&self) -> Option<Field> {
+        None
+    }
+
+    // Connection type, if resolve_many is Some then register connection graphql obj, includes {type_name}Connection
+    // and {type_name}Edge according to relay spec https://relay.dev/graphql/connections.htm
+    fn connection(&self) -> Option<Vec<Object>> {
+        self.resolve_many()?;
+
+        let edge = EdgeObject::new(self.name().to_string(), self.type_name().to_string());
+        let connection =
+            ConnectionObject::new(self.name().to_string(), self.type_name().to_string());
+
+        Some(vec![edge.create(), connection.create()])
+    }
+
+    // Create a new graphql object and also define its fields from type mapping
     fn create(&self) -> Object {
         let mut object = Object::new(self.type_name());
 
-        // Add fields (ie id, createdAt, etc) and their resolver
         for (field_name, field_type) in self.type_mapping() {
             let field_name = field_name.clone();
             let field_type = field_type.clone();
 
-            let field =
-                Field::new(field_name.to_string(), field_type, move |ctx| {
-                    let field_name = field_name.clone();
+            let field = Field::new(field_name.to_string(), field_type, move |ctx| {
+                let field_name = field_name.clone();
 
                 FieldFuture::new(async move {
-                    let mapping = ctx.parent_value.try_downcast_ref::<ValueMapping>()?;
+                    // All direct queries, single and plural, passes down results as Value of type Object, and
+                    // Object is an indexmap that contains fields and their corresponding result. The result
+                    // can also be another Object. This is evaluated repeatedly until Value is a string or number.
+                    if let Some(value) = ctx.parent_value.as_value() {
+                        return match value {
+                            Value::Object(indexmap) => field_value(&indexmap, field_name.as_str()),
+                            _ => Err("Incorrect value, requires Value::Object".into()),
+                        };
+                    }
 
-                        match mapping.get(field_name.as_str()) {
-                            Some(value) => Ok(Some(value.clone())),
-                            _ => Err(format!("{} field not found", field_name).into()),
-                        }
-                    })
-                });
+                    // Component union queries is a special case, it instead passes down a IndexMap<Name, Value>. This
+                    // could be avoided if async-graphql allowed union resolver to be passed down as Value.
+                    if let Some(indexmap) = ctx.parent_value.downcast_ref::<ValueMapping>() {
+                        return field_value(&indexmap, field_name.as_str());
+                    }
+
+                    return Err("Field resolver only accepts Value or IndexMap".into());
+                })
+            });
 
             object = object.field(field);
         }
@@ -74,5 +98,12 @@ pub trait ObjectTrait {
         }
 
         object
+    }
+}
+
+fn field_value(value_mapping: &ValueMapping, field_name: &str) -> Result<Option<Value>, Error> {
+    match value_mapping.get(field_name) {
+        Some(value) => Ok(Some(value.clone())),
+        _ => Err(format!("{} field not found", field_name).into()),
     }
 }

--- a/crates/torii/src/graphql/object/mod.rs
+++ b/crates/torii/src/graphql/object/mod.rs
@@ -7,7 +7,7 @@ mod query;
 pub mod system;
 pub mod system_call;
 
-use async_graphql::dynamic::{Field, FieldFuture, FieldValue, Object, TypeRef};
+use async_graphql::dynamic::{Field, FieldFuture, Object, TypeRef};
 use async_graphql::{Error, Name, Value};
 use indexmap::IndexMap;
 

--- a/crates/torii/src/graphql/object/mod.rs
+++ b/crates/torii/src/graphql/object/mod.rs
@@ -17,7 +17,7 @@ pub type ValueMapping = IndexMap<Name, Value>;
 pub trait ObjectTrait {
     fn name(&self) -> &str;
     fn type_name(&self) -> &str;
-    fn field_type_mapping(&self) -> &TypeMapping;
+    fn type_mapping(&self) -> &TypeMapping;
     fn resolvers(&self) -> Vec<Field>;
     fn nested_fields(&self) -> Option<Vec<Field>> {
         None
@@ -28,7 +28,7 @@ pub trait ObjectTrait {
         let mut object = Object::new(self.type_name());
 
         // Add fields (ie id, createdAt, etc)
-        for (field_name, field_type) in self.field_type_mapping() {
+        for (field_name, field_type) in self.type_mapping() {
             let field = create_field(field_name, field_type);
             object = object.field(field);
         }

--- a/crates/torii/src/graphql/object/query.rs
+++ b/crates/torii/src/graphql/object/query.rs
@@ -36,3 +36,9 @@ where
     let results: Vec<T> = builder.build_query_as().fetch_all(conn).await?;
     Ok(results)
 }
+
+pub async fn query_total_count(conn: &mut PoolConnection<Sqlite>, table_name: &str) -> Result<i64> {
+    let query = format!("SELECT COUNT(*) FROM {}", table_name);
+    let result: (i64,) = sqlx::query_as(&query).fetch_one(conn).await?;
+    Ok(result.0)
+}

--- a/crates/torii/src/graphql/object/system.rs
+++ b/crates/torii/src/graphql/object/system.rs
@@ -5,7 +5,8 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 use sqlx::{FromRow, Pool, Sqlite};
 
-use super::query::{query_all, query_by_id, ID};
+use super::connection::connection_output;
+use super::query::{query_all, query_by_id, query_total_count, ID};
 use super::system_call::system_calls_by_system_id;
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::graphql::constants::DEFAULT_LIMIT;
@@ -17,7 +18,6 @@ use crate::graphql::utils::extract_value::extract;
 pub struct System {
     pub id: String,
     pub name: String,
-    pub address: String,
     pub class_hash: String,
     pub transaction_hash: String,
     pub created_at: DateTime<Utc>,
@@ -33,7 +33,6 @@ impl SystemObject {
             type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::named(TypeRef::ID)),
                 (Name::new("name"), TypeRef::named(TypeRef::STRING)),
-                (Name::new("address"), TypeRef::named(ScalarType::Address.to_string())),
                 (Name::new("classHash"), TypeRef::named(ScalarType::Felt252.to_string())),
                 (Name::new("transactionHash"), TypeRef::named(ScalarType::Felt252.to_string())),
                 (Name::new("createdAt"), TypeRef::named(ScalarType::DateTime.to_string())),
@@ -45,7 +44,6 @@ impl SystemObject {
         IndexMap::from([
             (Name::new("id"), Value::from(system.id)),
             (Name::new("name"), Value::from(system.name)),
-            (Name::new("address"), Value::from(system.address)),
             (Name::new("classHash"), Value::from(system.class_hash)),
             (Name::new("transactionHash"), Value::from(system.transaction_hash)),
             (
@@ -77,7 +75,7 @@ impl ObjectTrait for SystemObject {
                     let id = ctx.args.try_get("id")?.string()?.to_string();
                     let system = query_by_id(&mut conn, "systems", ID::Str(id)).await?;
                     let result = SystemObject::value_mapping(system);
-                    Ok(Some(FieldValue::owned_any(result)))
+                    Ok(Some(Value::Object(result)))
                 })
             })
             .argument(InputValue::new("id", TypeRef::named_nn(TypeRef::ID))),
@@ -85,28 +83,21 @@ impl ObjectTrait for SystemObject {
     }
 
     fn resolve_many(&self) -> Option<Field> {
-        Some(
-            Field::new("systems", TypeRef::named_list(self.type_name()), |ctx| {
+        Some(Field::new(
+            "systems",
+            TypeRef::named(format!("{}Connection", self.type_name())),
+            |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
-                    let limit = ctx
-                        .args
-                        .try_get("limit")
-                        .and_then(|limit| limit.u64())
-                        .unwrap_or(DEFAULT_LIMIT);
+                    let total_count = query_total_count(&mut conn, "systems").await?;
+                    let data: Vec<System> = query_all(&mut conn, "systems", DEFAULT_LIMIT).await?;
+                    let systems: Vec<ValueMapping> =
+                        data.into_iter().map(SystemObject::value_mapping).collect();
 
-                    let systems: Vec<System> = query_all(&mut conn, "systems", limit).await?;
-                    let result: Vec<FieldValue<'_>> = systems
-                        .into_iter()
-                        .map(SystemObject::value_mapping)
-                        .map(FieldValue::owned_any)
-                        .collect();
-
-                    Ok(Some(FieldValue::list(result)))
+                    Ok(Some(Value::Object(connection_output(&systems, "id", total_count))))
                 })
-            })
-            .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
-        )
+            },
+        ))
     }
 
     fn nested_fields(&self) -> Option<Vec<Field>> {

--- a/crates/torii/src/graphql/object/system.rs
+++ b/crates/torii/src/graphql/object/system.rs
@@ -70,8 +70,8 @@ impl ObjectTrait for SystemObject {
         &self.type_mapping
     }
 
-    fn resolvers(&self) -> Vec<Field> {
-        vec![
+    fn resolve_one(&self) -> Option<Field> {
+        Some(
             Field::new(self.name(), TypeRef::named_nn(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -82,6 +82,11 @@ impl ObjectTrait for SystemObject {
                 })
             })
             .argument(InputValue::new("id", TypeRef::named_nn(TypeRef::ID))),
+        )
+    }
+
+    fn resolve_many(&self) -> Option<Field> {
+        Some(
             Field::new("systems", TypeRef::named_list(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -102,7 +107,7 @@ impl ObjectTrait for SystemObject {
                 })
             })
             .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT))),
-        ]
+        )
     }
 
     fn nested_fields(&self) -> Option<Vec<Field>> {

--- a/crates/torii/src/graphql/object/system.rs
+++ b/crates/torii/src/graphql/object/system.rs
@@ -32,12 +32,12 @@ impl SystemObject {
     pub fn new() -> Self {
         Self {
             type_mapping: IndexMap::from([
-                (Name::new("id"), TypeRef::ID.to_string()),
-                (Name::new("name"), TypeRef::STRING.to_string()),
-                (Name::new("address"), ScalarType::Address.to_string()),
-                (Name::new("classHash"), ScalarType::Felt252.to_string()),
-                (Name::new("transactionHash"), ScalarType::Felt252.to_string()),
-                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
+                (Name::new("id"), TypeRef::named(TypeRef::ID)),
+                (Name::new("name"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("address"), TypeRef::named(ScalarType::Address.to_string())),
+                (Name::new("classHash"), TypeRef::named(ScalarType::Felt252.to_string())),
+                (Name::new("transactionHash"), TypeRef::named(ScalarType::Felt252.to_string())),
+                (Name::new("createdAt"), TypeRef::named(ScalarType::DateTime.to_string())),
             ]),
         }
     }

--- a/crates/torii/src/graphql/object/system.rs
+++ b/crates/torii/src/graphql/object/system.rs
@@ -25,13 +25,13 @@ pub struct System {
 }
 
 pub struct SystemObject {
-    pub field_type_mapping: TypeMapping,
+    pub type_mapping: TypeMapping,
 }
 
 impl SystemObject {
     pub fn new() -> Self {
         Self {
-            field_type_mapping: IndexMap::from([
+            type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
                 (Name::new("name"), TypeRef::STRING.to_string()),
                 (Name::new("address"), ScalarType::Address.to_string()),
@@ -66,8 +66,8 @@ impl ObjectTrait for SystemObject {
         "System"
     }
 
-    fn field_type_mapping(&self) -> &TypeMapping {
-        &self.field_type_mapping
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
     }
 
     fn resolvers(&self) -> Vec<Field> {

--- a/crates/torii/src/graphql/object/system.rs
+++ b/crates/torii/src/graphql/object/system.rs
@@ -11,7 +11,6 @@ use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::graphql::constants::DEFAULT_LIMIT;
 use crate::graphql::types::ScalarType;
 use crate::graphql::utils::extract_value::extract;
-use crate::graphql::utils::remove_quotes;
 
 #[derive(FromRow, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -75,7 +74,7 @@ impl ObjectTrait for SystemObject {
             Field::new(self.name(), TypeRef::named_nn(self.type_name()), |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
-                    let id = remove_quotes(ctx.args.try_get("id")?.string()?);
+                    let id = ctx.args.try_get("id")?.string()?.to_string();
                     let system = query_by_id(&mut conn, "systems", ID::Str(id)).await?;
                     let result = SystemObject::value_mapping(system);
                     Ok(Some(FieldValue::owned_any(result)))

--- a/crates/torii/src/graphql/object/system_call.rs
+++ b/crates/torii/src/graphql/object/system_call.rs
@@ -23,13 +23,13 @@ pub struct SystemCall {
     pub system_id: String,
 }
 pub struct SystemCallObject {
-    pub field_type_mapping: TypeMapping,
+    pub type_mapping: TypeMapping,
 }
 
 impl SystemCallObject {
     pub fn new() -> Self {
         Self {
-            field_type_mapping: IndexMap::from([
+            type_mapping: IndexMap::from([
                 (Name::new("id"), TypeRef::ID.to_string()),
                 (Name::new("transactionHash"), TypeRef::STRING.to_string()),
                 (Name::new("data"), TypeRef::STRING.to_string()),
@@ -64,8 +64,8 @@ impl ObjectTrait for SystemCallObject {
         "SystemCall"
     }
 
-    fn field_type_mapping(&self) -> &TypeMapping {
-        &self.field_type_mapping
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
     }
 
     fn resolvers(&self) -> Vec<Field> {

--- a/crates/torii/src/graphql/object/system_call.rs
+++ b/crates/torii/src/graphql/object/system_call.rs
@@ -30,11 +30,11 @@ impl SystemCallObject {
     pub fn new() -> Self {
         Self {
             type_mapping: IndexMap::from([
-                (Name::new("id"), TypeRef::ID.to_string()),
-                (Name::new("transactionHash"), TypeRef::STRING.to_string()),
-                (Name::new("data"), TypeRef::STRING.to_string()),
-                (Name::new("systemId"), TypeRef::ID.to_string()),
-                (Name::new("createdAt"), ScalarType::DateTime.to_string()),
+                (Name::new("id"), TypeRef::named(TypeRef::ID)),
+                (Name::new("transactionHash"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("data"), TypeRef::named(TypeRef::STRING)),
+                (Name::new("systemId"), TypeRef::named(TypeRef::ID)),
+                (Name::new("createdAt"), TypeRef::named(ScalarType::DateTime.to_string())),
             ]),
         }
     }

--- a/crates/torii/src/graphql/utils/mod.rs
+++ b/crates/torii/src/graphql/utils/mod.rs
@@ -2,10 +2,6 @@ pub mod extract_value;
 pub mod parse_argument;
 pub mod value_accessor;
 
-pub fn remove_quotes(s: &str) -> String {
-    s.replace(&['\"', '\''][..], "")
-}
-
 pub fn format_name(input: &str) -> (String, String) {
     let name = input.to_lowercase();
     let type_name = input.to_string();

--- a/crates/torii/src/graphql/utils/mod.rs
+++ b/crates/torii/src/graphql/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod extract_value;
+pub mod parse_argument;
 pub mod value_accessor;
 
 pub fn remove_quotes(s: &str) -> String {

--- a/crates/torii/src/graphql/utils/parse_argument.rs
+++ b/crates/torii/src/graphql/utils/parse_argument.rs
@@ -1,0 +1,19 @@
+use async_graphql::{dynamic::ResolverContext, Result};
+
+pub trait ParseArgument: Sized {
+    fn parse(ctx: &ResolverContext<'_>, input: String) -> Result<Self>;
+}
+
+impl ParseArgument for u64 {
+    fn parse(ctx: &ResolverContext<'_>, input: String) -> Result<Self> {
+        let arg = ctx.args.try_get(input.as_str());
+        Ok(arg?.u64()?)
+    }
+}
+
+impl ParseArgument for String {
+    fn parse(ctx: &ResolverContext<'_>, input: String) -> Result<Self> {
+        let arg = ctx.args.try_get(input.as_str());
+        Ok(arg?.string()?.to_string())
+    }
+}


### PR DESCRIPTION
This PR enables relay connection support for plural queries https://relay.dev/graphql/connections.htm

Will resolve OrderBy and WhereInput filtering in another PR

```
nameComponents(
  first: Int,
  last: Int,
  after: Cursor,
  before: Cursor
): NameConnection
```