### PR TITLE
fix: enable `env-filter` feature for `tracing-subscriber`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ futures = "0.3.28"
 indoc = "1.0.7"
 itertools = "0.10.3"
 num-bigint = "0.4"
-parking_lot = "0.12.1"
 once_cell = "1.0"
+parking_lot = "0.12.1"
 pretty_assertions = "1.2.1"
 rayon = "0.9.0"
 salsa = "0.16.1"
@@ -83,7 +83,7 @@ thiserror = "1.0.32"
 tokio = { version = "1.32.0", features = [ "full" ] }
 toml = "0.7.4"
 tracing = "0.1.34"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 url = "2.4.0"
 
 [patch."https://github.com/starkware-libs/blockifier"]


### PR DESCRIPTION
the `SubscriberBuilder::with_env_filter()` method

https://github.com/dojoengine/dojo/blob/c6eae3d25ae7e6736d1a983ac850b5e774b66692/crates/katana/src/main.rs#L21-L23

requires that the `env-filter` feature of `tracing-subscriber` be enabled. Which is not enabled before, but for some reason it didn't give any errors whatsoever and the CI passed.