### PR TITLE
fix: emit events keyed by event name first

### DIFF
--- a/crates/dojo-erc/src/erc1155/systems.cairo
+++ b/crates/dojo-erc/src/erc1155/systems.cairo
@@ -11,7 +11,7 @@ use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
 
 use dojo_erc::erc1155::erc1155::ERC1155::{
     ApprovalForAll, TransferSingle, TransferBatch, IERC1155EventsDispatcher,
-    IERC1155EventsDispatcherTrait
+    IERC1155EventsDispatcherTrait, Event
 };
 use dojo_erc::erc1155::components::{ERC1155BalanceTrait, OperatorApprovalTrait};
 use dojo_erc::erc165::interface::{IERC165Dispatcher, IERC165DispatcherTrait, IACCOUNT_ID};
@@ -157,7 +157,7 @@ mod ERC1155SetApprovalForAll {
     use clone::Clone;
 
     use dojo_erc::erc1155::components::OperatorApprovalTrait;
-    use super::{IERC1155EventsDispatcher, IERC1155EventsDispatcherTrait, ApprovalForAll};
+    use super::{IERC1155EventsDispatcher, IERC1155EventsDispatcherTrait, ApprovalForAll, Event};
 
 
     #[derive(Drop, Serde)]

--- a/crates/dojo-erc/src/erc721/systems.cairo
+++ b/crates/dojo-erc/src/erc721/systems.cairo
@@ -8,7 +8,7 @@ use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
 use dojo_erc::erc721::erc721::ERC721;
 
 use dojo_erc::erc721::erc721::ERC721::{
-    IERC721EventsDispatcher, IERC721EventsDispatcherTrait, Approval, Transfer, ApprovalForAll
+    IERC721EventsDispatcher, IERC721EventsDispatcherTrait, Approval, Transfer, ApprovalForAll, Event
 };
 
 use ERC721Approve::ERC721ApproveParams;

--- a/crates/dojo-lang/src/inline_macros/emit.rs
+++ b/crates/dojo-lang/src/inline_macros/emit.rs
@@ -27,8 +27,8 @@ impl InlineMacro for EmitMacro {
             "{{
                 let mut keys = Default::<array::Array>::default();
                 let mut data = Default::<array::Array>::default();
-                starknet::Event::append_keys_and_data(@traits::Into::<_, Event>::into({}), ref keys, ref \
-             data);
+                starknet::Event::append_keys_and_data(@traits::Into::<_, Event>::into({}), ref \
+             keys, ref data);
                 {}.emit(keys, data.span());
             }}",
             event.as_syntax_node().get_text(db),

--- a/crates/dojo-lang/src/inline_macros/emit.rs
+++ b/crates/dojo-lang/src/inline_macros/emit.rs
@@ -27,7 +27,7 @@ impl InlineMacro for EmitMacro {
             "{{
                 let mut keys = Default::<array::Array>::default();
                 let mut data = Default::<array::Array>::default();
-                starknet::Event::append_keys_and_data(@Into::<_, Event>::into({}), ref keys, ref \
+                starknet::Event::append_keys_and_data(@traits::Into::<_, Event>::into({}), ref keys, ref \
              data);
                 {}.emit(keys, data.span());
             }}",

--- a/crates/dojo-lang/src/inline_macros/emit.rs
+++ b/crates/dojo-lang/src/inline_macros/emit.rs
@@ -27,7 +27,8 @@ impl InlineMacro for EmitMacro {
             "{{
                 let mut keys = Default::<array::Array>::default();
                 let mut data = Default::<array::Array>::default();
-                starknet::Event::append_keys_and_data(@{}, ref keys, ref data);
+                starknet::Event::append_keys_and_data(@Into::<_, Event>::into({}), ref keys, ref \
+             data);
                 {}.emit(keys, data.span());
             }}",
             event.as_syntax_node().get_text(db),

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -705,7 +705,7 @@ test_manifest_file
         }
       ],
       "outputs": [],
