### PR TITLE
feat(sozo): Print events in human readable form

### DIFF
--- a/crates/sozo/src/commands/events.rs
+++ b/crates/sozo/src/commands/events.rs
@@ -1,7 +1,12 @@
-use anyhow::Result;
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Result};
+use cairo_lang_starknet::abi::{self, Event, Item};
 use clap::Parser;
+use dojo_world::manifest::Manifest;
 use dojo_world::metadata::dojo_metadata_from_workspace;
 use scarb::core::Config;
+use starknet::core::utils::starknet_keccak;
 
 use super::options::starknet::StarknetOptions;
 use super::options::world::WorldOptions;
@@ -38,6 +43,15 @@ pub struct EventsArgs {
 
 impl EventsArgs {
     pub fn run(self, config: &Config) -> Result<()> {
+        let target_dir = config.target_dir().path_existent().unwrap();
+        let manifest_path = target_dir.join(config.profile().as_str()).join("manifest.json");
+
+        if !manifest_path.exists() {
+            return Err(anyhow!("Run scarb migrate before running this command"));
+        }
+
+        let manifest = Manifest::load_from_path(manifest_path)?;
+        let events = extract_events(&manifest);
         let env_metadata = if config.manifest_path().exists() {
             let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
 
@@ -46,8 +60,46 @@ impl EventsArgs {
         } else {
             None
         };
-        config.tokio_handle().block_on(events::execute(self, env_metadata))
+        config.tokio_handle().block_on(events::execute(self, env_metadata, events))
     }
+}
+
+fn extract_events(manifest: &Manifest) -> HashMap<String, Event> {
+    fn inner_helper(events: &mut HashMap<String, Event>, contract: &Option<abi::Contract>) {
+        if let Some(contract) = contract {
+            for item in &contract.items {
+                if let Item::Event(e) = item {
+                    match e.kind {
+                        abi::EventKind::Struct { .. } => {
+                            let event_name =
+                                starknet_keccak(e.name.split("::").last().unwrap().as_bytes());
+                            events.insert(event_name.to_string(), e.clone());
+                        }
+                        abi::EventKind::Enum { .. } => (),
+                    }
+                }
+            }
+        }
+    }
+
+    let mut events_map = HashMap::new();
+
+    inner_helper(&mut events_map, &manifest.world.abi);
+    inner_helper(&mut events_map, &manifest.executor.abi);
+
+    for system in &manifest.systems {
+        inner_helper(&mut events_map, &system.abi);
+    }
+
+    for contract in &manifest.contracts {
+        inner_helper(&mut events_map, &contract.abi);
+    }
+
+    for component in &manifest.components {
+        inner_helper(&mut events_map, &component.abi);
+    }
+
+    events_map
 }
 
 #[cfg(test)]

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -89,13 +89,23 @@ fn parse_event(
                     }
                     match field.ty.as_str() {
                         "core::starknet::contract_address::ContractAddress"
-                        | "core::felt252"
                         | "core::starknet::class_hash::ClassHash" => {
                             let value = match data.pop_front() {
                                 Some(addr) => addr,
                                 None => continue 'outer,
                             };
                             ret.push_str(&format!("{}: {:#x}\n", field.name, value));
+                        }
+                        "core::felt252" => {
+                            let value = match data.pop_front() {
+                                Some(addr) => addr,
+                                None => continue 'outer,
+                            };
+                            let value = match parse_cairo_short_string(&value) {
+                                Ok(v) => v,
+                                Err(_) => format!("{:#x}", value),
+                            };
+                            ret.push_str(&format!("{}: {}\n", field.name, value));
                         }
                         "core::integer::u8" => {
                             let value = match data.pop_front() {

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -78,7 +78,7 @@ fn parse_event(
         // Length is two only when its custom event
         if keys.len() == 2 {
             let name = parse_cairo_short_string(&keys[1]).ok()?;
-            ret.push_str(&format!("Component name: {}", name));
+            ret.push_str(&format!("Component name: {}\n", name));
         }
 
         match &e.kind {
@@ -136,8 +136,13 @@ fn parse_event(
                                 Err(_) => continue 'outer,
                             };
                             ret.push_str(&format!("{}: ", field.name));
-                            if length >= data.len() {
-                                ret.push_str(&format!("{:?}\n", data.range(..length)));
+                            if data.len() >= length {
+                                ret.push_str(&format!(
+                                    "{:?}\n",
+                                    data.drain(..length)
+                                        .map(|e| format!("{:#x}", e))
+                                        .collect::<Vec<_>>()
+                                ));
                             } else {
                                 continue 'outer;
                             }

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -1,4 +1,8 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
+use cairo_lang_starknet::abi::Event;
+use dojo_world::manifest::Manifest;
 use dojo_world::metadata::Environment;
 use starknet::core::types::{BlockId, EventFilter};
 use starknet::core::utils::starknet_keccak;
@@ -6,7 +10,12 @@ use starknet::providers::Provider;
 
 use crate::commands::events::EventsArgs;
 
-pub async fn execute(args: EventsArgs, env_metadata: Option<Environment>) -> Result<()> {
+pub async fn execute(
+    args: EventsArgs,
+    env_metadata: Option<Environment>,
+    manifest: HashMap<String, Event>,
+) -> Result<()> {
+    dbg!(&manifest.values().map(|e| e.name.clone()).collect::<Vec<_>>());
     let EventsArgs {
         chunk_size,
         starknet,
@@ -30,6 +39,7 @@ pub async fn execute(args: EventsArgs, env_metadata: Option<Environment>) -> Res
     let res = provider.get_events(event_filter, continuation_token, chunk_size).await?;
 
     let value = serde_json::to_value(res)?;
+
     println!("{}", serde_json::to_string_pretty(&value)?);
     Ok(())
 }

--- a/crates/sozo/src/ops/events.rs
+++ b/crates/sozo/src/ops/events.rs
@@ -124,7 +124,7 @@ fn parse_event(
                                 Some(addr) => addr,
                                 None => continue 'outer,
                             };
-                            ret.push_str(&format!("{}: {}\n", field.name, value.to_string()));
+                            ret.push_str(&format!("{}: {}\n", field.name, value));
                         }
                         "core::array::Span::<core::felt252>" => {
                             let length = match data.pop_front() {


### PR DESCRIPTION
Fix: #742 

High level overview:
- sozo reads manifest file
- extracts all the event from all contracts
- stores in in `Hashmap<String, Vec<Event>>`
    - where String is event named hashed as used by starknet for key
    - Vec<Event> instead of just Event because different components can have same event name
- after getting events from rpc try and parse event into one of known `Event`, if no match found print in json form
- when `--json` flag is specified print rpc response as json