### PR TITLE
fix: incorrect error code for tx hash not found

### DIFF
--- a/crates/katana/rpc/src/api/starknet.rs
+++ b/crates/katana/rpc/src/api/starknet.rs
@@ -31,7 +31,7 @@ pub enum StarknetApiError {
     #[error("Block not found")]
     BlockNotFound = 24,
     #[error("Transaction hash not found")]
-    TxnHashNotFound = 25,
+    TxnHashNotFound = 29,
     #[error("Invalid transaction index in a block")]
     InvalidTxnIndex = 27,
     #[error("Class hash not found")]


### PR DESCRIPTION
The error code for the tx hash not found error has been [changed](https://github.com/starkware-libs/starknet-specs/blob/6fadca1f1abf48523c0aa799a10061f40f973468/api/starknet_api_openrpc.json#L2999_L3002) to `29` since v0.4.0.

Starkli used to be able to work with Katana because `starknet-rs` has allowed this wrong code to be used. However, it no longer does in the latest version. Now watching txs with Starkli on Katana results in an error.