### PR TITLE
Graphql events keys filtering

### DIFF
--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -2,10 +2,12 @@ use async_graphql::dynamic::{Field, FieldFuture, TypeRef};
 use async_graphql::Value;
 use sqlx::{Pool, Sqlite};
 
+use super::connection::{connection_arguments, connection_output, parse_connection_arguments};
+use super::inputs::keys_input::{keys_argument, parse_keys_argument};
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::mapping::{EVENT_TYPE_MAPPING, SYSTEM_CALL_TYPE_MAPPING};
-use crate::query::constants::EVENT_TABLE;
-use crate::query::data::fetch_single_row;
+use crate::query::constants::{EVENT_TABLE, ID_COLUMN};
+use crate::query::data::{count_rows, fetch_multiple_rows, fetch_single_row};
 use crate::query::value_mapping_from_row;
 use crate::utils::extract;
 
@@ -30,6 +32,46 @@ impl ObjectTrait for EventObject {
 
     fn resolve_one(&self) -> Option<Field> {
         None
+    }
+
+    fn resolve_many(&self) -> Option<Field> {
+        let mut field = Field::new(
+            self.name().1,
+            TypeRef::named(format!("{}Connection", self.type_name())),
+            |ctx| {
+                FieldFuture::new(async move {
+                    let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
+                    let connection = parse_connection_arguments(&ctx)?;
+                    let keys = parse_keys_argument(&ctx)?;
+                    let total_count = count_rows(&mut conn, EVENT_TABLE, &keys, &None).await?;
+                    let data = fetch_multiple_rows(
+                        &mut conn,
+                        EVENT_TABLE,
+                        ID_COLUMN,
+                        &keys,
+                        &None,
+                        &None,
+                        &connection,
+                    )
+                    .await?;
+                    let results = connection_output(
+                        &data,
+                        &EVENT_TYPE_MAPPING,
+                        &None,
+                        ID_COLUMN,
+                        total_count,
+                        false,
+                    )?;
+
+                    Ok(Some(Value::Object(results)))
+                })
+            },
+        );
+
+        field = connection_arguments(field);
+        field = keys_argument(field);
+
+        Some(field)
     }
 
     fn related_fields(&self) -> Option<Vec<Field>> {

--- a/crates/torii/graphql/src/object/inputs/keys_input.rs
+++ b/crates/torii/graphql/src/object/inputs/keys_input.rs
@@ -1,0 +1,31 @@
+use async_graphql::dynamic::{Field, InputValue, ResolverContext, TypeRef};
+use async_graphql::Error;
+
+use crate::utils::extract;
+
+pub fn keys_argument(field: Field) -> Field {
+    field.argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING)))
+}
+
+pub fn parse_keys_argument(ctx: &ResolverContext<'_>) -> Result<Option<Vec<String>>, Error> {
+    let keys = extract::<Vec<String>>(ctx.args.as_index_map(), "keys");
+
+    if let Ok(keys) = keys {
+        if !keys.iter().all(|s| is_hex_or_star(s)) {
+            return Err("Key parts can only be hex string or wild card `*`".into());
+        }
+
+        return Ok(Some(keys));
+    }
+
+    Ok(None)
+}
+
+fn is_hex_or_star(s: &str) -> bool {
+    if s == "*" {
+        return true;
+    }
+    let s = if let Some(stripped) = s.strip_prefix("0x") { stripped } else { s };
+
+    s.chars().all(|c| c.is_ascii_hexdigit())
+}

--- a/crates/torii/graphql/src/object/inputs/mod.rs
+++ b/crates/torii/graphql/src/object/inputs/mod.rs
@@ -2,6 +2,7 @@ use async_graphql::dynamic::{Enum, InputObject};
 
 use super::TypeMapping;
 
+pub mod keys_input;
 pub mod order_input;
 pub mod where_input;
 

--- a/crates/torii/graphql/src/query/constants.rs
+++ b/crates/torii/graphql/src/query/constants.rs
@@ -9,3 +9,4 @@ pub const SYSTEM_TABLE: &str = "systems";
 pub const METADATA_TABLE: &str = "metadata";
 
 pub const ID_COLUMN: &str = "id";
+pub const EVENT_ID_COLUMN: &str = "event_id";

--- a/crates/torii/graphql/src/tests/types-test/src/systems.cairo
+++ b/crates/torii/graphql/src/tests/types-test/src/systems.cairo
@@ -12,12 +12,25 @@ mod records {
     use types_test::{seed, random};
     use super::IRecords;
 
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        RecordLogged: RecordLogged
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct RecordLogged {
+        record_id: u32,
+        type_u8: u8,
+        type_felt: felt252,
+    }
+
     #[external(v0)]
     impl RecordsImpl of IRecords<ContractState> {
         fn create(self: @ContractState, num_records: u8) {
             let world = self.world_dispatcher.read();
             let mut record_idx = 0;
-            
+
             loop {
                 if record_idx == num_records {
                     break ();
@@ -80,6 +93,8 @@ mod records {
                 );
 
                 record_idx += 1;
+
+                emit!(world, RecordLogged { record_id, type_u8: record_idx.into(), type_felt });
             };
             return ();
         }


### PR DESCRIPTION
Enable keys filtering on `events` query. Note: keys here are not entity keys in dojo context, but they refer to raw [event keys ](https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/starknet-events/#emitting_events)

We're also validating keys argument to only be hex string or `*` wildcard. Moving away from `%` wildcard which is a sql syntax. 

```
events (keys: ["*", "0x2"]) { ... }
```