### PR TITLE
introspect: enums

### DIFF
--- a/crates/dojo-lang/src/introspect.rs
+++ b/crates/dojo-lang/src/introspect.rs
@@ -181,7 +181,7 @@ pub fn handle_introspect_enum(
                 let ty_cairo: Vec<_> =
                     variant_type_arr.iter().map(|(ty_cairo, _)| ty_cairo.to_string()).collect();
                 // format!("'{}'", &ty_cairo.join("', '"))
-                ty_cairo.join("', '")
+                ty_cairo.join(",\n")
             } else {
                 "".to_string()
             }

--- a/crates/dojo-lang/src/introspect.rs
+++ b/crates/dojo-lang/src/introspect.rs
@@ -173,8 +173,7 @@ pub fn handle_introspect_enum(
             "
             (
                 '{member_name}',
-                \
-             dojo::database::schema::serialize_member_type(
+                dojo::database::schema::serialize_member_type(
                 @dojo::database::schema::Ty::Tuple(array![{}].span()))
             )",
             if !variant_type_arr.is_empty() {

--- a/crates/dojo-lang/src/introspect.rs
+++ b/crates/dojo-lang/src/introspect.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 
 use cairo_lang_defs::patcher::RewriteNode;
-use cairo_lang_syntax::node::ast::ItemStruct;
+use cairo_lang_defs::plugin::PluginDiagnostic;
+use cairo_lang_syntax::node::ast::{Expr, ItemEnum, ItemStruct, OptionTypeClause};
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
 use cairo_lang_syntax::node::{Terminal, TypedSyntaxNode};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 use dojo_world::manifest::Member;
+use itertools::Itertools;
 
 #[derive(Clone, Default)]
 struct TypeIntrospection(usize, Vec<usize>);
@@ -34,23 +36,175 @@ fn primitive_type_introspection() -> HashMap<String, TypeIntrospection> {
 /// Returns:
 /// * A RewriteNode containing the generated code.
 pub fn handle_introspect_struct(db: &dyn SyntaxGroup, struct_ast: ItemStruct) -> RewriteNode {
+    let name = struct_ast.name(db).text(db).into();
+
+    let mut member_types: Vec<String> = vec![];
+    let primitive_sizes = primitive_type_introspection();
+
     let members: Vec<_> = struct_ast
         .members(db)
         .elements(db)
         .iter()
-        .map(|member| Member {
-            name: member.name(db).text(db).to_string(),
-            ty: member.type_clause(db).ty(db).as_syntax_node().get_text(db).trim().to_string(),
-            key: member.has_attr(db, "key"),
+        .map(|member| {
+            let key = member.has_attr(db, "key");
+            let ty = member.type_clause(db).ty(db).as_syntax_node().get_text(db).trim().to_string();
+            let name = member.name(db).text(db).to_string();
+            let mut attrs = vec![];
+            if key {
+                attrs.push("'key'");
+            }
+
+            if primitive_sizes.get(&ty).is_some() {
+                // It's a primitive type
+                member_types.push(format!(
+                    "
+                    dojo::database::schema::serialize_member(@dojo::database::schema::Member {{
+                        name: '{name}',
+                        ty: dojo::database::schema::Ty::Primitive('{ty}'),
+                        attrs: array![{}].span()
+                    }})\n",
+                    attrs.join(","),
+                ));
+            } else {
+                // It's a custom struct/enum
+                member_types.push(format!(
+                    "
+                    dojo::database::schema::serialize_member(@dojo::database::schema::Member {{
+                        name: '{name}',
+                        ty: dojo::database::schema::SchemaIntrospection::<{ty}>::ty(),
+                        attrs: array![{}].span()
+                    }})\n",
+                    attrs.join(","),
+                ));
+            }
+
+            Member { name, ty, key }
         })
         .collect::<_>();
+    drop(primitive_sizes);
 
-    let primitive_sizes = primitive_type_introspection();
-    let mut size_precompute = 0;
+    let type_ty = format!(
+        "
+        dojo::database::schema::Ty::Struct(dojo::database::schema::Struct {{
+            name: '{name}',
+            attrs: array![].span(),
+            children: array![{}].span()
+        }})",
+        member_types.join(",\n")
+    );
 
+    handle_introspect_internal(db, name, vec![], 0, type_ty, members)
+}
+
+/// A handler for Dojo code derives Introspect for an enum
+/// Parameters:
+/// * db: The semantic database.
+/// * struct_ast: The AST of the struct.
+/// Returns:
+/// * A RewriteNode containing the generated code.
+pub fn handle_introspect_enum(
+    db: &dyn SyntaxGroup,
+    diagnostics: &mut Vec<PluginDiagnostic>,
+    enum_ast: ItemEnum,
+) -> RewriteNode {
+    let name = enum_ast.name(db).text(db).into();
+    let variant_type = enum_ast.variants(db).elements(db).first().unwrap().type_clause(db);
+    let variant_type_text = variant_type.as_syntax_node().get_text(db);
+    let variant_type_text = variant_type_text.trim();
+    let mut variant_type_arr = vec![];
+
+    if let OptionTypeClause::TypeClause(types_tuple) = variant_type {
+        if let Expr::Tuple(paren_list) = types_tuple.ty(db) {
+            let args = (*paren_list.expressions(db)).elements(db);
+            args.iter().for_each(|arg| {
+                let ty_name = arg.as_syntax_node().get_text(db);
+                variant_type_arr.push((
+                    // Not using Ty right now, but still keeping it for later.
+                    format!("dojo::database::schema::serialize_member_type(@dojo::database::schema::Ty::Primitive('{}'))", ty_name),
+                    ty_name,
+                ));
+            });
+        } else if let Expr::Path(type_path) = types_tuple.ty(db) {
+            let ty_name = type_path.as_syntax_node().get_text(db);
+            variant_type_arr.push((
+                // Not using Ty right now, but still keeping it for later.
+                format!("dojo::database::schema::serialize_member_type(@dojo::database::schema::SchemaIntrospection::<{}>::ty())", ty_name),
+                ty_name,
+            ));
+        } else {
+            diagnostics.push(PluginDiagnostic {
+                stable_ptr: types_tuple.stable_ptr().0,
+                message: "Only tuple and type paths are supported.".to_string(),
+            });
+        }
+    }
+
+    let members: Vec<_> = variant_type_arr
+        .iter()
+        .map(|(_, ty)| Member { name: ty.into(), ty: ty.into(), key: false })
+        .collect_vec();
+
+    let mut arms_ty: Vec<String> = vec![];
+
+    // Add diagnostics for different Typeclauses.
+    enum_ast.variants(db).elements(db).iter().for_each(|member| {
+        let member_name = member.name(db).text(db);
+        let member_type = member.type_clause(db).as_syntax_node();
+        let member_type_text = member_type.get_text(db);
+        if member_type_text.trim() != variant_type_text.trim() {
+            diagnostics.push(PluginDiagnostic {
+                stable_ptr: member_type.stable_ptr(),
+                message: format!("Enum arms need to have same type - {}.", variant_type_text),
+            });
+        }
+
+        // @TODO: Prepare type struct
+        arms_ty.push(format!(
+            "
+            (
+                '{member_name}',
+                dojo::database::schema::serialize_member_type(@dojo::database::schema::Ty::Tuple(array![{}].span()))
+            )",
+            if !variant_type_arr.is_empty() {
+                let ty_cairo: Vec<_> =
+                    variant_type_arr.iter().map(|(ty_cairo, _)| ty_cairo.to_string()).collect();
+                    // format!("'{}'", &ty_cairo.join("', '"))
+                    ty_cairo.join("', '")
+            } else {
+                "".to_string()
+            }
+        ));
+    });
+
+    let type_ty = format!(
+        "
+        dojo::database::schema::Ty::Enum(
+            dojo::database::schema::Enum {{
+                name: 'Direction',
+                attrs: array![].span(),
+                children: array![
+                {}
+                ].span()
+            }}
+        )",
+        arms_ty.join(",\n")
+    );
+    // Enums have 1 size and 8 bit layout by default
+    let layout = vec![RewriteNode::Text("layout.append(8);\n".into())];
+    let size_precompute = 1;
+    handle_introspect_internal(db, name, layout, size_precompute, type_ty, members)
+}
+
+fn handle_introspect_internal(
+    _db: &dyn SyntaxGroup,
+    name: String,
+    mut layout: Vec<RewriteNode>,
+    mut size_precompute: usize,
+    type_ty: String,
+    members: Vec<Member>,
+) -> RewriteNode {
     let mut size = vec![];
-    let mut layout = vec![];
-    let mut member_types = vec![];
+    let primitive_sizes = primitive_type_introspection();
 
     members.iter().for_each(|m| {
         let primitive_intro = primitive_sizes.get(&m.ty);
@@ -66,17 +220,6 @@ pub fn handle_introspect_struct(db: &dyn SyntaxGroup, struct_ast: ItemStruct) ->
                     layout.push(RewriteNode::Text(format!("layout.append({});\n", l)))
                 });
             }
-            // Do this for both keys and non keys
-            member_types.push(format!(
-                "dojo::database::schema::serialize_member(@dojo::database::schema::Member {{
-                name: '{}',
-                ty: dojo::database::schema::Ty::Primitive('{}'),
-                attrs: array![{}].span()
-            }})",
-                m.name,
-                m.ty,
-                attrs.join(","),
-            ));
         } else {
             // It's a custom type
             if m.key {
@@ -91,17 +234,6 @@ pub fn handle_introspect_struct(db: &dyn SyntaxGroup, struct_ast: ItemStruct) ->
                     m.ty
                 )));
             }
