### PR TITLE
Pass the world address to system constructors

### DIFF
--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -531,7 +531,7 @@ test_manifest_file
     {
       "name": "player_actions",
       "address": null,
-      "class_hash": "0x4b8aedc50c01814ad20b7e976f9d4fe76d13f56fa57aabd2a6399c7fbc1a187",
+      "class_hash": "0x176faa2635feddfa675516ce39c3a798c34483930fd790cf372e6652080641f",
       "abi": [
         {
           "type": "impl",
@@ -609,6 +609,16 @@ test_manifest_file
           ]
         },
         {
+          "type": "constructor",
+          "name": "constructor",
+          "inputs": [
+            {
+              "name": "world",
+              "type": "core::starknet::contract_address::ContractAddress"
+            }
+          ]
+        },
+        {
           "type": "function",
           "name": "name",
           "inputs": [],
@@ -653,7 +663,7 @@ test_manifest_file
     {
       "name": "player_actions_external",
       "address": null,
-      "class_hash": "0x49a96abd2a2e1148a290a7e0aa101e17653d0990456c6a400614534e3696e49",
+      "class_hash": "0xfcceee5744796c9fbe45058e9c725b1a3251031c81711e3ddaf23d35642e14",
       "abi": [
         {
           "type": "impl",
@@ -727,6 +737,16 @@ test_manifest_file
               ],
               "outputs": [],
               "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "constructor",
+          "name": "constructor",
+          "inputs": [
+            {
+              "name": "world",
+              "type": "core::starknet::contract_address::ContractAddress"
             }
           ]
         },

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -41,6 +41,9 @@ mod spawn {
     #[storage]
     struct Storage {}
 
+    #[constructor]
+    fn constructor(ref self: ContractState, world: ContractAddress) {}
+
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'spawn'
@@ -65,6 +68,9 @@ mod proxy {
     #[storage]
     struct Storage {}
 
+    #[constructor]
+    fn constructor(ref self: ContractState, world: ContractAddress) {}
+
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'proxy'
@@ -86,6 +92,9 @@ mod ctxnamed {
 
     #[storage]
     struct Storage {}
+
+    #[constructor]
+    fn constructor(ref self: ContractState, world: ContractAddress) {}
 
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {

--- a/crates/dojo-lang/src/system.rs
+++ b/crates/dojo-lang/src/system.rs
@@ -52,6 +52,13 @@ impl System {
                     #[storage]
                     struct Storage {}
 
+                    #[constructor]
+                    fn constructor(
+                        ref self: ContractState,
+                        world: ContractAddress
+                    ) {
+                    }
+
                     #[external(v0)]
                     fn name(self: @ContractState) -> felt252 {
                         '$name$'

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -417,7 +417,8 @@ where
     for contract in strategy.contracts.iter() {
         let name = &contract.diff.name;
         ui.print(italic_message(name).to_string());
-        match deploy_contract(contract, name, vec![], migrator, ui, &txn_config).await? {
+        let world_address = strategy.world_address.unwrap_or_else(|| strategy.world.as_ref().unwrap().contract_address);
+        match deploy_contract(contract, name, vec![world_address], migrator, ui, &txn_config).await? {
             ContractDeploymentOutput::Output(output) => {
                 ui.print_sub(format!("Contract address: {:#x}", output.contract_address));
                 ui.print_hidden_sub(format!("deploy transaction: {:#x}", output.transaction_hash));

--- a/crates/torii/client/src/contract/world_test.rs
+++ b/crates/torii/client/src/contract/world_test.rs
@@ -90,7 +90,7 @@ pub async fn deploy_world(
     for contract in strategy.contracts {
         let declare_res = contract.declare(&account, Default::default()).await.unwrap();
         contract
-            .deploy(declare_res.class_hash, vec![], &account, Default::default())
+            .deploy(declare_res.class_hash, vec![world_address], &account, Default::default())
             .await
             .unwrap();
     }

--- a/examples/ecs/src/systems/raw_contract.cairo
+++ b/examples/ecs/src/systems/raw_contract.cairo
@@ -33,6 +33,13 @@ mod player_actions_external {
         direction: Direction
     }
 
+    #[constructor]
+    fn constructor(
+        ref self: ContractState,
+        world: ContractAddress
+    ) {
+    }
+
     // impl: implement functions specified in trait
     #[external(v0)]
     impl PlayerActionsImpl of IPlayerActions<ContractState> {


### PR DESCRIPTION
This is required to fix #956 .
I think ideally it would be passed optionally, but this is probably fine.

I am assuming that one of `strategy.world` or `strategy.world_address`always exists, which I'm not entirely sure of.