### PR TITLE
feat(katana): allow output logs in JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8171,6 +8171,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8180,12 +8190,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ thiserror = "1.0.32"
 tokio = { version = "1.32.0", features = [ "full" ] }
 toml = "0.7.4"
 tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.16", features = [ "env-filter" ] }
+tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "json" ] }
 url = "2.4.0"
 
 # server


### PR DESCRIPTION
Allow outputting `katana` logs in JSON format. 

Changed:
- Added `--json-log` CLI args to enable this feature.
- `katana` now doesn't ignore `RUST_LOG`

Example output:

```console
RUST_LOG=info katana --silent --json-log

{"timestamp":"2023-10-05T20:17:21.764160Z","level":"INFO","fields":{"message":"Accepting new connection 1/100"},"target":"jsonrpsee_server::server","span":{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"},"spans":[{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"}]}
{"timestamp":"2023-10-05T20:17:22.408881Z","level":"INFO","fields":{"message":"Transaction received | Hash: 0x3eec6ed98222e6a200c5e03a89ec9bfd56042a4fb4ddbbfcb5b28b35edad15e"},"target":"txpool","span":{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"},"spans":[{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"}]}
{"timestamp":"2023-10-05T20:17:22.427843Z","level":"INFO","fields":{"message":"⛏️ Block 1 mined with 1 transactions"},"target":"backend"}
{"timestamp":"2023-10-05T20:17:22.714189Z","level":"INFO","fields":{"message":"Transaction received | Hash: 0x644ae4c305110e57de359a80023e6d0a167400010aff98d8bb1cdafc9a4b394"},"target":"txpool","span":{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"},"spans":[{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"}]}
{"timestamp":"2023-10-05T20:17:22.737465Z","level":"INFO","fields":{"message":"⛏️ Block 2 mined with 1 transactions"},"target":"backend"}
{"timestamp":"2023-10-05T20:17:23.782950Z","level":"INFO","fields":{"message":"Transaction received | Hash: 0x62fe1f9381ac9e30db622cbe3dc8b55231dfa4ec0a5a8a3133ffbd7c4e58dbb"},"target":"txpool","span":{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"},"spans":[{"conn_id":"0","remote_addr":"127.0.0.1:51912","name":"connection"}]}
{"timestamp":"2023-10-05T20:17:23.801517Z","level":"INFO","fields":{"message":"⛏️ Block 3 mined with 1 transactions"},"target":"backend"}
```