-            // Do this for both keys and non keys
-            member_types.push(format!(
-                "dojo::database::schema::serialize_member(@dojo::database::schema::Member {{
-                name: '{}',
-                ty: dojo::database::schema::SchemaIntrospection::<{}>::ty(),
-                attrs: array![{}].span()
-            }})",
-                m.name,
-                m.ty,
-                attrs.join(","),
-            ));
         }
     });
 
@@ -111,32 +243,29 @@ pub fn handle_introspect_struct(db: &dyn SyntaxGroup, struct_ast: ItemStruct) ->
 
     RewriteNode::interpolate_patched(
         "
-		impl $name$SchemaIntrospection of dojo::database::schema::SchemaIntrospection<$name$> {
-		   #[inline(always)]
-		   fn size() -> usize {
-			   $size$
-		   }
+        impl $name$SchemaIntrospection of dojo::database::schema::SchemaIntrospection<$name$> {
+            
+            #[inline(always)]
+            fn size() -> usize {
+                $size$
+            }
 
-		   #[inline(always)]
-		   fn layout(ref layout: Array<u8>) {
-			   $layout$
-		   }
+            #[inline(always)]
+            fn layout(ref layout: Array<u8>) {
+                $layout$
+            }
 
-		   #[inline(always)]
-		   fn ty() -> dojo::database::schema::Ty {
-			   dojo::database::schema::Ty::Struct(dojo::database::schema::Struct {
-				   name: '$name$',
-				   attrs: array![].span(),
-				   children: array![$member_types$].span()
-			   })
-		   }
-	    }
+            #[inline(always)]
+            fn ty() -> dojo::database::schema::Ty {
+                $ty$
+            }
+        }
         ",
         UnorderedHashMap::from([
-            ("name".to_string(), RewriteNode::new_trimmed(struct_ast.name(db).as_syntax_node())),
+            ("name".to_string(), RewriteNode::Text(name)),
             ("size".to_string(), RewriteNode::Text(size.join(" + "))),
             ("layout".to_string(), RewriteNode::new_modified(layout)),
-            ("member_types".to_string(), RewriteNode::Text(member_types.join(","))),
+            ("ty".to_string(), RewriteNode::Text(type_ty)),
         ]),
     )
 }

