### PR TITLE
Refactor graphql offset/limit pagination

### DIFF
--- a/crates/torii/graphql/src/constants.rs
+++ b/crates/torii/graphql/src/constants.rs
@@ -1,1 +1,1 @@
-pub const DEFAULT_LIMIT: i64 = 10;
+pub const DEFAULT_LIMIT: u64 = 10;

--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 use sqlx::{FromRow, Pool, Sqlite};
 
-use super::connection::connection_output;
+use super::results::results_output;
 use super::system_call::{SystemCall, SystemCallObject};
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::constants::DEFAULT_LIMIT;
@@ -89,7 +89,7 @@ impl ObjectTrait for EventObject {
     fn resolve_many(&self) -> Option<Field> {
         Some(Field::new(
             "events",
-            TypeRef::named(format!("{}Connection", self.type_name())),
+            TypeRef::named(format!("{}Results", self.type_name())),
             |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -98,7 +98,7 @@ impl ObjectTrait for EventObject {
                     let events: Vec<ValueMapping> =
                         data.into_iter().map(EventObject::value_mapping).collect();
 
-                    Ok(Some(Value::Object(connection_output(events, total_count))))
+                    Ok(Some(Value::Object(results_output(&events, total_count))))
                 })
             },
         ))

--- a/crates/torii/graphql/src/object/inputs/mod.rs
+++ b/crates/torii/graphql/src/object/inputs/mod.rs
@@ -1,4 +1,4 @@
-use async_graphql::dynamic::{Enum, InputObject};
+use async_graphql::dynamic::{Enum, Field, InputObject, InputValue, TypeRef};
 
 use super::TypeMapping;
 
@@ -20,4 +20,10 @@ pub trait InputObjectTrait {
     fn enum_objects(&self) -> Option<Vec<Enum>> {
         None
     }
+}
+
+pub fn limit_offset_argument(field: Field) -> Field {
+    field
+        .argument(InputValue::new("limit", TypeRef::named(TypeRef::INT)))
+        .argument(InputValue::new("offset", TypeRef::named(TypeRef::INT)))
 }

--- a/crates/torii/graphql/src/object/mod.rs
+++ b/crates/torii/graphql/src/object/mod.rs
@@ -1,17 +1,16 @@
-pub mod connection;
 pub mod entity;
 pub mod event;
 pub mod inputs;
 pub mod model;
 pub mod model_data;
+pub mod results;
 pub mod system;
 pub mod system_call;
 
 use async_graphql::dynamic::{Enum, Field, FieldFuture, InputObject, Object, SubscriptionField};
 use async_graphql::Value;
 
