### PR TITLE
fix the parameter order for the "is_writer" function call.

### DIFF
--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -225,7 +225,7 @@ mod world {
         /// * `system` - The name of the system.
         fn revoke_writer(ref self: ContractState, component: felt252, system: felt252) {
             assert(
-                IWorld::is_writer(@self, caller_system(@self), component)
+                IWorld::is_writer(@self, component, caller_system(@self))
                     || IWorld::is_owner(@self, get_caller_address(), component)
                     || IWorld::is_owner(@self, get_caller_address(), 0),
                 'not owner'
@@ -516,7 +516,7 @@ mod world {
         );
 
         assert(
-            IWorld::is_writer(self, caller_system(self), component)
+            IWorld::is_writer(self, component, caller_system(self))
                 || IWorld::is_owner(self, get_tx_info().unbox().account_contract_address, component)
                 || IWorld::is_owner(self, get_tx_info().unbox().account_contract_address, 0),
             'not writer'


### PR DESCRIPTION
The `is_writer` funtion call has a incorrect parameter order.
Since `is_writer` is defined as
`fn is_writer(self: @T, component: felt252, system: felt252) -> bool;`

The call in `world.cairo` is `IWorld::is_writer(@self, caller_system(@self), component)`