-      "class_hash": "0x5df94ea0e971f9c98c222350f0acdb8fea75759678a7d922ca454d14408430f",
+      "class_hash": "0x601d780f4ccee957d308dbb6ad98cb5d4bf8e4e4b9cf7b221b8264c1d7186ef",
       "dependencies": [],
       "abi": [
         {
@@ -791,9 +791,32 @@ test_manifest_file
         },
         {
           "type": "event",
+          "name": "dojo_examples::systems::move::Moved",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "address",
+              "type": "core::starknet::contract_address::ContractAddress",
+              "kind": "data"
+            },
+            {
+              "name": "direction",
+              "type": "dojo_examples::systems::move::Direction",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
           "name": "dojo_examples::systems::move::Event",
           "kind": "enum",
-          "variants": []
+          "variants": [
+            {
+              "name": "Moved",
+              "type": "dojo_examples::systems::move::Moved",
+              "kind": "nested"
+            }
+          ]
         }
       ]
     },

--- a/crates/dojo-lang/src/plugin_test_data/inline_macros
+++ b/crates/dojo-lang/src/plugin_test_data/inline_macros
@@ -192,7 +192,7 @@ fn foo() {
         let mut keys = Default::<array::Array>::default();
         let mut data = Default::<array::Array>::default();
         starknet::Event::append_keys_and_data(
-            @Into::<_, Event>::into(Struct { x: 10,  }), ref keys, ref data
+            @traits::Into::<_, Event>::into(Struct { x: 10,  }), ref keys, ref data
         );
         world.emit(keys, data.span());
     };
@@ -201,7 +201,9 @@ fn foo() {
     {
         let mut keys = Default::<array::Array>::default();
         let mut data = Default::<array::Array>::default();
-        starknet::Event::append_keys_and_data(@Into::<_, Event>::into(id), ref keys, ref data);
+        starknet::Event::append_keys_and_data(
+            @traits::Into::<_, Event>::into(id), ref keys, ref data
+        );
         world.emit(keys, data.span());
     };
 }

--- a/crates/dojo-lang/src/plugin_test_data/inline_macros
+++ b/crates/dojo-lang/src/plugin_test_data/inline_macros
@@ -191,7 +191,9 @@ fn foo() {
     {
         let mut keys = Default::<array::Array>::default();
         let mut data = Default::<array::Array>::default();
-        starknet::Event::append_keys_and_data(@Struct { x: 10,  }, ref keys, ref data);
+        starknet::Event::append_keys_and_data(
+            @Into::<_, Event>::into(Struct { x: 10,  }), ref keys, ref data
+        );
         world.emit(keys, data.span());
     };
 
@@ -199,7 +201,7 @@ fn foo() {
     {
         let mut keys = Default::<array::Array>::default();
         let mut data = Default::<array::Array>::default();
-        starknet::Event::append_keys_and_data(@id, ref keys, ref data);
+        starknet::Event::append_keys_and_data(@Into::<_, Event>::into(id), ref keys, ref data);
         world.emit(keys, data.span());
     };
 }

--- a/examples/ecs/src/systems.cairo
+++ b/examples/ecs/src/systems.cairo
@@ -35,12 +35,17 @@ mod move {
     use dojo_examples::components::Position;
     use dojo_examples::components::Moves;
 
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        Moved: Moved,
+    }
+
     #[derive(Drop, starknet::Event)]
     struct Moved {
         address: ContractAddress,
         direction: Direction
     }
-
 
     #[derive(Serde, Copy, Drop)]
     enum Direction {


### PR DESCRIPTION
Fix: #824 

see https://github.com/dojoengine/dojo/issues/824#issuecomment-1694579303 for explanation on the fix.

Note that this PR assumes we only allows `emit!` to be called on actually `starknet::Event`'s. Users of `emit!` would need to import corresponding `enum Event`
