### PR TITLE
chore(torii): graphql make component keys filterable

### DIFF
--- a/crates/torii/graphql/src/object/component_state.rs
+++ b/crates/torii/graphql/src/object/component_state.rs
@@ -292,7 +292,7 @@ pub async fn type_mapping_query(
                     type AS ty,
                     key,
                     created_at
-                FROM component_members WHERE key == FALSE AND component_id = ?
+                FROM component_members WHERE component_id = ?
             "#,
     )
     .bind(component_id)

--- a/crates/torii/graphql/src/tests/components_test.rs
+++ b/crates/torii/graphql/src/tests/components_test.rs
@@ -74,6 +74,7 @@ mod tests {
             ("where: { xLT: 42 }", 0),
             ("where: { xLTE: 42 }", 1),
             ("where: { x: 1337, yGTE: 1234 }", 0),
+            (r#"where: { player: "0x2" }"#, 1), // player is a key
         ]);
 
         for (filter, expected_total) in where_filters {


### PR DESCRIPTION
Keys were omitted previously in component queries. This PR exposes them in `where` filter

```
#[derive(Component, Copy, Drop, Serde, SerdeLen)]
struct Position {
    #[key]
    game_id: u32,
    #[key]
    player_id: ContractAddress
    x: u32,
    y: u32
}
```

Example query 
```
positionComponents (where: {game_id: 123, player_id: "0xdeadbeef"}) {
    ...
}
```