### PR TITLE
feat(katana): Get storage multiple

### DIFF
--- a/crates/katana/rpc/src/api/katana.rs
+++ b/crates/katana/rpc/src/api/katana.rs
@@ -4,6 +4,7 @@ use jsonrpsee::types::error::CallError;
 use jsonrpsee::types::ErrorObject;
 use katana_core::accounts::Account;
 use starknet::core::types::FieldElement;
+use starknet_api::hash::StarkFelt;
 
 #[derive(thiserror::Error, Clone, Copy, Debug)]
 #[allow(clippy::enum_variant_names)]
@@ -22,6 +23,9 @@ impl From<KatanaApiError> for Error {
     }
 }
 
+pub type ContractAddressFieldElement = FieldElement;
+pub type StorageKeyFieldElement = FieldElement;
+
 #[rpc(server, namespace = "katana")]
 pub trait KatanaApi {
     #[method(name = "generateBlock")]
@@ -38,6 +42,12 @@ pub trait KatanaApi {
 
     #[method(name = "predeployedAccounts")]
     async fn predeployed_accounts(&self) -> Result<Vec<Account>, Error>;
+
+    #[method(name = "getStorageAtMultiple")]
+    async fn get_storage_multiple(
+        &self,
+        storage_addresses: Vec<(ContractAddressFieldElement, Vec<StorageKeyFieldElement>)>,
+    ) -> Result<Vec<Vec<StarkFelt>>, Error>;
 
     #[method(name = "setStorageAt")]
     async fn set_storage_at(

--- a/crates/katana/rpc/src/katana.rs
+++ b/crates/katana/rpc/src/katana.rs
@@ -7,7 +7,9 @@ use starknet_api::hash::{StarkFelt, StarkHash};
 use starknet_api::state::StorageKey;
 use starknet_api::{patricia_key, stark_felt};
 
-use crate::api::katana::{KatanaApiError, KatanaApiServer};
+use crate::api::katana::{
+    ContractAddressFieldElement, KatanaApiError, KatanaApiServer, StorageKeyFieldElement,
+};
 
 pub struct KatanaApi<S> {
     sequencer: S,
@@ -55,6 +57,17 @@ where
 
     async fn predeployed_accounts(&self) -> Result<Vec<Account>, Error> {
         Ok(self.sequencer.backend().accounts.clone())
+    }
+
+    async fn get_storage_multiple(
+        &self,
+        storage_addresses: Vec<(ContractAddressFieldElement, Vec<StorageKeyFieldElement>)>,
+    ) -> Result<Vec<Vec<StarkFelt>>, Error> {
+        self.sequencer
+            .backend()
+            .get_storages_at(storage_addresses)
+            .await
+            .map_err(|_| Error::from(KatanaApiError::FailedToUpdateStorage))
     }
 
     async fn set_storage_at(


### PR DESCRIPTION
### Highlights
1. The structure is chosen to have compact requests and responses.
2. If the parameter `storage_addresses` seems complicated, it could be broken into,
   - `contract_address`: `FieldElement`
   - `keys`: `Vec<FieldElement>`
   - **But this limits to storage from one contract per call**
3. To have them Felts in nested Vecs be more semantic, I'm using some type aliases. Hopefully they'll be picked up at docs generation.
4. RPC method is `getStorageAtMultiple`, does that make sense?
5. We could also return hash map with `key: value` if we want more readability. But since storage addresses are hashed anyway, it wouldn't be tremendously better.

### Parameters:

```rs
(
  storage_addresses: Vec<
    (
      ContractAddressFieldElement,
      Vec<StorageKeyFieldElement>
    )
  >
)
```

### Returns:
```rs
Result(
  Vec<
    Vec<Felt>
  >
)
```