### PR TITLE
Fix graphql return felt arrays as lists

### DIFF
--- a/crates/dojo-types/src/primitive.rs
+++ b/crates/dojo-types/src/primitive.rs
@@ -35,20 +35,27 @@ pub enum PrimitiveError {
     ValueOutOfRange(#[from] ValueOutOfRangeError),
 }
 
+#[derive(AsRefStr, Debug, Display, EnumString, PartialEq)]
+#[strum(serialize_all = "UPPERCASE")]
+pub enum SqlType {
+    Integer,
+    Text,
+}
+
 impl Primitive {
-    pub fn to_sql_type(&self) -> String {
+    pub fn to_sql_type(&self) -> SqlType {
         match self {
             Primitive::U8(_)
             | Primitive::U16(_)
             | Primitive::U32(_)
             | Primitive::U64(_)
             | Primitive::USize(_)
-            | Primitive::Bool(_) => "INTEGER".to_string(),
+            | Primitive::Bool(_) => SqlType::Integer,
             Primitive::U128(_)
             | Primitive::U256(_)
             | Primitive::ContractAddress(_)
             | Primitive::ClassHash(_)
-            | Primitive::Felt252(_) => "TEXT".to_string(),
+            | Primitive::Felt252(_) => SqlType::Text,
         }
     }
 

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -14,6 +14,8 @@ use super::World;
 use crate::simple_broker::SimpleBroker;
 use crate::types::{Entity, Model as ModelType};
 
+pub const FELT_DELIMITER: &str = "/";
+
 #[cfg(test)]
 #[path = "sql_test.rs"]
 mod test;
@@ -401,5 +403,6 @@ impl Sql {
 }
 
 fn felts_sql_string(felts: &[FieldElement]) -> String {
-    felts.iter().map(|k| format!("{:#x}", k)).collect::<Vec<String>>().join("/") + "/"
+    felts.iter().map(|k| format!("{:#x}", k)).collect::<Vec<String>>().join(FELT_DELIMITER)
+        + FELT_DELIMITER
 }

--- a/crates/torii/graphql/src/mapping.rs
+++ b/crates/torii/graphql/src/mapping.rs
@@ -9,7 +9,7 @@ use crate::types::{GraphqlType, TypeData, TypeMapping};
 lazy_static! {
     pub static ref ENTITY_TYPE_MAPPING: TypeMapping = IndexMap::from([
         (Name::new("id"), TypeData::Simple(TypeRef::named(TypeRef::ID))),
-        (Name::new("keys"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("keys"), TypeData::Simple(TypeRef::named_list(TypeRef::STRING))),
         (Name::new("model_names"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
         (Name::new("event_id"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
         (
@@ -23,8 +23,8 @@ lazy_static! {
     ]);
     pub static ref EVENT_TYPE_MAPPING: TypeMapping = IndexMap::from([
         (Name::new("id"), TypeData::Simple(TypeRef::named(TypeRef::ID))),
-        (Name::new("keys"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("data"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("keys"), TypeData::Simple(TypeRef::named_list(TypeRef::STRING))),
+        (Name::new("data"), TypeData::Simple(TypeRef::named_list(TypeRef::STRING))),
         (
             Name::new("created_at"),
             TypeData::Simple(TypeRef::named(GraphqlType::DateTime.to_string())),


### PR DESCRIPTION
- Fixes entity query regression where keys are returned as string instead of list
- Events query also returns keys and data felt arrays as list