### PR TITLE
Compute entrypoints manifest

### DIFF
--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -741,7 +741,8 @@ test_manifest_file
       }
     ],
     "reads": [],
-    "writes": []
+    "writes": [],
+    "computed": []
   },
   "executor": {
     "name": "executor",
@@ -801,7 +802,8 @@ test_manifest_file
       }
     ],
     "reads": [],
-    "writes": []
+    "writes": [],
+    "computed": []
   },
   "base": {
     "name": "base",
@@ -868,7 +870,7 @@ test_manifest_file
     {
       "name": "actions",
       "address": null,
-      "class_hash": "0xba8e2a55038595954fe38abe74f8c1e5237fae4410e662e8085ca38f013f1f",
+      "class_hash": "0x308ad5fcd288ea5ded168bbc502261d75458c13fa1df552bd41ca3d86347dfe",
       "abi": [
         {
           "type": "impl",
@@ -961,6 +963,66 @@ test_manifest_file
           "state_mutability": "view"
         },
         {
+          "type": "struct",
+          "name": "dojo_examples::models::Vec2",
+          "members": [
+            {
+              "name": "x",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "y",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "tile_terrain",
+          "inputs": [
+            {
+              "name": "vec",
+              "type": "dojo_examples::models::Vec2"
+            }
+          ],
+          "outputs": [
+            {
+              "type": "core::felt252"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "struct",
+          "name": "dojo_examples::models::Position",
+          "members": [
+            {
+              "name": "player",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "vec",
+              "type": "dojo_examples::models::Vec2"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "quadrant",
+          "inputs": [
+            {
+              "name": "pos",
+              "type": "dojo_examples::models::Position"
+            }
+          ],
+          "outputs": [
+            {
+              "type": "core::integer::u8"
+            }
+          ],
+          "state_mutability": "view"
+        },
+        {
           "type": "event",
           "name": "dojo_examples::actions::actions::Moved",
           "kind": "struct",
@@ -997,6 +1059,18 @@ test_manifest_file
       "writes": [
         "Moves",
         "Position"
+      ],
+      "computed": [
+        {
+          "contract": "actions",
+          "entrypoint": "tile_terrain",
+          "model": null
+        },
+        {
+          "contract": "actions",
+          "entrypoint": "quadrant",
+          "model": "Position"
+        }
       ]
     }
   ],

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -14,7 +14,8 @@ use cairo_lang_syntax::attribute::structured::{
 };
 use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::helpers::QueryAttrs;
-use cairo_lang_syntax::node::{ast, Terminal};
+use cairo_lang_syntax::node::ids::SyntaxStablePtrId;
+use cairo_lang_syntax::node::{ast, Terminal, TypedSyntaxNode};
 use camino::{Utf8Path, Utf8PathBuf};
 use directories::ProjectDirs;
 use dojo_types::system::Dependency;
@@ -56,7 +57,26 @@ pub struct DojoAuxData {
     /// A list of systems that were processed by the plugin and their model dependencies.
     pub systems: Vec<SystemAuxData>,
 }
+
 impl GeneratedFileAuxData for DojoAuxData {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn eq(&self, other: &dyn GeneratedFileAuxData) -> bool {
+        if let Some(other) = other.as_any().downcast_ref::<Self>() { self == other } else { false }
+    }
+}
+
+/// Dojo related auxiliary data of the Dojo plugin.
+#[derive(Debug, Default, PartialEq)]
+pub struct ComputedValuesAuxData {
+    // Name of entrypoint to get computed value
+    pub entrypoint: SmolStr,
+    // Model to bind to
+    pub model: Option<String>,
+}
+
+impl GeneratedFileAuxData for ComputedValuesAuxData {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
@@ -111,6 +131,92 @@ impl BuiltinDojoPlugin {
             .source_id(SourceId::for_path(MANIFEST_PATH.as_path()).unwrap())
             .version_req(version_req)
             .build()
+    }
+
+    fn result_with_diagnostic(
+        &self,
+        stable_ptr: SyntaxStablePtrId,
+        message: String,
+    ) -> PluginResult {
+        PluginResult {
+            code: None,
+            diagnostics: vec![PluginDiagnostic { stable_ptr, message }],
+            remove_original_item: false,
+        }
+    }
+
+    fn handle_fn(&self, db: &dyn SyntaxGroup, fn_ast: ast::FunctionWithBody) -> PluginResult {
+        let attrs = fn_ast.attributes(db).query_attr(db, "computed");
+        if attrs.is_empty() {
+            return PluginResult::default();
+        }
+        if attrs.len() != 1 {
+            return self.result_with_diagnostic(
+                attrs[0].attr(db).stable_ptr().untyped(),
+                format!("Expected one computed macro per function, got {:?}.", attrs.len()),
+            );
+        }
+        let attr = attrs[0].clone().structurize(db);
+        let args = attr.args;
+        if args.len() > 1 {
+            return self.result_with_diagnostic(
+                attr.args_stable_ptr.untyped(),
+                "Expected one arg for computed macro.\nUsage: #[computed(Position)]".into(),
+            );
+        }
+        let fn_decl = fn_ast.declaration(db);
+        let fn_name = fn_decl.name(db).text(db);
+        let params = fn_decl.signature(db).parameters(db);
+        let param_els = params.elements(db);
+        let mut model = None;
+        if args.len() == 1 {
+            let model_name = args[0].text(db);
+            model = Some(model_name.clone());
+            let model_type_node = param_els[1].type_clause(db).ty(db);
+            if let ast::Expr::Path(model_type_path) = model_type_node {
+                let model_type = model_type_path
+                    .elements(db)
+                    .iter()
+                    .last()
+                    .unwrap()
+                    .as_syntax_node()
+                    .get_text(db);
+                if model_type != model_name {
+                    return self.result_with_diagnostic(
+                        model_type_path.stable_ptr().untyped(),
+                        "Computed functions second parameter should be the model.".into(),
+                    );
+                }
+            } else {
+                return self.result_with_diagnostic(
+                    params.stable_ptr().untyped(),
+                    format!(
+                        "Computed function parameter node of unsupported type {:?}.",
+                        model_type_node.as_syntax_node().get_text(db)
+                    ),
+                );
+            }
+            if param_els.len() != 2 {
+                return self.result_with_diagnostic(
+                    params.stable_ptr().untyped(),
+                    "Computed function should take 2 parameters, contract state and model.".into(),
+                );
+            }
+        }
+
+        PluginResult {
+            code: Some(PluginGeneratedFile {
+                name: fn_name.clone(),
+                content: "".into(),
+                aux_data: Some(DynGeneratedFileAuxData::new(ComputedValuesAuxData {
+                    model,
+                    entrypoint: fn_name,
+                })),
+                diagnostics_mappings: vec![],
+            }),
+            diagnostics: vec![],
+            remove_original_item: false,
+        }
     }
 }
 
@@ -305,12 +411,13 @@ impl MacroPlugin for BuiltinDojoPlugin {
                     remove_original_item: false,
                 }
             }
+            ast::Item::FreeFunction(fn_ast) => self.handle_fn(db, fn_ast),
             _ => PluginResult::default(),
         }
     }
 
     fn declared_attributes(&self) -> Vec<String> {
-        vec!["dojo::contract".to_string(), "key".to_string()]
+        vec!["dojo::contract".to_string(), "key".to_string(), "computed".to_string()]
     }
 }
 

--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -97,6 +97,17 @@ pub struct Output {
 
 #[serde_as]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ComputedValueEntrypoint {
+    // Name of the contract containing the entrypoint
+    pub contract: SmolStr,
+    // Name of entrypoint to get computed value
+    pub entrypoint: SmolStr,
+    // Component to compute for
+    pub model: Option<String>,
+}
+
+#[serde_as]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Contract {
     pub name: SmolStr,
     #[serde_as(as = "Option<UfeHex>")]
@@ -106,6 +117,7 @@ pub struct Contract {
     pub abi: Option<abi::Contract>,
     pub reads: Vec<String>,
     pub writes: Vec<String>,
+    pub computed: Vec<ComputedValueEntrypoint>,
 }
 
 #[serde_as]

--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -27,6 +27,31 @@ mod actions {
         direction: Direction
     }
 
+    #[external(v0)]
+    #[computed]
+    fn tile_terrain(self: @ContractState, vec: Vec2) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    #[computed(Position)]
+    fn quadrant(self: @ContractState, pos: Position) -> u8 {
+        // 10 is zero
+        if pos.vec.x < 10 {
+            if pos.vec.y < 10 {
+                3 // Quadrant - -
+            } else {
+                4 // Quadrant - +
+            }
+        } else {
+            if pos.vec.y < 10 {
+                2 // Quadrant + -
+            } else {
+                1 // Quadrant + +
+            }
+        }
+    }
+
     // impl: implement functions specified in trait
     #[external(v0)]
     impl ActionsImpl of IActions<ContractState> {


### PR DESCRIPTION
New `computed` field on Contract in manifest...

```js
      contract.computed = [
        // For `#[computed]`
        {
          "contract": "actions",
          "entrypoint": "entrypoint_name",
          "component": null
        },
        // For `#[computed(ModelName)]`
        {
          "contract": "actions",
          "entrypoint": "entrypoint_name",
          "component": "ModelName"
        }
      ];
```

⚠️ At the moment only FreeFunctions are supported (not the ones in impl).