### PR TITLE
fix: fee on instant mining

### DIFF
--- a/crates/katana/core/src/service.rs
+++ b/crates/katana/core/src/service.rs
@@ -398,8 +398,12 @@ impl InstantBlockProducer {
         let mut state = CachedStateWrapper::new(backend.state.read().await.as_ref_db());
         let block_context = backend.env.read().block.clone();
 
-        let results = TransactionExecutor::new(&mut state, &block_context, true)
-            .execute_many(transactions.clone());
+        let results = TransactionExecutor::new(
+            &mut state,
+            &block_context,
+            !backend.config.read().disable_fee,
+        )
+        .execute_many(transactions.clone());
 
         let outcome = backend
             .do_mine_block(create_execution_outcome(


### PR DESCRIPTION
Fixes the max fee validation issue by applying the current fee configuration in the instant mining. Resolves #873.