### PR TITLE
Support for dev mode with hot reloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,6 +2432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,6 +3758,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,6 +4054,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,6 +4314,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -4345,6 +4395,34 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "notify"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5738a2795d57ea20abec2d6d76c6081186709c0024187cd5977265eda6598b51"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e55ee272914f4563a2f8b8553eb6811f3c0caea81c756346bad15b7e3ef969f0"
+dependencies = [
+ "crossbeam-channel",
+ "notify",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -5939,6 +6017,8 @@ dependencies = [
  "dojo-test-utils",
  "dojo-world",
  "log",
+ "notify",
+ "notify-debouncer-mini",
  "scarb",
  "semver",
  "serde",

--- a/crates/sozo/Cargo.toml
+++ b/crates/sozo/Cargo.toml
@@ -36,6 +36,8 @@ torii-client = { path = "../torii/client" }
 tracing-log = "0.1.3"
 tracing.workspace = true
 url = "2.2.2"
+yansi.workspace = true
+notify = "6.0.1"
 
 [dev-dependencies]
 assert_fs = "1.0.10"

--- a/crates/sozo/Cargo.toml
+++ b/crates/sozo/Cargo.toml
@@ -36,9 +36,8 @@ torii-client = { path = "../torii/client" }
 tracing-log = "0.1.3"
 tracing.workspace = true
 url = "2.2.2"
-yansi.workspace = true
+notify-debouncer-mini = "0.3.0"
 notify = "6.0.1"
-
 [dev-dependencies]
 assert_fs = "1.0.10"
 dojo-test-utils = { path = "../dojo-test-utils", features = [ "build-examples" ] }

--- a/crates/sozo/src/args.rs
+++ b/crates/sozo/src/args.rs
@@ -11,6 +11,7 @@ use crate::commands::auth::AuthArgs;
 use crate::commands::build::BuildArgs;
 use crate::commands::completions::CompletionsArgs;
 use crate::commands::component::ComponentArgs;
+use crate::commands::dev::DevArgs;
 use crate::commands::events::EventsArgs;
 use crate::commands::execute::ExecuteArgs;
 use crate::commands::init::InitArgs;
@@ -57,6 +58,8 @@ pub enum Commands {
     #[command(about = "Run a migration, declaring and deploying contracts as necessary to \
                        update the world")]
     Migrate(Box<MigrateArgs>),
+    #[command(about = "Developer mode: watcher for building and migration")]
+    Dev(DevArgs),
     #[command(about = "Test the project's smart contracts")]
     Test(TestArgs),
     #[command(about = "Execute a world's system")]

--- a/crates/sozo/src/commands/dev.rs
+++ b/crates/sozo/src/commands/dev.rs
@@ -1,70 +1,134 @@
-use anyhow::Result;
-use clap::Args;
-use notify::event::{AccessMode, AccessKind, ModifyKind, RenameMode};
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher, EventKind};
-use scarb::core::Config;
-use scarb::ops;
+use anyhow::{anyhow, Result};
 
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_filesystem::db::{AsFilesGroupMut, FilesGroupEx, PrivRawFileContentQuery};
+use cairo_lang_filesystem::ids::FileId;
+use clap::Args;
+use notify::event::{AccessKind, AccessMode, ModifyKind, RenameMode};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use scarb::compiler::CompilationUnit;
+use scarb::core::{Config, Workspace};
+use scarb::ui::Status;
+
+use std::path::PathBuf;
 use std::sync::mpsc::channel;
+
+use super::scarb_internal::build_scarb_root_database;
 
 #[derive(Args, Debug)]
 pub struct DevArgs;
 
-fn check_event(event: Event) -> bool {
-    let matched = event.paths.iter().find(|&p| {
-        if let Some(filename) = p.file_name() {
-            if filename == "Scarb.toml" {
-                return true;
-            }
-        }
-        if let Some(extension) = p.extension() {
-            if extension == "cairo" {
-                return true;
-            }
-        }
-        false
-    });
-    if matched.is_some() {
-        match event.kind {
-            EventKind::Access(AccessKind::Close(AccessMode::Write)) => return true,
-            EventKind::Remove(_) => return true,
-            EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => return true,
-            _ => return false,
-        }
-    }
-    false
+enum DevAction {
+    None,
+    Reload,
+    Build(PathBuf),
 }
 
-fn build(config: &Config) -> Result<()> {
+fn handle_event(event: Event) -> DevAction {
+    let action = match event.kind {
+        EventKind::Modify(ModifyKind::Name(RenameMode::Both))
+        | EventKind::Modify(ModifyKind::Data(_))
+        | EventKind::Remove(_) => {
+            for p in event.paths.iter() {
+                if let Some(filename) = p.file_name() {
+                    if filename == "Scarb.toml" {
+                        return DevAction::Reload;
+                    } else {
+                        if let Some(extension) = p.extension() {
+                            if extension == "cairo" {
+                                return DevAction::Build(p.clone());
+                            }
+                        }
+                    }
+                }
+            }
+            DevAction::None
+        }
+        _ => DevAction::None,
+    };
+    action
+}
+
+struct DevContext<'a> {
+    pub db: RootDatabase,
+    pub unit: CompilationUnit,
+    pub ws: Workspace<'a>,
+    pub packages: Vec<scarb::core::PackageId>,
+}
+
+fn load_context(config: &Config) -> Result<DevContext> {
     let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
-    ops::compile(&ws)
+    let packages: Vec<scarb::core::PackageId> = ws.members().map(|p| p.id).collect();
+    let resolve = scarb::ops::resolve_workspace(&ws)?;
+    let compilation_units = scarb::ops::generate_compilation_units(&resolve, &ws)?
+        .into_iter()
+        .filter(|cu| packages.contains(&cu.main_package_id))
+        .collect::<Vec<_>>();
+    // we have only 1 unit in projects
+    let unit = compilation_units.get(0).unwrap();
+    let db = build_scarb_root_database(&unit, &ws).unwrap();
+    Ok(DevContext { db, unit: unit.clone(), ws, packages })
+}
+
+fn build(context: &mut DevContext) -> Result<()> {
+    let ws = &context.ws;
+    let packages = context.packages.clone();
+    let unit = &context.unit;
+    let package_name = unit.main_package_id.name.clone();
+    log::error!("compile");
+    ws.config().compilers().compile(unit.clone(), &mut ((*context).db), ws).map_err(|err| {
+        ws.config().ui().anyhow(&err);
+
+        anyhow!("could not compile `{package_name}` due to previous error")
+    })?;
+    ws.config().ui().print(Status::new("Rebuild", "done"));
+    Ok(())
 }
 
 impl DevArgs {
     pub fn run(self, config: &Config) -> Result<()> {
+        let mut context = load_context(config)?;
         let (tx, rx) = channel();
         // Automatically select the best implementation for your platform.
         let mut watcher = RecommendedWatcher::new(tx, notify::Config::default())?;
 
-        watcher.watch(config.manifest_path().parent().unwrap().as_std_path(), RecursiveMode::Recursive)?;
-        let mut result = build(config);
+        watcher.watch(
+            config.manifest_path().parent().unwrap().as_std_path(),
+            RecursiveMode::Recursive,
+        )?;
+        let mut result = build(&mut context);
 
         loop {
-            let mut need_rebuild = false;
+            let mut action = DevAction::None;
             match rx.recv() {
                 Ok(event) => {
                     if event.is_ok() {
-                        need_rebuild = check_event(event.ok().unwrap());
+                        action = handle_event(event.ok().unwrap());
                     }
                 }
                 Err(error) => {
                     log::error!("Error: {error:?}");
                     break;
                 }
+            };
+            match action {
+                DevAction::None => continue,
+                DevAction::Build(path) => {
+                    context.ws.config().ui().print(Status::new(
+                        "Need to rebuild",
+                        path.clone().as_path().to_str().unwrap(),
+                    ));
+                    let db = &mut context.db;
+                    let file = FileId::new(db, path);
+                    PrivRawFileContentQuery.in_db_mut(db.as_files_group_mut()).invalidate(&file);
+                    db.override_file_content(file, None);
+                }
+                DevAction::Reload => {
+                    context.ws.config().ui().print(Status::new("Reloading", "project"));
+                    context = load_context(config)?;
+                }
             }
-            if need_rebuild {
-                result = build(config);
-            }
+            result = build(&mut context);
         }
         result
     }

--- a/crates/sozo/src/commands/dev.rs
+++ b/crates/sozo/src/commands/dev.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+use clap::Args;
+use notify::event::{AccessMode, AccessKind, ModifyKind, RenameMode};
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher, EventKind};
+use scarb::core::Config;
+use scarb::ops;
+
+use std::sync::mpsc::channel;
+
+#[derive(Args, Debug)]
+pub struct DevArgs;
+
+fn check_event(event: Event) -> bool {
+    let matched = event.paths.iter().find(|&p| {
+        if let Some(filename) = p.file_name() {
+            if filename == "Scarb.toml" {
+                return true;
+            }
+        }
+        if let Some(extension) = p.extension() {
+            if extension == "cairo" {
+                return true;
+            }
+        }
+        false
+    });
+    if matched.is_some() {
+        match event.kind {
+            EventKind::Access(AccessKind::Close(AccessMode::Write)) => return true,
+            EventKind::Remove(_) => return true,
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => return true,
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn build(config: &Config) -> Result<()> {
+    let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
+    ops::compile(&ws)
+}
+
+impl DevArgs {
+    pub fn run(self, config: &Config) -> Result<()> {
+        let (tx, rx) = channel();
+        // Automatically select the best implementation for your platform.
+        let mut watcher = RecommendedWatcher::new(tx, notify::Config::default())?;
+
+        watcher.watch(config.manifest_path().parent().unwrap().as_std_path(), RecursiveMode::Recursive)?;
+        let mut result = build(config);
+
+        loop {
+            let mut need_rebuild = false;
+            match rx.recv() {
+                Ok(event) => {
+                    if event.is_ok() {
+                        need_rebuild = check_event(event.ok().unwrap());
+                    }
+                }
+                Err(error) => {
+                    log::error!("Error: {error:?}");
+                    break;
+                }
+            }
+            if need_rebuild {
+                result = build(config);
+            }
+        }
+        result
+    }
+}

--- a/crates/sozo/src/commands/mod.rs
+++ b/crates/sozo/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod auth;
 pub(crate) mod build;
 pub(crate) mod completions;
 pub(crate) mod component;
+pub(crate) mod dev;
 pub(crate) mod events;
 pub(crate) mod execute;
 pub(crate) mod init;
@@ -22,7 +23,7 @@ pub fn run(command: Commands, config: &Config) -> Result<()> {
         Commands::Test(args) => args.run(config),
         Commands::Build(args) => args.run(config),
         Commands::Migrate(args) => args.run(config),
-
+        Commands::Dev(args) => args.run(config),
         Commands::Auth(args) => args.run(config),
         Commands::Execute(args) => args.run(config),
         Commands::Component(args) => args.run(config),

--- a/crates/sozo/src/commands/mod.rs
+++ b/crates/sozo/src/commands/mod.rs
@@ -17,6 +17,9 @@ pub(crate) mod register;
 pub(crate) mod system;
 pub(crate) mod test;
 
+// copy of non pub functions from scarb
+pub(crate) mod scarb_internal;
+
 pub fn run(command: Commands, config: &Config) -> Result<()> {
     match command {
         Commands::Init(args) => args.run(config),

--- a/crates/sozo/src/commands/scarb_internal/mod.rs
+++ b/crates/sozo/src/commands/scarb_internal/mod.rs
@@ -1,0 +1,57 @@
+// I have copied source code from https://github.com/software-mansion/scarb/blob/bf927194941f6c0ce62677e7e2ef4f9122489ff6/scarb/src/compiler/db.rs
+// since build_scarb_root_database is not public
+use anyhow::Result;
+use cairo_lang_compiler::db::RootDatabase;
+use cairo_lang_compiler::project::{ProjectConfig, ProjectConfigContent};
+use cairo_lang_filesystem::ids::Directory;
+
+use scarb::compiler::CompilationUnit;
+use scarb::core::Workspace;
+
+pub(crate) fn build_scarb_root_database(
+    unit: &CompilationUnit,
+    ws: &Workspace<'_>,
+) -> Result<RootDatabase> {
+    let mut b = RootDatabase::builder();
+    b.with_project_config(build_project_config(unit)?);
+    b.with_cfg(unit.cfg_set.clone());
+
+    for plugin_info in &unit.cairo_plugins {
+        let package_id = plugin_info.package.id;
+        let plugin = ws.config().cairo_plugins().fetch(package_id)?;
+        let instance = plugin.instantiate()?;
+        for semantic_plugin in instance.semantic_plugins() {
+            b.with_semantic_plugin(semantic_plugin);
+        }
+    }
+
+    b.build()
+}
+
+fn build_project_config(unit: &CompilationUnit) -> Result<ProjectConfig> {
+    let crate_roots = unit
+        .components
+        .iter()
+        .filter(|component| !component.package.id.is_core())
+        .map(|component| {
+            (
+                component.cairo_package_name(),
+                component.target.source_root().into(),
+            )
+        })
+        .collect();
+
+    let corelib = Some(Directory(
+        unit.core_package_component().target.source_root().into(),
+    ));
+
+    let content = ProjectConfigContent { crate_roots };
+
+    let project_config = ProjectConfig {
+        base_path: unit.main_component().package.root().into(),
+        corelib,
+        content,
+    };
+
+    Ok(project_config)
+}

--- a/crates/sozo/src/main.rs
+++ b/crates/sozo/src/main.rs
@@ -30,8 +30,9 @@ fn cli_main(args: SozoArgs) -> Result<()> {
     let mut compilers = CompilerRepository::std();
     let cairo_plugins = CairoPluginRepository::new();
 
-    if let Commands::Build(_) = &args.command {
-        compilers.add(Box::new(DojoCompiler)).unwrap();
+    match &args.command {
+        Commands::Build(_) | Commands::Dev(_) => compilers.add(Box::new(DojoCompiler)).unwrap(),
+        _ => {}
     }
 
     let manifest_path = scarb::ops::find_manifest_path(args.manifest_path.as_deref())?;

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -64,41 +64,58 @@ where
     if total_diffs == 0 {
         config.ui().print("\n✨ No changes to be made. Remote World is already up to date!")
     } else {
-        // Prepare migration strategy based on the diff.
-
-        let strategy = prepare_migration(target_dir, diff, name, world_address, config)?;
-
-        println!("  ");
-
-        let block_height = execute_strategy(&strategy, &account, config)
-            .await
-            .map_err(|e| anyhow!(e))
-            .with_context(|| "Problem trying to migrate.")?;
-
-        if let Some(block_height) = block_height {
-            config.ui().print(format!(
-                "\n🎉 Successfully migrated World on block #{} at address {}",
-                block_height,
-                bold_message(format!(
-                    "{:#x}",
-                    strategy.world_address().expect("world address must exist")
-                ))
-            ));
-        } else {
-            config.ui().print(format!(
-                "\n🎉 Successfully migrated World at address {}",
-                bold_message(format!(
-                    "{:#x}",
-                    strategy.world_address().expect("world address must exist")
-                ))
-            ));
-        }
+        // Mirate according to the diff.
+        apply_diff(target_dir, diff, name, world_address, &account, config).await?;
     }
 
     Ok(())
 }
 
-async fn setup_env(
+pub(crate) async fn apply_diff<U, P, S>(
+    target_dir: U,
+    diff: WorldDiff,
+    name: Option<String>,
+    world_address: Option<FieldElement>,
+    account: &SingleOwnerAccount<P, S>,
+    config: &Config,
+) -> Result<FieldElement>
+where
+    U: AsRef<Path>,
+    P: Provider + Sync + Send + 'static,
+    S: Signer + Sync + Send + 'static,
+{
+    let strategy = prepare_migration(target_dir, diff, name, world_address, config)?;
+
+    println!("  ");
+
+    let block_height = execute_strategy(&strategy, &account, config)
+        .await
+        .map_err(|e| anyhow!(e))
+        .with_context(|| "Problem trying to migrate.")?;
+
+    if let Some(block_height) = block_height {
+        config.ui().print(format!(
+            "\n🎉 Successfully migrated World on block #{} at address {}",
+            block_height,
+            bold_message(format!(
+                "{:#x}",
+                strategy.world_address().expect("world address must exist")
+            ))
+        ));
+    } else {
+        config.ui().print(format!(
+            "\n🎉 Successfully migrated World at address {}",
+            bold_message(format!(
+                "{:#x}",
+                strategy.world_address().expect("world address must exist")
+            ))
+        ));
+    }
+
+    strategy.world_address()
+}
+
+pub(crate) async fn setup_env(
     account: AccountOptions,
     starknet: StarknetOptions,
     world: WorldOptions,


### PR DESCRIPTION
This PR add support to hot reloading of a worlds components and systems.

When `sozo` is run in dev mode in your dojo application directory:
```
sozo dev --name WORLD_NAME
```

For each changes in your project source files, a build will be done and if needed a migration.

Source code monitoring use [notify crate](https://github.com/notify-rs/notify) debounced at 1 seconds.

World migration use `sozo::ops::miggration` crate, I have to modified visibility of `setup_env` and add a new function `apply_diff`

Closes #557 