### PR TITLE
feat(sozo): add tx config for migration

### DIFF
--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -76,12 +76,21 @@ pub trait StateDiff {
     fn is_same(&self) -> bool;
 }
 
+/// The transaction configuration to use when sending a transaction.
+#[derive(Debug, Copy, Clone, Default)]
+pub struct TxConfig {
+    /// The multiplier for how much the actual transaction max fee should be relative to the
+    /// estimated fee. If `None` is provided, the multiplier is set to `1.1`.
+    pub fee_estimate_multiplier: Option<f64>,
+}
+
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait Declarable {
     async fn declare<P, S>(
         &self,
         account: &SingleOwnerAccount<P, S>,
+        txn_config: TxConfig,
     ) -> Result<
         DeclareOutput,
         MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError, <P as Provider>::Error>,
@@ -107,13 +116,18 @@ pub trait Declarable {
             Err(e) => return Err(MigrationError::Provider(e)),
         }
 
-        let DeclareTransactionResult { transaction_hash, class_hash } = account
-            .declare(Arc::new(flattened_class), casm_class_hash)
-            .send()
-            .await
-            .map_err(MigrationError::Migrator)?;
+        let mut txn = account.declare(Arc::new(flattened_class), casm_class_hash);
 
-        let _ = TransactionWaiter::new(transaction_hash, account.provider()).await.unwrap();
+        if let TxConfig { fee_estimate_multiplier: Some(multiplier) } = txn_config {
+            txn = txn.fee_estimate_multiplier(multiplier);
+        }
+
+        let DeclareTransactionResult { transaction_hash, class_hash } =
+            txn.send().await.map_err(MigrationError::Migrator)?;
+
+        TransactionWaiter::new(transaction_hash, account.provider())
+            .await
+            .map_err(MigrationError::WaitingError)?;
 
         return Ok(DeclareOutput { transaction_hash, class_hash });
     }
@@ -129,6 +143,7 @@ pub trait Deployable: Declarable + Sync {
         class_hash: FieldElement,
         constructor_calldata: Vec<FieldElement>,
         account: &SingleOwnerAccount<P, S>,
+        txn_config: TxConfig,
     ) -> Result<
         DeployOutput,
         MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError, <P as Provider>::Error>,
