### PR TITLE
refactor(sozo): manifest and world address logic

### DIFF
--- a/crates/torii/server/src/cli.rs
+++ b/crates/torii/server/src/cli.rs
@@ -51,9 +51,6 @@ struct Args {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
-    dbg!(&args.manifest);
-    dbg!(&args.world_address);
-
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(tracing::Level::INFO) // Set the maximum log level
         .finish();

--- a/crates/torii/server/src/cli.rs
+++ b/crates/torii/server/src/cli.rs
@@ -48,33 +48,6 @@ struct Args {
     start_block: u64,
 }
 
-fn get_world_address(
-    args: &Args,
-    manifest: &Manifest,
-    env_metadata: Option<&Environment>,
-) -> anyhow::Result<FieldElement> {
-    if let Some(address) = args.world_address {
-        return Ok(address);
-    }
-
-    if let Some(address) = manifest.world.address {
-        return Ok(address);
-    }
-
-    if let Some(world_address) =
-        env_metadata
-            .and_then(|env| env.world_address())
-            .or(std::env::var("DOJO_WORLD_ADDRESS").ok().as_deref())
-    {
-        Ok(FieldElement::from_str(world_address)?)
-    } else {
-        Err(anyhow!(
-            "Could not find World address. Please specify it with --world, or in manifest.json or \
-             [tool.dojo.env] in Scarb.toml"
-        ))
-    }
-}
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -190,4 +163,31 @@ fn get_manifest_and_env(
         None
     };
     Ok((manifest, env))
+}
+
+fn get_world_address(
+    args: &Args,
+    manifest: &Manifest,
+    env_metadata: Option<&Environment>,
+) -> anyhow::Result<FieldElement> {
+    if let Some(address) = args.world_address {
+        return Ok(address);
+    }
+
+    if let Some(address) = manifest.world.address {
+        return Ok(address);
+    }
+
+    if let Some(world_address) =
+        env_metadata
+            .and_then(|env| env.world_address())
+            .or(std::env::var("DOJO_WORLD_ADDRESS").ok().as_deref())
+    {
+        Ok(FieldElement::from_str(world_address)?)
+    } else {
+        Err(anyhow!(
+            "Could not find World address. Please specify it with --world, or in manifest.json or \
+             [tool.dojo.env] in Scarb.toml"
+        ))
+    }
 }


### PR DESCRIPTION
Fix: #794 

it will try to derive path (in specified order) for

`manifest.json` from :

- passed cli argument
- Environment variable (`DOJO_MANIFEST_FILE`)
- `Scarb.toml`'s target directory and profile information

`world_address` from:

- passed cli argument
- Environment variable (`DOJO_WORLD_ADDRESS`)
- `Scarb.toml`'s dojo.tool.env
- manifest.json
