### PR TITLE
lang: keep origin struct

### DIFF
--- a/crates/dojo-lang/src/component.rs
+++ b/crates/dojo-lang/src/component.rs
@@ -108,10 +108,6 @@ pub fn handle_component_struct(
     (
         RewriteNode::interpolate_patched(
             "
-            struct $type_name$ {
-                $members$
-            }
-
             impl $type_name$Component of dojo::component::Component<$type_name$> {
                 #[inline(always)]
                 fn name(self: @$type_name$) -> felt252 {
@@ -202,10 +198,6 @@ pub fn handle_component_struct(
                 (
                     "type_name".to_string(),
                     RewriteNode::new_trimmed(struct_ast.name(db).as_syntax_node()),
-                ),
-                (
-                    "members".to_string(),
-                    RewriteNode::Copied(struct_ast.members(db).as_syntax_node()),
                 ),
                 ("serialized_keys".to_string(), RewriteNode::new_modified(serialized_keys)),
                 ("serialized_values".to_string(), RewriteNode::new_modified(serialized_values)),

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -185,7 +185,7 @@ impl MacroPlugin for DojoPlugin {
                         diagnostics_mappings: builder.diagnostics_mappings,
                     }),
                     diagnostics,
-                    remove_original_item: true,
+                    remove_original_item: false,
                 }
             }
             _ => PluginResult::default(),

--- a/crates/dojo-lang/src/plugin_test_data/component
+++ b/crates/dojo-lang/src/plugin_test_data/component
@@ -10,7 +10,6 @@ use serde::Serde;
 struct Position {
     #[key]
     id: felt252,
-
     x: felt252,
     y: felt252
 }
@@ -53,6 +52,8 @@ struct Player {
 //! > generated_cairo_code
 use serde::Serde;
 
+
+#[derive(Component, Copy, Drop, Serde)]
 struct Position {
     #[key]
     id: felt252,
@@ -193,6 +194,8 @@ impl PositionImpl of PositionTrait {
     }
 }
 
+
+#[derive(Component, Serde)]
 struct Roles {
     role_ids: Array<u8>
 }
@@ -296,14 +299,16 @@ mod roles {
 
 use starknet::ContractAddress;
 
+
+#[derive(Component, Copy, Drop, Serde)]
 struct Player {
     #[key]
     game: felt252,
     #[key]
     player: ContractAddress,
-    name: felt252,
-}
 
+    name: felt252, 
+}
 impl PlayerComponent of dojo::component::Component<Player> {
     #[inline(always)]
     fn name(self: @Player) -> felt252 {
@@ -416,6 +421,6 @@ mod player {
 
 //! > expected_diagnostics
 error: Component must define atleast one #[key] attribute
- --> dummy_file.cairo:31:8
+ --> dummy_file.cairo:30:8
 struct Roles {
        ^***^

--- a/crates/dojo-lang/src/plugin_test_data/print
+++ b/crates/dojo-lang/src/plugin_test_data/print
@@ -35,6 +35,16 @@ struct Player {
 //! > generated_cairo_code
 use serde::Serde;
 
+
+#[derive(Print, Copy, Drop, Serde)]
+struct Position {
+    #[key]
+    id: felt252,
+
+    x: felt252,
+    y: felt252
+}
+
 #[cfg(test)]
 impl PositionPrintImpl of debug::PrintTrait<Position> {
     fn print(self: Position) {
@@ -45,6 +55,12 @@ impl PositionPrintImpl of debug::PrintTrait<Position> {
         debug::PrintTrait::print('y');
         debug::PrintTrait::print(self.y);
     }
+}
+
+
+#[derive(Print, Serde)]
+struct Roles {
+    role_ids: Array<u8>
 }
 
 #[cfg(test)]
@@ -58,6 +74,16 @@ impl RolesPrintImpl of debug::PrintTrait<Roles> {
 
 use starknet::ContractAddress;
 
+
+#[derive(Print, Copy, Drop, Serde)]
+struct Player {
+    #[key]
+    game: felt252,
+    #[key]
+    player: ContractAddress,
+
+    name: felt252, 
+}
 #[cfg(test)]
 impl PlayerPrintImpl of debug::PrintTrait<Player> {
     fn print(self: Player) {


### PR DESCRIPTION
fixes #917

### What was happening
* Our plugin removes the original struct
* `Component` derive adds a copy of component
* `Print` derive doesn't add it's own copy of the struct so it works with `Component` but not without.

### What was changed
* Original struct is retained.
* `Component` doesn't add the copy of struct.