### PR TITLE
fix(sozo-migrate): migrate contracts on update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,7 @@ dependencies = [
  "itertools 0.11.0",
  "num-bigint",
  "num-traits 0.2.17",
- "rayon 1.8.0",
+ "rayon",
  "salsa",
  "thiserror",
 ]
@@ -2828,7 +2828,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "path-slash",
- "rayon 1.8.0",
+ "rayon",
  "regex",
  "semver",
  "serde",
@@ -4674,7 +4674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
 dependencies = [
  "crossbeam",
- "rayon 1.8.0",
+ "rayon",
 ]
 
 [[package]]
@@ -6057,16 +6057,6 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
-dependencies = [
- "either",
- "rayon-core",
-]
 
 [[package]]
 name = "rayon"
@@ -8124,7 +8114,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prost 0.11.9",
  "prost 0.12.1",
- "rayon 0.9.0",
+ "rayon",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ num-bigint = "0.4"
 once_cell = "1.0"
 parking_lot = "0.12.1"
 pretty_assertions = "1.2.1"
-rayon = "0.9.0"
+rayon = "1.8.0"
 salsa = "0.16.1"
 scarb = { git = "https://github.com/software-mansion/scarb", rev = "7adb7fd" }
 scarb-ui = { git = "https://github.com/software-mansion/scarb", rev = "7adb7fd" }

