### PR TITLE
fix: use starknet::ContractAddress in #[system]

### DIFF
--- a/crates/dojo-core/src/base.cairo
+++ b/crates/dojo-core/src/base.cairo
@@ -16,17 +16,17 @@ mod base {
 
     #[storage]
     struct Storage {
-        world_dispatcher: IWorldDispatcher,
+        world_address: IWorldDispatcher,
     }
 
     #[constructor]
     fn constructor(ref self: ContractState) {
-        self.world_dispatcher.write(IWorldDispatcher { contract_address: get_caller_address() });
+        self.world_address.write(IWorldDispatcher { contract_address: get_caller_address() });
     }
 
     #[external(v0)]
     fn world(self: @ContractState) -> IWorldDispatcher {
-        self.world_dispatcher.read()
+        self.world_address.read()
     }
 
     #[external(v0)]

--- a/crates/dojo-core/src/base.cairo
+++ b/crates/dojo-core/src/base.cairo
@@ -16,17 +16,17 @@ mod base {
 
     #[storage]
     struct Storage {
-        world_address: IWorldDispatcher,
+        world_dispatcher: IWorldDispatcher,
     }
 
     #[constructor]
     fn constructor(ref self: ContractState) {
-        self.world_address.write(IWorldDispatcher { contract_address: get_caller_address() });
+        self.world_dispatcher.write(IWorldDispatcher { contract_address: get_caller_address() });
     }
 
     #[external(v0)]
     fn world(self: @ContractState) -> IWorldDispatcher {
-        self.world_address.read()
+        self.world_dispatcher.read()
     }
 
     #[external(v0)]

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -613,7 +613,7 @@ test_manifest_file
   },
   "base": {
     "name": "base",
-    "class_hash": "0x7aec2b7d7064c1294a339cd90060331ff704ab573e4ee9a1b699be2215c11c9",
+    "class_hash": "0x1db2927e2e9d4f45b66801ee0a4a04898eb369ccc6470771870e4fe2672d92b",
     "abi": [
       {
         "type": "impl",
@@ -677,7 +677,7 @@ test_manifest_file
     {
       "name": "player_actions",
       "address": null,
-      "class_hash": "0x502be43722c9e678d3c1f93e48f867c36e3852856571cde8925ec74cd0d6547",
+      "class_hash": "0xce73ce5a14e17dfc601a7cfc78f701f4eab0bb002e0e34522d7cfe55cfdc13",
       "abi": [
         {
           "type": "impl",
@@ -780,7 +780,7 @@ test_manifest_file
     {
       "name": "player_actions_external",
       "address": null,
-      "class_hash": "0x49d4d81317dd7ca15f598715a8c79198512060d94885b701d42afde9fa30a27",
+      "class_hash": "0x60d7692845904cf6697e1e1c2faa6e6789b5e2fac9c6ddc16c82e57a2b95a4e",
       "abi": [
         {
           "type": "impl",

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -613,7 +613,7 @@ test_manifest_file
   },
   "base": {
     "name": "base",
-    "class_hash": "0x1db2927e2e9d4f45b66801ee0a4a04898eb369ccc6470771870e4fe2672d92b",
+    "class_hash": "0x7aec2b7d7064c1294a339cd90060331ff704ab573e4ee9a1b699be2215c11c9",
     "abi": [
       {
         "type": "impl",
@@ -677,7 +677,7 @@ test_manifest_file
     {
       "name": "player_actions",
       "address": null,
-      "class_hash": "0xce73ce5a14e17dfc601a7cfc78f701f4eab0bb002e0e34522d7cfe55cfdc13",
+      "class_hash": "0x53ce2324af80c9c879e2ccefd0feaef0c3461b6ddfb2e0d35a0e78d5ba76a08",
       "abi": [
         {
           "type": "impl",
@@ -780,7 +780,7 @@ test_manifest_file
     {
       "name": "player_actions_external",
       "address": null,
-      "class_hash": "0x60d7692845904cf6697e1e1c2faa6e6789b5e2fac9c6ddc16c82e57a2b95a4e",
+      "class_hash": "0x1a80dbade1b3429f121303b3443a30d6412b85691f7733abe1ec5250509f081",
       "abi": [
         {
           "type": "impl",

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -40,7 +40,7 @@ mod spawn {
 
     #[storage]
     struct Storage {
-        world_dispatcher: starknet::ContractAddress,
+        world_address: starknet::ContractAddress,
     }
 
     #[external(v0)]
@@ -66,7 +66,7 @@ mod proxy {
 
     #[storage]
     struct Storage {
-        world_dispatcher: starknet::ContractAddress,
+        world_address: starknet::ContractAddress,
     }
 
     #[external(v0)]
@@ -90,7 +90,7 @@ mod ctxnamed {
 
     #[storage]
     struct Storage {
-        world_dispatcher: starknet::ContractAddress,
+        world_address: starknet::ContractAddress,
     }
 
     #[external(v0)]

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -40,7 +40,7 @@ mod spawn {
 
     #[storage]
     struct Storage {
-        world_address: starknet::ContractAddress,
+        world_dispatcher: IWorldDispatcher,
     }
 
     #[external(v0)]
@@ -66,7 +66,7 @@ mod proxy {
 
     #[storage]
     struct Storage {
-        world_address: starknet::ContractAddress,
+        world_dispatcher: IWorldDispatcher,
     }
 
     #[external(v0)]
@@ -90,7 +90,7 @@ mod ctxnamed {
 
     #[storage]
     struct Storage {
-        world_address: starknet::ContractAddress,
+        world_dispatcher: IWorldDispatcher,
     }
 
     #[external(v0)]

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -40,7 +40,7 @@ mod spawn {
 
     #[storage]
     struct Storage {
-        world_dispatcher: ContractAddress,
+        world_dispatcher: starknet::ContractAddress,
     }
 
     #[external(v0)]
@@ -66,7 +66,7 @@ mod proxy {
 
     #[storage]
     struct Storage {
-        world_dispatcher: ContractAddress,
+        world_dispatcher: starknet::ContractAddress,
     }
 
     #[external(v0)]
@@ -90,7 +90,7 @@ mod ctxnamed {
 
     #[storage]
     struct Storage {
-        world_dispatcher: ContractAddress,
+        world_dispatcher: starknet::ContractAddress,
     }
 
     #[external(v0)]

--- a/crates/dojo-lang/src/system.rs
+++ b/crates/dojo-lang/src/system.rs
@@ -51,7 +51,7 @@ impl System {
 
                     #[storage]
                     struct Storage {
-                        world_dispatcher: starknet::ContractAddress,
+                        world_address: starknet::ContractAddress,
                     }
 
                     #[external(v0)]

--- a/crates/dojo-lang/src/system.rs
+++ b/crates/dojo-lang/src/system.rs
@@ -51,7 +51,7 @@ impl System {
 
                     #[storage]
                     struct Storage {
-                        world_dispatcher: ContractAddress,
+                        world_dispatcher: starknet::ContractAddress,
                     }
 
                     #[external(v0)]

--- a/crates/dojo-lang/src/system.rs
+++ b/crates/dojo-lang/src/system.rs
@@ -51,7 +51,7 @@ impl System {
 
                     #[storage]
                     struct Storage {
-                        world_address: starknet::ContractAddress,
+                        world_dispatcher: IWorldDispatcher,
                     }
 
                     #[external(v0)]

--- a/examples/ecs/src/systems/raw_contract.cairo
+++ b/examples/ecs/src/systems/raw_contract.cairo
@@ -20,7 +20,7 @@ mod player_actions_external {
 
     #[storage]
     struct Storage {
-        world_address: ContractAddress,
+        world_dispatcher: IWorldDispatcher,
     }
 
     #[event]
@@ -39,7 +39,7 @@ mod player_actions_external {
     #[external(v0)]
     impl PlayerActionsImpl of IPlayerActions<ContractState> {
         fn spawn(self: @ContractState) {
-            let world = IWorldDispatcher { contract_address: self.world_address.read() };
+            let world = self.world_dispatcher.read();
             let player = get_caller_address();
             let position = get!(world, player, (Position));
             set!(
@@ -52,7 +52,7 @@ mod player_actions_external {
         }
 
         fn move(self: @ContractState, direction: Direction) {
-            let world = IWorldDispatcher { contract_address: self.world_address.read() };
+            let world = self.world_dispatcher.read();
             let player = get_caller_address();
             let (mut position, mut moves) = get!(world, player, (Position, Moves));
             moves.remaining -= 1;

--- a/examples/ecs/src/systems/raw_contract.cairo
+++ b/examples/ecs/src/systems/raw_contract.cairo
@@ -20,7 +20,7 @@ mod player_actions_external {
 
     #[storage]
     struct Storage {
-        world_dispatcher: ContractAddress,
+        world_address: ContractAddress,
     }
 
     #[event]
@@ -39,7 +39,7 @@ mod player_actions_external {
     #[external(v0)]
     impl PlayerActionsImpl of IPlayerActions<ContractState> {
         fn spawn(self: @ContractState) {
-            let world = IWorldDispatcher { contract_address: self.world_dispatcher.read() };
+            let world = IWorldDispatcher { contract_address: self.world_address.read() };
             let player = get_caller_address();
             let position = get!(world, player, (Position));
             set!(
@@ -52,7 +52,7 @@ mod player_actions_external {
         }
 
         fn move(self: @ContractState, direction: Direction) {
-            let world = IWorldDispatcher { contract_address: self.world_dispatcher.read() };
+            let world = IWorldDispatcher { contract_address: self.world_address.read() };
             let player = get_caller_address();
             let (mut position, mut moves) = get!(world, player, (Position, Moves));
             moves.remaining -= 1;

--- a/examples/ecs/src/systems/with_decorator.cairo
+++ b/examples/ecs/src/systems/with_decorator.cairo
@@ -33,7 +33,7 @@ mod player_actions {
     impl PlayerActionsImpl of IPlayerActions<ContractState> {
         // ContractState is defined by system decorator expansion
         fn spawn(self: @ContractState) {
-            let world = IWorldDispatcher { contract_address: self.world_dispatcher.read() };
+            let world = IWorldDispatcher { contract_address: self.world_address.read() };
             let player = get_caller_address();
             let position = get!(world, player, (Position));
             set!(
@@ -48,7 +48,7 @@ mod player_actions {
         }
 
         fn move(self: @ContractState, direction: Direction) {
-            let world = IWorldDispatcher { contract_address: self.world_dispatcher.read() };
+            let world = IWorldDispatcher { contract_address: self.world_address.read() };
             let player = get_caller_address();
             let (mut position, mut moves) = get!(world, player, (Position, Moves));
             moves.remaining -= 1;

--- a/examples/ecs/src/systems/with_decorator.cairo
+++ b/examples/ecs/src/systems/with_decorator.cairo
@@ -33,7 +33,7 @@ mod player_actions {
     impl PlayerActionsImpl of IPlayerActions<ContractState> {
         // ContractState is defined by system decorator expansion
         fn spawn(self: @ContractState) {
-            let world = IWorldDispatcher { contract_address: self.world_address.read() };
+            let world = self.world_dispatcher.read();
             let player = get_caller_address();
             let position = get!(world, player, (Position));
             set!(
@@ -48,7 +48,7 @@ mod player_actions {
         }
 
         fn move(self: @ContractState, direction: Direction) {
-            let world = IWorldDispatcher { contract_address: self.world_address.read() };
+            let world = self.world_dispatcher.read();
             let player = get_caller_address();
             let (mut position, mut moves) = get!(world, player, (Position, Moves));
             moves.remaining -= 1;


### PR DESCRIPTION
- fixes #995 
- use starknet::ContractAddress instead of ContractAddress
- use world_address instead of world_dispatcher
