### PR TITLE
semantic: test constraints

### DIFF
--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -117,7 +117,7 @@ impl Compiler for DojoCompiler {
         let mut manifest = target_dir
             .open_ro("manifest.json", "output file", ws.config())
             .map(|file| dojo_world::manifest::Manifest::try_from(file.deref()).unwrap_or_default())
-            .unwrap_or(dojo_world::manifest::Manifest::default());
+            .unwrap_or_default();
 
         update_manifest(&mut manifest, db, &main_crate_ids, compiled_classes)?;
 

--- a/crates/dojo-lang/src/semantics/test_data/get
+++ b/crates/dojo-lang/src/semantics/test_data/get
@@ -90,7 +90,7 @@ get!(world)
 true
 
 //! > dojo_semantic
-get_success
+get_tail
 
 //! > test_runner_name
 test_semantics

--- a/crates/dojo-test-utils/build.rs
+++ b/crates/dojo-test-utils/build.rs
@@ -10,8 +10,7 @@ fn main() {
     use scarb::ops::{self, CompileOpts};
     use scarb_ui::Verbosity;
 
-    let project_paths =
-        vec!["../../examples/spawn-and-move", "../torii/graphql/src/tests/types-test"];
+    let project_paths = ["../../examples/spawn-and-move", "../torii/graphql/src/tests/types-test"];
 
     project_paths.iter().for_each(|path| compile(path));
 


### PR DESCRIPTION
```
chore: clippy/fmt
semantic: test constraints
```

Minor updates to add semantic test constraints like `get!` should return a tail and correct inputs should not result in diagnostic errors.

Helps to enforce the constraints are met and `CAIRO_FIX_TESTS` with incorrect semantics doesn't make failing tests pass.