### PR TITLE
fix(katana): fix undeclared sierra class hash on interval mining mode

### DIFF
--- a/crates/katana/core/src/backend/executor.rs
+++ b/crates/katana/core/src/backend/executor.rs
@@ -11,17 +11,15 @@ use blockifier::transaction::transactions::ExecutableTransaction;
 use convert_case::{Case, Casing};
 use parking_lot::RwLock;
 use starknet::core::types::{Event, FieldElement, MsgToL1};
-use starknet_api::transaction::Transaction;
 use tokio::sync::RwLock as AsyncRwLock;
 use tracing::{info, trace, warn};
 
 use super::state::MemDb;
 use super::storage::block::{PartialBlock, PartialHeader};
-use super::storage::transaction::{RejectedTransaction, TransactionOutput};
+use super::storage::transaction::{RejectedTransaction, Transaction, TransactionOutput};
 use super::storage::BlockchainStorage;
 use crate::backend::storage::transaction::KnownTransaction;
 use crate::env::Env;
-use crate::utils::transaction::convert_blockifier_to_api_tx;
 
 #[derive(Debug)]
 pub struct PendingBlockExecutor {
@@ -77,18 +75,17 @@ impl PendingBlockExecutor {
     // if it passes the validation logic. Otherwise, the transaction will be
     // rejected. On both cases, the transaction will still be stored in the
     // storage.
-    pub async fn add_transaction(
-        &mut self,
-        transaction: ExecutionTransaction,
-        charge_fee: bool,
-    ) -> bool {
-        let api_tx = convert_blockifier_to_api_tx(&transaction);
-        let hash: FieldElement = api_tx.transaction_hash().0.into();
+    pub async fn add_transaction(&mut self, transaction: Transaction, charge_fee: bool) -> bool {
+        let transaction_hash = transaction.hash();
 
-        info!("Transaction received | Hash: {}", api_tx.transaction_hash());
+        info!("Transaction received | Hash: {transaction_hash:#x}");
 
-        let res =
-            execute_transaction(transaction, &mut self.state, &self.env.read().block, charge_fee);
+        let res = execute_transaction(
+            ExecutionTransaction::AccountTransaction(transaction.clone().into()),
+            &mut self.state,
+            &self.env.read().block,
+            charge_fee,
+        );
 
         match res {
             Ok(execution_info) => {
@@ -97,7 +94,7 @@ impl PendingBlockExecutor {
                     pretty_print_resources(&execution_info.actual_resources)
                 );
 
-                let executed_tx = Arc::new(ExecutedTransaction::new(api_tx, execution_info));
+                let executed_tx = Arc::new(ExecutedTransaction::new(transaction, execution_info));
 
                 trace_events(&executed_tx.output.events);
 
@@ -109,9 +106,9 @@ impl PendingBlockExecutor {
 
             Err(err) => {
                 self.storage.write().await.transactions.insert(
-                    hash,
+                    transaction_hash,
                     KnownTransaction::Rejected(Box::new(RejectedTransaction {
-                        transaction: api_tx,
+                        transaction: transaction.into(),
                         execution_error: err.to_string(),
                     })),
                 );
@@ -124,7 +121,7 @@ impl PendingBlockExecutor {
 
 #[derive(Debug)]
 pub struct ExecutedTransaction {
-    pub transaction: Transaction,
+    pub inner: Transaction,
     pub output: TransactionOutput,
     pub execution_info: TransactionExecutionInfo,
 }
@@ -136,14 +133,10 @@ impl ExecutedTransaction {
         let messages_sent = Self::l2_to_l1_messages(&execution_info);
 
         Self {
-            transaction,
+            inner: transaction,
             execution_info,
             output: TransactionOutput { actual_fee, events, messages_sent },
         }
-    }
-
-    pub fn hash(&self) -> FieldElement {
-        self.transaction.transaction_hash().0.into()
     }
 
     fn events(execution_info: &TransactionExecutionInfo) -> Vec<Event> {

--- a/crates/katana/core/src/backend/executor.rs
+++ b/crates/katana/core/src/backend/executor.rs
@@ -13,7 +13,7 @@ use parking_lot::RwLock;
 use starknet::core::types::{Event, FieldElement, MsgToL1};
 use starknet_api::transaction::Transaction;
 use tokio::sync::RwLock as AsyncRwLock;
-use tracing::{trace, warn};
+use tracing::{info, trace, warn};
 
 use super::state::MemDb;
 use super::storage::block::{PartialBlock, PartialHeader};
@@ -84,6 +84,9 @@ impl PendingBlockExecutor {
     ) -> bool {
         let api_tx = convert_blockifier_to_api_tx(&transaction);
         let hash: FieldElement = api_tx.transaction_hash().0.into();
+
+        info!("Transaction received | Hash: {}", api_tx.transaction_hash());
+
         let res =
             execute_transaction(transaction, &mut self.state, &self.env.read().block, charge_fee);
 

--- a/crates/katana/core/src/backend/mod.rs
+++ b/crates/katana/core/src/backend/mod.rs
@@ -43,7 +43,6 @@ use crate::db::serde::state::SerializableState;
 use crate::db::Db;
 use crate::env::{BlockContextGenerator, Env};
 use crate::sequencer_error::SequencerError;
-use crate::utils::transaction::convert_blockifier_to_api_tx;
 use crate::utils::{convert_state_diff_to_rpc_state_diff, get_current_timestamp};
 
 pub struct ExternalFunctionCall {
@@ -158,11 +157,7 @@ impl Backend {
 
     // execute the tx
     pub async fn handle_transaction(&self, transaction: Transaction) {
-        let api_tx = convert_blockifier_to_api_tx(&transaction);
-
         let is_valid = if let Some(pending_block) = self.pending_block.write().await.as_mut() {
-            info!("Transaction received | Hash: {}", api_tx.transaction_hash());
-
             let charge_fee = !self.config.read().disable_fee;
             pending_block.add_transaction(transaction, charge_fee).await
         } else {

--- a/crates/katana/core/src/backend/mod.rs
+++ b/crates/katana/core/src/backend/mod.rs
@@ -12,11 +12,11 @@ use blockifier::state::state_api::State;
 use blockifier::transaction::account_transaction::AccountTransaction;
 use blockifier::transaction::errors::TransactionExecutionError;
 use blockifier::transaction::objects::AccountTransactionContext;
-use blockifier::transaction::transaction_execution::Transaction;
+use blockifier::transaction::transaction_execution::Transaction as ExecutionTransaction;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use parking_lot::RwLock;
-use starknet::core::types::{BlockId, BlockTag, FeeEstimate, FieldElement};
+use starknet::core::types::{BlockId, BlockTag, FeeEstimate};
 use starknet_api::block::BlockTimestamp;
 use starknet_api::core::{ContractAddress, EntryPointSelector};
 use starknet_api::hash::StarkFelt;
@@ -34,7 +34,7 @@ pub mod storage;
 use self::config::StarknetConfig;
 use self::executor::{execute_transaction, PendingBlockExecutor};
 use self::storage::block::{Block, PartialHeader};
-use self::storage::transaction::{IncludedTransaction, KnownTransaction, TransactionStatus};
+use self::storage::transaction::{IncludedTransaction, Transaction, TransactionStatus};
 use self::storage::{BlockchainStorage, InMemoryBlockStates};
 use crate::accounts::{Account, DevAccountGenerator};
 use crate::backend::state::{MemDb, StateExt};
@@ -128,7 +128,7 @@ impl Backend {
         let mut state = CachedState::new(state);
 
         let exec_info = execute_transaction(
-            Transaction::AccountTransaction(transaction),
+            ExecutionTransaction::AccountTransaction(transaction),
             &mut state,
             &self.env.read().block,
             true,
@@ -184,12 +184,24 @@ impl Backend {
             Block::new(partial_block.header, partial_block.transactions, partial_block.outputs)
         };
 
-        let pending_txs = block.transactions.clone();
-
         let block_hash = block.header.hash();
         let block_number = block.header.number;
+        let tx_count = block.transactions.len();
 
-        info!("⛏️ Block {block_number} mined with {} transactions", pending_txs.len());
+        // Stores the pending transaction in storage
+        for tx in &block.transactions {
+            let transaction_hash = tx.inner.hash();
+            self.storage.write().await.transactions.insert(
+                transaction_hash,
+                IncludedTransaction {
+                    block_number,
+                    block_hash,
+                    transaction: tx.clone(),
+                    status: TransactionStatus::AcceptedOnL2,
+                }
+                .into(),
+            );
+        }
 
         // get state diffs
         let pending_state_diff = pending.state.to_state_diff();
@@ -198,26 +210,14 @@ impl Backend {
         // store block and the state diff
         self.storage.write().await.append_block(block_hash, block, state_diff);
 
+        info!("⛏️ Block {block_number} mined with {tx_count} transactions");
+
         // apply the pending state to the current state
         self.state.write().await.apply_state(&mut pending.state);
 
         // store the current state
         let state = self.state.read().await.clone();
         self.states.write().await.insert(block_hash, state);
-
-        // Stores the pending transaction in storage
-        for tx in pending_txs {
-            let hash: FieldElement = tx.transaction.transaction_hash().0.into();
-            self.storage.write().await.transactions.insert(
-                hash,
-                KnownTransaction::Included(IncludedTransaction {
-                    block_number,
-                    block_hash,
-                    transaction: tx.clone(),
-                    status: TransactionStatus::AcceptedOnL2,
-                }),
-            );
-        }
     }
 
     pub async fn open_pending_block(&self) {

--- a/crates/katana/core/src/backend/storage/block.rs
+++ b/crates/katana/core/src/backend/storage/block.rs
@@ -154,7 +154,7 @@ impl From<Block> for BlockWithTxs {
             transactions: value
                 .transactions
                 .into_iter()
-                .map(|t| api_to_rpc_transaction(t.transaction.clone()))
+                .map(|t| api_to_rpc_transaction(t.inner.clone().into()))
                 .collect(),
         }
     }
@@ -174,7 +174,7 @@ impl From<ExecutedBlock> for MaybePendingBlockWithTxs {
                 transactions: block
                     .transactions
                     .into_iter()
-                    .map(|t| api_to_rpc_transaction(t.transaction.clone()))
+                    .map(|t| api_to_rpc_transaction(t.inner.clone().into()))
                     .collect(),
             }),
             ExecutedBlock::Pending(block) => {
@@ -185,7 +185,7 @@ impl From<ExecutedBlock> for MaybePendingBlockWithTxs {
                     transactions: block
                         .transactions
                         .into_iter()
-                        .map(|t| api_to_rpc_transaction(t.transaction.clone()))
+                        .map(|t| api_to_rpc_transaction(t.inner.clone().into()))
                         .collect(),
                 })
             }
@@ -205,11 +205,7 @@ impl From<ExecutedBlock> for MaybePendingBlockWithTxHashes {
                     timestamp: block.header.timestamp,
                     parent_hash: block.header.parent_hash,
                     sequencer_address: block.header.sequencer_address,
-                    transactions: block
-                        .transactions
-                        .into_iter()
-                        .map(|t| t.transaction.transaction_hash().0.into())
-                        .collect(),
+                    transactions: block.transactions.into_iter().map(|t| t.inner.hash()).collect(),
                 })
             }
             ExecutedBlock::Pending(block) => {
@@ -217,11 +213,7 @@ impl From<ExecutedBlock> for MaybePendingBlockWithTxHashes {
                     timestamp: block.header.timestamp,
                     parent_hash: block.header.parent_hash,
                     sequencer_address: block.header.sequencer_address,
-                    transactions: block
-                        .transactions
-                        .into_iter()
-                        .map(|t| t.transaction.transaction_hash().0.into())
-                        .collect(),
+                    transactions: block.transactions.into_iter().map(|t| t.inner.hash()).collect(),
                 })
             }
         }

--- a/crates/katana/core/src/backend/storage/transaction.rs
+++ b/crates/katana/core/src/backend/storage/transaction.rs
@@ -1,16 +1,26 @@
 use std::sync::Arc;
 
-use starknet::core::types::{
-    DeclareTransactionReceipt, DeployAccountTransactionReceipt, DeployTransactionReceipt, Event,
-    FieldElement, InvokeTransactionReceipt, L1HandlerTransactionReceipt, MsgToL1,
-    PendingDeclareTransactionReceipt, PendingDeployAccountTransactionReceipt,
-    PendingDeployTransactionReceipt, PendingInvokeTransactionReceipt,
-    PendingL1HandlerTransactionReceipt, PendingTransactionReceipt as RpcPendingTransactionReceipt,
-    Transaction as RpcTransaction, TransactionReceipt as RpcTransactionReceipt,
-    TransactionStatus as RpcTransactionStatus,
+use blockifier::execution::contract_class::ContractClass;
+use blockifier::transaction::account_transaction::AccountTransaction;
+use blockifier::transaction::transactions::{
+    DeclareTransaction as ExecutionDeclareTransaction,
+    DeployAccountTransaction as ExecutionDeployAccountTransaction,
 };
-use starknet::core::utils::get_contract_address;
-use starknet_api::transaction::Transaction as ApiTransaction;
+use starknet::core::types::{
+    DeclareTransactionReceipt, DeployAccountTransactionReceipt, Event, FieldElement,
+    FlattenedSierraClass, InvokeTransactionReceipt, MsgToL1, PendingDeclareTransactionReceipt,
+    PendingDeployAccountTransactionReceipt, PendingInvokeTransactionReceipt,
+    PendingTransactionReceipt as RpcPendingTransactionReceipt, Transaction as RpcTransaction,
+    TransactionReceipt as RpcTransactionReceipt, TransactionStatus as RpcTransactionStatus,
+};
+use starknet_api::core::{ContractAddress, PatriciaKey};
+use starknet_api::hash::StarkHash;
+use starknet_api::patricia_key;
+use starknet_api::transaction::{
+    DeclareTransaction as ApiDeclareTransaction,
+    DeployAccountTransaction as ApiDeployAccountTransaction,
+    InvokeTransaction as ApiInvokeTransaction, Transaction as ApiTransaction,
+};
 
 use crate::backend::executor::ExecutedTransaction;
 use crate::utils::transaction::api_to_rpc_transaction;
@@ -80,136 +90,107 @@ pub struct TransactionOutput {
     pub messages_sent: Vec<MsgToL1>,
 }
 
+#[derive(Debug, Clone)]
+pub enum Transaction {
+    Invoke(InvokeTransaction),
+    Declare(DeclareTransaction),
+    DeployAccount(DeployAccountTransaction),
+}
+
+impl Transaction {
+    pub fn hash(&self) -> FieldElement {
+        match self {
+            Transaction::Invoke(tx) => tx.0.transaction_hash().0.into(),
+            Transaction::Declare(tx) => tx.inner.transaction_hash().0.into(),
+            Transaction::DeployAccount(tx) => tx.inner.transaction_hash.0.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct InvokeTransaction(pub ApiInvokeTransaction);
+
+#[derive(Debug, Clone)]
+pub struct DeclareTransaction {
+    pub inner: ApiDeclareTransaction,
+    pub compiled_class: ContractClass,
+    pub sierra_class: Option<FlattenedSierraClass>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeployAccountTransaction {
+    pub inner: ApiDeployAccountTransaction,
+    pub contract_address: FieldElement,
+}
+
 impl IncludedTransaction {
     pub fn receipt(&self) -> RpcTransactionReceipt {
-        match &self.transaction.transaction {
-            ApiTransaction::Invoke(tx) => RpcTransactionReceipt::Invoke(InvokeTransactionReceipt {
+        match &self.transaction.inner {
+            Transaction::Invoke(_) => RpcTransactionReceipt::Invoke(InvokeTransactionReceipt {
                 status: self.status.into(),
                 block_hash: self.block_hash,
                 block_number: self.block_number,
                 events: self.transaction.output.events.clone(),
                 messages_sent: self.transaction.output.messages_sent.clone(),
-                transaction_hash: tx.transaction_hash().0.into(),
+                transaction_hash: self.transaction.inner.hash(),
                 actual_fee: self.transaction.execution_info.actual_fee.0.into(),
             }),
 
-            ApiTransaction::Declare(tx) => {
-                RpcTransactionReceipt::Declare(DeclareTransactionReceipt {
-                    status: self.status.into(),
-                    block_hash: self.block_hash,
-                    block_number: self.block_number,
-                    events: self.transaction.output.events.clone(),
-                    transaction_hash: tx.transaction_hash().0.into(),
-                    messages_sent: self.transaction.output.messages_sent.clone(),
-                    actual_fee: self.transaction.execution_info.actual_fee.0.into(),
-                })
-            }
+            Transaction::Declare(_) => RpcTransactionReceipt::Declare(DeclareTransactionReceipt {
+                status: self.status.into(),
+                block_hash: self.block_hash,
+                block_number: self.block_number,
+                events: self.transaction.output.events.clone(),
+                transaction_hash: self.transaction.inner.hash(),
+                messages_sent: self.transaction.output.messages_sent.clone(),
+                actual_fee: self.transaction.execution_info.actual_fee.0.into(),
+            }),
 
-            ApiTransaction::DeployAccount(tx) => {
+            Transaction::DeployAccount(tx) => {
                 RpcTransactionReceipt::DeployAccount(DeployAccountTransactionReceipt {
                     status: self.status.into(),
                     block_hash: self.block_hash,
                     block_number: self.block_number,
+                    contract_address: tx.contract_address,
                     events: self.transaction.output.events.clone(),
-                    transaction_hash: tx.transaction_hash.0.into(),
-                    // TODO: store the contract address instead of computing everytime
-                    contract_address: get_contract_address(
-                        tx.contract_address_salt.0.into(),
-                        tx.class_hash.0.into(),
-                        &tx.constructor_calldata.0.iter().map(|f| (*f).into()).collect::<Vec<_>>(),
-                        FieldElement::ZERO,
-                    ),
+                    transaction_hash: self.transaction.inner.hash(),
                     messages_sent: self.transaction.output.messages_sent.clone(),
                     actual_fee: self.transaction.execution_info.actual_fee.0.into(),
                 })
             }
-
-            ApiTransaction::L1Handler(tx) => {
-                RpcTransactionReceipt::L1Handler(L1HandlerTransactionReceipt {
-                    status: self.status.into(),
-                    block_hash: self.block_hash,
-                    block_number: self.block_number,
-                    events: self.transaction.output.events.clone(),
-                    transaction_hash: tx.transaction_hash.0.into(),
-                    messages_sent: self.transaction.output.messages_sent.clone(),
-                    actual_fee: self.transaction.execution_info.actual_fee.0.into(),
-                })
-            }
-
-            ApiTransaction::Deploy(tx) => RpcTransactionReceipt::Deploy(DeployTransactionReceipt {
-                status: self.status.into(),
-                block_hash: self.block_hash,
-                block_number: self.block_number,
-                events: self.transaction.output.events.clone(),
-                transaction_hash: tx.transaction_hash.0.into(),
-                // TODO: store the contract address instead of computing everytime
-                contract_address: get_contract_address(
-                    tx.contract_address_salt.0.into(),
-                    tx.class_hash.0.into(),
-                    &tx.constructor_calldata.0.iter().map(|f| (*f).into()).collect::<Vec<_>>(),
-                    FieldElement::ZERO,
-                ),
-                messages_sent: self.transaction.output.messages_sent.clone(),
-                actual_fee: self.transaction.execution_info.actual_fee.0.into(),
-            }),
         }
     }
 }
 
 impl PendingTransaction {
     pub fn receipt(&self) -> RpcPendingTransactionReceipt {
-        match &self.0.transaction {
-            ApiTransaction::Invoke(tx) => {
+        match &self.0.inner {
+            Transaction::Invoke(_) => {
                 RpcPendingTransactionReceipt::Invoke(PendingInvokeTransactionReceipt {
                     events: self.0.output.events.clone(),
-                    transaction_hash: tx.transaction_hash().0.into(),
+                    transaction_hash: self.0.inner.hash(),
                     messages_sent: self.0.output.messages_sent.clone(),
                     actual_fee: self.0.execution_info.actual_fee.0.into(),
                 })
             }
 
-            ApiTransaction::Declare(tx) => {
+            Transaction::Declare(_) => {
                 RpcPendingTransactionReceipt::Declare(PendingDeclareTransactionReceipt {
                     events: self.0.output.events.clone(),
-                    transaction_hash: tx.transaction_hash().0.into(),
+                    transaction_hash: self.0.inner.hash(),
                     messages_sent: self.0.output.messages_sent.clone(),
                     actual_fee: self.0.execution_info.actual_fee.0.into(),
                 })
             }
 
-            ApiTransaction::DeployAccount(tx) => RpcPendingTransactionReceipt::DeployAccount(
+            Transaction::DeployAccount(_) => RpcPendingTransactionReceipt::DeployAccount(
                 PendingDeployAccountTransactionReceipt {
                     events: self.0.output.events.clone(),
-                    transaction_hash: tx.transaction_hash.0.into(),
+                    transaction_hash: self.0.inner.hash(),
                     messages_sent: self.0.output.messages_sent.clone(),
                     actual_fee: self.0.execution_info.actual_fee.0.into(),
                 },
             ),
-
-            ApiTransaction::L1Handler(tx) => {
-                RpcPendingTransactionReceipt::L1Handler(PendingL1HandlerTransactionReceipt {
-                    events: self.0.output.events.clone(),
-                    transaction_hash: tx.transaction_hash.0.into(),
-                    messages_sent: self.0.output.messages_sent.clone(),
-                    actual_fee: self.0.execution_info.actual_fee.0.into(),
-                })
-            }
-
-            ApiTransaction::Deploy(tx) => {
-                RpcPendingTransactionReceipt::Deploy(PendingDeployTransactionReceipt {
-                    events: self.0.output.events.clone(),
-                    transaction_hash: tx.transaction_hash.0.into(),
-                    messages_sent: self.0.output.messages_sent.clone(),
-                    actual_fee: self.0.execution_info.actual_fee.0.into(),
-                    // TODO: store the contract address instead of computing everytime
-                    contract_address: get_contract_address(
-                        tx.contract_address_salt.0.into(),
-                        tx.class_hash.0.into(),
-                        &tx.constructor_calldata.0.iter().map(|f| (*f).into()).collect::<Vec<_>>(),
-                        FieldElement::ZERO,
-                    ),
-                })
-            }
         }
     }
 }
@@ -257,10 +238,38 @@ impl From<RejectedTransaction> for KnownTransaction {
 impl From<KnownTransaction> for RpcTransaction {
     fn from(transaction: KnownTransaction) -> Self {
         match transaction {
-            KnownTransaction::Pending(tx) => api_to_rpc_transaction(tx.0.transaction.clone()),
+            KnownTransaction::Pending(tx) => api_to_rpc_transaction(tx.0.inner.clone().into()),
             KnownTransaction::Rejected(tx) => api_to_rpc_transaction(tx.transaction),
             KnownTransaction::Included(tx) => {
-                api_to_rpc_transaction(tx.transaction.transaction.clone())
+                api_to_rpc_transaction(tx.transaction.inner.clone().into())
+            }
+        }
+    }
+}
+
+impl From<Transaction> for ApiTransaction {
+    fn from(value: Transaction) -> Self {
+        match value {
+            Transaction::Invoke(tx) => ApiTransaction::Invoke(tx.0),
+            Transaction::Declare(tx) => ApiTransaction::Declare(tx.inner),
+            Transaction::DeployAccount(tx) => ApiTransaction::DeployAccount(tx.inner),
+        }
+    }
+}
+
+impl From<Transaction> for AccountTransaction {
+    fn from(value: Transaction) -> Self {
+        match value {
+            Transaction::Invoke(tx) => AccountTransaction::Invoke(tx.0),
+            Transaction::Declare(tx) => AccountTransaction::Declare(
+                ExecutionDeclareTransaction::new(tx.inner, tx.compiled_class)
+                    .expect("declare tx must have valid compiled class"),
+            ),
+            Transaction::DeployAccount(tx) => {
+                AccountTransaction::DeployAccount(ExecutionDeployAccountTransaction {
+                    tx: tx.inner,
+                    contract_address: ContractAddress(patricia_key!(tx.contract_address)),
+                })
             }
         }
     }

--- a/crates/katana/core/src/db/serde/state.rs
+++ b/crates/katana/core/src/db/serde/state.rs
@@ -9,19 +9,22 @@ use starknet::core::types::{FieldElement, FlattenedSierraClass};
 
 use crate::db::serde::contract::SerializableContractClass;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct SerializableState {
     /// Address to storage record.
     pub storage: BTreeMap<FieldElement, SerializableStorageRecord>,
     /// Class hash to class record.
     pub classes: BTreeMap<FieldElement, SerializableClassRecord>,
+    /// Class hash to sierra class.
+    pub sierra_classes: BTreeMap<FieldElement, FlattenedSierraClass>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SerializableClassRecord {
+    /// The compiled class hash.
     pub compiled_hash: FieldElement,
+    /// The compiled class.
     pub class: SerializableContractClass,
-    pub sierra_class: Option<FlattenedSierraClass>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -220,20 +220,7 @@ impl Sequencer for KatanaSequencer {
     }
 
     async fn add_declare_transaction(&self, transaction: DeclareTransaction) {
-        let class_hash = transaction.inner.class_hash();
-        let sierra_class = transaction.sierra_class.clone();
-
         self.backend.handle_transaction(Transaction::Declare(transaction)).await;
-
-        if let Some(sierra_class) = sierra_class {
-            self.backend
-                .state
-                .write()
-                .await
-                .classes
-                .entry(class_hash)
-                .and_modify(|r| r.sierra_class = Some(sierra_class));
-        }
     }
 
     async fn add_invoke_transaction(&self, transaction: InvokeTransaction) {

--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -9,16 +9,13 @@ use auto_impl::auto_impl;
 use blockifier::execution::contract_class::ContractClass;
 use blockifier::state::state_api::StateReader;
 use blockifier::transaction::account_transaction::AccountTransaction;
-use blockifier::transaction::transaction_execution::Transaction;
-use blockifier::transaction::transactions::{DeclareTransaction, DeployAccountTransaction};
 use starknet::core::types::{
     BlockId, BlockTag, EmittedEvent, Event, EventsPage, FeeEstimate, FieldElement,
-    FlattenedSierraClass, MaybePendingTransactionReceipt, StateUpdate,
+    MaybePendingTransactionReceipt, StateUpdate,
 };
 use starknet_api::core::{ChainId, ClassHash, ContractAddress, Nonce};
 use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
-use starknet_api::transaction::{InvokeTransaction, TransactionHash};
 use tokio::time;
 
 use crate::backend::config::StarknetConfig;
@@ -26,7 +23,8 @@ use crate::backend::contract::StarknetContract;
 use crate::backend::state::{MemDb, StateExt};
 use crate::backend::storage::block::ExecutedBlock;
 use crate::backend::storage::transaction::{
-    KnownTransaction, PendingTransaction, TransactionStatus,
+    DeclareTransaction, DeployAccountTransaction, InvokeTransaction, KnownTransaction,
+    PendingTransaction, Transaction, TransactionStatus,
 };
 use crate::backend::{Backend, ExternalFunctionCall};
 use crate::sequencer_error::SequencerError;
@@ -97,13 +95,9 @@ pub trait Sequencer {
     async fn add_deploy_account_transaction(
         &self,
         transaction: DeployAccountTransaction,
-    ) -> (TransactionHash, ContractAddress);
+    ) -> (FieldElement, FieldElement);
 
-    async fn add_declare_transaction(
-        &self,
-        transaction: DeclareTransaction,
-        sierra_class: Option<FlattenedSierraClass>,
-    );
+    async fn add_declare_transaction(&self, transaction: DeclareTransaction);
 
     async fn add_invoke_transaction(&self, transaction: InvokeTransaction);
 
@@ -216,31 +210,20 @@ impl Sequencer for KatanaSequencer {
     async fn add_deploy_account_transaction(
         &self,
         transaction: DeployAccountTransaction,
-    ) -> (TransactionHash, ContractAddress) {
-        let transaction_hash = transaction.tx.transaction_hash;
+    ) -> (FieldElement, FieldElement) {
+        let transaction_hash = transaction.inner.transaction_hash.0.into();
         let contract_address = transaction.contract_address;
 
-        self.backend
-            .handle_transaction(Transaction::AccountTransaction(AccountTransaction::DeployAccount(
-                transaction,
-            )))
-            .await;
+        self.backend.handle_transaction(Transaction::DeployAccount(transaction)).await;
 
         (transaction_hash, contract_address)
     }
 
-    async fn add_declare_transaction(
-        &self,
-        transaction: DeclareTransaction,
-        sierra_class: Option<FlattenedSierraClass>,
-    ) {
-        let class_hash = transaction.tx().class_hash();
+    async fn add_declare_transaction(&self, transaction: DeclareTransaction) {
+        let class_hash = transaction.inner.class_hash();
+        let sierra_class = transaction.sierra_class.clone();
 
-        self.backend
-            .handle_transaction(Transaction::AccountTransaction(AccountTransaction::Declare(
-                transaction,
-            )))
-            .await;
+        self.backend.handle_transaction(Transaction::Declare(transaction)).await;
 
         if let Some(sierra_class) = sierra_class {
             self.backend
@@ -254,11 +237,7 @@ impl Sequencer for KatanaSequencer {
     }
 
     async fn add_invoke_transaction(&self, transaction: InvokeTransaction) {
-        self.backend
-            .handle_transaction(Transaction::AccountTransaction(AccountTransaction::Invoke(
-                transaction,
-            )))
-            .await;
+        self.backend.handle_transaction(Transaction::Invoke(transaction)).await;
     }
 
     async fn estimate_fee(
@@ -269,13 +248,6 @@ impl Sequencer for KatanaSequencer {
         if self.block(block_id).await.is_none() {
             return Err(SequencerError::BlockNotFound(block_id));
         }
-
-        match &account_transaction {
-            AccountTransaction::Invoke(InvokeTransaction::V1(tx)) => tx.sender_address,
-            AccountTransaction::Declare(tx) => tx.tx().sender_address(),
-            AccountTransaction::DeployAccount(tx) => tx.contract_address,
-            _ => return Err(SequencerError::UnsupportedTransaction),
-        };
 
         let state = self.state(&block_id).await?;
 
@@ -418,9 +390,7 @@ impl Sequencer for KatanaSequencer {
             None => self.backend.pending_block.read().await.as_ref().and_then(|b| {
                 b.transactions
                     .iter()
-                    .find(|tx| {
-                        Into::<FieldElement>::into(tx.transaction.transaction_hash().0) == *hash
-                    })
+                    .find(|tx| tx.inner.hash() == *hash)
                     .map(|_| TransactionStatus::AcceptedOnL2)
             }),
         }
@@ -451,7 +421,7 @@ impl Sequencer for KatanaSequencer {
             None => self.backend.pending_block.read().await.as_ref().and_then(|b| {
                 b.transactions
                     .iter()
-                    .find(|tx| tx.hash() == *hash)
+                    .find(|tx| tx.inner.hash() == *hash)
                     .map(|tx| PendingTransaction(tx.clone()).into())
             }),
         }
@@ -560,7 +530,7 @@ impl Sequencer for KatanaSequencer {
                     data: e.data.clone(),
                     block_hash,
                     block_number,
-                    transaction_hash: txn.hash(),
+                    transaction_hash: txn.inner.hash(),
                 }));
 
                 if filtered_events.len() >= chunk_size as usize {

--- a/crates/katana/src/args.rs
+++ b/crates/katana/src/args.rs
@@ -36,7 +36,6 @@ pub struct KatanaArgs {
     pub dump_state: Option<PathBuf>,
 
     #[arg(long)]
-    #[arg(hide = true)]
     #[arg(value_name = "PATH")]
     #[arg(value_parser = SerializableState::parse)]
     #[arg(help = "Initialize the chain from a previously saved state snapshot.")]


### PR DESCRIPTION
- refactor(katana-core): remove redundancy
- refactor(katana): add unified tx type to simplify conversion
- refactor(katana): separate sierra class mappings
- Unhide `--load-state` CLI message
