### PR TITLE
`katana` dev mode

### DIFF
--- a/crates/katana/rpc/src/api/mod.rs
+++ b/crates/katana/rpc/src/api/mod.rs
@@ -1,2 +1,9 @@
 pub mod katana;
 pub mod starknet;
+
+/// List of APIs supported by Katana.
+#[derive(Debug, Copy, Clone)]
+pub enum ApiKind {
+    Starknet,
+    Katana,
+}

--- a/crates/katana/rpc/src/config.rs
+++ b/crates/katana/rpc/src/config.rs
@@ -1,7 +1,10 @@
+use crate::api::ApiKind;
+
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub port: u16,
     pub host: String,
+    pub apis: Vec<ApiKind>,
 }
 
 impl ServerConfig {

--- a/crates/katana/src/args.rs
+++ b/crates/katana/src/args.rs
@@ -8,6 +8,7 @@ use katana_core::constants::{
 };
 use katana_core::db::serde::state::SerializableState;
 use katana_core::sequencer::SequencerConfig;
+use katana_rpc::api::ApiKind;
 use katana_rpc::config::ServerConfig;
 use tracing::Subscriber;
 use tracing_subscriber::{fmt, EnvFilter};
@@ -42,6 +43,9 @@ pub struct KatanaArgs {
     #[arg(value_name = "URL")]
     #[arg(help = "The Starknet RPC provider to fork the network from.")]
     pub rpc_url: Option<Url>,
+
+    #[arg(long)]
+    pub dev: bool,
 
     #[arg(long)]
     #[arg(help = "Output logs in JSON format.")]
@@ -170,7 +174,14 @@ impl KatanaArgs {
     }
 
     pub fn server_config(&self) -> ServerConfig {
+        let mut apis = vec![ApiKind::Starknet];
+        // only enable `katana` API in dev mode
+        if self.dev {
+            apis.push(ApiKind::Katana);
+        }
+
         ServerConfig {
+            apis,
             port: self.server.port,
             host: self.server.host.clone().unwrap_or("0.0.0.0".into()),
         }

--- a/crates/katana/src/main.rs
+++ b/crates/katana/src/main.rs
@@ -5,7 +5,7 @@ use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Shell};
 use console::Style;
 use katana_core::sequencer::KatanaSequencer;
-use katana_rpc::{spawn, KatanaApi, NodeHandle, StarknetApi};
+use katana_rpc::{spawn, NodeHandle};
 use tokio::signal::ctrl_c;
 use tracing::{error, info};
 
@@ -33,10 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let starknet_config = config.starknet_config();
 
     let sequencer = Arc::new(KatanaSequencer::new(sequencer_config, starknet_config).await);
-    let starknet_api = StarknetApi::new(sequencer.clone());
-    let katana_api = KatanaApi::new(sequencer.clone());
-
-    let NodeHandle { addr, handle, .. } = spawn(katana_api, starknet_api, server_config).await?;
+    let NodeHandle { addr, handle, .. } = spawn(Arc::clone(&sequencer), server_config).await?;
 
     if !config.silent {
         let accounts = sequencer.backend.accounts.iter();


### PR DESCRIPTION
Enable the `katana_*` namespace only on `dev` mode as it exposes some RPC methods which allow state manipulation. 

`dev` mode is disabled by default.

In the future, we should allow to pick and choose what APIs to expose from `katana`