@@ -137,7 +152,7 @@ pub trait Deployable: Declarable + Sync {
         P: Provider + Sync + Send,
         S: Signer + Sync + Send,
     {
-        let declare = match self.declare(account).await {
+        let declare = match self.declare(account, txn_config).await {
             Ok(res) => Some(res),
 
             Err(MigrationError::ClassAlreadyDeclared) => None,
@@ -176,19 +191,22 @@ pub trait Deployable: Declarable + Sync {
             Err(e) => return Err(MigrationError::Provider(e)),
         }
 
-        let InvokeTransactionResult { transaction_hash } = account
-            .execute(vec![Call {
-                calldata,
-                // devnet UDC address
-                to: FieldElement::from_hex_be(
-                    "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
-                )
-                .unwrap(),
-                selector: get_selector_from_name("deployContract").unwrap(),
-            }])
-            .send()
-            .await
-            .map_err(MigrationError::Migrator)?;
+        let mut txn = account.execute(vec![Call {
+            calldata,
+            // devnet UDC address
+            to: FieldElement::from_hex_be(
+                "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+            )
+            .unwrap(),
+            selector: get_selector_from_name("deployContract").unwrap(),
+        }]);
+
+        if let TxConfig { fee_estimate_multiplier: Some(multiplier) } = txn_config {
+            txn = txn.fee_estimate_multiplier(multiplier);
+        }
+
+        let InvokeTransactionResult { transaction_hash } =
+            txn.send().await.map_err(MigrationError::Migrator)?;
 
         let txn = TransactionWaiter::new(transaction_hash, account.provider())
             .await

--- a/crates/sozo/src/commands/migrate.rs
+++ b/crates/sozo/src/commands/migrate.rs
@@ -5,6 +5,7 @@ use scarb::core::Config;
 
 use super::options::account::AccountOptions;
 use super::options::starknet::StarknetOptions;
+use super::options::transaction::TransactionOptions;
 use super::options::world::WorldOptions;
 use crate::ops::migration;
 
@@ -28,6 +29,9 @@ pub struct MigrateArgs {
 
     #[command(flatten)]
     pub account: AccountOptions,
+
+    #[command(flatten)]
+    pub transaction: TransactionOptions,
 }
 
 impl MigrateArgs {

--- a/crates/sozo/src/commands/options/mod.rs
+++ b/crates/sozo/src/commands/options/mod.rs
@@ -1,3 +1,4 @@
 pub mod account;
 pub mod starknet;
+pub mod transaction;
 pub mod world;

--- a/crates/sozo/src/commands/options/transaction.rs
+++ b/crates/sozo/src/commands/options/transaction.rs
@@ -1,0 +1,20 @@
+use clap::Args;
+use dojo_world::migration::TxConfig;
+
+#[derive(Debug, Args, Clone)]
+#[command(next_help_heading = "Transaction options")]
+pub struct TransactionOptions {
+    #[arg(long)]
+    #[arg(value_name = "MULTIPLIER")]
+    #[arg(help = "The multiplier to use for the fee estimate.")]
+    #[arg(long_help = "The multiplier to use for the fee estimate. This value will be used on \
+                       the estimated fee which will be used as the max fee for the transaction. \
+                       (max_fee = estimated_fee * multiplier)")]
+    pub fee_estimate_multiplier: Option<f64>,
+}
+
+impl From<TransactionOptions> for TxConfig {
+    fn from(value: TransactionOptions) -> Self {
+        Self { fee_estimate_multiplier: value.fee_estimate_multiplier }
+    }
+}

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -31,6 +31,7 @@ use self::ui::{bold_message, italic_message};
 use crate::commands::migrate::MigrateArgs;
 use crate::commands::options::account::AccountOptions;
 use crate::commands::options::starknet::StarknetOptions;
+use crate::commands::options::transaction::TransactionOptions;
 use crate::commands::options::world::WorldOptions;
 
 pub async fn execute<U>(
@@ -70,7 +71,7 @@ where
 
         println!("  ");
 
-        let block_height = execute_strategy(&strategy, &account, config)
+        let block_height = execute_strategy(&strategy, &account, config, Some(args.transaction))
             .await
             .map_err(|e| anyhow!(e))
             .with_context(|| "Problem trying to migrate.")?;
@@ -220,6 +221,7 @@ async fn execute_strategy<P, S>(
     strategy: &MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
     ws_config: &Config,
+    txn_config: Option<TransactionOptions>,
 ) -> Result<Option<u64>>
 where
     P: Provider + Sync + Send + 'static,
@@ -230,7 +232,15 @@ where
         Some(executor) => {
             ws_config.ui().print_header("# Executor");
 
-            match executor.deploy(executor.diff.local, vec![], migrator).await {
+            match executor
+                .deploy(
+                    executor.diff.local,
+                    vec![],
+                    migrator,
+                    txn_config.clone().map(|c| c.into()).unwrap_or_default(),
+                )
+                .await
+            {
                 Ok(val) => {
                     if let Some(declare) = val.clone().declare {
                         ws_config.ui().print_hidden_sub(format!(
@@ -282,6 +292,7 @@ where
                     world.diff.local,
                     vec![strategy.executor.as_ref().unwrap().contract_address],
                     migrator,
+                    txn_config.clone().map(|c| c.into()).unwrap_or_default(),
                 )
                 .await
             {
@@ -314,8 +325,8 @@ where
         None => {}
     };
 
-    register_components(strategy, migrator, ws_config).await?;
-    register_systems(strategy, migrator, ws_config).await?;
+    register_components(strategy, migrator, ws_config, txn_config.clone()).await?;
+    register_systems(strategy, migrator, ws_config, txn_config).await?;
 
     Ok(block_height)
 }
@@ -324,6 +335,7 @@ async fn register_components<P, S>(
     strategy: &MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
     ws_config: &Config,
+    txn_config: Option<TransactionOptions>,
 ) -> Result<Option<RegisterOutput>>
 where
     P: Provider + Sync + Send + 'static,
@@ -342,7 +354,8 @@ where
     for c in components.iter() {
         ws_config.ui().print(italic_message(&c.diff.name).to_string());
 
-        let res = c.declare(migrator).await;
+        let res =
+            c.declare(migrator, txn_config.clone().map(|c| c.into()).unwrap_or_default()).await;
         match res {
             Ok(output) => {
                 ws_config.ui().print_hidden_sub(format!(
@@ -371,8 +384,7 @@ where
         .await
         .map_err(|e| anyhow!("Failed to register components to World: {e}"))?;
 
-    let _ =
-        TransactionWaiter::new(transaction_hash, migrator.provider()).await.map_err(
+    TransactionWaiter::new(transaction_hash, migrator.provider()).await.map_err(
             MigrationError::<
                 <SingleOwnerAccount<P, S> as Account>::SignError,
                 <P as Provider>::Error,
@@ -388,6 +400,7 @@ async fn register_systems<P, S>(
     strategy: &MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
     ws_config: &Config,
+    txn_config: Option<TransactionOptions>,
 ) -> Result<Option<RegisterOutput>>
 where
     P: Provider + Sync + Send + 'static,
@@ -406,7 +419,8 @@ where
     for s in strategy.systems.iter() {
         ws_config.ui().print(italic_message(&s.diff.name).to_string());
 
-        let res = s.declare(migrator).await;
+        let res =
+            s.declare(migrator, txn_config.clone().map(|c| c.into()).unwrap_or_default()).await;
         match res {
             Ok(output) => {
                 ws_config.ui().print_hidden_sub(format!(
@@ -435,8 +449,7 @@ where
         .await
         .map_err(|e| anyhow!("Failed to register systems to World: {e}"))?;
 
-    let _ =
-        TransactionWaiter::new(transaction_hash, migrator.provider()).await.map_err(
+    TransactionWaiter::new(transaction_hash, migrator.provider()).await.map_err(
             MigrationError::<
                 <SingleOwnerAccount<P, S> as Account>::SignError,
                 <P as Provider>::Error,

--- a/crates/torii/client/src/contract/world_test.rs
+++ b/crates/torii/client/src/contract/world_test.rs
@@ -47,21 +47,26 @@ pub async fn deploy_world(
     let executor_address = strategy
         .executor
         .unwrap()
-        .deploy(manifest.clone().executor.class_hash, vec![], &account)
+        .deploy(manifest.clone().executor.class_hash, vec![], &account, Default::default())
         .await
         .unwrap()
         .contract_address;
     let world_address = strategy
         .world
         .unwrap()
-        .deploy(manifest.clone().world.class_hash, vec![executor_address], &account)
+        .deploy(
+            manifest.clone().world.class_hash,
+            vec![executor_address],
+            &account,
+            Default::default(),
+        )
         .await
         .unwrap()
         .contract_address;
 
     let mut declare_output = vec![];
     for component in strategy.components {
-        let res = component.declare(&account).await.unwrap();
+        let res = component.declare(&account, Default::default()).await.unwrap();
         declare_output.push(res);
     }
 
@@ -72,7 +77,7 @@ pub async fn deploy_world(
 
     let mut declare_output = vec![];
     for system in strategy.systems {
-        let res = system.declare(&account).await.unwrap();
+        let res = system.declare(&account, Default::default()).await.unwrap();
         declare_output.push(res);
     }
 


### PR DESCRIPTION
- Added new CLI args:

```rust
// CLI arg type in `sozo` crate
struct TransactionOptions {
    fee_estimate_multiplier: Option<f64>
}


// `TransactionOptions` will be converted into `TxConfig` and 
// as such From<TransactionOptions> is implemented for this type.
//
// Reside in `dojo-world` crate. 
// This is so that `dojo-world` doesn't have to depend on `sozo` crate.
struct TxConfig {
    fee_estimate_multiplier: Option<f64>
}
```

```console
Transaction options:
      --fee-estimate-multiplier <MULTIPLIER>
          The multiplier to use for the fee estimate. This value will be used on the estimated fee which will be used as the max fee for the transaction. (max_fee = estimated_fee * multiplier)
```

- This argument is only available for `sozo migrate`
- This PR only allow the configs to be usable for **_declare_** and **_deploy_** transactions