### PR TITLE
fix(inline_macro): remove trivia from macro name

### DIFF
--- a/crates/dojo-lang/src/inline_macro_plugin.rs
+++ b/crates/dojo-lang/src/inline_macro_plugin.rs
@@ -62,7 +62,7 @@ impl InlineMacroExpanderData {
 
     /// Expand a single inline macro.
     fn handle_macro(&mut self, db: &dyn SyntaxGroup, inline_macro: &ast::ExprInlineMacro) {
-        let macro_name = inline_macro.path(db).as_syntax_node().get_text(db).trim().to_string();
+        let macro_name = inline_macro.path(db).as_syntax_node().get_text_without_trivia(db);
         let macro_plugin = get_inline_macro_plugin(&macro_name);
 
         if let Some(macro_plugin) = macro_plugin {

--- a/crates/dojo-lang/src/plugin_test_data/inline_macros
+++ b/crates/dojo-lang/src/plugin_test_data/inline_macros
@@ -204,3 +204,23 @@ fn foo() {
 }
 
 //! > expected_diagnostics
+
+//! > ==========================================================================
+
+//! > Test comment affects macro name
+
+//! > test_runner_name
+test_function_diagnostics
+
+//! > function
+fn foo() {
+   // This comment should not appear in the macro name
+   array![0_felt252];
+}
+
+//! > function_name
+foo
+
+//! > module_code
+
+//! > expected_diagnostics

--- a/crates/dojo-lang/src/plugin_test_data/inline_macros
+++ b/crates/dojo-lang/src/plugin_test_data/inline_macros
@@ -177,6 +177,7 @@ test_expand_plugin
 
 //! > cairo_code
 fn foo() {
+    // A comment should not affect macro name
     emit!(world, Struct {
         x: 10,
     });
@@ -202,25 +203,5 @@ fn foo() {
         world.emit(keys, data.span());
     };
 }
-
-//! > expected_diagnostics
-
-//! > ==========================================================================
-
-//! > Test comment affects macro name
-
-//! > test_runner_name
-test_function_diagnostics
-
-//! > function
-fn foo() {
-   // This comment should not appear in the macro name
-   array![0_felt252];
-}
-
-//! > function_name
-foo
-
-//! > module_code
 
 //! > expected_diagnostics


### PR DESCRIPTION
Fixes #798