### PR TITLE
Derive upgradable for contracts

### DIFF
--- a/crates/dojo-core/src/base.cairo
+++ b/crates/dojo-core/src/base.cairo
@@ -1,5 +1,3 @@
-use starknet::{ClassHash, SyscallResult, SyscallResultTrait};
-
 use dojo::world::IWorldDispatcher;
 
 #[starknet::interface]

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -428,6 +428,8 @@ mod world {
         fn upgrade_contract(
             ref self: ContractState, address: ContractAddress, class_hash: ClassHash
         ) -> ClassHash {
+            // Only owner can upgrade contract
+            assert(self.is_owner(get_caller_address(), WORLD), 'only owner can upgrade contract');
             IUpgradeableDispatcher { contract_address: address }.upgrade(class_hash);
             EventEmitter::emit(ref self, ContractUpgraded { class_hash, address });
             class_hash

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -408,6 +408,8 @@ mod world {
             let upgradable_dispatcher = IUpgradeableDispatcher { contract_address };
             upgradable_dispatcher.upgrade(class_hash);
 
+            self.owners.write((contract_address.into(), get_caller_address()), true);
+
             EventEmitter::emit(
                 ref self, ContractDeployed { salt, class_hash, address: contract_address }
             );
@@ -429,7 +431,7 @@ mod world {
             ref self: ContractState, address: ContractAddress, class_hash: ClassHash
         ) -> ClassHash {
             // Only owner can upgrade contract
-            assert(self.is_owner(get_caller_address(), address), 'only owner can upgrade contract');
+            assert_can_write(@self, address.into(), get_caller_address());
             IUpgradeableDispatcher { contract_address: address }.upgrade(class_hash);
             EventEmitter::emit(ref self, ContractUpgraded { class_hash, address });
             class_hash
@@ -604,12 +606,12 @@ mod world {
     ///
     /// # Arguments
     ///
-    /// * `model` - The name of the model being written to.
+    /// * `resource` - The name of the resource being written to.
     /// * `caller` - The name of the caller writing.
-    fn assert_can_write(self: @ContractState, model: felt252, caller: ContractAddress) {
+    fn assert_can_write(self: @ContractState, resource: felt252, caller: ContractAddress) {
         assert(
-            IWorld::is_writer(self, model, caller)
-                || IWorld::is_owner(self, get_tx_info().unbox().account_contract_address, model)
+            IWorld::is_writer(self, resource, caller)
+                || IWorld::is_owner(self, get_tx_info().unbox().account_contract_address, resource)
                 || IWorld::is_owner(self, get_tx_info().unbox().account_contract_address, WORLD),
             'not writer'
         );

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -9,6 +9,7 @@ trait IWorld<T> {
     fn model(self: @T, name: felt252) -> ClassHash;
     fn register_model(ref self: T, class_hash: ClassHash);
     fn deploy_contract(ref self: T, salt: felt252, class_hash: ClassHash) -> ContractAddress;
+    fn upgrade_contract(ref self: T, address: ContractAddress, class_hash: ClassHash) -> ClassHash;
     fn uuid(ref self: T) -> usize;
     fn emit(self: @T, keys: Array<felt252>, values: Span<felt252>);
     fn entity(
@@ -46,11 +47,14 @@ trait IWorld<T> {
 
 #[starknet::contract]
 mod world {
+    use core::traits::TryInto;
     use array::{ArrayTrait, SpanTrait};
     use traits::Into;
     use option::OptionTrait;
     use box::BoxTrait;
     use serde::Serde;
+    use core::hash::{HashStateExTrait, HashStateTrait};
+    use pedersen::{PedersenTrait, HashStateImpl, PedersenImpl};
     use starknet::{
         get_caller_address, get_contract_address, get_tx_info,
         contract_address::ContractAddressIntoFelt252, ClassHash, Zeroable, ContractAddress,
@@ -75,6 +79,7 @@ mod world {
     enum Event {
         WorldSpawned: WorldSpawned,
         ContractDeployed: ContractDeployed,
+        ContractUpgraded: ContractUpgraded,
         MetadataUpdate: MetadataUpdate,
         ModelRegistered: ModelRegistered,
         StoreSetRecord: StoreSetRecord,
@@ -93,6 +98,12 @@ mod world {
     #[derive(Drop, starknet::Event)]
     struct ContractDeployed {
         salt: felt252,
+        class_hash: ClassHash,
+        address: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ContractUpgraded {
         class_hash: ClassHash,
         address: ContractAddress,
     }
@@ -386,7 +397,7 @@ mod world {
         ///
         /// # Returns
         ///
-        /// * `ClassHash` - The class hash of the model.
+        /// * `ContractAddress` - The address of the newly deployed contract.
         fn deploy_contract(
             ref self: ContractState, salt: felt252, class_hash: ClassHash
         ) -> ContractAddress {
@@ -402,6 +413,24 @@ mod world {
             );
 
             contract_address
+        }
+
+        /// Upgrade an already deployed contract associated with the world.
+        ///
+        /// # Arguments
+        ///
+        /// * `name` - The name of the contract.
+        /// * `class_hash` - The class_hash of the contract.
+        ///
+        /// # Returns
+        ///
+        /// * `ClassHash` - The new class hash of the contract.
+        fn upgrade_contract(
+            ref self: ContractState, address: ContractAddress, class_hash: ClassHash
+        ) -> ClassHash {
+            IUpgradeableDispatcher { contract_address: address }.upgrade(class_hash);
+            EventEmitter::emit(ref self, ContractUpgraded { class_hash, address });
+            class_hash
         }
 
         /// Issues an autoincremented id to the caller.
@@ -528,10 +557,7 @@ mod world {
         /// # Returns
         /// * `Span<felt252>` - The entity IDs.
         /// * `Span<Span<felt252>>` - The entities.
-        fn entity_ids(
-            self: @ContractState,
-            model: felt252
-        ) -> Span<felt252> {
+        fn entity_ids(self: @ContractState, model: felt252) -> Span<felt252> {
             database::scan_ids(model, Option::None(()))
         }
 

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -429,7 +429,7 @@ mod world {
             ref self: ContractState, address: ContractAddress, class_hash: ClassHash
         ) -> ClassHash {
             // Only owner can upgrade contract
-            assert(self.is_owner(get_caller_address(), WORLD), 'only owner can upgrade contract');
+            assert(self.is_owner(get_caller_address(), address), 'only owner can upgrade contract');
             IUpgradeableDispatcher { contract_address: address }.upgrade(class_hash);
             EventEmitter::emit(ref self, ContractUpgraded { class_hash, address });
             class_hash

--- a/crates/dojo-lang/src/contract.rs
+++ b/crates/dojo-lang/src/contract.rs
@@ -48,8 +48,6 @@ impl DojoContract {
                     use dojo::world;
                     use dojo::world::IWorldDispatcher;
                     use dojo::world::IWorldDispatcherTrait;
-                    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
-                    use starknet::ClassHash;
 
                     #[storage]
                     struct Storage {
@@ -62,14 +60,14 @@ impl DojoContract {
                     }
 
                     #[external(v0)]
-                    impl Upgradeable of IUpgradeable<ContractState> {
-                        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+                    impl Upgradeable of dojo::upgradable::IUpgradeable<ContractState> {
+                        fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
                             let caller = get_caller_address();
                             assert(
                                 self.world_dispatcher.read().contract_address == caller, 'only \
                  World can upgrade'
                             );
-                            UpgradeableTrait::upgrade(new_class_hash);
+                            dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
                         }
                     }
 

--- a/crates/dojo-lang/src/contract.rs
+++ b/crates/dojo-lang/src/contract.rs
@@ -48,6 +48,8 @@ impl DojoContract {
                     use dojo::world;
                     use dojo::world::IWorldDispatcher;
                     use dojo::world::IWorldDispatcherTrait;
+                    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+                    use starknet::ClassHash;
 
                     #[storage]
                     struct Storage {
@@ -57,6 +59,18 @@ impl DojoContract {
                     #[external(v0)]
                     fn name(self: @ContractState) -> felt252 {
                         '$name$'
+                    }
+
+                    #[external(v0)]
+                    impl Upgradeable of IUpgradeable<ContractState> {
+                        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+                            let caller = get_caller_address();
+                            assert(
+                                self.world_dispatcher.read().contract_address == caller, 'only \
+                 World can upgrade'
+                            );
+                            UpgradeableTrait::upgrade(new_class_hash);
+                        }
                     }
 
                     $body$

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -8,7 +8,7 @@ test_manifest_file
   "world": {
     "name": "world",
     "address": null,
-    "class_hash": "0x2611f073498530f0faa0fda87956a405ae8cbd85cc6a28f4d8961d66cc51e4b",
+    "class_hash": "0x3a169231d52d573644a0c6b607eea710d8e24aca21160ab85c50fcb202cffde",
     "abi": [
       {
         "type": "impl",
@@ -153,6 +153,26 @@ test_manifest_file
             "outputs": [
               {
                 "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "upgrade_contract",
+            "inputs": [
+              {
+                "name": "address",
+                "type": "core::starknet::contract_address::ContractAddress"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::starknet::class_hash::ClassHash"
               }
             ],
             "state_mutability": "external"
@@ -503,6 +523,23 @@ test_manifest_file
       },
       {
         "type": "event",
+        "name": "dojo::world::world::ContractUpgraded",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          },
+          {
+            "name": "address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
         "name": "dojo::world::world::MetadataUpdate",
         "kind": "struct",
         "members": [
@@ -658,6 +695,11 @@ test_manifest_file
           {
             "name": "ContractDeployed",
             "type": "dojo::world::world::ContractDeployed",
+            "kind": "nested"
+          },
+          {
+            "name": "ContractUpgraded",
+            "type": "dojo::world::world::ContractUpgraded",
             "kind": "nested"
           },
           {
@@ -822,8 +864,31 @@ test_manifest_file
     {
       "name": "actions",
       "address": null,
-      "class_hash": "0x4b3a8688b75ebacf254b07671f3dacaada9f23bac37c61f9561bbe4ead1c112",
+      "class_hash": "0x879e001074687da51991333bd4c3f8121bfa77547dd6daa4ff9330d1cfcd7e",
       "abi": [
+        {
+          "type": "impl",
+          "name": "Upgradeable",
+          "interface_name": "dojo::upgradable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::upgradable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
         {
           "type": "impl",
           "name": "ActionsImpl",

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -8,7 +8,7 @@ test_manifest_file
   "world": {
     "name": "world",
     "address": null,
-    "class_hash": "0x3a169231d52d573644a0c6b607eea710d8e24aca21160ab85c50fcb202cffde",
+    "class_hash": "0x19af849897d279f731bee0850312b8b6843ba9e70376d97c8205825f4e45b64",
     "abi": [
       {
         "type": "impl",

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -8,7 +8,7 @@ test_manifest_file
   "world": {
     "name": "world",
     "address": null,
-    "class_hash": "0x19af849897d279f731bee0850312b8b6843ba9e70376d97c8205825f4e45b64",
+    "class_hash": "0x5179c281a8d3cca6cfb820201fa7a81150b56f9db492405a29e9564222370b8",
     "abi": [
       {
         "type": "impl",

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -37,8 +37,6 @@ mod spawn {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
-    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
-    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -51,13 +49,14 @@ mod spawn {
     }
 
     #[external(v0)]
-    impl Upgradeable of IUpgradeable<ContractState> {
-        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+    impl Upgradeable of dojo::upgradable::IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only \
+ World can upgrade'
             );
-            UpgradeableTrait::upgrade(new_class_hash);
+            dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
         }
     }
 
@@ -90,13 +89,14 @@ mod proxy {
     }
 
     #[external(v0)]
-    impl Upgradeable of IUpgradeable<ContractState> {
-        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+    impl Upgradeable of dojo::upgradable::IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only \
+ World can upgrade'
             );
-            UpgradeableTrait::upgrade(new_class_hash);
+            dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
         }
     }
 
@@ -127,13 +127,14 @@ mod ctxnamed {
     }
 
     #[external(v0)]
-    impl Upgradeable of IUpgradeable<ContractState> {
-        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+    impl Upgradeable of dojo::upgradable::IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only \
+ World can upgrade'
             );
-            UpgradeableTrait::upgrade(new_class_hash);
+            dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
         }
     }
 

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -37,6 +37,8 @@ mod spawn {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
+    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -46,6 +48,17 @@ mod spawn {
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'spawn'
+    }
+
+    #[external(v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            let caller = get_caller_address();
+            assert(
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
+            );
+            UpgradeableTrait::upgrade(new_class_hash);
+        }
     }
 
     use traits::Into;
@@ -63,6 +76,8 @@ mod proxy {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
+    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -72,6 +87,17 @@ mod proxy {
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'proxy'
+    }
+
+    #[external(v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            let caller = get_caller_address();
+            assert(
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
+            );
+            UpgradeableTrait::upgrade(new_class_hash);
+        }
     }
 
 
@@ -87,6 +113,8 @@ mod ctxnamed {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
+    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
+    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -96,6 +124,17 @@ mod ctxnamed {
     #[external(v0)]
     fn name(self: @ContractState) -> felt252 {
         'ctxnamed'
+    }
+
+    #[external(v0)]
+    impl Upgradeable of IUpgradeable<ContractState> {
+        fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
+            let caller = get_caller_address();
+            assert(
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
+            );
+            UpgradeableTrait::upgrade(new_class_hash);
+        }
     }
 
     use traits::Into;

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -53,8 +53,7 @@ mod spawn {
         fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 'only \
- World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
             );
             dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
         }
@@ -75,8 +74,6 @@ mod proxy {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
-    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
-    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -93,8 +90,7 @@ mod proxy {
         fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 'only \
- World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
             );
             dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
         }
@@ -113,8 +109,6 @@ mod ctxnamed {
     use dojo::world;
     use dojo::world::IWorldDispatcher;
     use dojo::world::IWorldDispatcherTrait;
-    use dojo::upgradable::{IUpgradeable, UpgradeableTrait};
-    use starknet::ClassHash;
 
     #[storage]
     struct Storage {
@@ -131,8 +125,7 @@ mod ctxnamed {
         fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
             let caller = get_caller_address();
             assert(
-                self.world_dispatcher.read().contract_address == caller, 'only \
- World can upgrade'
+                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
             );
             dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
         }


### PR DESCRIPTION
Changed:
- derive upgradable on contracts with `#[dojo::contract]` attribute, to allow upgrading contracts implementation.
```rust
#[external(v0)]
impl Upgradeable of IUpgradeable<ContractState> {
    fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
        let caller = get_caller_address();
        assert(
            self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
        );
        UpgradeableTrait::upgrade(new_class_hash);
    }
}

```
- add `IWorld::upgrade_contract` function in the World contract for upgrading deployed contract to a new implementation
```rust
/// `address` - Address of the contract to be upgraded
/// `class_hash` - Class hash of the new implementation
fn upgrade_contract(ref self: T, address: ContractAddress, class_hash: ClassHash) -> ClassHash {
   IUpgradeableDispatcher { contract_address: address }.upgrade(class_hash); 
   EventEmitter::emit(ref self, ContractUpgraded { class_hash, address });
   class_hash
}
```
- add `ContractUpgraded` event which will be emitted upon upgrading a contract.
- improve remote manifest generation

NOTES:

upon this change, to allow systems contract to be upgradable #[dojo::contract] MUST be used over #[starknet::contract] provided by the base language

---

This is needed in order to have `sozo migrate` perform update on any models/systems changes.