### PR TITLE
fix(katana): missing fee token decimals

### DIFF
--- a/crates/katana/core/src/backend/in_memory_db.rs
+++ b/crates/katana/core/src/backend/in_memory_db.rs
@@ -12,8 +12,8 @@ use starknet_api::patricia_key;
 use starknet_api::state::StorageKey;
 
 use crate::constants::{
-    ERC20_CONTRACT, ERC20_CONTRACT_CLASS_HASH, FEE_TOKEN_ADDRESS, UDC_ADDRESS, UDC_CLASS_HASH,
-    UDC_CONTRACT,
+    ERC20_CONTRACT, ERC20_CONTRACT_CLASS_HASH, ERC20_DECIMALS_STORAGE_SLOT, FEE_TOKEN_ADDRESS,
+    UDC_ADDRESS, UDC_CLASS_HASH, UDC_CONTRACT,
 };
 use crate::db::cached::{AsCachedDb, CachedDb, ClassRecord, MaybeAsCachedDb, StorageRecord};
 use crate::db::serde::state::{
@@ -245,10 +245,13 @@ fn deploy_fee_contract(state: &mut MemDb) {
 
     state.db.classes.insert(hash, ClassRecord { class: (*ERC20_CONTRACT).clone(), compiled_hash });
     state.db.contracts.insert(address, hash);
-    state
-        .db
-        .storage
-        .insert(address, StorageRecord { nonce: Nonce(1_u128.into()), storage: HashMap::new() });
+    state.db.storage.insert(
+        address,
+        StorageRecord {
+            nonce: Nonce(1_u128.into()),
+            storage: [(*ERC20_DECIMALS_STORAGE_SLOT, 18_u128.into())].into_iter().collect(),
+        },
+    );
 }
 
 fn deploy_universal_deployer_contract(state: &mut MemDb) {

--- a/crates/katana/core/src/constants.rs
+++ b/crates/katana/core/src/constants.rs
@@ -2,6 +2,7 @@ use blockifier::execution::contract_class::ContractClass;
 use lazy_static::lazy_static;
 use starknet_api::hash::StarkFelt;
 use starknet_api::stark_felt;
+use starknet_api::state::StorageKey;
 
 use crate::utils::contract::get_contract_class;
 
@@ -31,4 +32,8 @@ lazy_static! {
     pub static ref DEFAULT_ACCOUNT_CONTRACT: ContractClass = get_contract_class(include_str!("../contracts/compiled/account.json"));
 
     pub static ref DEFAULT_PREFUNDED_ACCOUNT_BALANCE: StarkFelt = stark_felt!("0x3635c9adc5dea00000"); // 10^21
+
+    // Storage slots
+
+    pub static ref ERC20_DECIMALS_STORAGE_SLOT: StorageKey = stark_felt!("0x01f0d4aa99431d246bac9b8e48c33e888245b15e9678f64f9bdfc8823dc8f979").try_into().unwrap();
 }


### PR DESCRIPTION
Currently when calling `decimals()` on the fee token you'd get `0`, since the storage slot isn't initialized.

Too lazy to create an issue first as it's quite self-explanatory.