### PR TITLE
feat(sozo): default `--name` to be package name from `Scarb.toml`

### DIFF
--- a/crates/sozo/src/commands/migrate.rs
+++ b/crates/sozo/src/commands/migrate.rs
@@ -31,8 +31,15 @@ pub struct MigrateArgs {
 }
 
 impl MigrateArgs {
-    pub fn run(self, config: &Config) -> Result<()> {
+    pub fn run(mut self, config: &Config) -> Result<()> {
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
+
+        // If `name` was not specified use package name from `Scarb.toml` file if it exists
+        if self.name.is_none() {
+            if let Some(root_package) = ws.root_package() {
+                self.name = Some(root_package.id.name.to_string());
+            }
+        }
 
         let target_dir = ws.target_dir().path_existent().unwrap();
         let target_dir = target_dir.join(ws.config().profile().as_str());

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -45,7 +45,7 @@ where
     // Setup account for migration and fetch world address if it exists.
 
     let (world_address, account) =
-        setup_env(account, starknet, world, env_metadata.as_ref(), config).await?;
+        setup_env(account, starknet, world, env_metadata.as_ref(), config, name.as_ref()).await?;
 
     // Load local and remote World manifests.
 
@@ -102,6 +102,7 @@ async fn setup_env(
     world: WorldOptions,
     env_metadata: Option<&Environment>,
     config: &Config,
+    name: Option<&String>,
 ) -> Result<(Option<FieldElement>, SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>)> {
     let world_address = world.address(env_metadata).ok();
 
@@ -112,7 +113,10 @@ async fn setup_env(
 
         let address = account.address();
 
-        config.ui().print(format!("\nMigration account: {address:#x}\n"));
+        config.ui().print(format!("\nMigration account: {address:#x}"));
+        if let Some(name) = name {
+            config.ui().print(format!("\nWorld seed: {name}\n"));
+        }
 
         match account.provider().get_class_hash_at(BlockId::Tag(BlockTag::Pending), address).await {
             Ok(_) => Ok(account),


### PR DESCRIPTION
Fix: #785 

Not able to test this properly due to #678

also i think it would be great if we print the world seed somewhere on console, how about something like:

```
Migration account: 0x3ee9e18edc71a6df30ac3aca2e0b02a198fbce19b7480a63a0d71cbd76652e0
World seed: dojo_examples (or whatever was passed) 

[1] 🌎 Building World state....
  > No remote World found
[2] 🧰 Evaluating Worlds diff....
  > Total diffs found: 7
[3] 📦 Preparing for migration....
  > Total items to be migrated (7): New 7 Update 0
  
 ```