### PR TITLE
refactor(katana): state helper trait

### DIFF
--- a/crates/katana/core/src/accounts.rs
+++ b/crates/katana/core/src/accounts.rs
@@ -58,14 +58,14 @@ impl Account {
     }
 
     // TODO: separate fund logic from this struct - implement FeeToken type
-    pub fn deploy_and_fund<S: Database>(&self, state: &mut S) -> StateResult<()> {
+    pub fn deploy_and_fund(&self, state: &mut dyn Database) -> StateResult<()> {
         self.declare(state)?;
         self.deploy(state)?;
         self.fund(state);
         Ok(())
     }
 
-    fn deploy<S: Database>(&self, state: &mut S) -> StateResult<()> {
+    fn deploy(&self, state: &mut dyn Database) -> StateResult<()> {
         let address = ContractAddress(patricia_key!(self.address));
         // set the class hash at the account address
         state.set_class_hash_at(address, ClassHash(self.class_hash.into()))?;
@@ -80,7 +80,7 @@ impl Account {
         Ok(())
     }
 
-    fn fund<S: Database>(&self, state: &mut S) {
+    fn fund(&self, state: &mut dyn Database) {
         state.set_storage_at(
             ContractAddress(patricia_key!(*FEE_TOKEN_ADDRESS)),
             get_storage_var_address("ERC20_balances", &[self.address.into()]).unwrap(),
@@ -88,7 +88,7 @@ impl Account {
         );
     }
 
-    fn declare<S: Database>(&self, state: &mut S) -> StateResult<()> {
+    fn declare(&self, state: &mut dyn Database) -> StateResult<()> {
         let class_hash = ClassHash(self.class_hash.into());
 
         if state.get_compiled_contract_class(&class_hash).is_ok() {

--- a/crates/katana/core/src/db/cached.rs
+++ b/crates/katana/core/src/db/cached.rs
@@ -267,7 +267,7 @@ where
 
 pub type AsCachedDb = CachedDb<()>;
 
-/// A helper trait for accessing the inner [CachedDb] of a [Database] if it exists.
+/// A helper trait for getting a [CachedDb] from a database implementation.
 ///
 /// **THIS IS JUST A TEMPORARY SOLUTION THEREFORE NOT MUCH THOUGHT HAS BEEN PUT INTO IT. DO NOT RELY
 /// ON THIS TRAIT AS IT MAY BE REMOVED IN THE FUTURE**.

--- a/crates/katana/core/src/db/mod.rs
+++ b/crates/katana/core/src/db/mod.rs
@@ -11,18 +11,19 @@ use starknet_api::hash::StarkHash;
 use starknet_api::patricia_key;
 use starknet_api::state::StorageKey;
 
+use self::cached::MaybeAsCachedDb;
 use self::serde::state::SerializableState;
 
 pub mod cached;
 pub mod serde;
 
-/// An extension of the `StateReader` trait, to allow fetching Sierra class from the state.
+/// An extension of the [StateReader] trait, to allow fetching Sierra class from the state.
 pub trait StateExtRef: StateReader + fmt::Debug {
     /// Returns the Sierra class for the given class hash.
     fn get_sierra_class(&mut self, class_hash: &ClassHash) -> StateResult<FlattenedSierraClass>;
 }
 
-/// An extension of the `State` trait, to allow setting Sierra class.
+/// An extension of the [State] trait, to allow storing Sierra classes.
 pub trait StateExt: State + StateExtRef {
     /// Set the Sierra class for the given class hash.
     fn set_sierra_class(
@@ -33,7 +34,7 @@ pub trait StateExt: State + StateExtRef {
 }
 
 /// A trait which represents a state database.
-pub trait Database: StateExt + AsStateRefDb + Send + Sync {
+pub trait Database: StateExt + AsStateRefDb + Send + Sync + MaybeAsCachedDb {
     /// Set the exact nonce value for the given contract address.
     fn set_nonce(&mut self, addr: ContractAddress, nonce: Nonce);
 
@@ -87,7 +88,7 @@ pub trait AsStateRefDb {
 /// It implements [Clone] so that it can be cloned into a
 /// [CachedState](blockifier::state::cached_state::CachedState) for executing transactions
 /// based on this state, as [CachedState](blockifier::state::cached_state::CachedState) requires the
-/// an ownership of the inner [StateReader] that it wraps.
+/// ownership of the inner [StateReader] that it wraps.
 ///
 /// The inner type is wrapped inside a [Mutex] to allow interior mutability due to the fact
 /// that the [StateReader] trait requires mutable access to the type that implements it.

--- a/crates/katana/core/src/fork/db.rs
+++ b/crates/katana/core/src/fork/db.rs
@@ -12,7 +12,7 @@ use starknet_api::hash::StarkFelt;
 use starknet_api::state::StorageKey;
 
 use super::backend::SharedBackend;
-use crate::db::cached::CachedDb;
+use crate::db::cached::{AsCachedDb, CachedDb, MaybeAsCachedDb};
 use crate::db::serde::state::{
     SerializableClassRecord, SerializableState, SerializableStorageRecord,
 };
@@ -94,8 +94,7 @@ impl State for ForkedDb {
 
 impl StateReader for ForkedDb {
     fn get_nonce_at(&mut self, contract_address: ContractAddress) -> StateResult<Nonce> {
-        let nonce = self.db.get_nonce_at(contract_address)?;
-        Ok(nonce)
+        self.db.get_nonce_at(contract_address)
     }
 
     fn get_storage_at(
@@ -144,6 +143,18 @@ impl StateExt for ForkedDb {
 impl AsStateRefDb for ForkedDb {
     fn as_ref_db(&self) -> StateRefDb {
         StateRefDb::new(self.clone())
+    }
+}
+
+impl MaybeAsCachedDb for ForkedDb {
+    fn maybe_as_cached_db(&self) -> Option<AsCachedDb> {
+        Some(CachedDb {
+            db: (),
+            classes: self.db.classes.clone(),
+            storage: self.db.storage.clone(),
+            contracts: self.db.contracts.clone(),
+            sierra_classes: self.db.sierra_classes.clone(),
+        })
     }
 }
 


### PR DESCRIPTION
Changes:
- Remove some redundancies
- Add helper trait, `MaybeAsCachedDb`, for accessing a `Database` inner `CachedDb` if exist

Adding `MaybeAsCachedDb` is merely a temporary solution for directly accessing the storage mappings of the state database. It's no longer possible to do this after the changes made in #805, in order to generalize the state database implementations. Prior to this, the storage mapping was accessible because trait object wasn't used here: 

https://github.com/dojoengine/dojo/blob/7ec1dcdb40588e0d0c97508a69ac872160226451/crates/katana/core/src/backend/mod.rs#L65

**IMPORTANT NOTE**: This will very likely to be removed in the future.