### PR TITLE
fix(katana): missing fee token meta fields

### DIFF
--- a/crates/katana/core/src/backend/in_memory_db.rs
+++ b/crates/katana/core/src/backend/in_memory_db.rs
@@ -12,8 +12,9 @@ use starknet_api::patricia_key;
 use starknet_api::state::StorageKey;
 
 use crate::constants::{
-    ERC20_CONTRACT, ERC20_CONTRACT_CLASS_HASH, ERC20_DECIMALS_STORAGE_SLOT, FEE_TOKEN_ADDRESS,
-    UDC_ADDRESS, UDC_CLASS_HASH, UDC_CONTRACT,
+    ERC20_CONTRACT, ERC20_CONTRACT_CLASS_HASH, ERC20_DECIMALS_STORAGE_SLOT,
+    ERC20_NAME_STORAGE_SLOT, ERC20_SYMBOL_STORAGE_SLOT, FEE_TOKEN_ADDRESS, UDC_ADDRESS,
+    UDC_CLASS_HASH, UDC_CONTRACT,
 };
 use crate::db::cached::{AsCachedDb, CachedDb, ClassRecord, MaybeAsCachedDb, StorageRecord};
 use crate::db::serde::state::{
@@ -249,7 +250,13 @@ fn deploy_fee_contract(state: &mut MemDb) {
         address,
         StorageRecord {
             nonce: Nonce(1_u128.into()),
-            storage: [(*ERC20_DECIMALS_STORAGE_SLOT, 18_u128.into())].into_iter().collect(),
+            storage: [
+                (*ERC20_NAME_STORAGE_SLOT, 0x4574686572_u128.into()),
+                (*ERC20_SYMBOL_STORAGE_SLOT, 0x455448_u128.into()),
+                (*ERC20_DECIMALS_STORAGE_SLOT, 18_u128.into()),
+            ]
+            .into_iter()
+            .collect(),
         },
     );
 }

--- a/crates/katana/core/src/constants.rs
+++ b/crates/katana/core/src/constants.rs
@@ -35,5 +35,7 @@ lazy_static! {
 
     // Storage slots
 
+    pub static ref ERC20_NAME_STORAGE_SLOT: StorageKey = stark_felt!("0x0341c1bdfd89f69748aa00b5742b03adbffd79b8e80cab5c50d91cd8c2a79be1").try_into().unwrap();
+    pub static ref ERC20_SYMBOL_STORAGE_SLOT: StorageKey = stark_felt!("0x00b6ce5410fca59d078ee9b2a4371a9d684c530d697c64fbef0ae6d5e8f0ac72").try_into().unwrap();
     pub static ref ERC20_DECIMALS_STORAGE_SLOT: StorageKey = stark_felt!("0x01f0d4aa99431d246bac9b8e48c33e888245b15e9678f64f9bdfc8823dc8f979").try_into().unwrap();
 }


### PR DESCRIPTION
Follow-up PR to #950. I'm trying to make Argent X work with Katana. Looks like Argent X needs `name` and `symbol` from the fee token too. In this PR I'm setting them to be `Ether` and `ETH` respectively, taking the same values from the Goerli testnet.