### PR TITLE
🚧✨ Store contract abi and source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,7 @@ dependencies = [
  "cairo-lang-filesystem",
  "cairo-lang-project",
  "cairo-lang-starknet",
+ "cairo-lang-utils",
  "camino",
  "convert_case 0.6.0",
  "dojo-lang",

--- a/crates/dojo-core/Scarb.lock
+++ b/crates/dojo-core/Scarb.lock
@@ -3,11 +3,11 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "dojo_plugin",
 ]
 
 [[package]]
 name = "dojo_plugin"
-version = "0.3.1"
+version = "0.3.2"

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -314,7 +314,7 @@ fn get_dojo_model_artifacts(
         {
             let model_contract_name = model.name.to_case(Case::Snake);
 
-            let (class_hash, abi, _) = compiled_classes
+            let (class_hash, abi, source) = compiled_classes
                 .get(model_contract_name.as_str())
                 .cloned()
                 .ok_or(anyhow!("Model {} not found in target.", model.name))?;
@@ -323,6 +323,7 @@ fn get_dojo_model_artifacts(
                 model.name.clone(),
                 dojo_world::manifest::Model {
                     abi,
+                    source,
                     class_hash,
                     name: model.name.clone(),
                     members: model.members.clone(),

--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -12,6 +12,7 @@ async-trait.workspace = true
 cairo-lang-filesystem.workspace = true
 cairo-lang-project.workspace = true
 cairo-lang-starknet.workspace = true
+cairo-lang-utils.workspace = true
 camino.workspace = true
 convert_case.workspace = true
 futures.workspace = true

--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 
 use ::serde::{Deserialize, Serialize};
 use cairo_lang_starknet::abi;
-use cairo_lang_utils::bigint::BigUintAsHex;
 use serde_with::serde_as;
 use smol_str::SmolStr;
 use starknet::core::serde::unsigned_field_element::UfeHex;
@@ -79,7 +78,6 @@ pub struct Model {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     pub abi: Option<abi::Contract>,
-    pub source: Vec<BigUintAsHex>,
 }
 
 /// System input ABI.
@@ -106,7 +104,6 @@ pub struct Contract {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     pub abi: Option<abi::Contract>,
-    pub source: Vec<BigUintAsHex>,
     pub reads: Vec<String>,
     pub writes: Vec<String>,
 }
@@ -118,7 +115,6 @@ pub struct Class {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     pub abi: Option<abi::Contract>,
-    pub source: Vec<BigUintAsHex>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use ::serde::{Deserialize, Serialize};
 use cairo_lang_starknet::abi;
+use cairo_lang_utils::bigint::BigUintAsHex;
 use serde_with::serde_as;
 use smol_str::SmolStr;
 use starknet::core::serde::unsigned_field_element::UfeHex;
@@ -104,6 +105,7 @@ pub struct Contract {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     pub abi: Option<abi::Contract>,
+    pub source: Vec<BigUintAsHex>,
     pub reads: Vec<String>,
     pub writes: Vec<String>,
 }
@@ -115,6 +117,7 @@ pub struct Class {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     pub abi: Option<abi::Contract>,
+    pub source: Vec<BigUintAsHex>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -79,6 +79,7 @@ pub struct Model {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     pub abi: Option<abi::Contract>,
+    pub source: Vec<BigUintAsHex>,
 }
 
 /// System input ABI.

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -75,6 +75,8 @@ pub struct WorldMetadata {
     pub icon_uri: Option<Uri>,
     pub website: Option<Url>,
     pub socials: Option<HashMap<String, String>>,
+    pub abi_uri: Option<Uri>,
+    pub source_uri: Option<Uri>,
 }
 
 #[derive(Default, Deserialize, Clone, Debug)]
@@ -143,6 +145,21 @@ impl WorldMetadata {
             let response = client.add(reader).await?;
             meta.cover_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
         };
+        
+        if let Some(Uri::File(abi)) = &self.abi_uri {
+            let abi_data = std::fs::read(abi)?;
+            let reader = Cursor::new(abi_data);
+            let response = client.add(reader).await?;
+            meta.abi_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
+        };
+
+        if let Some(Uri::File(source)) = &self.source_uri {
+            let source_data = std::fs::read(source)?;
+            let reader = Cursor::new(source_data);
+            let response = client.add(reader).await?;
+            meta.source_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
+        };
+
 
         let serialized = json!(meta).to_string();
         let reader = Cursor::new(serialized);

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -145,7 +145,7 @@ impl WorldMetadata {
             let response = client.add(reader).await?;
             meta.cover_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
         };
-        
+
         if let Some(Uri::File(abi)) = &self.abi_uri {
             let abi_data = std::fs::read(abi)?;
             let reader = Cursor::new(abi_data);
@@ -159,7 +159,6 @@ impl WorldMetadata {
             let response = client.add(reader).await?;
             meta.source_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
         };
-
 
         let serialized = json!(meta).to_string();
         let reader = Cursor::new(serialized);

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -76,7 +76,6 @@ pub struct WorldMetadata {
     pub website: Option<Url>,
     pub socials: Option<HashMap<String, String>>,
     pub abi_uri: Option<Uri>,
-    pub source_uri: Option<Uri>,
 }
 
 #[derive(Default, Deserialize, Clone, Debug)]
@@ -151,13 +150,6 @@ impl WorldMetadata {
             let reader = Cursor::new(abi_data);
             let response = client.add(reader).await?;
             meta.abi_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
-        };
-
-        if let Some(Uri::File(source)) = &self.source_uri {
-            let source_data = std::fs::read(source)?;
-            let reader = Cursor::new(source_data);
-            let response = client.add(reader).await?;
-            meta.source_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
         };
 
         let serialized = json!(meta).to_string();

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -25,7 +25,6 @@ icon_uri = "file://example_icon.png"
 website = "https://dojoengine.org"
 socials.x = "https://x.com/dojostarknet"
 abi_uri = "file://path/abi.json"
-source_uri = "file://path/source.json"
         "#,
     )
     .unwrap();
@@ -59,7 +58,6 @@ source_uri = "file://path/source.json"
     assert_eq!(world.website, Some(Url::parse("https://dojoengine.org").unwrap()));
     assert_eq!(world.socials.unwrap().get("x"), Some(&"https://x.com/dojostarknet".to_string()));
     assert_eq!(world.abi_uri, Some(Uri::File("path/abi.json".into())));
-    assert_eq!(world.source_uri, Some(Uri::File("path/source.json".into())));
 }
 
 #[tokio::test]
@@ -72,7 +70,6 @@ async fn world_metadata_hash_and_upload() {
         website: Some(Url::parse("https://dojoengine.org").unwrap()),
         socials: Some(HashMap::from([("x".to_string(), "https://x.com/dojostarknet".to_string())])),
         abi_uri: None,
-        source_uri: None,
     };
 
     let _ = meta.upload().await.unwrap();

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -24,6 +24,8 @@ cover_uri = "file://example_cover.png"
 icon_uri = "file://example_icon.png"
 website = "https://dojoengine.org"
 socials.x = "https://x.com/dojostarknet"
+abi_uri = "file://path/abi.json"
+source_uri = "file://path/source.json"
         "#,
     )
     .unwrap();
@@ -56,6 +58,8 @@ socials.x = "https://x.com/dojostarknet"
     assert_eq!(world.icon_uri, Some(Uri::File("example_icon.png".into())));
     assert_eq!(world.website, Some(Url::parse("https://dojoengine.org").unwrap()));
     assert_eq!(world.socials.unwrap().get("x"), Some(&"https://x.com/dojostarknet".to_string()));
+    assert_eq!(world.abi_uri, Some(Uri::File("path/abi.json".into())));
+    assert_eq!(world.source_uri, Some(Uri::File("path/source.json".into())));
 }
 
 #[tokio::test]
@@ -67,6 +71,8 @@ async fn world_metadata_hash_and_upload() {
         icon_uri: None,
         website: Some(Url::parse("https://dojoengine.org").unwrap()),
         socials: Some(HashMap::from([("x".to_string(), "https://x.com/dojostarknet".to_string())])),
+        abi_uri: None,
+        source_uri: None,
     };
 
     let _ = meta.upload().await.unwrap();

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{anyhow, bail, Context, Result};
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::manifest::{Manifest, ManifestError};
-use dojo_world::metadata::{dojo_metadata_from_workspace, WorldMetadata, Metadata};
+use dojo_world::metadata::{dojo_metadata_from_workspace, Metadata, WorldMetadata};
 use dojo_world::migration::contract::ContractMigration;
 use dojo_world::migration::strategy::{generate_salt, prepare_for_migration, MigrationStrategy};
 use dojo_world::migration::world::WorldDiff;


### PR DESCRIPTION
Closes #1121 

> The upload method should be updated to upload the serialized abi json and the contract source to ipfs and set the ipfs uri into the WorldMetadata before upload.

I tried to add tests into `metadata_tests.rs` file, but it seems tests in it are not play at all while running `cargo run --bin sozo -- --manifest-path crates/dojo-core/Scarb.toml test` (neither in the CI) not sure where does it come from but I guess it was the case before I did anything, so probably expected for some reason.

> It should be modified to always create a WorldMetadata with the abi and source fields and merge in the user defined metadata from the manifest.

I decided to override default WorldMetadata (with `abi `and `source`) by the user manifest, so I guess both fields could be overridden by a user input, which is more flexible but mb less secure.

> We will need to update the compiler to output the flattened source representation too.

About this topic, I understood to add the sierra program code into the manifest file generated after a build, I hope I have git it correctly.

Workload ~ 5h