### PR TITLE
World deployments with deterministic addresses

### DIFF
--- a/crates/dojo-core/src/base.cairo
+++ b/crates/dojo-core/src/base.cairo
@@ -1,0 +1,43 @@
+use starknet::{ClassHash, SyscallResult, SyscallResultTrait};
+
+use dojo::world::IWorldDispatcher;
+
+#[starknet::interface]
+trait IBase<T> {
+    fn world(self: @T) -> IWorldDispatcher;
+}
+
+#[starknet::contract]
+mod base {
+    use starknet::{ClassHash, get_caller_address};
+
+    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+    use dojo::world::IWorldDispatcher;
+
+    #[storage]
+    struct Storage {
+        world_dispatcher: IWorldDispatcher,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState) {
+        self.world_dispatcher.write(IWorldDispatcher { contract_address: get_caller_address() });
+    }
+
+    #[external(v0)]
+    fn world(self: @ContractState) -> IWorldDispatcher {
+        self.world_dispatcher.read()
+    }
+
+    #[external(v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        /// Upgrade contract implementation to new_class_hash
+        ///
+        /// # Arguments
+        ///
+        /// * `new_class_hash` - The new implementation class hahs.
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            UpgradeableTrait::upgrade(new_class_hash);
+        }
+    }
+}

--- a/crates/dojo-core/src/base_test.cairo
+++ b/crates/dojo-core/src/base_test.cairo
@@ -1,0 +1,43 @@
+use option::OptionTrait;
+use starknet::ClassHash;
+use traits::TryInto;
+
+use dojo::base::base;
+use dojo::upgradable::{IUpgradeableDispatcher, IUpgradeableDispatcherTrait};
+use dojo::test_utils::deploy_contract;
+
+#[starknet::contract]
+mod contract_upgrade {
+    #[storage]
+    struct Storage {}
+
+    #[starknet::interface]
+    trait IQuantumLeap<TState> {
+        fn plz_more_tps(self: @TState) -> felt252;
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState) {}
+
+    #[external(v0)]
+    impl QuantumLeap of IQuantumLeap<ContractState> {
+        fn plz_more_tps(self: @ContractState) -> felt252 {
+            'daddy'
+        }
+    }
+}
+
+use contract_upgrade::{IQuantumLeapDispatcher, IQuantumLeapDispatcherTrait};
+
+#[test]
+#[available_gas(6000000)]
+fn test_upgrade() {
+    let base_address = deploy_contract(base::TEST_CLASS_HASH, array![].span());
+    let upgradable_dispatcher = IUpgradeableDispatcher { contract_address: base_address };
+
+    let new_class_hash: ClassHash = contract_upgrade::TEST_CLASS_HASH.try_into().unwrap();
+    upgradable_dispatcher.upgrade(new_class_hash);
+
+    let quantum_dispatcher = IQuantumLeapDispatcher { contract_address: base_address };
+    assert(quantum_dispatcher.plz_more_tps() == 'daddy', 'quantum leap failed');
+}

--- a/crates/dojo-core/src/lib.cairo
+++ b/crates/dojo-core/src/lib.cairo
@@ -1,3 +1,6 @@
+mod base;
+#[cfg(test)]
+mod base_test;
 mod database;
 #[cfg(test)]
 mod database_test;
@@ -11,6 +14,7 @@ mod packing_test;
 mod world;
 #[cfg(test)]
 mod world_test;
