### PR TITLE
fix: size return values invalid index

### DIFF
--- a/crates/torii/client/src/contract/component.rs
+++ b/crates/torii/client/src/contract/component.rs
@@ -90,7 +90,7 @@ impl<'a, P: Provider + Sync> ComponentReader<'a, P> {
             .await
             .map_err(ComponentError::ContractReaderError)?;
 
-        Ok(res[2])
+        Ok(res[1])
     }
 
     pub async fn layout(


### PR DESCRIPTION
Return values of the call is an array of two elements ( [array_size, actual_value] ), but the index is invalid.

Error:

```
index out of bounds: the len is 2 but the index is 2
```