### PR TITLE
Initiate value of newly added entities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8209,7 +8209,6 @@ dependencies = [
 name = "torii-client"
 version = "0.3.0-rc9"
 dependencies = [
- "anyhow",
  "async-trait",
  "camino",
  "crypto-bigint",

--- a/crates/torii/client/Cargo.toml
+++ b/crates/torii/client/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.3.0-rc9"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow.workspace = true
 async-trait.workspace = true
 crypto-bigint = "0.5.3"
 dojo-types = { path = "../../dojo-types" }

--- a/crates/torii/client/src/client/error.rs
+++ b/crates/torii/client/src/client/error.rs
@@ -19,8 +19,6 @@ pub enum Error {
     #[error(transparent)]
     GrpcClient(#[from] torii_grpc::client::Error),
     #[error(transparent)]
-    Other(#[from] anyhow::Error),
-    #[error(transparent)]
     Model(#[from] ModelError<<JsonRpcClient<HttpTransport> as Provider>::Error>),
 }
 

--- a/crates/torii/client/src/client/subscription.rs
+++ b/crates/torii/client/src/client/subscription.rs
@@ -43,14 +43,14 @@ impl SubscribedEntities {
 
     pub fn add_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         for entity in entities {
-            Self::add_entity(&self, entity)?;
+            Self::add_entity(self, entity)?;
         }
         Ok(())
     }
 
     pub fn remove_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         for entity in entities {
-            Self::remove_entity(&self, entity)?;
+            Self::remove_entity(self, entity)?;
         }
         Ok(())
     }

--- a/crates/torii/client/src/client/subscription.rs
+++ b/crates/torii/client/src/client/subscription.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Poll;
 
-use anyhow::{anyhow, Result};
 use dojo_types::schema::EntityModel;
 use dojo_types::WorldMetadata;
 use futures::channel::mpsc::{self, Receiver, Sender};
@@ -44,60 +43,70 @@ impl SubscribedEntities {
 
     pub fn add_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         for entity in entities {
-            if !self.entities.write().insert(entity.clone()) {
-                continue;
-            }
-
-            let model_packed_size = self
-                .metadata
-                .read()
-                .models
-                .get(&entity.model)
-                .map(|c| c.packed_size)
-                .ok_or(Error::UnknownModel(entity.model.clone()))?;
-
-            let storage_addresses = compute_all_storage_addresses(
-                cairo_short_string_to_felt(&entity.model)
-                    .map_err(ParseError::CairoShortStringToFelt)?,
-                &entity.keys,
-                model_packed_size,
-            );
-
-            let storage_lock = &mut self.subscribed_storage_addresses.write();
-            storage_addresses.into_iter().for_each(|address| {
-                storage_lock.insert(address);
-            });
+            Self::add_entity(&self, entity)?;
         }
-
         Ok(())
     }
 
     pub fn remove_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         for entity in entities {
-            if !self.entities.write().remove(&entity) {
-                continue;
-            }
-
-            let model_packed_size = self
-                .metadata
-                .read()
-                .models
-                .get(&entity.model)
-                .map(|c| c.packed_size)
-                .ok_or(anyhow!("unknown component {}", entity.model))?;
-
-            let storage_addresses = compute_all_storage_addresses(
-                cairo_short_string_to_felt(&entity.model)
-                    .map_err(ParseError::CairoShortStringToFelt)?,
-                &entity.keys,
-                model_packed_size,
-            );
-
-            let storage_lock = &mut self.subscribed_storage_addresses.write();
-            storage_addresses.iter().for_each(|address| {
-                storage_lock.remove(address);
-            });
+            Self::remove_entity(&self, entity)?;
         }
+        Ok(())
+    }
+
+    pub(crate) fn add_entity(&self, entity: EntityModel) -> Result<(), Error> {
+        if !self.entities.write().insert(entity.clone()) {
+            return Ok(());
+        }
+
+        let model_packed_size = self
+            .metadata
+            .read()
+            .models
+            .get(&entity.model)
+            .map(|c| c.packed_size)
+            .ok_or(Error::UnknownModel(entity.model.clone()))?;
+
+        let storage_addresses = compute_all_storage_addresses(
+            cairo_short_string_to_felt(&entity.model)
+                .map_err(ParseError::CairoShortStringToFelt)?,
+            &entity.keys,
+            model_packed_size,
+        );
+
+        let storage_lock = &mut self.subscribed_storage_addresses.write();
+        storage_addresses.into_iter().for_each(|address| {
+            storage_lock.insert(address);
+        });
+
+        Ok(())
+    }
+
+    pub(crate) fn remove_entity(&self, entity: EntityModel) -> Result<(), Error> {
+        if !self.entities.write().remove(&entity) {
+            return Ok(());
+        }
+
+        let model_packed_size = self
+            .metadata
+            .read()
+            .models
+            .get(&entity.model)
+            .map(|c| c.packed_size)
+            .ok_or(Error::UnknownModel(entity.model.clone()))?;
+
+        let storage_addresses = compute_all_storage_addresses(
+            cairo_short_string_to_felt(&entity.model)
+                .map_err(ParseError::CairoShortStringToFelt)?,
+            &entity.keys,
+            model_packed_size,
+        );
+
+        let storage_lock = &mut self.subscribed_storage_addresses.write();
+        storage_addresses.iter().for_each(|address| {
+            storage_lock.remove(address);
+        });
 
         Ok(())
     }

--- a/crates/torii/client/wasm/Cargo.lock
+++ b/crates/torii/client/wasm/Cargo.lock
@@ -3982,7 +3982,6 @@ dependencies = [
 name = "torii-client"
 version = "0.3.0-rc9"
 dependencies = [
- "anyhow",
  "async-trait",
  "crypto-bigint",
  "dojo-types",

--- a/crates/torii/client/wasm/worker.js
+++ b/crates/torii/client/wasm/worker.js
@@ -15,8 +15,8 @@ async function setup() {
 
 	try {
 		const client = await spawn_client(
-			"http://localhost:8080/grpc",
-			"http://localhost:5050",
+			"http://0.0.0.0:8080/grpc",
+			"http://0.0.0.0:5050",
 			"0x3fa481f41522b90b3684ecfab7650c259a76387fab9c380b7a959e3d4ac69f",
 			[
 				{


### PR DESCRIPTION
When adding new entities to be synced by the client, the latest values of the entities must be fetched first