### PR TITLE
chore: enable rustfmt nightly for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "cairo1.enableLanguageServer": true,
     "rust-analyzer.linkedProjects": [
         "./crates/dojo-lang/Cargo.toml"
+    ],
+    "rust-analyzer.rustfmt.extraArgs": [
+        "+nightly"
     ]
 }


### PR DESCRIPTION
So auto-format on save works in VSCode.

Credits: https://github.com/dojoengine/dojo/blob/main/rustfmt.toml#L22