### PR TITLE
Use `nextest` for runnning test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
       - uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install nextest test runner
+        uses: taiki-e/install-action@nextest
       - run: |
-          cargo test --all-features
+          cargo nextest run --all-features
 
   ensure-wasm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://nexte.st/index.html

faster test execution than using `cargo test`. from local test, able to get 2-3x speedup when running tests