--- a/crates/dojo-lang/src/introspect.rs
+++ b/crates/dojo-lang/src/introspect.rs
@@ -120,7 +120,12 @@ pub fn handle_introspect_enum(
                 let ty_name = arg.as_syntax_node().get_text(db);
                 variant_type_arr.push((
                     // Not using Ty right now, but still keeping it for later.
-                    format!("dojo::database::schema::serialize_member_type(@dojo::database::schema::Ty::Primitive('{}'))", ty_name),
+                    format!(
+                        "dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Primitive('{}')
+                        )",
+                        ty_name
+                    ),
                     ty_name,
                 ));
             });
@@ -128,7 +133,12 @@ pub fn handle_introspect_enum(
             let ty_name = type_path.as_syntax_node().get_text(db);
             variant_type_arr.push((
                 // Not using Ty right now, but still keeping it for later.
-                format!("dojo::database::schema::serialize_member_type(@dojo::database::schema::SchemaIntrospection::<{}>::ty())", ty_name),
+                format!(
+                    "dojo::database::schema::serialize_member_type(
+                        @dojo::database::schema::SchemaIntrospection::<{}>::ty()
+                    )",
+                    ty_name
+                ),
                 ty_name,
             ));
         } else {
@@ -163,13 +173,15 @@ pub fn handle_introspect_enum(
             "
             (
                 '{member_name}',
-                dojo::database::schema::serialize_member_type(@dojo::database::schema::Ty::Tuple(array![{}].span()))
+                \
+             dojo::database::schema::serialize_member_type(
+                @dojo::database::schema::Ty::Tuple(array![{}].span()))
             )",
             if !variant_type_arr.is_empty() {
                 let ty_cairo: Vec<_> =
                     variant_type_arr.iter().map(|(ty_cairo, _)| ty_cairo.to_string()).collect();
-                    // format!("'{}'", &ty_cairo.join("', '"))
-                    ty_cairo.join("', '")
+                // format!("'{}'", &ty_cairo.join("', '"))
+                ty_cairo.join("', '")
             } else {
                 "".to_string()
             }

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -97,7 +97,7 @@ impl CairoPlugin for BuiltinDojoPlugin {
 struct BuiltinDojoPluginInstance;
 impl CairoPluginInstance for BuiltinDojoPluginInstance {
     fn macro_plugins(&self) -> Vec<Arc<dyn MacroPlugin>> {
-        vec![Arc::new(BuiltinDojoPlugin::default())]
+        vec![Arc::new(BuiltinDojoPlugin)]
     }
 
     fn inline_macro_plugins(&self) -> Vec<(String, Arc<dyn InlineMacroExprPlugin>)> {

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -25,7 +25,7 @@ use crate::contract::DojoContract;
 use crate::inline_macros::emit::EmitMacro;
 use crate::inline_macros::get::GetMacro;
 use crate::inline_macros::set::SetMacro;
-use crate::introspect::handle_introspect_struct;
+use crate::introspect::{handle_introspect_enum, handle_introspect_struct};
 use crate::model::handle_model_struct;
 use crate::print::derive_print;
 
@@ -113,6 +113,82 @@ impl MacroPlugin for BuiltinDojoPlugin {
     fn generate_code(&self, db: &dyn SyntaxGroup, item_ast: ast::Item) -> PluginResult {
         match item_ast {
             ast::Item::Module(module_ast) => self.handle_mod(db, module_ast),
+            ast::Item::Enum(enum_ast) => {
+                let aux_data = DojoAuxData::default();
+                let mut rewrite_nodes = vec![];
+                let mut diagnostics = vec![];
+
+                // Iterate over all the derive attributes of the struct
+                for attr in enum_ast.attributes(db).query_attr(db, "derive") {
+                    let attr = attr.structurize(db);
+
+                    // Check if the derive attribute has arguments
+                    if attr.args.is_empty() {
+                        diagnostics.push(PluginDiagnostic {
+                            stable_ptr: attr.args_stable_ptr.untyped(),
+                            message: "Expected args.".into(),
+                        });
+                        continue;
+                    }
+
+                    // Iterate over all the arguments of the derive attribute
+                    for arg in attr.args {
+                        // Check if the argument is a path then set it to arg
+                        let AttributeArg {
+                            variant:
+                                AttributeArgVariant::Unnamed { value: ast::Expr::Path(path), .. },
+                            ..
+                        } = arg
+                        else {
+                            diagnostics.push(PluginDiagnostic {
+                                stable_ptr: arg.arg_stable_ptr.untyped(),
+                                message: "Expected path.".into(),
+                            });
+                            continue;
+                        };
+
+                        // Check if the path has a single segment
+                        let [ast::PathSegment::Simple(segment)] = &path.elements(db)[..] else {
+                            continue;
+                        };
+
+                        // Get the text of the segment and check if it is "Model"
+                        let derived = segment.ident(db).text(db);
+
+                        match derived.as_str() {
+                            "Introspect" => {
+                                rewrite_nodes.push(handle_introspect_enum(
+                                    db,
+                                    &mut diagnostics,
+                                    enum_ast.clone(),
+                                ));
+                            }
+                            _ => continue,
+                        }
+                    }
+                }
+
+                if rewrite_nodes.is_empty() {
+                    return PluginResult { diagnostics, ..PluginResult::default() };
+                }
+
+                let name = enum_ast.name(db).text(db);
+                let mut builder = PatchBuilder::new(db);
+                for node in rewrite_nodes {
+                    builder.add_modified(node);
+                }
+
+                PluginResult {
+                    code: Some(PluginGeneratedFile {
+                        name,
+                        content: builder.code,
+                        aux_data: Some(DynGeneratedFileAuxData::new(aux_data)),
+                        diagnostics_mappings: builder.diagnostics_mappings,
+                    }),
+                    diagnostics,
+                    remove_original_item: false,
+                }
+            }
             ast::Item::Struct(struct_ast) => {
                 let mut aux_data = DojoAuxData::default();
                 let mut rewrite_nodes = vec![];

--- a/crates/dojo-lang/src/plugin_test_data/introspect
+++ b/crates/dojo-lang/src/plugin_test_data/introspect
@@ -244,7 +244,8 @@ impl EnumTupleSchemaIntrospection of dojo::database::schema::SchemaIntrospection
                                 array![
                                     dojo::database::schema::serialize_member_type(
                                         @dojo::database::schema::Ty::Primitive('u8')
-                                    ) ', ' dojo::database::schema::serialize_member_type(
+                                    ),
+                                    dojo::database::schema::serialize_member_type(
                                         @dojo::database::schema::Ty::Primitive('u8')
                                     )
                                 ]
@@ -259,7 +260,8 @@ impl EnumTupleSchemaIntrospection of dojo::database::schema::SchemaIntrospection
                                 array![
                                     dojo::database::schema::serialize_member_type(
                                         @dojo::database::schema::Ty::Primitive('u8')
-                                    ) ', ' dojo::database::schema::serialize_member_type(
+                                    ),
+                                    dojo::database::schema::serialize_member_type(
                                         @dojo::database::schema::Ty::Primitive('u8')
                                     )
                                 ]

--- a/crates/dojo-lang/src/plugin_test_data/introspect
+++ b/crates/dojo-lang/src/plugin_test_data/introspect
@@ -12,6 +12,30 @@ struct Vec2 {
     y: u32
 }
 
+#[derive(Serde, Copy, Drop, Introspect)]
+enum PlainEnum {
+    Left: (),
+    Right: (),
+}
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum EnumPrimitive {
+    Left: (u16,),
+    Right: (u16,),
+}
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum EnumTuple {
+    Left: (u8, u8),
+    Right: (u8, u8),
+}
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum EnumCustom {
+    Left: Vec2,
+    Right: Vec2,
+}
+
 #[derive(Model, Copy, Drop, Print, Introspect)]
 struct Position {
     #[key]
@@ -72,6 +96,236 @@ impl Vec2SchemaIntrospection of dojo::database::schema::SchemaIntrospection<Vec2
                             ty: dojo::database::schema::Ty::Primitive('u32'),
                             attrs: array![].span()
                         }
+                    )
+                ]
+                    .span()
+            }
+        )
+    }
+}
+
+
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum PlainEnum {
+    Left: (),
+    Right: (),
+}
+
+impl PlainEnumSchemaIntrospection of dojo::database::schema::SchemaIntrospection<PlainEnum> {
+    #[inline(always)]
+    fn size() -> usize {
+        1
+    }
+
+    #[inline(always)]
+    fn layout(ref layout: Array<u8>) {
+        layout.append(8);
+    }
+
+    #[inline(always)]
+    fn ty() -> dojo::database::schema::Ty {
+        dojo::database::schema::Ty::Enum(
+            dojo::database::schema::Enum {
+                name: 'Direction',
+                attrs: array![].span(),
+                children: array![
+                    (
+                        'Left',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(array![].span())
+                        )
+                    ),
+                    (
+                        'Right',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(array![].span())
+                        )
+                    )
+                ]
+                    .span()
+            }
+        )
+    }
+}
+
+
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum EnumPrimitive {
+    Left: (u16,),
+    Right: (u16,),
+}
+
+impl EnumPrimitiveSchemaIntrospection of dojo::database::schema::SchemaIntrospection<EnumPrimitive> {
+    #[inline(always)]
+    fn size() -> usize {
+        2
+    }
+
+    #[inline(always)]
+    fn layout(ref layout: Array<u8>) {
+        layout.append(8);
+        layout.append(16);
+    }
+
+    #[inline(always)]
+    fn ty() -> dojo::database::schema::Ty {
+        dojo::database::schema::Ty::Enum(
+            dojo::database::schema::Enum {
+                name: 'Direction',
+                attrs: array![].span(),
+                children: array![
+                    (
+                        'Left',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(
+                                array![
+                                    dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::Ty::Primitive('u16')
+                                    )
+                                ]
+                                    .span()
+                            )
+                        )
+                    ),
+                    (
+                        'Right',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(
+                                array![
+                                    dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::Ty::Primitive('u16')
+                                    )
+                                ]
+                                    .span()
+                            )
+                        )
+                    )
+                ]
+                    .span()
+            }
+        )
+    }
+}
+
+
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum EnumTuple {
+    Left: (u8, u8),
+    Right: (u8, u8),
+}
+
+impl EnumTupleSchemaIntrospection of dojo::database::schema::SchemaIntrospection<EnumTuple> {
+    #[inline(always)]
+    fn size() -> usize {
+        3
+    }
+
+    #[inline(always)]
+    fn layout(ref layout: Array<u8>) {
+        layout.append(8);
+        layout.append(8);
+        layout.append(8);
+    }
+
+    #[inline(always)]
+    fn ty() -> dojo::database::schema::Ty {
+        dojo::database::schema::Ty::Enum(
+            dojo::database::schema::Enum {
+                name: 'Direction',
+                attrs: array![].span(),
+                children: array![
+                    (
+                        'Left',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(
+                                array![
+                                    dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::Ty::Primitive('u8')
+                                    ) ', ' dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::Ty::Primitive('u8')
+                                    )
+                                ]
+                                    .span()
+                            )
+                        )
+                    ),
+                    (
+                        'Right',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(
+                                array![
+                                    dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::Ty::Primitive('u8')
+                                    ) ', ' dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::Ty::Primitive('u8')
+                                    )
+                                ]
+                                    .span()
+                            )
+                        )
+                    )
+                ]
+                    .span()
+            }
+        )
+    }
+}
+
+
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum EnumCustom {
+    Left: Vec2,
+    Right: Vec2,
+}
+
+impl EnumCustomSchemaIntrospection of dojo::database::schema::SchemaIntrospection<EnumCustom> {
+    #[inline(always)]
+    fn size() -> usize {
+        dojo::database::schema::SchemaIntrospection::<Vec2>::size() + 1
+    }
+
+    #[inline(always)]
+    fn layout(ref layout: Array<u8>) {
+        layout.append(8);
+        dojo::database::schema::SchemaIntrospection::<Vec2>::layout(ref layout);
+    }
+
+    #[inline(always)]
+    fn ty() -> dojo::database::schema::Ty {
+        dojo::database::schema::Ty::Enum(
+            dojo::database::schema::Enum {
+                name: 'Direction',
+                attrs: array![].span(),
+                children: array![
+                    (
+                        'Left',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(
+                                array![
+                                    dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::SchemaIntrospection::<Vec2>::ty()
+                                    )
+                                ]
+                                    .span()
+                            )
+                        )
+                    ),
+                    (
+                        'Right',
+                        dojo::database::schema::serialize_member_type(
+                            @dojo::database::schema::Ty::Tuple(
+                                array![
+                                    dojo::database::schema::serialize_member_type(
+                                        @dojo::database::schema::SchemaIntrospection::<Vec2>::ty()
+                                    )
+                                ]
+                                    .span()
+                            )
+                        )
                     )
                 ]
                     .span()

--- a/crates/sozo/src/commands/events.rs
+++ b/crates/sozo/src/commands/events.rs
@@ -77,7 +77,7 @@ fn extract_events(manifest: &Manifest) -> HashMap<String, Vec<Event>> {
                         abi::EventKind::Struct { .. } => {
                             let event_name =
                                 starknet_keccak(e.name.split("::").last().unwrap().as_bytes());
-                            let vec = events.entry(event_name.to_string()).or_insert(Vec::new());
+                            let vec = events.entry(event_name.to_string()).or_default();
                             vec.push(e.clone());
                         }
                         abi::EventKind::Enum { .. } => (),

--- a/crates/torii/client/src/client/storage.rs
+++ b/crates/torii/client/src/client/storage.rs
@@ -87,7 +87,7 @@ impl ModelStorage {
     }
 
     fn index_entity(&self, model: FieldElement, raw_keys: Vec<FieldElement>) {
-        self.model_index.write().entry(model).or_insert_with(HashSet::new).insert(raw_keys);
+        self.model_index.write().entry(model).or_default().insert(raw_keys);
     }
 }
 

--- a/examples/ecs/src/models.cairo
+++ b/examples/ecs/src/models.cairo
@@ -5,43 +5,13 @@ use dojo::database::schema::{
     Enum, Member, Ty, Struct, SchemaIntrospection, serialize_member, serialize_member_type
 };
 
-#[derive(Serde, Copy, Drop)]
+#[derive(Serde, Copy, Drop, Introspect)]
 enum Direction {
     None: (),
     Left: (),
     Right: (),
     Up: (),
     Down: (),
-}
-
-impl DirectionSchemaIntrospectionImpl of SchemaIntrospection<Direction> {
-    #[inline(always)]
-    fn size() -> usize {
-        1
-    }
-
-    #[inline(always)]
-    fn layout(ref layout: Array<u8>) {
-        layout.append(8);
-    }
-
-    #[inline(always)]
-    fn ty() -> Ty {
-        Ty::Enum(
-            Enum {
-                name: 'Direction',
-                attrs: array![].span(),
-                children: array![
-                    ('None', serialize_member_type(@Ty::Tuple(array![].span()))),
-                    ('Left', serialize_member_type(@Ty::Tuple(array![].span()))),
-                    ('Right', serialize_member_type(@Ty::Tuple(array![].span()))),
-                    ('Up', serialize_member_type(@Ty::Tuple(array![].span()))),
-                    ('Down', serialize_member_type(@Ty::Tuple(array![].span())))
-                ]
-                    .span()
-            }
-        )
-    }
 }
 
 impl DirectionPrintImpl of PrintTrait<Direction> {


### PR DESCRIPTION
### Enums and Introspect impls

```rs
#[derive(Serde, Copy, Drop, Introspect)]
enum PlainEnum {
    Left: (),
    Right: (),
}

impl PlainEnumSchemaIntrospection of dojo::database::schema::SchemaIntrospection<PlainEnum> {
    #[inline(always)]
    fn size() -> usize {
        1
    }

    #[inline(always)]
    fn layout(ref layout: Array<u8>) {
        layout.append(8);
    }

    #[inline(always)]
    fn ty() -> dojo::database::schema::Ty {
        dojo::database::schema::Ty::Enum(
            dojo::database::schema::Enum {
                name: 'Direction',
                attrs: array![].span(),
                children: array![
                    (
                        'Left',
                        serialize_member_type(@dojo::database::schema::Ty::Tuple(array![].span()))
                    ),
                    (
                        'Right',
                        serialize_member_type(@dojo::database::schema::Ty::Tuple(array![].span()))
                    )
                ]
                    .span()
            }
        )
    }
}



#[derive(Serde, Copy, Drop, Introspect)]
enum EnumPrimitive {
    Left: (u16,),
    Right: (u16,),
}

impl EnumPrimitiveSchemaIntrospection of dojo::database::schema::SchemaIntrospection<EnumPrimitive> {
    #[inline(always)]
    fn size() -> usize {
        2
    }

    #[inline(always)]
    fn layout(ref layout: Array<u8>) {
        layout.append(8);
        layout.append(16);
    }

    #[inline(always)]
    fn ty() -> dojo::database::schema::Ty {
        dojo::database::schema::Ty::Enum(
            dojo::database::schema::Enum {
                name: 'Direction',
                attrs: array![].span(),
                children: array![
                    (
                        'Left',
                        serialize_member_type(
                            @dojo::database::schema::Ty::Tuple(array!['u16'].span())
                        )
                    ),
                    (
                        'Right',
                        serialize_member_type(
                            @dojo::database::schema::Ty::Tuple(array!['u16'].span())
                        )
                    )
                ]
                    .span()
            }
        )
    }
}



#[derive(Serde, Copy, Drop, Introspect)]
enum EnumTuple {
    Left: (u8, u8),
    Right: (u8, u8),
}

impl EnumTupleSchemaIntrospection of dojo::database::schema::SchemaIntrospection<EnumTuple> {
    #[inline(always)]
    fn size() -> usize {
        3
    }

    #[inline(always)]
    fn layout(ref layout: Array<u8>) {
        layout.append(8);
        layout.append(8);
        layout.append(8);
    }

    #[inline(always)]
    fn ty() -> dojo::database::schema::Ty {
        dojo::database::schema::Ty::Enum(
            dojo::database::schema::Enum {
                name: 'Direction',
                attrs: array![].span(),
                children: array![
                    (
                        'Left',
                        serialize_member_type(
                            @dojo::database::schema::Ty::Tuple(array!['u8', 'u8'].span())
                        )
                    ),
                    (
                        'Right',
                        serialize_member_type(
                            @dojo::database::schema::Ty::Tuple(array!['u8', 'u8'].span())
                        )
                    )
                ]
                    .span()
            }
        )
    }
}



#[derive(Serde, Copy, Drop, Introspect)]
enum EnumCustom {
    Left: Vec2,
    Right: Vec2,
}

impl EnumCustomSchemaIntrospection of dojo::database::schema::SchemaIntrospection<EnumCustom> {
    #[inline(always)]
    fn size() -> usize {
        dojo::database::schema::SchemaIntrospection::<Vec2>::size() + 1
    }

    #[inline(always)]
    fn layout(ref layout: Array<u8>) {
        layout.append(8);
        dojo::database::schema::SchemaIntrospection::<Vec2>::layout(ref layout);
    }

    #[inline(always)]
    fn ty() -> dojo::database::schema::Ty {
        dojo::database::schema::Ty::Enum(
            dojo::database::schema::Enum {
                name: 'Direction',
                attrs: array![].span(),
                children: array![
                    (
                        'Left',
                        serialize_member_type(
                            @dojo::database::schema::Ty::Tuple(array!['Vec2'].span())
                        )
                    ),
                    (
                        'Right',
                        serialize_member_type(
                            @dojo::database::schema::Ty::Tuple(array!['Vec2'].span())
                        )
                    )
                ]
                    .span()
            }
        )
    }
}
```
```