### PR TITLE
[sozo] Bump default timeout to 5 minutes and interval to 2.5 seconds

### DIFF
--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -83,8 +83,8 @@ impl<'a, P> TransactionWaiter<'a, P>
 where
     P: Provider + Send,
 {
-    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
-    const DEFAULT_INTERVAL: Duration = Duration::from_millis(250);
+    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
+    const DEFAULT_INTERVAL: Duration = Duration::from_millis(2500);
 
     pub fn new(tx: FieldElement, provider: &'a P) -> Self {
         Self {


### PR DESCRIPTION
These values work on testnet (and shouldn't change much on katana ? Maybe add an initial delay there?)

The interval change is mostly because `sozo` burns too many free RPC queries otherwise.