### PR TITLE
build: add Rust performance profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,12 @@ members = [
   "crates/torii/server",
 ]
 
+[profile.performance]
+codegen-units = 1
+incremental = false
+inherits = "release"
+lto = "fat"
+
 [workspace.package]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
Add a little `performance` Rust profile for some optimizations when building binaries.

To use the profile:

```console
cargo build --profile performance
```