### PR TITLE
feat: bump blockifier dependency to allow more than `MAX_STEPS_PER_TX` cairo steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.1.0-rc0"
-source = "git+https://github.com/dojoengine/blockifier?rev=c794d1b#c794d1b85b0937de9e0f4e3edbc9322792f7ab2e"
+source = "git+https://github.com/dojoengine/blockifier?rev=f7df9ba#f7df9ba98a8e0549813fbde945741fd50930ff29"
 dependencies = [
  "ark-ff",
  "ark-secp256k1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
 url = "2.4.0"
 
 [patch."https://github.com/starkware-libs/blockifier"]
-blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "c794d1b" }
+blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "f7df9ba" }
 
 [patch.crates-io]
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "262b7eb4b11ab165a2a936a5f914e78aa732d4a2" }


### PR DESCRIPTION
This PR bumps the dojo blockifier dependency to the latest commit { you can check the [following](https://github.com/dojoengine/blockifier/pull/5) PR, which bought this change  }, this will allow us to use more cairo steps than the previous limitation via [MAX_STEPS_PER_TX ](https://github.com/dojoengine/blockifier/blob/f5b684df4f3ead90aecf3fe3e98f20e7919d615e/crates/blockifier/src/abi/constants.rs#L29) constant when max_fee is 0.

resolve #897 