--- a/crates/dojo-core/src/base.cairo
+++ b/crates/dojo-core/src/base.cairo
@@ -1,5 +1,3 @@
-use starknet::{ClassHash, SyscallResult, SyscallResultTrait};
-
 use dojo::world::IWorldDispatcher;
 
 #[starknet::interface]

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -9,6 +9,7 @@ trait IWorld<T> {
     fn model(self: @T, name: felt252) -> ClassHash;
     fn register_model(ref self: T, class_hash: ClassHash);
     fn deploy_contract(ref self: T, salt: felt252, class_hash: ClassHash) -> ContractAddress;
+    fn upgrade_contract(ref self: T, address: ContractAddress, class_hash: ClassHash) -> ClassHash;
     fn uuid(ref self: T) -> usize;
     fn emit(self: @T, keys: Array<felt252>, values: Span<felt252>);
     fn entity(
@@ -46,11 +47,14 @@ trait IWorld<T> {
 
 #[starknet::contract]
 mod world {
+    use core::traits::TryInto;
     use array::{ArrayTrait, SpanTrait};
     use traits::Into;
     use option::OptionTrait;
     use box::BoxTrait;
     use serde::Serde;
+    use core::hash::{HashStateExTrait, HashStateTrait};
+    use pedersen::{PedersenTrait, HashStateImpl, PedersenImpl};
     use starknet::{
         get_caller_address, get_contract_address, get_tx_info,
         contract_address::ContractAddressIntoFelt252, ClassHash, Zeroable, ContractAddress,
@@ -75,6 +79,7 @@ mod world {
     enum Event {
         WorldSpawned: WorldSpawned,
         ContractDeployed: ContractDeployed,
+        ContractUpgraded: ContractUpgraded,
         MetadataUpdate: MetadataUpdate,
         ModelRegistered: ModelRegistered,
         StoreSetRecord: StoreSetRecord,
@@ -93,6 +98,12 @@ mod world {
     #[derive(Drop, starknet::Event)]
     struct ContractDeployed {
         salt: felt252,
+        class_hash: ClassHash,
+        address: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ContractUpgraded {
         class_hash: ClassHash,
         address: ContractAddress,
     }
@@ -386,7 +397,7 @@ mod world {
         ///
         /// # Returns
         ///
-        /// * `ClassHash` - The class hash of the model.
+        /// * `ContractAddress` - The address of the newly deployed contract.
         fn deploy_contract(
             ref self: ContractState, salt: felt252, class_hash: ClassHash
         ) -> ContractAddress {
@@ -402,6 +413,24 @@ mod world {
             );
 
             contract_address
+        }
+
+        /// Upgrade an already deployed contract associated with the world.
+        ///
+        /// # Arguments
+        ///
+        /// * `name` - The name of the contract.
+        /// * `class_hash` - The class_hash of the contract.
+        ///
+        /// # Returns
+        ///
+        /// * `ClassHash` - The new class hash of the contract.
+        fn upgrade_contract(
+            ref self: ContractState, address: ContractAddress, class_hash: ClassHash
+        ) -> ClassHash {
+            IUpgradeableDispatcher { contract_address: address }.upgrade(class_hash);
+            EventEmitter::emit(ref self, ContractUpgraded { class_hash, address });
+            class_hash
         }
 
         /// Issues an autoincremented id to the caller.
@@ -528,10 +557,7 @@ mod world {
         /// # Returns
         /// * `Span<felt252>` - The entity IDs.
         /// * `Span<Span<felt252>>` - The entities.
-        fn entity_ids(
-            self: @ContractState,
-            model: felt252
-        ) -> Span<felt252> {
+        fn entity_ids(self: @ContractState, model: felt252) -> Span<felt252> {
             database::scan_ids(model, Option::None(()))
         }
 

--- a/crates/dojo-lang/src/contract.rs
+++ b/crates/dojo-lang/src/contract.rs
@@ -66,8 +66,8 @@ impl DojoContract {
                         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
                             let caller = get_caller_address();
                             assert(
-                                self.world_dispatcher.read().contract_address == caller, 
-                                'only World can upgrade'
+                                self.world_dispatcher.read().contract_address == caller, 'only \
+                 World can upgrade'
                             );
                             UpgradeableTrait::upgrade(new_class_hash);
                         }

--- a/crates/dojo-lang/src/contract.rs
+++ b/crates/dojo-lang/src/contract.rs
@@ -48,6 +48,8 @@ impl DojoContract {
                     use dojo::world;
                     use dojo::world::IWorldDispatcher;
                     use dojo::world::IWorldDispatcherTrait;
+                    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+                    use starknet::ClassHash;
 
                     #[storage]
                     struct Storage {
@@ -57,6 +59,18 @@ impl DojoContract {
                     #[external(v0)]
                     fn name(self: @ContractState) -> felt252 {
                         '$name$'
+                    }
+
+                    #[external(v0)]
+                    impl Upgradeable of IUpgradeable<ContractState> {
+                        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+                            let caller = get_caller_address();
+                            assert(
+                                self.world_dispatcher.read().contract_address == caller, 
+                                'only World can upgrade'
+                            );
+                            UpgradeableTrait::upgrade(new_class_hash);
+                        }
                     }
 
                     $body$

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -8,7 +8,7 @@ test_manifest_file
   "world": {
     "name": "world",
     "address": null,
-    "class_hash": "0x2611f073498530f0faa0fda87956a405ae8cbd85cc6a28f4d8961d66cc51e4b",
+    "class_hash": "0x3a169231d52d573644a0c6b607eea710d8e24aca21160ab85c50fcb202cffde",
     "abi": [
       {
         "type": "impl",
@@ -153,6 +153,26 @@ test_manifest_file
             "outputs": [
               {
                 "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "upgrade_contract",
+            "inputs": [
+              {
+                "name": "address",
+                "type": "core::starknet::contract_address::ContractAddress"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::starknet::class_hash::ClassHash"
               }
             ],
             "state_mutability": "external"
@@ -503,6 +523,23 @@ test_manifest_file
       },
       {
         "type": "event",
+        "name": "dojo::world::world::ContractUpgraded",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          },
+          {
+            "name": "address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
         "name": "dojo::world::world::MetadataUpdate",
         "kind": "struct",
         "members": [
@@ -658,6 +695,11 @@ test_manifest_file
           {
             "name": "ContractDeployed",
             "type": "dojo::world::world::ContractDeployed",
+            "kind": "nested"
+          },
+          {
+            "name": "ContractUpgraded",
+            "type": "dojo::world::world::ContractUpgraded",
             "kind": "nested"
           },
           {
@@ -822,7 +864,7 @@ test_manifest_file
     {
       "name": "actions",
       "address": null,
-      "class_hash": "0x4b3a8688b75ebacf254b07671f3dacaada9f23bac37c61f9561bbe4ead1c112",
+      "class_hash": "0x879e001074687da51991333bd4c3f8121bfa77547dd6daa4ff9330d1cfcd7e",
       "abi": [
         {
           "type": "impl",
@@ -884,11 +926,18 @@ test_manifest_file
           "items": [
             {
               "type": "function",
-              "name": "upgrade",
+              "name": "spawn",
+              "inputs": [],
+              "outputs": [],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "move",
               "inputs": [
                 {
-                  "name": "new_class_hash",
-                  "type": "core::starknet::class_hash::ClassHash"
+                  "name": "direction",
+                  "type": "dojo_examples::models::Direction"
                 }
               ],
               "outputs": [],

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -826,6 +826,29 @@ test_manifest_file
       "abi": [
         {
           "type": "impl",
+          "name": "Upgradeable",
+          "interface_name": "dojo::upgradable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::upgradable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "impl",
           "name": "ActionsImpl",
           "interface_name": "dojo_examples::actions::IActions"
         },
@@ -861,18 +884,11 @@ test_manifest_file
           "items": [
             {
               "type": "function",
-              "name": "spawn",
-              "inputs": [],
-              "outputs": [],
-              "state_mutability": "view"
-            },
-            {
-              "type": "function",
-              "name": "move",
+              "name": "upgrade",
               "inputs": [
                 {
-                  "name": "direction",
-                  "type": "dojo_examples::models::Direction"
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
                 }
               ],
               "outputs": [],

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -55,8 +55,7 @@ mod spawn {
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 
-                'only World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
             );
             UpgradeableTrait::upgrade(new_class_hash);
         }
@@ -95,8 +94,7 @@ mod proxy {
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 
-                'only World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
             );
             UpgradeableTrait::upgrade(new_class_hash);
         }
@@ -133,8 +131,7 @@ mod ctxnamed {
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 
-                'only World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
             );
             UpgradeableTrait::upgrade(new_class_hash);
         }

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -37,6 +37,8 @@ mod spawn {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
+    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -46,6 +48,18 @@ mod spawn {
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'spawn'
+    }
+
+    #[external(v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            let caller = get_caller_address();
+            assert(
+                self.world_dispatcher.read().contract_address == caller, 
+                'only World can upgrade'
+            );
+            UpgradeableTrait::upgrade(new_class_hash);
+        }
     }
 
     use traits::Into;
@@ -63,6 +77,8 @@ mod proxy {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
+    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -72,6 +88,18 @@ mod proxy {
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'proxy'
+    }
+
+    #[external(v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            let caller = get_caller_address();
+            assert(
+                self.world_dispatcher.read().contract_address == caller, 
+                'only World can upgrade'
+            );
+            UpgradeableTrait::upgrade(new_class_hash);
+        }
     }
 
 
@@ -87,6 +115,8 @@ mod ctxnamed {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
+    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -96,6 +126,18 @@ mod ctxnamed {
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'ctxnamed'
+    }
+
+    #[external(v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            let caller = get_caller_address();
+            assert(
+                self.world_dispatcher.read().contract_address == caller, 
+                'only World can upgrade'
+            );
+            UpgradeableTrait::upgrade(new_class_hash);
+        }
     }
 
     use traits::Into;

--- a/crates/torii/client/wasm/Cargo.lock
+++ b/crates/torii/client/wasm/Cargo.lock
@@ -2616,9 +2616,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "0.9.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",


### PR DESCRIPTION
Changed:
- derive upgradable on contracts with `#[dojo::contract]` attribute, to allow upgrading contracts implementation.
- add `upgrade_contract` function in the World contract for upgrading deployed contract.
- add `ContractUpgraded` event which will be emitted upon upgrading a contract.
- improve remote manifest generation

Fixed:
- fix updating changed contracts on `sozo migrate`

NOTES:
- upon this change, to allow systems contract to be upgradable `#[dojo::contract]` MUST be used over `#[starknet::contract]` provided by the base language.