### PR TITLE
Create remote manifest using events

### DIFF
--- a/crates/dojo-test-utils/Cargo.toml
+++ b/crates/dojo-test-utils/Cargo.toml
@@ -15,7 +15,7 @@ cairo-lang-project.workspace = true
 cairo-lang-starknet.workspace = true
 camino.workspace = true
 dojo-lang = { path = "../dojo-lang" }
-dojo-world = { path = "../dojo-world", features = [ "manifest" ] }
+dojo-world = { path = "../dojo-world", features = [ "manifest", "migration" ] }
 jsonrpsee = { version = "0.16.2", features = [ "server" ] }
 katana-core = { path = "../katana/core" }
 katana-rpc = { path = "../katana/rpc" }

--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -41,6 +41,6 @@ toml.workspace = true
 
 [features]
 contracts = [ "dep:dojo-types", "dep:http" ]
-manifest = [ "dep:dojo-types" ]
+manifest = [ "contracts", "dep:dojo-types", "dep:url" ]
 metadata = [ "dep:ipfs-api-backend-hyper", "dep:scarb", "dep:url" ]
 migration = [ "dep:tokio" ]

--- a/crates/dojo-world/src/contracts/world_test.rs
+++ b/crates/dojo-world/src/contracts/world_test.rs
@@ -93,7 +93,7 @@ pub async fn deploy_world(
     for contract in strategy.contracts {
         let declare_res = contract.declare(&account, Default::default()).await.unwrap();
         contract
-            .deploy(declare_res.class_hash, vec![], &account, Default::default())
+            .world_deploy(world_address, declare_res.class_hash, &account, Default::default())
             .await
             .unwrap();
     }

--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
@@ -6,14 +7,21 @@ use cairo_lang_starknet::abi;
 use serde_with::serde_as;
 use smol_str::SmolStr;
 use starknet::core::serde::unsigned_field_element::UfeHex;
-use starknet::core::types::{BlockId, BlockTag, FieldElement, FunctionCall, StarknetError};
-use starknet::core::utils::{
-    cairo_short_string_to_felt, get_selector_from_name, CairoShortStringToFeltError,
+use starknet::core::types::{
+    BlockId, BlockTag, EmittedEvent, EventFilter, FieldElement, FunctionCall, StarknetError,
 };
+use starknet::core::utils::{
+    parse_cairo_short_string, starknet_keccak, CairoShortStringToFeltError,
+};
+use starknet::macros::selector;
 use starknet::providers::{
     MaybeUnknownErrorCode, Provider, ProviderError, StarknetErrorWithMessage,
 };
 use thiserror::Error;
+
+use crate::contracts::model::ModelError;
+use crate::contracts::world::ContractReaderError;
+use crate::contracts::WorldContractReader;
 
 #[cfg(test)]
 #[path = "manifest_test.rs"]
@@ -35,6 +43,10 @@ pub enum ManifestError<E> {
     InvalidNameError(#[from] CairoShortStringToFeltError),
     #[error(transparent)]
     Provider(#[from] ProviderError<E>),
+    #[error(transparent)]
+    ContractRead(#[from] ContractReaderError<E>),
+    #[error(transparent)]
+    Model(#[from] ModelError<E>),
 }
 
 /// Represents a model member.
@@ -131,87 +143,44 @@ impl Manifest {
     pub async fn load_from_remote<P>(
         provider: P,
         world_address: FieldElement,
-        match_manifest: Option<Manifest>,
     ) -> Result<Self, ManifestError<<P as Provider>::Error>>
     where
+        P::Error: 'static,
         P: Provider + Send + Sync,
     {
-        let world_class_hash = provider
-            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), world_address)
-            .await
-            .map_err(|err| match err {
+        const BLOCK_ID: BlockId = BlockId::Tag(BlockTag::Pending);
+
+        let world_class_hash =
+            provider.get_class_hash_at(BLOCK_ID, world_address).await.map_err(|err| match err {
                 ProviderError::StarknetError(StarknetErrorWithMessage {
                     code: MaybeUnknownErrorCode::Known(StarknetError::ContractNotFound),
                     ..
                 }) => ManifestError::RemoteWorldNotFound,
-                _ => ManifestError::Provider(err),
+                err => err.into(),
             })?;
 
-        let executor_address = provider
-            .call(
-                FunctionCall {
-                    contract_address: world_address,
-                    calldata: vec![],
-                    entry_point_selector: get_selector_from_name("executor").unwrap(),
-                },
-                BlockId::Tag(BlockTag::Pending),
-            )
-            .await
-            .map_err(ManifestError::Provider)?[0];
+        let world = WorldContractReader::new(world_address, &provider).with_block(BLOCK_ID);
+
+        let executor_address = world.executor().await?;
+        let base_class_hash = world.base().await?;
 
         let executor_class_hash = provider
-            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), executor_address)
+            .get_class_hash_at(BLOCK_ID, executor_address)
             .await
             .map_err(|err| match err {
                 ProviderError::StarknetError(StarknetErrorWithMessage {
                     code: MaybeUnknownErrorCode::Known(StarknetError::ContractNotFound),
                     ..
                 }) => ManifestError::ExecutorNotFound,
-                _ => ManifestError::Provider(err),
+                err => err.into(),
             })?;
 
-        let base_class_hash = provider
-            .call(
-                FunctionCall {
-                    contract_address: world_address,
-                    calldata: vec![],
-                    entry_point_selector: get_selector_from_name("base").unwrap(),
-                },
-                BlockId::Tag(BlockTag::Pending),
-            )
-            .await
-            .map_err(ManifestError::Provider)?[0];
-
-        let mut models = vec![];
-
-        if let Some(match_manifest) = match_manifest {
-            for model in match_manifest.models {
-                let result = provider
-                    .call(
-                        FunctionCall {
-                            contract_address: world_address,
-                            calldata: vec![
-                                cairo_short_string_to_felt(&model.name)
-                                    .map_err(ManifestError::InvalidNameError)?,
-                            ],
-                            entry_point_selector: get_selector_from_name("model").unwrap(),
-                        },
-                        BlockId::Tag(BlockTag::Pending),
-                    )
-                    .await
-                    .map_err(ManifestError::Provider)?;
-
-                models.push(Model {
-                    name: model.name.clone(),
-                    class_hash: result[0],
-                    ..Default::default()
-                });
-            }
-        }
+        let models = get_remote_world_registered_models(world_address, &provider).await.unwrap();
+        let contracts = get_remote_world_deployed_contracts(world_address, provider).await.unwrap();
 
         Ok(Manifest {
             models,
-            contracts: vec![],
+            contracts,
             world: Contract {
                 name: WORLD_CONTRACT_NAME.into(),
                 class_hash: world_class_hash,
@@ -231,4 +200,131 @@ impl Manifest {
             },
         })
     }
+}
+
+pub(self) static MODEL_REGISTERED_EVENT_NAME: &str = "ModelRegistered";
+pub(self) static CONTRACT_DEPLOYED_EVENT_NAME: &str = "ContractDeployed";
+
+async fn get_remote_world_deployed_contracts<P>(
+    world: FieldElement,
+    provider: P,
+) -> anyhow::Result<Vec<Contract>>
+where
+    P::Error: 'static,
+    P: Provider + Send + Sync,
+{
+    let event_key = vec![starknet_keccak(CONTRACT_DEPLOYED_EVENT_NAME.as_bytes())];
+
+    let mut contracts =
+        parse_contract_events(&provider, world, vec![event_key], parse_deployed_contracts_events)
+            .await?;
+
+    for (address, contract) in &mut contracts {
+        let name = match provider
+            .call(
+                FunctionCall {
+                    calldata: vec![],
+                    contract_address: *address,
+                    entry_point_selector: selector!("name"),
+                },
+                BlockId::Tag(BlockTag::Latest),
+            )
+            .await
+        {
+            Ok(res) => parse_cairo_short_string(&res[0])?.into(),
+
+            Err(ProviderError::StarknetError(StarknetErrorWithMessage {
+                code: MaybeUnknownErrorCode::Known(StarknetError::ContractError),
+                ..
+            })) => SmolStr::from(""),
+
+            Err(err) => return Err(err.into()),
+        };
+
+        contract.name = name;
+    }
+
+    Ok(contracts.into_iter().map(|(_, contract)| contract).collect())
+}
+
+async fn get_remote_world_registered_models(
+    world: FieldElement,
+    provider: impl Provider,
+) -> anyhow::Result<Vec<Model>> {
+    let event_key = vec![starknet_keccak(MODEL_REGISTERED_EVENT_NAME.as_bytes())];
+    Ok(parse_contract_events(provider, world, vec![event_key], parse_registered_model_events)
+        .await?)
+}
+
+async fn parse_contract_events<T>(
+    provider: impl Provider,
+    world: FieldElement,
+    keys: Vec<Vec<FieldElement>>,
+    f: impl FnOnce(Vec<EmittedEvent>) -> T,
+) -> anyhow::Result<T> {
+    const DEFAULT_CHUNK_SIZE: u64 = 100;
+
+    let mut events: Vec<EmittedEvent> = vec![];
+    let mut continuation_token = None;
+
+    let filter =
+        EventFilter { to_block: None, from_block: None, address: Some(world), keys: Some(keys) };
+
+    loop {
+        let res = provider
+            .get_events(filter.clone(), continuation_token, DEFAULT_CHUNK_SIZE)
+            .await
+            .unwrap();
+
+        continuation_token = res.continuation_token;
+        events.extend(res.events);
+
+        if continuation_token.is_none() {
+            break;
+        }
+    }
+
+    Ok(f(events))
+}
+
+fn parse_deployed_contracts_events(events: Vec<EmittedEvent>) -> HashMap<FieldElement, Contract> {
+    events
+        .into_iter()
+        .map(|event| {
+            let mut data = event.data.into_iter();
+
+            let _ = data.next().expect("salt is missing from event");
+            let class_hash = data.next().expect("class hash is missing from event");
+            let address = data.next().expect("addresss is missing from event");
+
+            (address, Contract { address: Some(address), class_hash, ..Default::default() })
+        })
+        .collect()
+}
+
+fn parse_registered_model_events(events: Vec<EmittedEvent>) -> Vec<Model> {
+    let mut models: HashMap<String, FieldElement> = HashMap::with_capacity(events.len());
+
+    for event in events {
+        let mut data = event.data.into_iter();
+
+        let model_name = data.next().expect("name is missing from event");
+        let model_name = parse_cairo_short_string(&model_name).unwrap();
+
+        let class_hash = data.next().expect("class hash is missing from event");
+        let prev_class_hash = data.next().expect("prev class hash is missing from event");
+
+        if let Some(current_class_hash) = models.get_mut(&model_name) {
+            if current_class_hash == &prev_class_hash {
+                *current_class_hash = class_hash;
+            }
+        } else {
+            models.insert(model_name, class_hash);
+        }
+    }
+
+    models
+        .into_iter()
+        .map(|(name, class_hash)| Model { name, class_hash, ..Default::default() })
+        .collect()
 }

--- a/crates/dojo-world/src/manifest_test.rs
+++ b/crates/dojo-world/src/manifest_test.rs
@@ -1,10 +1,66 @@
+use std::collections::HashMap;
+
 use dojo_test_utils::rpc::MockJsonRpcTransport;
 use serde_json::json;
-use starknet::core::types::FieldElement;
+use starknet::core::types::{EmittedEvent, FieldElement};
+use starknet::macros::{felt, short_string};
 use starknet::providers::jsonrpc::{JsonRpcClient, JsonRpcMethod};
 
-use super::Manifest;
+use super::{
+    parse_deployed_contracts_events, parse_registered_model_events, Class, Contract, Manifest,
+    Model, BASE_CONTRACT_NAME, EXECUTOR_CONTRACT_NAME, WORLD_CONTRACT_NAME,
+};
 use crate::manifest::ManifestError;
+
+fn create_example_remote_manifest() -> Manifest {
+    Manifest {
+        world: Contract {
+            abi: None,
+            name: WORLD_CONTRACT_NAME.into(),
+            address: Some(felt!(
+                "0x04e10dcec3ed05fecb289ec2aefd81a0e73ba0dfb66c8e6b01e20593f471c70c"
+            )),
+            class_hash: felt!("0x05c3494b21bc92d40abdc40cdc54af66f22fb92bf876665d982c765a2cc0e06a"),
+        },
+        executor: Contract {
+            abi: None,
+            address: Some(felt!(
+                "0x05c3494b21bc92d40abdc40cdc54af66f22fb92bf876665d982c765a2cc0e06a"
+            )),
+            class_hash: felt!("0x02b35dd4816731188ed1ad16caa73bde76075c9d9cb8cbfa3e447d3ab9b1ab33"),
+            name: EXECUTOR_CONTRACT_NAME.into(),
+        },
+        base: Class {
+            name: BASE_CONTRACT_NAME.into(),
+            class_hash: felt!("0x07aec2b7d7064c1294a339cd90060331ff704ab573e4ee9a1b699be2215c11c9"),
+            abi: None,
+        },
+        contracts: vec![Contract {
+            name: "player_actions".into(),
+            address: Some(felt!(
+                "0x06f359762e26f9d5562284ec8c55c7d4854a8a90fdcdc09795e31a8d78fc6221"
+            )),
+            class_hash: felt!("0x0723e7c7e8748c0a81bf4b426e3c5dee84df728d1630324d75077a21b0271bb4"),
+            abi: None,
+        }],
+        models: vec![
+            Model {
+                name: "Position".into(),
+                class_hash: felt!(
+                    "0x06ffc643cbc4b2fb9c424242b18175a5e142269b45f4463d1cd4dddb7a2e5095"
+                ),
+                ..Default::default()
+            },
+            Model {
+                name: "Moves".into(),
+                class_hash: felt!(
+                    "0x07a3234437ebfadbae8465c1e81660c714e09bb77fa248ccfe66c6f3e6a03698"
+                ),
+                ..Default::default()
+            },
+        ],
+    }
+}
 
 #[tokio::test]
 async fn test_manifest_from_remote_throw_error_on_not_deployed() {
@@ -22,7 +78,7 @@ async fn test_manifest_from_remote_throw_error_on_not_deployed() {
     );
 
     let rpc = JsonRpcClient::new(mock_transport);
-    let err = Manifest::load_from_remote(rpc, FieldElement::ONE, None).await.unwrap_err();
+    let err = Manifest::load_from_remote(rpc, FieldElement::ONE).await.unwrap_err();
 
     match err {
         ManifestError::RemoteWorldNotFound => {
@@ -30,4 +86,114 @@ async fn test_manifest_from_remote_throw_error_on_not_deployed() {
         }
         err => panic!("Unexpected error: {err}"),
     }
+}
+
+#[test]
+fn test_parse_registered_model_events() {
+    let expected_models = create_example_remote_manifest().models;
+
+    let events = vec![
+        EmittedEvent {
+            data: vec![
+                short_string!("Position"),
+                felt!("0x06ffc643cbc4b2fb9c424242b18175a5e142269b45f4463d1cd4dddb7a2e5095"),
+                felt!("0xbeef"),
+            ],
+            keys: vec![],
+            block_hash: Default::default(),
+            from_address: Default::default(),
+            block_number: Default::default(),
+            transaction_hash: Default::default(),
+        },
+        EmittedEvent {
+            data: vec![short_string!("Position"), felt!("0xbeef"), felt!("0")],
+            keys: vec![],
+            block_hash: Default::default(),
+            from_address: Default::default(),
+            block_number: Default::default(),
+            transaction_hash: Default::default(),
+        },
+        EmittedEvent {
+            data: vec![
+                short_string!("Moves"),
+                felt!("0x07a3234437ebfadbae8465c1e81660c714e09bb77fa248ccfe66c6f3e6a03698"),
+                felt!("0"),
+            ],
+            keys: vec![],
+            block_hash: Default::default(),
+            from_address: Default::default(),
+            block_number: Default::default(),
+            transaction_hash: Default::default(),
+        },
+    ];
+
+    let actual_models = parse_registered_model_events(events);
+
+    assert_eq!(actual_models.len(), 2);
+    assert!(expected_models.contains(&actual_models[0]));
+    assert!(expected_models.contains(&actual_models[1]));
+}
+
+#[test]
+fn test_parse_deployed_contracts_events() {
+    let expected_contracts = HashMap::from([
+        (
+            felt!("0x123"),
+            Contract {
+                name: "".into(),
+                class_hash: felt!("0x1"),
+                address: Some(felt!("0x123")),
+                ..Default::default()
+            },
+        ),
+        (
+            felt!("0x456"),
+            Contract {
+                name: "".into(),
+                class_hash: felt!("0x2"),
+                address: Some(felt!("0x456")),
+                ..Default::default()
+            },
+        ),
+        (
+            felt!("0x789"),
+            Contract {
+                name: "".into(),
+                class_hash: felt!("0x3"),
+                address: Some(felt!("0x789")),
+                ..Default::default()
+            },
+        ),
+    ]);
+
+    let events = vec![
+        EmittedEvent {
+            data: vec![felt!("0x0"), felt!("0x1"), felt!("0x123")],
+            keys: vec![],
+            block_hash: Default::default(),
+            from_address: Default::default(),
+            block_number: Default::default(),
+            transaction_hash: Default::default(),
+        },
+        EmittedEvent {
+            data: vec![felt!("0x0"), felt!("0x2"), felt!("0x456")],
+            keys: vec![],
+            block_hash: Default::default(),
+            from_address: Default::default(),
+            block_number: Default::default(),
+            transaction_hash: Default::default(),
+        },
+        EmittedEvent {
+            data: vec![felt!("0x0"), felt!("0x3"), felt!("0x789")],
+            keys: vec![],
+            block_hash: Default::default(),
+            from_address: Default::default(),
+            block_number: Default::default(),
+            transaction_hash: Default::default(),
+        },
+    ];
+
+    let actual_contracts = parse_deployed_contracts_events(events);
+
+    assert_eq!(actual_contracts, expected_contracts);
 }

--- a/crates/sozo/src/ops/migration/migration_test.rs
+++ b/crates/sozo/src/ops/migration/migration_test.rs
@@ -138,7 +138,6 @@ async fn migration_from_remote() {
     let remote_manifest = Manifest::load_from_remote(
         JsonRpcClient::new(HttpTransport::new(sequencer.url())),
         migration.world_address().unwrap(),
-        None,
     )
     .await
     .unwrap();

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -218,7 +218,7 @@ where
         ui.print_sub(format!("Found remote World: {world_address:#x}"));
         ui.print_sub("Fetching remote state");
 
-        Manifest::load_from_remote(account.provider(), world_address, Some(local_manifest.clone()))
+        Manifest::load_from_remote(account.provider(), world_address)
             .await
             .map(Some)
             .map_err(|e| match e {


### PR DESCRIPTION
Able to build remote manifest using events, removing the reliance on a `match_manifest`