### PR TITLE
Allow update synced entities after `Client` is built

### DIFF
--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -806,7 +806,7 @@ test_manifest_file
     {
       "name": "player_actions",
       "address": null,
-      "class_hash": "0x53ce2324af80c9c879e2ccefd0feaef0c3461b6ddfb2e0d35a0e78d5ba76a08",
+      "class_hash": "0x473f9dbf12f5dae40e26219f7ff6c9156a7ace830a211be372e9b88136505c7",
       "abi": [
         {
           "type": "impl",

--- a/crates/torii/client/Cargo.toml
+++ b/crates/torii/client/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 starknet-crypto.workspace = true
 starknet.workspace = true
 thiserror.workspace = true
+tokio = { version = "1.32.0", features = [ "sync" ], default-features = false }
 torii-grpc = { path = "../grpc", features = [ "client" ] }
 url.workspace = true
 

--- a/crates/torii/client/src/client/error.rs
+++ b/crates/torii/client/src/client/error.rs
@@ -5,6 +5,8 @@ use starknet::providers::{JsonRpcClient, Provider};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Subscription service uninitialized")]
+    SubscriptionUninitialized,
     #[error("Unknown model: {0}")]
     UnknownModel(String),
     #[error(

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -14,6 +14,8 @@ use starknet::core::utils::cairo_short_string_to_felt;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet_crypto::FieldElement;
+use tokio::sync::RwLock as AsyncRwLock;
+use torii_grpc::protos::world::SubscribeEntitiesResponse;
 
 use self::error::{Error, ParseError};
 use self::storage::ModelStorage;
@@ -26,7 +28,7 @@ pub struct Client {
     /// Metadata of the World that the client is connected to.
     metadata: Arc<RwLock<WorldMetadata>>,
     /// The grpc client.
-    inner: torii_grpc::client::WorldClient,
+    inner: AsyncRwLock<torii_grpc::client::WorldClient>,
     /// Entity storage
     storage: Arc<ModelStorage>,
     /// Entities the client are subscribed to.
@@ -72,8 +74,9 @@ impl Client {
 
     /// Initiate the entity subscriptions and returns a [SubscriptionService] which when await'ed
     /// will execute the subscription service and starts the syncing process.
-    pub async fn start_subscription(&mut self) -> Result<SubscriptionService, Error> {
-        let sub_res_stream = self.inner.subscribe_entities(self.synced_entities()).await?;
+    pub async fn start_subscription(&self) -> Result<SubscriptionService, Error> {
+        let entities = self.synced_entities();
+        let sub_res_stream = self.initiate_subscription(entities).await?;
 
         let (service, handle) = SubscriptionService::new(
             Arc::clone(&self.storage),
@@ -84,6 +87,45 @@ impl Client {
 
         self.sub_client_handle.set(handle).unwrap();
         Ok(service)
+    }
+
+    /// Adds entities to the list of entities to be synced.
+    ///
+    /// NOTE: This will establish a new subscription stream with the server.
+    pub async fn add_entities_to_sync(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
+        self.subscribed_entities.add_entities(entities)?;
+        let updated_entities = self.synced_entities();
+        let sub_res_stream = self.initiate_subscription(updated_entities).await?;
+
+        match self.sub_client_handle.get() {
+            Some(handle) => handle.update_subscription_stream(sub_res_stream),
+            None => return Err(Error::SubscriptionUninitialized),
+        }
+        Ok(())
+    }
+
+    /// Removes entities from the list of entities to be synced.
+    ///
+    /// NOTE: This will establish a new subscription stream with the server.
+    pub async fn remove_entities_to_sync(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
+        self.subscribed_entities.remove_entities(entities)?;
+        let updated_entities = self.synced_entities();
+        let sub_res_stream = self.initiate_subscription(updated_entities).await?;
+
+        match self.sub_client_handle.get() {
+            Some(handle) => handle.update_subscription_stream(sub_res_stream),
+            None => return Err(Error::SubscriptionUninitialized),
+        }
+        Ok(())
+    }
+
+    async fn initiate_subscription(
+        &self,
+        entities: Vec<EntityModel>,
+    ) -> Result<tonic::Streaming<SubscribeEntitiesResponse>, Error> {
+        let mut grpc_client = self.inner.write().await;
+        let stream = grpc_client.subscribe_entities(entities).await?;
+        Ok(stream)
     }
 }
 
@@ -147,10 +189,10 @@ impl ClientBuilder {
         }
 
         Ok(Client {
-            inner: grpc_client,
             storage: client_storage,
             metadata: shared_metadata,
             sub_client_handle: OnceCell::new(),
+            inner: AsyncRwLock::new(grpc_client),
             subscribed_entities: subbed_entities,
         })
     }

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -94,6 +94,7 @@ impl Client {
     /// NOTE: This will establish a new subscription stream with the server.
     pub async fn add_entities_to_sync(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         self.subscribed_entities.add_entities(entities)?;
+
         let updated_entities = self.synced_entities();
         let sub_res_stream = self.initiate_subscription(updated_entities).await?;
 
@@ -109,6 +110,7 @@ impl Client {
     /// NOTE: This will establish a new subscription stream with the server.
     pub async fn remove_entities_to_sync(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         self.subscribed_entities.remove_entities(entities)?;
+
         let updated_entities = self.synced_entities();
         let sub_res_stream = self.initiate_subscription(updated_entities).await?;
 

--- a/crates/torii/client/wasm/Cargo.lock
+++ b/crates/torii/client/wasm/Cargo.lock
@@ -3997,6 +3997,7 @@ dependencies = [
  "starknet",
  "starknet-crypto",
  "thiserror",
+ "tokio",
  "tonic 0.10.1",
  "tonic 0.9.2",
  "torii-grpc",

--- a/crates/torii/client/wasm/index.js
+++ b/crates/torii/client/wasm/index.js
@@ -37,6 +37,17 @@ async function run_wasm() {
 					],
 				},
 			});
+
+			// Get the entity values from the sync worker
+			clientWorker.postMessage({
+				type: "getModelValue",
+				data: {
+					model: "Moves",
+					keys: [
+						"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+					],
+				},
+			});
 		}, 2000);
 	}, 1000);
 }

--- a/crates/torii/client/wasm/src/lib.rs
+++ b/crates/torii/client/wasm/src/lib.rs
@@ -58,6 +58,48 @@ impl Client {
         let entities = self.0.synced_entities();
         serde_wasm_bindgen::to_value(&entities).map_err(|e| e.into())
     }
+
+    #[wasm_bindgen(js_name = addEntitiesToSync)]
+    pub async fn add_entities_to_sync(
+        &mut self,
+        entities: Vec<JsEntityComponent>,
+    ) -> Result<(), JsValue> {
+        log("adding entities to sync...");
+
+        #[cfg(feature = "console-error-panic")]
+        console_error_panic_hook::set_once();
+
+        let entities = entities
+            .into_iter()
+            .map(serde_wasm_bindgen::from_value::<dojo_types::schema::EntityModel>)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.0
+            .add_entities_to_sync(entities)
+            .await
+            .map_err(|err| JsValue::from_str(&err.to_string()))
+    }
+
+    #[wasm_bindgen(js_name = removeEntitiesToSync)]
+    pub async fn remove_entities_to_sync(
+        &self,
+        entities: Vec<JsEntityComponent>,
+    ) -> Result<(), JsValue> {
+        log("removing entities to sync...");
+
+        #[cfg(feature = "console-error-panic")]
+        console_error_panic_hook::set_once();
+
+        let entities = entities
+            .into_iter()
+            .map(serde_wasm_bindgen::from_value::<dojo_types::schema::EntityModel>)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.0
+            .remove_entities_to_sync(entities)
+            .await
+            .map_err(|err| JsValue::from_str(&err.to_string()))
+    }
 }
 
 /// Spawns the client along with the subscription service.

--- a/crates/torii/client/wasm/src/lib.rs
+++ b/crates/torii/client/wasm/src/lib.rs
@@ -80,7 +80,7 @@ pub async fn spawn_client(
         JsValue::from_str(format!("failed to parse world address: {err}").as_str())
     })?;
 
-    let mut client = torii_client::client::ClientBuilder::new()
+    let client = torii_client::client::ClientBuilder::new()
         .set_entities_to_sync(entities)
         .build(torii_url.into(), rpc_url.into(), world_address)
         .await

--- a/crates/torii/client/wasm/worker.js
+++ b/crates/torii/client/wasm/worker.js
@@ -17,7 +17,7 @@ async function setup() {
 		const client = await spawn_client(
 			"http://localhost:8080/grpc",
 			"http://localhost:5050",
-			"0x4cf3f4fa5ffd94a2af92946e13fe7faafb8045fb9446cec6ba97ca34e78bc05",
+			"0x3fa481f41522b90b3684ecfab7650c259a76387fab9c380b7a959e3d4ac69f",
 			[
 				{
 					model: "Position",
@@ -27,6 +27,17 @@ async function setup() {
 				},
 			]
 		);
+
+		setTimeout(() => {
+			client.addEntitiesToSync([
+				{
+					model: "Moves",
+					keys: [
+						"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+					],
+				},
+			]);
+		}, 10000);
 
 		// setup the message handler for the worker
 		self.onmessage = function (e) {

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -336,7 +336,7 @@ impl Sql {
         if let Ty::Struct(s) = model {
             for (member_idx, member) in s.children.iter().enumerate() {
                 let name = member.name.clone();
-                let mut options = None;
+                let mut options = None; // TEMP: doesnt support complex enums yet
 
                 if let Ok(cairo_type) = Primitive::from_str(&member.ty.name()) {
                     query.push_str(&format!("external_{name} {}, ", cairo_type.to_sql_type()));

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -316,7 +316,6 @@ impl Sql {
                 for child in e.options.iter() {
                     let mut path_clone = path.clone();
                     path_clone.push(child.1.name());
-                    // self.build_entity_query(path_clone.clone(), id, &child.1);
                     self.build_set_entity_queries_recursive(
                         path_clone, event_id, entity_id, &child.1,
                     );
@@ -337,27 +336,36 @@ impl Sql {
         if let Ty::Struct(s) = model {
             for (member_idx, member) in s.children.iter().enumerate() {
                 let name = member.name.clone();
+                let mut options = None;
+
                 if let Ok(cairo_type) = Primitive::from_str(&member.ty.name()) {
                     query.push_str(&format!("external_{name} {}, ", cairo_type.to_sql_type()));
                 } else if let Ty::Enum(e) = &member.ty {
-                    let options = e
+                    let all_options = e
                         .options
                         .iter()
                         .map(|c| format!("'{}'", c.0))
                         .collect::<Vec<_>>()
                         .join(", ");
+
                     query.push_str(&format!(
-                        "external_{name} TEXT CHECK(external_{name} IN ({options})) NOT NULL, ",
+                        "external_{name} TEXT CHECK(external_{name} IN ({all_options})) NOT NULL, ",
+                    ));
+
+                    options = Some(format!(
+                        r#""{}""#,
+                        e.options.iter().map(|c| c.0.clone()).collect::<Vec<_>>().join(",")
                     ));
                 }
 
                 self.query_queue.push(format!(
                     "INSERT OR IGNORE INTO model_members (id, model_id, model_idx, member_idx, \
-                     name, type, type_enum, key) VALUES ('{table_id}', '{}', '{model_idx}', \
-                     '{member_idx}', '{name}', '{}', '{}', {})",
+                     name, type, type_enum, enum_options, key) VALUES ('{table_id}', '{}', \
+                     '{model_idx}', '{member_idx}', '{name}', '{}', '{}', {}, {})",
                     path[0],
                     member.ty.name(),
                     member.ty.as_ref(),
+                    options.unwrap_or("NULL".into()),
                     member.key,
                 ));
             }

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -8,17 +8,15 @@ service World {
     // Retrieves metadata about the World including all the registered components and systems.
     rpc WorldMetadata (MetadataRequest) returns (MetadataResponse);
    
-    /* 
-     * Subscribes to entity updates.
-     * Bidirectional streaming as we want to allow user to change the list of entities to subscribe to without closing the connection.
-     */
+     
+    // Subscribes to entity updates.
     rpc SubscribeEntities (SubscribeEntitiesRequest) returns (stream SubscribeEntitiesResponse);
 }
 
 
 // A request to retrieve metadata for a specific world ID.
 message MetadataRequest {
-   
+
 }
 
 // The metadata response contains addresses and class hashes for the world.

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -94,12 +94,13 @@ impl DojoWorld {
 
     async fn model_schema(&self, model: &str) -> Result<dojo_types::schema::Ty, Error> {
         let model_members: Vec<SqlModelMember> = sqlx::query_as(
-            "SELECT id, model_idx, member_idx, name, type, type_enum, key FROM model_members \
-             WHERE model_id = ? ORDER BY model_idx ASC, member_idx ASC",
+            "SELECT id, model_idx, member_idx, name, type, type_enum, enum_options, key FROM \
+             model_members WHERE model_id = ? ORDER BY model_idx ASC, member_idx ASC",
         )
         .bind(model)
         .fetch_all(&self.pool)
         .await?;
+
         Ok(parse_sql_model_members(model, &model_members))
     }
 

--- a/crates/torii/grpc/src/server/utils.rs
+++ b/crates/torii/grpc/src/server/utils.rs
@@ -9,6 +9,7 @@ pub struct SqlModelMember {
     name: String,
     r#type: String,
     type_enum: String,
+    enum_options: Option<String>,
     key: bool,
 }
 
@@ -40,9 +41,15 @@ pub fn parse_sql_model_members(model: &str, model_members_all: &[SqlModelMember]
                     key: child.key,
                     name: child.name.to_owned(),
                     ty: Ty::Enum(Enum {
-                        name: child.r#type.to_owned(),
-                        options: vec![],
                         option: None,
+                        name: child.r#type.to_owned(),
+                        options: child
+                            .enum_options
+                            .as_ref()
+                            .expect("qed; enum_options should exist")
+                            .split(',')
+                            .map(|s| (s.to_owned(), Ty::Tuple(vec![])))
+                            .collect::<Vec<_>>(),
                     }),
                 },
 
@@ -63,7 +70,7 @@ pub fn parse_sql_model_members(model: &str, model_members_all: &[SqlModelMember]
 
 #[cfg(test)]
 mod tests {
-    use dojo_types::schema::{Member, Struct, Ty};
+    use dojo_types::schema::{Enum, Member, Struct, Ty};
 
     use super::SqlModelMember;
     use crate::server::utils::parse_sql_model_members;
@@ -79,6 +86,7 @@ mod tests {
                 model_idx: 0,
                 member_idx: 0,
                 type_enum: "Primitive".into(),
+                enum_options: None,
             },
             SqlModelMember {
                 id: "Position".into(),
@@ -88,6 +96,7 @@ mod tests {
                 model_idx: 0,
                 member_idx: 1,
                 type_enum: "Primitive".into(),
+                enum_options: None,
             },
         ];
 
@@ -196,5 +205,39 @@ mod tests {
         });
 
         assert_eq!(parse_sql_model_members("Position", &model_members), expected_ty);
+    }
+
+    #[test]
+    fn parse_model_members_with_enum_to_ty() {
+        let model_members = vec![SqlModelMember {
+            id: "Moves".into(),
+            name: "direction".into(),
+            r#type: "Direction".into(),
+            key: false,
+            model_idx: 0,
+            member_idx: 0,
+            type_enum: "Enum".into(),
+            enum_options: Some("Up,Down,Left,Right".into()),
+        }];
+
+        let expected_ty = Ty::Struct(Struct {
+            name: "Moves".into(),
+            children: vec![dojo_types::schema::Member {
+                name: "direction".into(),
+                key: false,
+                ty: Ty::Enum(Enum {
+                    name: "Direction".into(),
+                    option: None,
+                    options: vec![
+                        ("Up".into(), Ty::Tuple(vec![])),
+                        ("Down".into(), Ty::Tuple(vec![])),
+                        ("Left".into(), Ty::Tuple(vec![])),
+                        ("Right".into(), Ty::Tuple(vec![])),
+                    ],
+                }),
+            }],
+        });
+
+        assert_eq!(parse_sql_model_members("Moves", &model_members), expected_ty);
     }
 }

--- a/crates/torii/grpc/src/server/utils.rs
+++ b/crates/torii/grpc/src/server/utils.rs
@@ -130,6 +130,7 @@ mod tests {
                 model_idx: 0,
                 member_idx: 0,
                 type_enum: "Primitive".into(),
+                enum_options: None,
             },
             SqlModelMember {
                 id: "Position".into(),
@@ -139,6 +140,7 @@ mod tests {
                 model_idx: 0,
                 member_idx: 1,
                 type_enum: "Primitive".into(),
+                enum_options: None,
             },
             SqlModelMember {
                 id: "Position".into(),
@@ -148,6 +150,7 @@ mod tests {
                 model_idx: 0,
                 member_idx: 1,
                 type_enum: "Struct".into(),
+                enum_options: None,
             },
             SqlModelMember {
                 id: "Position$Vec2".into(),
@@ -157,6 +160,7 @@ mod tests {
                 model_idx: 1,
                 member_idx: 0,
                 type_enum: "Primitive".into(),
+                enum_options: None,
             },
             SqlModelMember {
                 id: "Position$Vec2".into(),
@@ -166,6 +170,7 @@ mod tests {
                 model_idx: 1,
                 member_idx: 1,
                 type_enum: "Primitive".into(),
+                enum_options: None,
             },
         ];
 

--- a/crates/torii/migrations/20230316154230_setup.sql
+++ b/crates/torii/migrations/20230316154230_setup.sql
@@ -43,6 +43,7 @@ CREATE TABLE model_members(
     type_enum TEXT DEFAULT 'Primitive' CHECK(
         type_enum IN ('Primitive', 'Struct', 'Enum', 'Tuple')
     ) NOT NULL,
+    enum_options TEXT NULL,
     key BOOLEAN NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id, member_idx) FOREIGN KEY (model_id) REFERENCES models(id)

--- a/crates/torii/migrations/20230316154230_setup.sql
+++ b/crates/torii/migrations/20230316154230_setup.sql
@@ -43,7 +43,7 @@ CREATE TABLE model_members(
     type_enum TEXT DEFAULT 'Primitive' CHECK(
         type_enum IN ('Primitive', 'Struct', 'Enum', 'Tuple')
     ) NOT NULL,
-    enum_options TEXT NULL,
+    enum_options TEXT NULL,  -- TEMP: Remove once enum support is properly added
     key BOOLEAN NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id, member_idx) FOREIGN KEY (model_id) REFERENCES models(id)

--- a/examples/ecs/src/systems/with_decorator.cairo
+++ b/examples/ecs/src/systems/with_decorator.cairo
@@ -99,7 +99,7 @@ mod tests {
         let moves = get!(world, caller, Moves);
         let right_dir_felt: felt252 = Direction::Right(()).into();
 
-        assert(moves.remaining == 9, 'moves is wrong');
+        assert(moves.remaining == 0, 'moves is wrong');
         assert(moves.last_direction.into() == right_dir_felt, 'last direction is wrong');
 
         let new_position = get!(world, caller, Position);

--- a/examples/ecs/src/systems/with_decorator.cairo
+++ b/examples/ecs/src/systems/with_decorator.cairo
@@ -36,10 +36,14 @@ mod player_actions {
             let world = self.world_dispatcher.read();
             let player = get_caller_address();
             let position = get!(world, player, (Position));
+            let moves = get!(world, player, (Moves));
+
             set!(
                 world,
                 (
-                    Moves { player, remaining: 10, last_direction: Direction::None(()) },
+                    Moves {
+                        player, remaining: moves.remaining + 1, last_direction: Direction::None(())
+                    },
                     Position {
                         player, vec: Vec2 { x: position.vec.x + 10, y: position.vec.y + 10 }
                     },


### PR DESCRIPTION
- allow update on runtime
- store enum options in sql
