### PR TITLE
feat(torii-client): add entity change listener

### DIFF
--- a/crates/torii/client/src/client/error.rs
+++ b/crates/torii/client/src/client/error.rs
@@ -1,5 +1,5 @@
 use dojo_world::contracts::model::ModelError;
-use starknet::core::utils::CairoShortStringToFeltError;
+use starknet::core::utils::{CairoShortStringToFeltError, ParseCairoShortStringError};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
 
@@ -30,4 +30,6 @@ pub enum ParseError {
     FeltFromStr(#[from] starknet::core::types::FromStrError),
     #[error(transparent)]
     CairoShortStringToFelt(#[from] CairoShortStringToFeltError),
+    #[error(transparent)]
+    ParseCairoShortString(#[from] ParseCairoShortStringError),
 }

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -15,7 +15,7 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet_crypto::FieldElement;
 use tokio::sync::RwLock as AsyncRwLock;
-use torii_grpc::protos::world::SubscribeEntitiesResponse;
+use torii_grpc::client::EntityUpdateStreaming;
 
 use self::error::{Error, ParseError};
 use self::storage::ModelStorage;
@@ -140,7 +140,7 @@ impl Client {
     async fn initiate_subscription(
         &self,
         entities: Vec<EntityModel>,
-    ) -> Result<tonic::Streaming<SubscribeEntitiesResponse>, Error> {
+    ) -> Result<EntityUpdateStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
         let stream = grpc_client.subscribe_entities(entities).await?;
         Ok(stream)

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -59,7 +59,7 @@ impl Client {
         let mut schema = self.metadata.read().model(model).map(|m| m.schema.clone())?;
 
         let Ok(Some(raw_values)) =
-            self.storage.get_entity(cairo_short_string_to_felt(model).ok()?, keys)
+            self.storage.get_entity_storage(cairo_short_string_to_felt(model).ok()?, keys)
         else {
             return Some(schema);
         };
@@ -137,6 +137,10 @@ impl Client {
         Ok(())
     }
 
+    pub fn storage(&self) -> Arc<ModelStorage> {
+        Arc::clone(&self.storage)
+    }
+
     async fn initiate_subscription(
         &self,
         entities: Vec<EntityModel>,
@@ -149,7 +153,7 @@ impl Client {
     async fn initiate_entity(&self, model: &str, keys: Vec<FieldElement>) -> Result<(), Error> {
         let model_reader = self.world_reader.model(model).await?;
         let values = model_reader.entity_storage(&keys).await?;
-        self.storage.set_entity(
+        self.storage.set_entity_storage(
             cairo_short_string_to_felt(model).map_err(ParseError::CairoShortStringToFelt)?,
             keys,
             values,
@@ -207,7 +211,7 @@ impl ClientBuilder {
                 let model_reader = world_reader.model(&model).await?;
                 let values = model_reader.entity_storage(&keys).await?;
 
-                client_storage.set_entity(
+                client_storage.set_entity_storage(
                     cairo_short_string_to_felt(&model).unwrap(),
                     keys,
                     values,

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -22,7 +22,6 @@ use self::storage::ModelStorage;
 use self::subscription::{SubscribedEntities, SubscriptionClientHandle};
 use crate::client::subscription::SubscriptionService;
 
-// TODO: expose the World interface from the `Client`
 // TODO: remove reliance on RPC
 #[allow(unused)]
 pub struct Client {

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -3,13 +3,14 @@ pub mod storage;
 pub mod subscription;
 
 use std::cell::OnceCell;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use dojo_types::packing::unpack;
 use dojo_types::schema::{EntityModel, Ty};
 use dojo_types::WorldMetadata;
 use dojo_world::contracts::WorldContractReader;
-use parking_lot::RwLock;
+use parking_lot::{RwLock, RwLockReadGuard};
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
@@ -45,9 +46,13 @@ impl Client {
         ClientBuilder::new()
     }
 
-    /// Returns the metadata of the world that the client is connected to.
-    pub fn metadata(&self) -> WorldMetadata {
-        self.metadata.read().clone()
+    /// Returns a read lock on the World metadata that the client is connected to.
+    pub fn metadata(&self) -> RwLockReadGuard<'_, WorldMetadata> {
+        self.metadata.read()
+    }
+
+    pub fn subscribed_entities(&self) -> RwLockReadGuard<'_, HashSet<EntityModel>> {
+        self.subscribed_entities.entities.read()
     }
 
     /// Returns the model value of an entity.
@@ -78,15 +83,10 @@ impl Client {
         Some(schema)
     }
 
-    /// Returns the list of entities that the client is subscribed to.
-    pub fn synced_entities(&self) -> Vec<EntityModel> {
-        self.subscribed_entities.entities.read().clone().into_iter().collect()
-    }
-
     /// Initiate the entity subscriptions and returns a [SubscriptionService] which when await'ed
     /// will execute the subscription service and starts the syncing process.
     pub async fn start_subscription(&self) -> Result<SubscriptionService, Error> {
-        let entities = self.synced_entities();
+        let entities = self.subscribed_entities.entities.read().clone().into_iter().collect();
         let sub_res_stream = self.initiate_subscription(entities).await?;
 
         let (service, handle) = SubscriptionService::new(
@@ -110,7 +110,8 @@ impl Client {
 
         self.subscribed_entities.add_entities(entities)?;
 
-        let updated_entities = self.synced_entities();
+        let updated_entities =
+            self.subscribed_entities.entities.read().clone().into_iter().collect();
         let sub_res_stream = self.initiate_subscription(updated_entities).await?;
 
         match self.sub_client_handle.get() {
@@ -126,7 +127,8 @@ impl Client {
     pub async fn remove_entities_to_sync(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         self.subscribed_entities.remove_entities(entities)?;
 
-        let updated_entities = self.synced_entities();
+        let updated_entities =
+            self.subscribed_entities.entities.read().clone().into_iter().collect();
         let sub_res_stream = self.initiate_subscription(updated_entities).await?;
 
         match self.sub_client_handle.get() {

--- a/crates/torii/client/src/client/storage.rs
+++ b/crates/torii/client/src/client/storage.rs
@@ -3,11 +3,12 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use dojo_types::WorldMetadata;
-use parking_lot::RwLock;
+use futures::channel::mpsc::{channel, Receiver, Sender};
+use parking_lot::{Mutex, RwLock};
 use starknet::core::utils::parse_cairo_short_string;
 use starknet_crypto::FieldElement;
 
-use super::error::Error;
+use super::error::{Error, ParseError};
 use crate::utils::compute_all_storage_addresses;
 
 pub type EntityKeys = Vec<FieldElement>;
@@ -17,25 +18,77 @@ pub type StorageValue = FieldElement;
 
 /// An in-memory storage for storing the component values of entities.
 // TODO: check if we can use sql db instead.
-pub(crate) struct ModelStorage {
+pub struct ModelStorage {
     metadata: Arc<RwLock<WorldMetadata>>,
-    pub(crate) storage: RwLock<HashMap<StorageKey, StorageValue>>,
+    storage: RwLock<HashMap<StorageKey, StorageValue>>,
+    // a map of model name to a set of entity keys.
     model_index: RwLock<HashMap<FieldElement, HashSet<EntityKeys>>>,
+
+    // listener for storage updates.
+    senders: Mutex<HashMap<u8, Sender<()>>>,
+    listeners: Mutex<HashMap<StorageKey, Vec<u8>>>,
 }
 
 impl ModelStorage {
     pub(super) fn new(metadata: Arc<RwLock<WorldMetadata>>) -> Self {
-        Self { metadata, storage: Default::default(), model_index: Default::default() }
+        Self {
+            metadata,
+            storage: Default::default(),
+            model_index: Default::default(),
+            senders: Default::default(),
+            listeners: Default::default(),
+        }
     }
 
-    #[allow(unused)]
-    pub(super) fn set_entity(
+    /// Listen to entity changes.
+    ///
+    /// # Arguments
+    /// * `model` - the model name.
+    /// * `keys` - the keys of the entity.
+    ///
+    /// # Returns
+    /// A receiver that will receive updates for the specified storage keys.
+    pub fn add_listener(
+        &self,
+        model: FieldElement,
+        keys: &[FieldElement],
+    ) -> Result<Receiver<()>, Error> {
+        let storage_addresses = self.get_entity_storage_addresses(model, keys)?;
+
+        let (sender, receiver) = channel(128);
+        let listener_id = self.senders.lock().len() as u8;
+        self.senders.lock().insert(listener_id, sender);
+
+        storage_addresses.iter().for_each(|key| {
+            self.listeners.lock().entry(*key).or_default().push(listener_id);
+        });
+
+        Ok(receiver)
+    }
+
+    /// Retrieves the raw values of an entity.
+    pub fn get_entity_storage(
+        &self,
+        model: FieldElement,
+        raw_keys: &[FieldElement],
+    ) -> Result<Option<Vec<FieldElement>>, Error> {
+        let storage_addresses = self.get_entity_storage_addresses(model, raw_keys)?;
+        Ok(storage_addresses
+            .into_iter()
+            .map(|storage_address| self.storage.read().get(&storage_address).copied())
+            .collect::<Option<Vec<_>>>())
+    }
+
+    /// Set the raw values of an entity.
+    pub fn set_entity_storage(
         &self,
         model: FieldElement,
         raw_keys: Vec<FieldElement>,
         raw_values: Vec<FieldElement>,
     ) -> Result<(), Error> {
-        let model_name = parse_cairo_short_string(&model).expect("valid cairo short string");
+        let model_name =
+            parse_cairo_short_string(&model).map_err(ParseError::ParseCairoShortString)?;
+
         let model_packed_size = self
             .metadata
             .read()
@@ -55,35 +108,54 @@ impl ModelStorage {
             Ordering::Equal => {}
         }
 
-        let storage_addresses = compute_all_storage_addresses(model, &raw_keys, model_packed_size);
-        storage_addresses.iter().zip(&raw_values).for_each(|(storage_address, value)| {
-            self.storage.write().insert(*storage_address, *value);
-        });
+        let storage_addresses = self.get_entity_storage_addresses(model, &raw_keys)?;
+        self.set_storages_at(storage_addresses.into_iter().zip(raw_values).collect());
         self.index_entity(model, raw_keys);
 
         Ok(())
     }
 
-    pub(super) fn get_entity(
+    /// Set the value of storage slots in bulk
+    pub(super) fn set_storages_at(&self, storage_entries: Vec<(FieldElement, FieldElement)>) {
+        let mut senders: HashSet<u8> = Default::default();
+
+        for (key, _) in &storage_entries {
+            if let Some(lists) = self.listeners.lock().get(&key) {
+                for id in lists {
+                    senders.insert(*id);
+                }
+            }
+        }
+
+        self.storage.write().extend(storage_entries);
+
+        for sender_id in senders {
+            self.notify_listener(sender_id);
+        }
+    }
+
+    fn notify_listener(&self, id: u8) {
+        if let Some(sender) = self.senders.lock().get_mut(&id) {
+            let _ = sender.try_send(());
+        }
+    }
+
+    fn get_entity_storage_addresses(
         &self,
         model: FieldElement,
         raw_keys: &[FieldElement],
-    ) -> Result<Option<Vec<FieldElement>>, Error> {
-        let model_name = parse_cairo_short_string(&model).expect("valid cairo short string");
+    ) -> Result<Vec<FieldElement>, Error> {
+        let model_name =
+            parse_cairo_short_string(&model).map_err(ParseError::ParseCairoShortString)?;
+
         let model_packed_size = self
             .metadata
             .read()
-            .model(&parse_cairo_short_string(&model).expect("valid cairo short string"))
+            .model(&model_name)
             .map(|c| c.packed_size)
             .ok_or(Error::UnknownModel(model_name))?;
 
-        let storage_addresses = compute_all_storage_addresses(model, raw_keys, model_packed_size);
-        let values = storage_addresses
-            .into_iter()
-            .map(|storage_address| self.storage.read().get(&storage_address).copied())
-            .collect::<Option<Vec<_>>>();
-
-        Ok(values)
+        Ok(compute_all_storage_addresses(model, raw_keys, model_packed_size))
     }
 
     fn index_entity(&self, model: FieldElement, raw_keys: Vec<FieldElement>) {
@@ -136,7 +208,7 @@ mod tests {
 
         let values = vec![felt!("1"), felt!("2"), felt!("3"), felt!("4"), felt!("5")];
         let model = cairo_short_string_to_felt(&entity.model).unwrap();
-        let result = storage.set_entity(model, entity.keys, values);
+        let result = storage.set_entity_storage(model, entity.keys, values);
 
         assert!(storage.storage.read().is_empty());
         matches!(
@@ -155,7 +227,7 @@ mod tests {
 
         let values = vec![felt!("1"), felt!("2")];
         let model = cairo_short_string_to_felt(&entity.model).unwrap();
-        let result = storage.set_entity(model, entity.keys, values);
+        let result = storage.set_entity_storage(model, entity.keys, values);
 
         assert!(storage.storage.read().is_empty());
         matches!(
@@ -186,11 +258,11 @@ mod tests {
         let model_name_in_felt = cairo_short_string_to_felt(&entity.model).unwrap();
 
         storage
-            .set_entity(model_name_in_felt, entity.keys.clone(), expected_values.clone())
+            .set_entity_storage(model_name_in_felt, entity.keys.clone(), expected_values.clone())
             .expect("set storage values");
 
         let actual_values = storage
-            .get_entity(model_name_in_felt, &entity.keys)
+            .get_entity_storage(model_name_in_felt, &entity.keys)
             .expect("model exist")
             .expect("values are set");
 

--- a/crates/torii/client/src/client/storage.rs
+++ b/crates/torii/client/src/client/storage.rs
@@ -120,7 +120,7 @@ impl ModelStorage {
         let mut senders: HashSet<u8> = Default::default();
 
         for (key, _) in &storage_entries {
-            if let Some(lists) = self.listeners.lock().get(&key) {
+            if let Some(lists) = self.listeners.lock().get(key) {
                 for id in lists {
                     senders.insert(*id);
                 }

--- a/crates/torii/client/src/client/subscription.rs
+++ b/crates/torii/client/src/client/subscription.rs
@@ -30,7 +30,7 @@ pub struct SubscribedEntities {
 }
 
 impl SubscribedEntities {
-    pub(crate) fn new(metadata: Arc<RwLock<WorldMetadata>>) -> Self {
+    pub(super) fn new(metadata: Arc<RwLock<WorldMetadata>>) -> Self {
         Self {
             metadata,
             entities: Default::default(),
@@ -38,21 +38,21 @@ impl SubscribedEntities {
         }
     }
 
-    pub fn add_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
+    pub(super) fn add_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         for entity in entities {
             Self::add_entity(self, entity)?;
         }
         Ok(())
     }
 
-    pub fn remove_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
+    pub(super) fn remove_entities(&self, entities: Vec<EntityModel>) -> Result<(), Error> {
         for entity in entities {
             Self::remove_entity(self, entity)?;
         }
         Ok(())
     }
 
-    pub(crate) fn add_entity(&self, entity: EntityModel) -> Result<(), Error> {
+    pub(super) fn add_entity(&self, entity: EntityModel) -> Result<(), Error> {
         if !self.entities.write().insert(entity.clone()) {
             return Ok(());
         }
@@ -80,7 +80,7 @@ impl SubscribedEntities {
         Ok(())
     }
 
-    pub(crate) fn remove_entity(&self, entity: EntityModel) -> Result<(), Error> {
+    pub(super) fn remove_entity(&self, entity: EntityModel) -> Result<(), Error> {
         if !self.entities.write().remove(&entity) {
             return Ok(());
         }

--- a/crates/torii/client/src/client/subscription.rs
+++ b/crates/torii/client/src/client/subscription.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::future::Future;
-use std::str::FromStr;
 use std::sync::Arc;
 use std::task::Poll;
 
@@ -10,19 +9,17 @@ use dojo_types::WorldMetadata;
 use futures::channel::mpsc::{self, Receiver, Sender};
 use futures_util::StreamExt;
 use parking_lot::{Mutex, RwLock};
+use starknet::core::types::{MaybePendingStateUpdate, StateDiff};
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_crypto::FieldElement;
-use torii_grpc::protos;
-use torii_grpc::protos::types::EntityDiff;
-use torii_grpc::protos::world::SubscribeEntitiesResponse;
+use torii_grpc::client::EntityUpdateStreaming;
 
 use super::error::{Error, ParseError};
 use super::ModelStorage;
 use crate::utils::compute_all_storage_addresses;
 
-#[derive(Debug)]
 pub enum SubscriptionEvent {
-    UpdateSubsciptionStream(tonic::Streaming<SubscribeEntitiesResponse>),
+    UpdateSubsciptionStream(EntityUpdateStreaming),
 }
 
 pub struct SubscribedEntities {
@@ -120,10 +117,7 @@ impl SubscriptionClientHandle {
         Self(Mutex::new(sender))
     }
 
-    pub(crate) fn update_subscription_stream(
-        &self,
-        stream: tonic::Streaming<SubscribeEntitiesResponse>,
-    ) {
+    pub(crate) fn update_subscription_stream(&self, stream: EntityUpdateStreaming) {
         let _ = self.0.lock().try_send(SubscriptionEvent::UpdateSubsciptionStream(stream));
     }
 }
@@ -132,7 +126,8 @@ impl SubscriptionClientHandle {
 pub struct SubscriptionService {
     req_rcv: Receiver<SubscriptionEvent>,
     /// The stream returned by the subscription server to receive the response
-    sub_res_stream: RefCell<Option<tonic::Streaming<SubscribeEntitiesResponse>>>,
+    sub_res_stream: RefCell<Option<EntityUpdateStreaming>>,
+
     /// Callback to be called on error
     err_callback: Option<Box<dyn Fn(tonic::Status) + Send + Sync>>,
 
@@ -147,7 +142,7 @@ impl SubscriptionService {
         storage: Arc<ModelStorage>,
         world_metadata: Arc<RwLock<WorldMetadata>>,
         subscribed_entities: Arc<SubscribedEntities>,
-        sub_res_stream: tonic::Streaming<SubscribeEntitiesResponse>,
+        sub_res_stream: EntityUpdateStreaming,
     ) -> (Self, SubscriptionClientHandle) {
         let (req_sender, req_rcv) = mpsc::channel(128);
 
@@ -177,21 +172,13 @@ impl SubscriptionService {
     }
 
     // handle the response from the subscription stream
-    fn handle_response(&self, response: Result<SubscribeEntitiesResponse, tonic::Status>) {
+    fn handle_response(&self, response: Result<MaybePendingStateUpdate, tonic::Status>) {
         match response {
-            Ok(res) => {
-                let entity_diff = res
-                    .entity_update
-                    .and_then(|e| e.update)
-                    .and_then(|update| match update {
-                        protos::types::maybe_pending_entity_update::Update::EntityUpdate(
-                            update,
-                        ) => update.entity_diff,
-                        protos::types::maybe_pending_entity_update::Update::PendingEntityUpdate(
-                            update,
-                        ) => update.entity_diff,
-                    })
-                    .expect("have entity update");
+            Ok(update) => {
+                let entity_diff = match update {
+                    MaybePendingStateUpdate::Update(update) => update.state_diff,
+                    MaybePendingStateUpdate::PendingUpdate(update) => update.state_diff,
+                };
 
                 self.process_entity_diff(entity_diff);
             }
@@ -204,10 +191,10 @@ impl SubscriptionService {
         }
     }
 
-    fn process_entity_diff(&self, diff: EntityDiff) {
+    fn process_entity_diff(&self, diff: StateDiff) {
         let storage_entries = diff.storage_diffs.into_iter().find_map(|d| {
             let expected = self.world_metadata.read().world_address;
-            let current = FieldElement::from_str(&d.address).expect("valid FieldElement value");
+            let current = d.address;
             if current == expected { Some(d.storage_entries) } else { None }
         });
 
@@ -215,16 +202,11 @@ impl SubscriptionService {
             return;
         };
 
-        entries.into_iter().enumerate().for_each(|(i, entry)| {
-            let key = FieldElement::from_str(&entry.key).expect("valid FieldElement value");
-            let value = FieldElement::from_str(&entry.value).expect("valid FieldElement value");
-
-            println!("[{i}] key: {key:#x} value: {value:#x}", key = key, value = value);
-
-            if self.subscribed_entities.subscribed_storage_addresses.read().contains(&key) {
-                self.storage.storage.write().insert(key, value);
+        entries.into_iter().for_each(|entry| {
+            if self.subscribed_entities.subscribed_storage_addresses.read().contains(&entry.key) {
+                self.storage.storage.write().insert(entry.key, entry.value);
             } else {
-                panic!("unknown storage address");
+                eprintln!("unknown storage address");
             }
         })
     }

--- a/crates/torii/client/wasm/Cargo.lock
+++ b/crates/torii/client/wasm/Cargo.lock
@@ -1556,6 +1556,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "gloo-utils"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "good_lp"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,7 +2939,7 @@ checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.26.0",
  "syn 1.0.109",
 ]
 
@@ -3010,6 +3023,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3921,6 +3945,7 @@ dependencies = [
  "tokio",
  "torii-client",
  "torii-grpc",
+ "tsify",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -4031,6 +4056,31 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "tsify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b26cf145f2f3b9ff84e182c448eaf05468e247f148cf3d2a7d67d78ff023a0"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a94b0f0954b3e59bfc2c246b4c8574390d94a4ad4ad246aaf2fb07d7dfd3b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals 0.28.0",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "typenum"

--- a/crates/torii/client/wasm/Cargo.toml
+++ b/crates/torii/client/wasm/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = [ "cdylib", "rlib" ]
 async-std = { version = "1.12.0", default-features = false, features = [ "std" ] }
 async-trait = "0.1.68"
 dojo-types = { path = "../../../dojo-types" }
+futures = "0.3.28"
 parking_lot = "0.12.1"
 serde = { version = "1.0.156", features = [ "derive" ] }
 serde_json = "1.0.64"
@@ -25,7 +26,6 @@ torii-grpc = { path = "../../grpc", features = [ "client" ] }
 url = "2.4.0"
 
 # WASM
-futures = "0.3.28"
 js-sys = "0.3.64"
 serde-wasm-bindgen = "0.6.0"
 wasm-bindgen = "0.2.87"

--- a/crates/torii/client/wasm/Cargo.toml
+++ b/crates/torii/client/wasm/Cargo.toml
@@ -37,6 +37,7 @@ web-sys = { version = "0.3.4", features = [ 'MessageEvent', 'Window', 'Worker', 
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.7", optional = true }
+tsify = "0.4.5"
 
 # Compiler optimization when running test to prevent ‘locals exceed maximum’ error, 
 # where a function is using more that the maximum allowed local variables.

--- a/crates/torii/client/wasm/build.sh
+++ b/crates/torii/client/wasm/build.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-# This example requires to *not* create ES modules, therefore we pass the flag
-# `--target no-modules`
-wasm-pack build --target no-modules --features console-error-panic

--- a/crates/torii/client/wasm/index.js
+++ b/crates/torii/client/wasm/index.js
@@ -7,49 +7,49 @@ async function run_wasm() {
 
 	const clientWorker = new Worker("./worker.js");
 
-	clientWorker.onmessage = function (e) {
-		const event = e.data.type;
-		const data = e.data.data;
+	// clientWorker.onmessage = function (e) {
+	// 	const event = e.data.type;
+	// 	const data = e.data.data;
 
-		if (event === "getModelValue") {
-			console.log(
-				"Main thread | model: ",
-				data.model,
-				"keys: ",
-				data.keys,
-				"values: ",
-				data.values
-			);
-		} else {
-			console.log("Sync Worker: Unknown event type", event);
-		}
-	};
+	// 	if (event === "getModelValue") {
+	// 		console.log(
+	// 			"Main thread | model: ",
+	// 			data.model,
+	// 			"keys: ",
+	// 			data.keys,
+	// 			"values: ",
+	// 			data.values
+	// 		);
+	// 	} else {
+	// 		console.log("Sync Worker: Unknown event type", event);
+	// 	}
+	// };
 
-	setTimeout(() => {
-		setInterval(() => {
-			// Get the entity values from the sync worker
-			clientWorker.postMessage({
-				type: "getModelValue",
-				data: {
-					model: "Position",
-					keys: [
-						"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
-					],
-				},
-			});
+	// setTimeout(() => {
+	// 	setInterval(() => {
+	// 		// Get the entity values from the sync worker
+	// 		clientWorker.postMessage({
+	// 			type: "getModelValue",
+	// 			data: {
+	// 				model: "Position",
+	// 				keys: [
+	// 					"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+	// 				],
+	// 			},
+	// 		});
 
-			// Get the entity values from the sync worker
-			clientWorker.postMessage({
-				type: "getModelValue",
-				data: {
-					model: "Moves",
-					keys: [
-						"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
-					],
-				},
-			});
-		}, 2000);
-	}, 1000);
+	// 		// // Get the entity values from the sync worker
+	// 		// clientWorker.postMessage({
+	// 		// 	type: "getModelValue",
+	// 		// 	data: {
+	// 		// 		model: "Moves",
+	// 		// 		keys: [
+	// 		// 			"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+	// 		// 		],
+	// 		// 	},
+	// 		// });
+	// 	}, 2000);
+	// }, 1000);
 }
 
 run_wasm();

--- a/crates/torii/client/wasm/scripts/build_bundler.sh
+++ b/crates/torii/client/wasm/scripts/build_bundler.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -ex
+
+# This example requires to *not* create ES modules, therefore we pass the flag
+# `--target no-modules`
+wasm-pack build --release --features console-error-panic

--- a/crates/torii/client/wasm/scripts/build_no_module.sh
+++ b/crates/torii/client/wasm/scripts/build_no_module.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -ex
+
+# This example requires to *not* create ES modules, therefore we pass the flag
+# `--target no-modules`
+wasm-pack build --target no-modules --release --features console-error-panic

--- a/crates/torii/client/wasm/src/lib.rs
+++ b/crates/torii/client/wasm/src/lib.rs
@@ -24,11 +24,11 @@ pub struct Client(torii_client::client::Client);
 #[wasm_bindgen]
 impl Client {
     #[wasm_bindgen(js_name = getModelValue)]
-    pub async fn get_model_value(
+    pub fn get_model_value(
         &self,
         model: &str,
         keys: Vec<JsFieldElement>,
-    ) -> Result<Option<JsValue>, JsValue> {
+    ) -> Result<JsValue, JsValue> {
         #[cfg(feature = "console-error-panic")]
         console_error_panic_hook::set_once();
 
@@ -41,11 +41,8 @@ impl Client {
             })?;
 
         match self.0.entity(model, &keys) {
-            Some(ty) => {
-                let json = parse_ty_as_json_str(&ty);
-                Ok(Some(serde_wasm_bindgen::to_value(&json)?))
-            }
-            None => Ok(None),
+            Some(ty) => Ok(serde_wasm_bindgen::to_value(&parse_ty_as_json_str(&ty))?),
+            None => Ok(JsValue::NULL),
         }
     }
 

--- a/crates/torii/client/wasm/src/lib.rs
+++ b/crates/torii/client/wasm/src/lib.rs
@@ -146,7 +146,7 @@ pub async fn create_client(
 
     let client = torii_client::client::ClientBuilder::new()
         .set_entities_to_sync(entities)
-        .build(torii_url.into(), rpc_url.into(), world_address)
+        .build(torii_url, rpc_url, world_address)
         .await
         .map_err(|err| JsValue::from_str(format!("failed to build client: {err}").as_str()))?;
 

--- a/crates/torii/client/wasm/src/lib.rs
+++ b/crates/torii/client/wasm/src/lib.rs
@@ -103,16 +103,18 @@ impl Client {
     }
 
     #[wasm_bindgen(js_name = onEntityChange)]
-    pub fn on_entity_change(&self, entity: JsEntityModel) -> Result<(), JsValue> {
+    pub fn on_entity_change(
+        &self,
+        entity: JsEntityModel,
+        callback: js_sys::Function,
+    ) -> Result<(), JsValue> {
         let entity = serde_wasm_bindgen::from_value::<dojo_types::schema::EntityModel>(entity)?;
         let model = cairo_short_string_to_felt(&entity.model).expect("invalid model name");
         let mut rcv = self.inner.storage().add_listener(model, &entity.keys).unwrap();
 
-        log(&format!("listening to {}", entity.model));
-
         wasm_bindgen_futures::spawn_local(async move {
-            while let Some(event) = rcv.next().await {
-                log(&format!("received event for {}: {:?}", entity.model, event));
+            while let Some(_) = rcv.next().await {
+                let _ = callback.call0(&JsValue::null());
             }
         });
 

--- a/crates/torii/client/wasm/src/lib.rs
+++ b/crates/torii/client/wasm/src/lib.rs
@@ -5,8 +5,10 @@ use std::str::FromStr;
 use futures::StreamExt;
 use starknet::core::types::FieldElement;
 use starknet::core::utils::cairo_short_string_to_felt;
+use types::ClientConfig;
 use wasm_bindgen::prelude::*;
 
+mod types;
 mod utils;
 
 use utils::parse_ty_as_json_str;
@@ -18,6 +20,9 @@ type JsEntityModel = JsValue;
 extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
+
+    #[wasm_bindgen(js_namespace = console)]
+    fn error(s: &str);
 }
 
 #[wasm_bindgen]
@@ -27,6 +32,7 @@ pub struct Client {
 
 #[wasm_bindgen]
 impl Client {
+    /// Retrieves the model value of an entity.
     #[wasm_bindgen(js_name = getModelValue)]
     pub fn get_model_value(
         &self,
@@ -50,16 +56,7 @@ impl Client {
         }
     }
 
-    /// Returns the list of entities that are currently being synced.
-    #[wasm_bindgen(getter, js_name = syncedEntities)]
-    pub fn synced_entities(&self) -> Result<JsValue, JsValue> {
-        #[cfg(feature = "console-error-panic")]
-        console_error_panic_hook::set_once();
-
-        let entities = self.inner.synced_entities();
-        serde_wasm_bindgen::to_value(&entities).map_err(|e| e.into())
-    }
-
+    /// Register new entities to be synced.
     #[wasm_bindgen(js_name = addEntitiesToSync)]
     pub async fn add_entities_to_sync(
         &mut self,
@@ -81,6 +78,7 @@ impl Client {
             .map_err(|err| JsValue::from_str(&err.to_string()))
     }
 
+    /// Remove the entities from being synced.
     #[wasm_bindgen(js_name = removeEntitiesToSync)]
     pub async fn remove_entities_to_sync(
         &self,
@@ -102,12 +100,16 @@ impl Client {
             .map_err(|err| JsValue::from_str(&err.to_string()))
     }
 
+    /// Register a callback to be called every time the specified entity change.
     #[wasm_bindgen(js_name = onEntityChange)]
     pub fn on_entity_change(
         &self,
         entity: JsEntityModel,
         callback: js_sys::Function,
     ) -> Result<(), JsValue> {
+        #[cfg(feature = "console-error-panic")]
+        console_error_panic_hook::set_once();
+
         let entity = serde_wasm_bindgen::from_value::<dojo_types::schema::EntityModel>(entity)?;
         let model = cairo_short_string_to_felt(&entity.model).expect("invalid model name");
         let mut rcv = self.inner.storage().add_listener(model, &entity.keys).unwrap();
@@ -122,23 +124,23 @@ impl Client {
     }
 }
 
-/// Spawns the client along with the subscription service.
-#[wasm_bindgen]
-pub async fn spawn_client(
-    torii_url: &str,
-    rpc_url: &str,
-    world_address: &str,
+/// Create the a client with the given configurations.
+#[wasm_bindgen(js_name = createClient)]
+pub async fn create_client(
     initial_entities_to_sync: Vec<JsEntityModel>,
+    config: ClientConfig,
 ) -> Result<Client, JsValue> {
     #[cfg(feature = "console-error-panic")]
     console_error_panic_hook::set_once();
+
+    let ClientConfig { rpc_url, torii_url, world_address } = config;
 
     let entities = initial_entities_to_sync
         .into_iter()
         .map(serde_wasm_bindgen::from_value::<dojo_types::schema::EntityModel>)
         .collect::<Result<Vec<_>, _>>()?;
 
-    let world_address = FieldElement::from_str(world_address).map_err(|err| {
+    let world_address = FieldElement::from_str(&world_address).map_err(|err| {
         JsValue::from_str(format!("failed to parse world address: {err}").as_str())
     })?;
 

--- a/crates/torii/client/wasm/src/lib.rs
+++ b/crates/torii/client/wasm/src/lib.rs
@@ -113,7 +113,7 @@ impl Client {
         let mut rcv = self.inner.storage().add_listener(model, &entity.keys).unwrap();
 
         wasm_bindgen_futures::spawn_local(async move {
-            while let Some(_) = rcv.next().await {
+            while rcv.next().await.is_some() {
                 let _ = callback.call0(&JsValue::null());
             }
         });

--- a/crates/torii/client/wasm/src/types.rs
+++ b/crates/torii/client/wasm/src/types.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+
+#[derive(Tsify, Serialize, Deserialize)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub struct ClientConfig {
+    #[serde(rename = "rpcUrl")]
+    pub rpc_url: String,
+    #[serde(rename = "toriiUrl")]
+    pub torii_url: String,
+    #[serde(rename = "worldAddress")]
+    pub world_address: String,
+}

--- a/crates/torii/client/wasm/worker.js
+++ b/crates/torii/client/wasm/worker.js
@@ -17,7 +17,7 @@ async function setup() {
 		const client = await spawn_client(
 			"http://0.0.0.0:8080/grpc",
 			"http://0.0.0.0:5050",
-			"0x3fa481f41522b90b3684ecfab7650c259a76387fab9c380b7a959e3d4ac69f",
+			"0x1af130f7b9027f3748c1e3b10ca4a82ac836a30ac4f2f84025e83a99a922a0c",
 			[
 				{
 					model: "Position",
@@ -25,33 +25,51 @@ async function setup() {
 						"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
 					],
 				},
-			]
-		);
-
-		setTimeout(() => {
-			client.addEntitiesToSync([
 				{
 					model: "Moves",
 					keys: [
 						"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
 					],
 				},
-			]);
-		}, 10000);
+			]
+		);
 
-		// setup the message handler for the worker
-		self.onmessage = function (e) {
-			const event = e.data.type;
-			const data = e.data.data;
+		client.onEntityChange({
+			model: "Moves",
+			keys: ["0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"],
+		});
 
-			if (event === "getModelValue") {
-				getModelValueHandler(client, data);
-			} else if (event === "addEntityToSync") {
-				addEntityToSyncHandler(client, data);
-			} else {
-				console.log("Sync Worker: Unknown event type", event);
-			}
-		};
+		client.onEntityChange({
+			model: "Position",
+			keys: ["0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"],
+		});
+
+		console.log("registered listeners");
+
+		// setTimeout(() => {
+		// 	client.addEntitiesToSync([
+		// 		{
+		// 			model: "Moves",
+		// 			keys: [
+		// 				"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+		// 			],
+		// 		},
+		// 	]);
+		// }, 10000);
+
+		// // setup the message handler for the worker
+		// self.onmessage = function (e) {
+		// 	const event = e.data.type;
+		// 	const data = e.data.data;
+
+		// 	if (event === "getModelValue") {
+		// 		getModelValueHandler(client, data);
+		// 	} else if (event === "addEntityToSync") {
+		// 		addEntityToSyncHandler(client, data);
+		// 	} else {
+		// 		console.log("Sync Worker: Unknown event type", event);
+		// 	}
+		// };
 
 		console.log("Torii client initialized 🔥");
 	} catch (e) {

--- a/crates/torii/client/wasm/worker.js
+++ b/crates/torii/client/wasm/worker.js
@@ -34,17 +34,25 @@ async function setup() {
 			]
 		);
 
-		client.onEntityChange({
-			model: "Moves",
-			keys: ["0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"],
-		});
+		client.onEntityChange(
+			{
+				model: "Position",
+				keys: [
+					"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+				],
+			},
+			() => {
+				const values = client.getModelValue("Position", [
+					"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+				]);
+				console.log("Position changed", values);
+			}
+		);
 
-		client.onEntityChange({
-			model: "Position",
-			keys: ["0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"],
-		});
-
-		console.log("registered listeners");
+		// client.onEntityChange({
+		// 	model: "Moves",
+		// 	keys: ["0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"],
+		// });
 
 		// setTimeout(() => {
 		// 	client.addEntitiesToSync([
@@ -88,7 +96,7 @@ async function getModelValueHandler(client, data) {
 	const model = data.model;
 	const keys = data.keys;
 
-	const values = await client.getModelValue(model, keys);
+	const values = client.getModelValue(model, keys);
 
 	console.log("Sync Worker | Got model value | values: ", values);
 

--- a/crates/torii/client/wasm/worker.js
+++ b/crates/torii/client/wasm/worker.js
@@ -5,7 +5,7 @@ importScripts("./pkg/torii_client_wasm.js");
 
 // In the worker, we have a different struct that we want to use as in
 // `index.js`.
-const { spawn_client } = wasm_bindgen;
+const { createClient } = wasm_bindgen;
 
 async function setup() {
 	console.log("Initializing torii client worker 🚧");
@@ -14,10 +14,7 @@ async function setup() {
 	await wasm_bindgen("./pkg/torii_client_wasm_bg.wasm");
 
 	try {
-		const client = await spawn_client(
-			"http://0.0.0.0:8080/grpc",
-			"http://0.0.0.0:5050",
-			"0x1af130f7b9027f3748c1e3b10ca4a82ac836a30ac4f2f84025e83a99a922a0c",
+		const client = await createClient(
 			[
 				{
 					model: "Position",
@@ -31,7 +28,13 @@ async function setup() {
 						"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
 					],
 				},
-			]
+			],
+			{
+				rpcUrl: "http://0.0.0.0:5050",
+				toriiUrl: "http://0.0.0.0:8080/grpc",
+				worldAddress:
+					"0x1af130f7b9027f3748c1e3b10ca4a82ac836a30ac4f2f84025e83a99a922a0c",
+			}
 		);
 
 		client.onEntityChange(
@@ -49,10 +52,20 @@ async function setup() {
 			}
 		);
 
-		// client.onEntityChange({
-		// 	model: "Moves",
-		// 	keys: ["0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"],
-		// });
+		client.onEntityChange(
+			{
+				model: "Moves",
+				keys: [
+					"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+				],
+			},
+			() => {
+				const values = client.getModelValue("Moves", [
+					"0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973",
+				]);
+				console.log("Moves changed", values);
+			}
+		);
 
 		// setTimeout(() => {
 		// 	client.addEntitiesToSync([

--- a/crates/torii/grpc/Cargo.toml
+++ b/crates/torii/grpc/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 [dependencies]
 bytes = "1.0"
 dojo-types = { path = "../../dojo-types" }
+futures-util = "0.3.28"
 futures.workspace = true
 parking_lot.workspace = true
 rayon.workspace = true
@@ -31,7 +32,6 @@ wasm-prost.workspace = true
 wasm-tonic.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-futures-util = "0.3.28"
 prost.workspace = true
 sqlx = { version = "0.6.2", features = [ "chrono", "macros", "offline", "runtime-actix-rustls", "sqlite", "uuid" ] }
 tokio-stream = "0.1.14"


### PR DESCRIPTION
This would allow us to have in the JS binding, something like this 

```js
client.onEntityChange({ model: "Position", keys: [ .. ] }, () => {
  // do something here
})
```

