### PR TITLE
feat(katana): configurable max RPC connections

### DIFF
--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -37,6 +37,7 @@ impl TestSequencer {
             ServerConfig {
                 port: 0,
                 host: "0.0.0.0".into(),
+                max_connections: 100,
                 apis: vec![ApiKind::Starknet, ApiKind::Katana],
             },
         )

--- a/crates/katana/rpc/src/config.rs
+++ b/crates/katana/rpc/src/config.rs
@@ -4,6 +4,7 @@ use crate::api::ApiKind;
 pub struct ServerConfig {
     pub port: u16,
     pub host: String,
+    pub max_connections: u32,
     pub apis: Vec<ApiKind>,
 }
 

--- a/crates/katana/rpc/src/lib.rs
+++ b/crates/katana/rpc/src/lib.rs
@@ -56,6 +56,7 @@ pub async fn spawn(sequencer: Arc<KatanaSequencer>, config: ServerConfig) -> Res
         .set_logger(RpcLogger)
         .set_host_filtering(AllowHosts::Any)
         .set_middleware(middleware)
+        .max_connections(config.max_connections)
         .build(config.addr())
         .await?;
 

--- a/crates/katana/src/args.rs
+++ b/crates/katana/src/args.rs
@@ -101,6 +101,11 @@ pub struct ServerOptions {
     #[arg(long)]
     #[arg(help = "The IP address the server will listen on.")]
     pub host: Option<String>,
+
+    #[arg(long)]
+    #[arg(default_value = "100")]
+    #[arg(help = "Maximum number of concurrent connections allowed.")]
+    pub max_connections: u32,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -184,6 +189,7 @@ impl KatanaArgs {
             apis,
             port: self.server.port,
             host: self.server.host.clone().unwrap_or("0.0.0.0".into()),
+            max_connections: self.server.max_connections,
         }
     }
 


### PR DESCRIPTION
`jsonrpsee` imposes a limit of 100 concurrent connections by default. Katana currently offers no way to configure this. This PR adds a `--max-connections` option for setting this value.