-use self::connection::edge::EdgeObject;
-use self::connection::ConnectionObject;
+use self::results::ResultsObject;
 use crate::types::{TypeMapping, ValueMapping};
 
 pub trait ObjectTrait {
@@ -55,20 +54,11 @@ pub trait ObjectTrait {
         None
     }
 
-    // Connection type, if resolve_many is Some then register connection graphql obj, includes
-    // {type_name}Connection and {type_name}Edge according to relay spec https://relay.dev/graphql/connections.htm
-    fn connection(&self) -> Option<Vec<Object>> {
+    fn results_objects(&self) -> Option<Vec<Object>> {
         self.resolve_many()?;
+        let results = ResultsObject::new(self.name().to_string(), self.type_name().to_string());
 
-        let edge = EdgeObject::new(self.name().to_string(), self.type_name().to_string());
-        let connection =
-            ConnectionObject::new(self.name().to_string(), self.type_name().to_string());
-
-        let mut objects = Vec::new();
-        objects.extend(edge.objects());
-        objects.extend(connection.objects());
-
-        Some(objects)
+        Some(results.objects())
     }
 
     fn objects(&self) -> Vec<Object> {

--- a/crates/torii/graphql/src/object/model.rs
+++ b/crates/torii/graphql/src/object/model.rs
@@ -9,7 +9,7 @@ use tokio_stream::StreamExt;
 use torii_core::simple_broker::SimpleBroker;
 use torii_core::types::Model;
 
-use super::connection::connection_output;
+use super::results::results_output;
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::constants::DEFAULT_LIMIT;
 use crate::query::{query_all, query_by_id, query_total_count};
@@ -89,7 +89,7 @@ impl ObjectTrait for ModelObject {
     fn resolve_many(&self) -> Option<Field> {
         Some(Field::new(
             "models",
-            TypeRef::named(format!("{}Connection", self.type_name())),
+            TypeRef::named(format!("{}Results", self.type_name())),
             |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -98,7 +98,7 @@ impl ObjectTrait for ModelObject {
                     let models: Vec<ValueMapping> =
                         data.into_iter().map(ModelObject::value_mapping).collect();
 
-                    Ok(Some(Value::Object(connection_output(models, total_count))))
+                    Ok(Some(Value::Object(results_output(&models, total_count))))
                 })
             },
         ))

--- a/crates/torii/graphql/src/object/results.rs
+++ b/crates/torii/graphql/src/object/results.rs
@@ -1,0 +1,49 @@
+use async_graphql::dynamic::TypeRef;
+use async_graphql::{Name, Value};
+
+use crate::object::ObjectTrait;
+use crate::types::{TypeData, TypeMapping, ValueMapping};
+
+pub struct ResultsObject {
+    pub name: String,
+    pub type_name: String,
+    pub type_mapping: TypeMapping,
+}
+
+impl ResultsObject {
+    pub fn new(name: String, type_name: String) -> Self {
+        let type_mapping = TypeMapping::from([
+            (Name::new("items"), TypeData::Simple(TypeRef::named_list(type_name.clone()))),
+            (Name::new("totalCount"), TypeData::Simple(TypeRef::named_nn(TypeRef::INT))),
+        ]);
+
+        Self {
+            name: format!("{}Results", name),
+            type_name: format!("{}Results", type_name),
+            type_mapping,
+        }
+    }
+}
+
+impl ObjectTrait for ResultsObject {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn type_name(&self) -> &str {
+        &self.type_name
+    }
+
+    fn type_mapping(&self) -> &TypeMapping {
+        &self.type_mapping
+    }
+}
+
+pub fn results_output(value_mapping: &[ValueMapping], total_count: i64) -> ValueMapping {
+    let items: Vec<Value> = value_mapping.iter().map(|v| Value::Object(v.clone())).collect();
+
+    ValueMapping::from([
+        (Name::new("totalCount"), Value::from(total_count)),
+        (Name::new("items"), Value::List(items)),
+    ])
+}

--- a/crates/torii/graphql/src/object/system.rs
+++ b/crates/torii/graphql/src/object/system.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 use serde::Deserialize;
 use sqlx::{FromRow, Pool, Sqlite};
 
-use super::connection::connection_output;
+use super::results::results_output;
 use super::system_call::system_calls_by_system_id;
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::constants::DEFAULT_LIMIT;
@@ -96,7 +96,7 @@ impl ObjectTrait for SystemObject {
     fn resolve_many(&self) -> Option<Field> {
         Some(Field::new(
             "systems",
-            TypeRef::named(format!("{}Connection", self.type_name())),
+            TypeRef::named(format!("{}Results", self.type_name())),
             |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -105,7 +105,7 @@ impl ObjectTrait for SystemObject {
                     let systems: Vec<ValueMapping> =
                         data.into_iter().map(SystemObject::value_mapping).collect();
 
-                    Ok(Some(Value::Object(connection_output(systems, total_count))))
+                    Ok(Some(Value::Object(results_output(&systems, total_count))))
                 })
             },
         ))

--- a/crates/torii/graphql/src/object/system_call.rs
+++ b/crates/torii/graphql/src/object/system_call.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use sqlx::pool::PoolConnection;
 use sqlx::{FromRow, Pool, Result, Sqlite};
 
-use super::connection::connection_output;
+use super::results::results_output;
 use super::system::SystemObject;
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::constants::DEFAULT_LIMIT;
@@ -90,7 +90,7 @@ impl ObjectTrait for SystemCallObject {
     fn resolve_many(&self) -> Option<Field> {
         Some(Field::new(
             "systemCalls",
-            TypeRef::named(format!("{}Connection", self.type_name())),
+            TypeRef::named(format!("{}Results", self.type_name())),
             |ctx| {
                 FieldFuture::new(async move {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
@@ -101,7 +101,7 @@ impl ObjectTrait for SystemCallObject {
                     let system_calls: Vec<ValueMapping> =
                         data.into_iter().map(SystemCallObject::value_mapping).collect();
 
-                    Ok(Some(Value::Object(connection_output(system_calls, total_count))))
+                    Ok(Some(Value::Object(results_output(&system_calls, total_count))))
                 })
             },
         ))

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -31,7 +31,7 @@ where
 pub async fn query_all<T>(
     conn: &mut PoolConnection<Sqlite>,
     table_name: &str,
-    limit: i64,
+    limit: u64,
 ) -> Result<Vec<T>>
 where
     T: Send + Unpin + for<'a> FromRow<'a, SqliteRow>,

--- a/crates/torii/graphql/src/query/order.rs
+++ b/crates/torii/graphql/src/query/order.rs
@@ -1,30 +1,10 @@
-use core::fmt;
+use strum_macros::{AsRefStr, EnumString};
 
-#[derive(Debug)]
+#[derive(AsRefStr, Debug, EnumString)]
+#[strum(serialize_all = "UPPERCASE")]
 pub enum Direction {
     Asc,
     Desc,
-}
-
-impl fmt::Display for Direction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Direction::Asc => write!(f, "ASC"),
-            Direction::Desc => write!(f, "DESC"),
-        }
-    }
-}
-
-impl TryFrom<&str> for Direction {
-    type Error = String;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "ASC" => Ok(Direction::Asc),
-            "DESC" => Ok(Direction::Desc),
-            _ => Err(format!("Invalid direction: {}", value)),
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/crates/torii/graphql/src/schema.rs
+++ b/crates/torii/graphql/src/schema.rs
@@ -5,7 +5,6 @@ use async_graphql::dynamic::{
 use sqlx::SqlitePool;
 use torii_core::types::Model;
 
-use super::object::connection::page_info::PageInfoObject;
 use super::object::entity::EntityObject;
 use super::object::event::EventObject;
 use super::object::model_data::ModelDataObject;
@@ -30,7 +29,6 @@ pub async fn build_schema(pool: &SqlitePool) -> Result<Schema> {
         Box::<SystemObject>::default(),
         Box::<EventObject>::default(),
         Box::<SystemCallObject>::default(),
-        Box::<PageInfoObject>::default(),
     ];
 
     // build model data gql objects
@@ -72,10 +70,10 @@ pub async fn build_schema(pool: &SqlitePool) -> Result<Schema> {
             }
         }
 
-        // register connection types, relay
-        if let Some(conn_objects) = object.connection() {
-            for object in conn_objects {
-                schema_builder = schema_builder.register(object);
+        // register results objects
+        if let Some(results_objects) = object.results_objects() {
+            for results in results_objects {
+                schema_builder = schema_builder.register(results);
             }
         }
 

--- a/crates/torii/graphql/src/tests/types-test/src/models.cairo
+++ b/crates/torii/graphql/src/tests/types-test/src/models.cairo
@@ -10,7 +10,7 @@ struct Record {
     type_u32: u32,
     type_u64: u64,
     type_u128: u128,
-    type_u256: u256,
+    //type_u256: u256,
     type_bool: bool,
     type_felt: felt252,
     type_class_hash: ClassHash,

--- a/crates/torii/graphql/src/tests/types-test/src/systems.cairo
+++ b/crates/torii/graphql/src/tests/types-test/src/systems.cairo
@@ -31,7 +31,7 @@ mod records {
                         type_u32: record_idx.into(),
                         type_u64: record_idx.into(),
                         type_u128: record_idx.into(),
-                        type_u256: type_felt.into(),
+                        //type_u256: type_felt.into(),
                         type_bool: if record_idx % 2 == 0 {
                             true
                         } else {

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly fmt --check --all -- "$@"
+cargo +nightly fmt  --all -- "$@"


### PR DESCRIPTION
Refactoring cursor based pagination to offset/limit

```
nameModels (first: xxx, after: xxx) { ... }
```
```
nameModels (offset: xxx, limit: xxx) { ... }
```

This will also change the return type from connection to results
```
NameConnection {
   totalCount: Int!
   edges: [NameEdge] 
}
```
```
NameResults {
   totalCount: Int!
   items: [Name]
}
```

Resolves https://github.com/dojoengine/dojo/issues/967