+mod upgradable;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/dojo-core/src/test_utils.cairo
+++ b/crates/dojo-core/src/test_utils.cairo
@@ -21,11 +21,11 @@ use dojo::world::{world, IWorldDispatcher, IWorldDispatcherTrait};
 /// # Returns
 /// * address of contract deployed
 fn deploy_contract(class_hash: felt252, calldata: Span<felt252>) -> ContractAddress {
-    let (system_contract, _) = starknet::deploy_syscall(
+    let (contract, _) = starknet::deploy_syscall(
         class_hash.try_into().unwrap(), 0, calldata, false
     )
         .unwrap();
-    system_contract
+    contract
 }
 
 /// Deploy classhash and passes in world address to constructor
@@ -49,10 +49,8 @@ fn spawn_test_world(models: Array<felt252>) -> IWorldDispatcher {
     )
         .unwrap();
     // deploy world
-    let mut world_constructor_calldata = array::ArrayTrait::new();
-    world_constructor_calldata.append(executor_address.into());
     let (world_address, _) = deploy_syscall(
-        world::TEST_CLASS_HASH.try_into().unwrap(), 0, world_constructor_calldata.span(), false
+        world::TEST_CLASS_HASH.try_into().unwrap(), 0, array![executor_address.into(), dojo::base::base::TEST_CLASS_HASH].span(), false
     )
         .unwrap();
     let world = IWorldDispatcher { contract_address: world_address };

--- a/crates/dojo-core/src/upgradable.cairo
+++ b/crates/dojo-core/src/upgradable.cairo
@@ -1,0 +1,19 @@
+use starknet::{ClassHash, SyscallResult, SyscallResultTrait};
+use zeroable::Zeroable;
+use result::ResultTrait;
+
+#[starknet::interface]
+trait IUpgradeable<T> {
+    fn upgrade(ref self: T, new_class_hash: ClassHash);
+}
+
+trait UpgradeableTrait {
+    fn upgrade(new_class_hash: ClassHash);
+}
+
+impl UpgradeableTraitImpl of UpgradeableTrait {
+    fn upgrade(new_class_hash: ClassHash) {
+        assert(new_class_hash.is_non_zero(), 'class_hash cannot be zero');
+        starknet::replace_class_syscall(new_class_hash).unwrap_syscall();
+    }
+}

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -161,6 +161,7 @@ fn find_project_contracts(
 
 pub fn collect_core_crate_ids(db: &RootDatabase) -> Vec<CrateId> {
     [
+        ContractSelector("dojo::base::base".to_string()),
         ContractSelector("dojo::executor::executor".to_string()),
         ContractSelector("dojo::world::world".to_string()),
     ]

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -8,7 +8,7 @@ test_manifest_file
   "world": {
     "name": "world",
     "address": null,
-    "class_hash": "0xad01919d2f7edc172b74b0e258afb7bb44252582e02d5e245b88fcb488fb78",
+    "class_hash": "0x45539636cfa153f8ea0975102b04d35f455240c98c1dcf1eeb0013bef358d35",
     "abi": [
       {
         "type": "impl",
@@ -104,6 +104,26 @@ test_manifest_file
             ],
             "outputs": [],
             "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "deploy_contract",
+            "inputs": [
+              {
+                "name": "salt",
+                "type": "core::felt252"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "state_mutability": "view"
           },
           {
             "type": "function",
@@ -249,6 +269,17 @@ test_manifest_file
           },
           {
             "type": "function",
+            "name": "base",
+            "inputs": [],
+            "outputs": [
+              {
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "state_mutability": "view"
+          },
+          {
+            "type": "function",
             "name": "delete_entity",
             "inputs": [
               {
@@ -376,6 +407,10 @@ test_manifest_file
           {
             "name": "executor",
             "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "contract_base",
+            "type": "core::starknet::class_hash::ClassHash"
           }
         ]
       },
@@ -539,6 +574,67 @@ test_manifest_file
       {
         "type": "event",
         "name": "dojo::executor::executor::Event",
+        "kind": "enum",
+        "variants": []
+      }
+    ]
+  },
+  "base": {
+    "name": "base",
+    "class_hash": "0x7aec2b7d7064c1294a339cd90060331ff704ab573e4ee9a1b699be2215c11c9",
+    "abi": [
+      {
+        "type": "impl",
+        "name": "Upgradeable",
+        "interface_name": "dojo::upgradable::IUpgradeable"
+      },
+      {
+        "type": "interface",
+        "name": "dojo::upgradable::IUpgradeable",
+        "items": [
+          {
+            "type": "function",
+            "name": "upgrade",
+            "inputs": [
+              {
+                "name": "new_class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          }
+        ]
+      },
+      {
+        "type": "constructor",
+        "name": "constructor",
+        "inputs": []
+      },
+      {
+        "type": "struct",
+        "name": "dojo::world::IWorldDispatcher",
+        "members": [
+          {
+            "name": "contract_address",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ]
+      },
+      {
+        "type": "function",
+        "name": "world",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::world::IWorldDispatcher"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "event",
+        "name": "dojo::base::base::Event",
         "kind": "enum",
         "variants": []
       }

--- a/crates/dojo-world/src/migration/world.rs
+++ b/crates/dojo-world/src/migration/world.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use super::class::ClassDiff;
 use super::contract::ContractDiff;
 use super::StateDiff;
-use crate::manifest::{Manifest, EXECUTOR_CONTRACT_NAME, WORLD_CONTRACT_NAME};
+use crate::manifest::{Manifest, BASE_CONTRACT_NAME, EXECUTOR_CONTRACT_NAME, WORLD_CONTRACT_NAME};
 
 #[cfg(test)]
 #[path = "world_test.rs"]
@@ -14,6 +14,7 @@ mod tests;
 pub struct WorldDiff {
     pub world: ContractDiff,
     pub executor: ContractDiff,
+    pub base: ClassDiff,
     pub contracts: Vec<ContractDiff>,
     pub models: Vec<ClassDiff>,
     pub systems: Vec<ClassDiff>,
@@ -65,13 +66,19 @@ impl WorldDiff {
             remote: remote.as_ref().map(|m| m.executor.class_hash),
         };
 
+        let base = ClassDiff {
+            name: BASE_CONTRACT_NAME.into(),
+            local: local.base.class_hash,
+            remote: remote.as_ref().map(|m| m.base.class_hash),
+        };
+
         let world = ContractDiff {
             name: WORLD_CONTRACT_NAME.into(),
             local: local.world.class_hash,
             remote: remote.map(|m| m.world.class_hash),
         };
 
-        WorldDiff { world, executor, systems, contracts, models }
+        WorldDiff { world, executor, base, systems, contracts, models }
     }
 
     pub fn count_diffs(&self) -> usize {

--- a/crates/torii/client/src/contract/world_test.rs
+++ b/crates/torii/client/src/contract/world_test.rs
@@ -54,6 +54,9 @@ pub async fn deploy_world(
         .unwrap()
         .contract_address;
 
+    let base_class_hash =
+        strategy.base.unwrap().declare(&account, Default::default()).await.unwrap().class_hash;
+
     // wait for the tx to be mined
     tokio::time::sleep(Duration::from_millis(250)).await;
 
@@ -62,7 +65,7 @@ pub async fn deploy_world(
         .unwrap()
         .deploy(
             manifest.clone().world.class_hash,
-            vec![executor_address],
+            vec![executor_address, base_class_hash],
             &account,
             Default::default(),
         )


### PR DESCRIPTION
World deployer that deploys a placeholder contract and then replaces it with the actual contract impl
It allows us to get deterministic addresses based on the contract name, so we don't need to maintain an onchain registry
Downside is we can't use constructors. We need to use the initialize pattern. I think constructors will be uncommon with the dojo architecture (and aren't supported by sozo right now)