### PR TITLE
Add page info field to connection object

### DIFF
--- a/crates/torii/core/Cargo.toml
+++ b/crates/torii/core/Cargo.toml
@@ -14,7 +14,7 @@ async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 dojo-types = { path = "../../dojo-types" }
-dojo-world = { path = "../../dojo-world", features = [ "contracts", "manifest" ] }
+dojo-world = { path = "../../dojo-world", features = [ "contracts", "manifest", "metadata" ] }
 futures-channel = "0.3.0"
 futures-util = "0.3.0"
 hex.workspace = true

--- a/crates/torii/core/Cargo.toml
+++ b/crates/torii/core/Cargo.toml
@@ -14,7 +14,7 @@ async-trait.workspace = true
 base64.workspace = true
 chrono.workspace = true
 dojo-types = { path = "../../dojo-types" }
-dojo-world = { path = "../../dojo-world", features = [ "contracts", "manifest", "metadata" ] }
+dojo-world = { path = "../../dojo-world", features = [ "contracts", "manifest" ] }
 futures-channel = "0.3.0"
 futures-util = "0.3.0"
 hex.workspace = true

--- a/crates/torii/graphql/src/constants.rs
+++ b/crates/torii/graphql/src/constants.rs
@@ -1,6 +1,5 @@
 pub const DEFAULT_LIMIT: u64 = 10;
 pub const BOOLEAN_TRUE: i64 = 1;
-pub const PAGE_INFO_OFFSET: u64 = 2;
 
 pub const ENTITY_TABLE: &str = "entities";
 pub const EVENT_TABLE: &str = "events";

--- a/crates/torii/graphql/src/constants.rs
+++ b/crates/torii/graphql/src/constants.rs
@@ -1,5 +1,6 @@
 pub const DEFAULT_LIMIT: u64 = 10;
 pub const BOOLEAN_TRUE: i64 = 1;
+pub const PAGE_INFO_OFFSET: u64 = 2;
 
 pub const ENTITY_TABLE: &str = "entities";
 pub const EVENT_TABLE: &str = "events";
@@ -21,6 +22,7 @@ pub const EVENT_TYPE_NAME: &str = "World__Event";
 pub const SOCIAL_TYPE_NAME: &str = "World__Social";
 pub const CONTENT_TYPE_NAME: &str = "World__Content";
 pub const METADATA_TYPE_NAME: &str = "World__Metadata";
+pub const PAGE_INFO_TYPE_NAME: &str = "World__PageInfo";
 pub const TRANSACTION_TYPE_NAME: &str = "World__Transaction";
 pub const QUERY_TYPE_NAME: &str = "World__Query";
 pub const SUBSCRIPTION_TYPE_NAME: &str = "World__Subscription";

--- a/crates/torii/graphql/src/object/connection/mod.rs
+++ b/crates/torii/graphql/src/object/connection/mod.rs
@@ -43,7 +43,7 @@ impl ConnectionObject {
             (Name::new("total_count"), TypeData::Simple(TypeRef::named_nn(TypeRef::INT))),
             (
                 Name::new("page_info"),
-                TypeData::Nested((TypeRef::named(PAGE_INFO_TYPE_NAME), IndexMap::new())),
+                TypeData::Nested((TypeRef::named_nn(PAGE_INFO_TYPE_NAME), IndexMap::new())),
             ),
         ]);
 
@@ -117,7 +117,7 @@ pub fn connection_output(
     id_column: &str,
     total_count: i64,
     is_external: bool,
-    page_info: Option<PageInfo>,
+    page_info: PageInfo,
 ) -> sqlx::Result<ValueMapping> {
     let model_edges = data
         .iter()

--- a/crates/torii/graphql/src/object/connection/mod.rs
+++ b/crates/torii/graphql/src/object/connection/mod.rs
@@ -1,12 +1,13 @@
 use async_graphql::connection::PageInfo;
+use async_graphql::dynamic::indexmap::IndexMap;
 use async_graphql::dynamic::{Field, InputValue, ResolverContext, TypeRef};
 use async_graphql::{Error, Name, Value};
 use sqlx::sqlite::SqliteRow;
 use sqlx::Row;
 
 use self::page_info::PageInfoObject;
-
 use super::ObjectTrait;
+use crate::constants::PAGE_INFO_TYPE_NAME;
 use crate::query::order::Order;
 use crate::query::value_mapping_from_row;
 use crate::types::{GraphqlType, TypeData, TypeMapping, ValueMapping};
@@ -40,6 +41,10 @@ impl ConnectionObject {
                 TypeData::Simple(TypeRef::named_list(format!("{}Edge", type_name))),
             ),
             (Name::new("total_count"), TypeData::Simple(TypeRef::named_nn(TypeRef::INT))),
+            (
+                Name::new("page_info"),
+                TypeData::Nested((TypeRef::named(PAGE_INFO_TYPE_NAME), IndexMap::new())),
+            ),
         ]);
 
         Self {

--- a/crates/torii/graphql/src/object/connection/mod.rs
+++ b/crates/torii/graphql/src/object/connection/mod.rs
@@ -1,7 +1,10 @@
+use async_graphql::connection::PageInfo;
 use async_graphql::dynamic::{Field, InputValue, ResolverContext, TypeRef};
 use async_graphql::{Error, Name, Value};
 use sqlx::sqlite::SqliteRow;
 use sqlx::Row;
+
+use self::page_info::PageInfoObject;
 
 use super::ObjectTrait;
 use crate::query::order::Order;
@@ -109,6 +112,7 @@ pub fn connection_output(
     id_column: &str,
     total_count: i64,
     is_external: bool,
+    page_info: PageInfo,
 ) -> sqlx::Result<ValueMapping> {
     let model_edges = data
         .iter()
@@ -130,9 +134,11 @@ pub fn connection_output(
             Ok(Value::Object(edge))
         })
         .collect::<sqlx::Result<Vec<Value>>>();
+    let page_info = PageInfoObject::value_mapping(page_info);
 
     Ok(ValueMapping::from([
         (Name::new("total_count"), Value::from(total_count)),
         (Name::new("edges"), Value::List(model_edges?)),
+        (Name::new("page_info"), Value::Object(page_info)),
     ]))
 }

--- a/crates/torii/graphql/src/object/connection/mod.rs
+++ b/crates/torii/graphql/src/object/connection/mod.rs
@@ -117,7 +117,7 @@ pub fn connection_output(
     id_column: &str,
     total_count: i64,
     is_external: bool,
-    page_info: PageInfo,
+    page_info: Option<PageInfo>,
 ) -> sqlx::Result<ValueMapping> {
     let model_edges = data
         .iter()
@@ -139,11 +139,10 @@ pub fn connection_output(
             Ok(Value::Object(edge))
         })
         .collect::<sqlx::Result<Vec<Value>>>();
-    let page_info = PageInfoObject::value_mapping(page_info);
 
     Ok(ValueMapping::from([
         (Name::new("total_count"), Value::from(total_count)),
         (Name::new("edges"), Value::List(model_edges?)),
-        (Name::new("page_info"), Value::Object(page_info)),
+        (Name::new("page_info"), PageInfoObject::value(page_info)),
     ]))
 }

--- a/crates/torii/graphql/src/object/connection/page_info.rs
+++ b/crates/torii/graphql/src/object/connection/page_info.rs
@@ -31,27 +31,24 @@ impl ObjectTrait for PageInfoObject {
 }
 
 impl PageInfoObject {
-    pub fn value(page_info: Option<PageInfo>) -> Value {
-        match page_info {
-            Some(page_info) => Value::Object(IndexMap::from([
-                (Name::new("has_previous_page"), Value::from(page_info.has_previous_page)),
-                (Name::new("has_next_page"), Value::from(page_info.has_next_page)),
-                (
-                    Name::new("start_cursor"),
-                    match page_info.start_cursor {
-                        Some(val) => Value::from(val),
-                        None => Value::Null,
-                    },
-                ),
-                (
-                    Name::new("end_cursor"),
-                    match page_info.end_cursor {
-                        Some(val) => Value::from(val),
-                        None => Value::Null,
-                    },
-                ),
-            ])),
-            None => Value::Null,
-        }
+    pub fn value(page_info: PageInfo) -> Value {
+        Value::Object(IndexMap::from([
+            (Name::new("has_previous_page"), Value::from(page_info.has_previous_page)),
+            (Name::new("has_next_page"), Value::from(page_info.has_next_page)),
+            (
+                Name::new("start_cursor"),
+                match page_info.start_cursor {
+                    Some(val) => Value::from(val),
+                    None => Value::Null,
+                },
+            ),
+            (
+                Name::new("end_cursor"),
+                match page_info.end_cursor {
+                    Some(val) => Value::from(val),
+                    None => Value::Null,
+                },
+            ),
+        ]))
     }
 }

--- a/crates/torii/graphql/src/object/connection/page_info.rs
+++ b/crates/torii/graphql/src/object/connection/page_info.rs
@@ -1,7 +1,11 @@
+use async_graphql::connection::PageInfo;
+use async_graphql::dynamic::indexmap::IndexMap;
 use async_graphql::dynamic::Field;
+use async_graphql::{Name, Value};
 
 use crate::mapping::PAGE_INFO_TYPE_MAPPING;
 use crate::object::{ObjectTrait, TypeMapping};
+use crate::types::ValueMapping;
 
 pub struct PageInfoObject;
 
@@ -24,5 +28,28 @@ impl ObjectTrait for PageInfoObject {
 
     fn resolve_many(&self) -> Option<Field> {
         None
+    }
+}
+
+impl PageInfoObject {
+    pub fn value_mapping(page_info: PageInfo) -> ValueMapping {
+        IndexMap::from([
+            (Name::new("has_revious_page"), Value::from(page_info.has_previous_page)),
+            (Name::new("has_next_page"), Value::from(page_info.has_next_page)),
+            (
+                Name::new("start_cursor"),
+                match page_info.start_cursor {
+                    Some(val) => Value::from(val),
+                    None => Value::Null,
+                },
+            ),
+            (
+                Name::new("end_cursor"),
+                match page_info.end_cursor {
+                    Some(val) => Value::from(val),
+                    None => Value::Null,
+                },
+            ),
+        ])
     }
 }

--- a/crates/torii/graphql/src/object/connection/page_info.rs
+++ b/crates/torii/graphql/src/object/connection/page_info.rs
@@ -5,7 +5,6 @@ use async_graphql::{Name, Value};
 
 use crate::mapping::PAGE_INFO_TYPE_MAPPING;
 use crate::object::{ObjectTrait, TypeMapping};
-use crate::types::ValueMapping;
 
 pub struct PageInfoObject;
 
@@ -32,24 +31,27 @@ impl ObjectTrait for PageInfoObject {
 }
 
 impl PageInfoObject {
-    pub fn value_mapping(page_info: PageInfo) -> ValueMapping {
-        IndexMap::from([
-            (Name::new("has_previous_page"), Value::from(page_info.has_previous_page)),
-            (Name::new("has_next_page"), Value::from(page_info.has_next_page)),
-            (
-                Name::new("start_cursor"),
-                match page_info.start_cursor {
-                    Some(val) => Value::from(val),
-                    None => Value::Null,
-                },
-            ),
-            (
-                Name::new("end_cursor"),
-                match page_info.end_cursor {
-                    Some(val) => Value::from(val),
-                    None => Value::Null,
-                },
-            ),
-        ])
+    pub fn value(page_info: Option<PageInfo>) -> Value {
+        match page_info {
+            Some(page_info) => Value::Object(IndexMap::from([
+                (Name::new("has_previous_page"), Value::from(page_info.has_previous_page)),
+                (Name::new("has_next_page"), Value::from(page_info.has_next_page)),
+                (
+                    Name::new("start_cursor"),
+                    match page_info.start_cursor {
+                        Some(val) => Value::from(val),
+                        None => Value::Null,
+                    },
+                ),
+                (
+                    Name::new("end_cursor"),
+                    match page_info.end_cursor {
+                        Some(val) => Value::from(val),
+                        None => Value::Null,
+                    },
+                ),
+            ])),
+            None => Value::Null,
+        }
     }
 }

--- a/crates/torii/graphql/src/object/connection/page_info.rs
+++ b/crates/torii/graphql/src/object/connection/page_info.rs
@@ -34,7 +34,7 @@ impl ObjectTrait for PageInfoObject {
 impl PageInfoObject {
     pub fn value_mapping(page_info: PageInfo) -> ValueMapping {
         IndexMap::from([
-            (Name::new("has_revious_page"), Value::from(page_info.has_previous_page)),
+            (Name::new("has_previous_page"), Value::from(page_info.has_previous_page)),
             (Name::new("has_next_page"), Value::from(page_info.has_next_page)),
             (
                 Name::new("start_cursor"),

--- a/crates/torii/graphql/src/object/entity.rs
+++ b/crates/torii/graphql/src/object/entity.rs
@@ -84,10 +84,8 @@ impl ObjectTrait for EntityObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![SubscriptionField::new(
-            "entityUpdated",
-            TypeRef::named_nn(self.type_name()),
-            |ctx| {
+        Some(vec![
+            SubscriptionField::new("entityUpdated", TypeRef::named_nn(self.type_name()), |ctx| {
                 SubscriptionFieldFuture::new(async move {
                     let id = match ctx.args.get("id") {
                         Some(id) => Some(id.string()?.to_string()),
@@ -104,9 +102,9 @@ impl ObjectTrait for EntityObject {
                         }
                     }))
                 })
-            },
-        )
-        .argument(InputValue::new("id", TypeRef::named(TypeRef::ID)))])
+            })
+            .argument(InputValue::new("id", TypeRef::named(TypeRef::ID))),
+        ])
     }
 }
 

--- a/crates/torii/graphql/src/object/entity.rs
+++ b/crates/torii/graphql/src/object/entity.rs
@@ -60,6 +60,7 @@ impl ObjectTrait for EntityObject {
                         &None,
                         &None,
                         &connection,
+                        total_count,
                     )
                     .await?;
                     let results = connection_output(

--- a/crates/torii/graphql/src/object/entity.rs
+++ b/crates/torii/graphql/src/object/entity.rs
@@ -15,7 +15,7 @@ use super::inputs::keys_input::{keys_argument, parse_keys_argument};
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::constants::{ENTITY_NAMES, ENTITY_TABLE, ENTITY_TYPE_NAME, EVENT_ID_COLUMN};
 use crate::mapping::ENTITY_TYPE_MAPPING;
-use crate::query::data::{count_rows, fetch_multiple_rows, fetch_page_info};
+use crate::query::data::{count_rows, fetch_multiple_rows};
 use crate::query::{type_mapping_query, value_mapping_from_row};
 use crate::types::TypeData;
 use crate::utils::extract;
@@ -52,17 +52,7 @@ impl ObjectTrait for EntityObject {
                     let connection = parse_connection_arguments(&ctx)?;
                     let keys = parse_keys_argument(&ctx)?;
                     let total_count = count_rows(&mut conn, ENTITY_TABLE, &keys, &None).await?;
-                    let data = fetch_multiple_rows(
-                        &mut conn,
-                        ENTITY_TABLE,
-                        EVENT_ID_COLUMN,
-                        &keys,
-                        &None,
-                        &None,
-                        &connection,
-                    )
-                    .await?;
-                    let page_info = fetch_page_info(
+                    let (data, page_info) = fetch_multiple_rows(
                         &mut conn,
                         ENTITY_TABLE,
                         EVENT_ID_COLUMN,

--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -13,7 +13,7 @@ use super::inputs::keys_input::{keys_argument, parse_keys_argument};
 use super::{ObjectTrait, TypeMapping};
 use crate::constants::{EVENT_NAMES, EVENT_TABLE, EVENT_TYPE_NAME, ID_COLUMN};
 use crate::mapping::EVENT_TYPE_MAPPING;
-use crate::query::data::{count_rows, fetch_multiple_rows, fetch_page_info};
+use crate::query::data::{count_rows, fetch_multiple_rows};
 use crate::types::ValueMapping;
 
 pub struct EventObject;
@@ -49,17 +49,7 @@ impl ObjectTrait for EventObject {
                     let connection = parse_connection_arguments(&ctx)?;
                     let keys = parse_keys_argument(&ctx)?;
                     let total_count = count_rows(&mut conn, EVENT_TABLE, &keys, &None).await?;
-                    let data = fetch_multiple_rows(
-                        &mut conn,
-                        EVENT_TABLE,
-                        ID_COLUMN,
-                        &keys,
-                        &None,
-                        &None,
-                        &connection,
-                    )
-                    .await?;
-                    let page_info = fetch_page_info(
+                    let (data, page_info) = fetch_multiple_rows(
                         &mut conn,
                         EVENT_TABLE,
                         ID_COLUMN,

--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -81,17 +81,15 @@ impl ObjectTrait for EventObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![SubscriptionField::new(
-            "eventEmitted",
-            TypeRef::named_nn(self.type_name()),
-            |ctx| {
+        Some(vec![
+            SubscriptionField::new("eventEmitted", TypeRef::named_nn(self.type_name()), |ctx| {
                 SubscriptionFieldFuture::new(async move {
                     let input_keys = parse_keys_argument(&ctx)?;
                     Ok(EventObject::subscription_stream(input_keys))
                 })
-            },
-        )
-        .argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING)))])
+            })
+            .argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING))),
+        ])
     }
 }
 

--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -57,6 +57,7 @@ impl ObjectTrait for EventObject {
                         &None,
                         &None,
                         &connection,
+                        total_count,
                     )
                     .await?;
                     let results = connection_output(

--- a/crates/torii/graphql/src/object/metadata/mod.rs
+++ b/crates/torii/graphql/src/object/metadata/mod.rs
@@ -54,7 +54,7 @@ impl ObjectTrait for MetadataObject {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
                     let connection = parse_connection_arguments(&ctx)?;
                     let total_count = count_rows(&mut conn, &table_name, &None, &None).await?;
-                    let data = fetch_multiple_rows(
+                    let (data, _page_info) = fetch_multiple_rows(
                         &mut conn,
                         &table_name,
                         ID_COLUMN,

--- a/crates/torii/graphql/src/object/metadata/mod.rs
+++ b/crates/torii/graphql/src/object/metadata/mod.rs
@@ -1,8 +1,10 @@
+use async_graphql::connection::PageInfo;
 use async_graphql::dynamic::{Field, FieldFuture, TypeRef};
 use async_graphql::{Name, Value};
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Pool, Row, Sqlite};
 
+use super::connection::page_info::PageInfoObject;
 use super::connection::{connection_arguments, cursor, parse_connection_arguments};
 use super::ObjectTrait;
 use crate::constants::{
@@ -54,7 +56,7 @@ impl ObjectTrait for MetadataObject {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
                     let connection = parse_connection_arguments(&ctx)?;
                     let total_count = count_rows(&mut conn, &table_name, &None, &None).await?;
-                    let (data, _page_info) = fetch_multiple_rows(
+                    let (data, page_info) = fetch_multiple_rows(
                         &mut conn,
                         &table_name,
                         ID_COLUMN,
@@ -62,11 +64,13 @@ impl ObjectTrait for MetadataObject {
                         &None,
                         &None,
                         &connection,
+                        total_count,
                     )
                     .await?;
 
                     // convert json field to value_mapping expected by content object
-                    let results = metadata_connection_output(&data, &type_mapping, total_count)?;
+                    let results =
+                        metadata_connection_output(&data, &type_mapping, total_count, page_info)?;
 
                     Ok(Some(Value::Object(results)))
                 })
@@ -85,6 +89,7 @@ fn metadata_connection_output(
     data: &[SqliteRow],
     types: &TypeMapping,
     total_count: i64,
+    page_info: PageInfo,
 ) -> sqlx::Result<ValueMapping> {
     let edges = data
         .iter()
@@ -107,9 +112,10 @@ fn metadata_connection_output(
 
             value_mapping.insert(Name::new("content"), Value::Object(content));
 
-            let mut edge = ValueMapping::new();
-            edge.insert(Name::new("node"), Value::Object(value_mapping));
-            edge.insert(Name::new("cursor"), Value::String(cursor));
+            let edge = ValueMapping::from([
+                (Name::new("node"), Value::Object(value_mapping)),
+                (Name::new("cursor"), Value::String(cursor)),
+            ]);
 
             Ok(Value::Object(edge))
         })
@@ -118,6 +124,7 @@ fn metadata_connection_output(
     Ok(ValueMapping::from([
         (Name::new("total_count"), Value::from(total_count)),
         (Name::new("edges"), Value::List(edges?)),
+        (Name::new("page_info"), PageInfoObject::value(page_info)),
     ]))
 }
 

--- a/crates/torii/graphql/src/object/mod.rs
+++ b/crates/torii/graphql/src/object/mod.rs
@@ -18,7 +18,7 @@ use self::connection::{
     connection_arguments, connection_output, parse_connection_arguments, ConnectionObject,
 };
 use crate::constants::ID_COLUMN;
-use crate::query::data::{count_rows, fetch_multiple_rows, fetch_page_info, fetch_single_row};
+use crate::query::data::{count_rows, fetch_multiple_rows, fetch_single_row};
 use crate::query::value_mapping_from_row;
 use crate::types::{TypeMapping, ValueMapping};
 use crate::utils::extract;
@@ -96,17 +96,7 @@ pub trait ObjectTrait: Send + Sync {
                     let mut conn = ctx.data::<Pool<Sqlite>>()?.acquire().await?;
                     let connection = parse_connection_arguments(&ctx)?;
                     let total_count = count_rows(&mut conn, &table_name, &None, &None).await?;
-                    let data = fetch_multiple_rows(
-                        &mut conn,
-                        &table_name,
-                        ID_COLUMN,
-                        &None,
-                        &None,
-                        &None,
-                        &connection,
-                    )
-                    .await?;
-                    let page_info = fetch_page_info(
+                    let (data, page_info) = fetch_multiple_rows(
                         &mut conn,
                         &table_name,
                         ID_COLUMN,

--- a/crates/torii/graphql/src/object/mod.rs
+++ b/crates/torii/graphql/src/object/mod.rs
@@ -18,7 +18,7 @@ use self::connection::{
     connection_arguments, connection_output, parse_connection_arguments, ConnectionObject,
 };
 use crate::constants::ID_COLUMN;
-use crate::query::data::{count_rows, fetch_multiple_rows, fetch_single_row};
+use crate::query::data::{count_rows, fetch_multiple_rows, fetch_page_info, fetch_single_row};
 use crate::query::value_mapping_from_row;
 use crate::types::{TypeMapping, ValueMapping};
 use crate::utils::extract;
@@ -106,6 +106,16 @@ pub trait ObjectTrait: Send + Sync {
                         &connection,
                     )
                     .await?;
+                    let page_info = fetch_page_info(
+                        &mut conn,
+                        &table_name,
+                        ID_COLUMN,
+                        &None,
+                        &None,
+                        &None,
+                        &connection,
+                    )
+                    .await?;
                     let results = connection_output(
                         &data,
                         &type_mapping,
@@ -113,6 +123,7 @@ pub trait ObjectTrait: Send + Sync {
                         ID_COLUMN,
                         total_count,
                         false,
+                        page_info,
                     )?;
 
                     Ok(Some(Value::Object(results)))

--- a/crates/torii/graphql/src/object/mod.rs
+++ b/crates/torii/graphql/src/object/mod.rs
@@ -104,6 +104,7 @@ pub trait ObjectTrait: Send + Sync {
                         &None,
                         &None,
                         &connection,
+                        total_count,
                     )
                     .await?;
                     let results = connection_output(

--- a/crates/torii/graphql/src/object/model_data.rs
+++ b/crates/torii/graphql/src/object/model_data.rs
@@ -11,7 +11,7 @@ use super::inputs::InputObjectTrait;
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::constants::{ENTITY_ID_COLUMN, ENTITY_TABLE, ID_COLUMN, INTERNAL_ENTITY_ID_KEY};
 use crate::mapping::ENTITY_TYPE_MAPPING;
-use crate::query::data::{count_rows, fetch_multiple_rows, fetch_single_row};
+use crate::query::data::{count_rows, fetch_multiple_rows, fetch_page_info, fetch_single_row};
 use crate::query::value_mapping_from_row;
 use crate::types::TypeData;
 use crate::utils::extract;
@@ -90,6 +90,7 @@ impl ObjectTrait for ModelDataObject {
                 let connection = parse_connection_arguments(&ctx)?;
                 let id_column = "event_id";
 
+                let total_count = count_rows(&mut conn, &type_name, &None, &filters).await?;
                 let data = fetch_multiple_rows(
                     &mut conn,
                     &type_name,
@@ -101,9 +102,25 @@ impl ObjectTrait for ModelDataObject {
                 )
                 .await?;
 
-                let total_count = count_rows(&mut conn, &type_name, &None, &filters).await?;
-                let connection =
-                    connection_output(&data, &type_mapping, &order, id_column, total_count, true)?;
+                let page_info = fetch_page_info(
+                    &mut conn,
+                    &type_name,
+                    id_column,
+                    &None,
+                    &order,
+                    &filters,
+                    &connection,
+                )
+                .await?;
+                let connection = connection_output(
+                    &data,
+                    &type_mapping,
+                    &order,
+                    id_column,
+                    total_count,
+                    true,
+                    page_info,
+                )?;
 
                 Ok(Some(Value::Object(connection)))
             })

--- a/crates/torii/graphql/src/object/model_data.rs
+++ b/crates/torii/graphql/src/object/model_data.rs
@@ -99,6 +99,7 @@ impl ObjectTrait for ModelDataObject {
                     &order,
                     &filters,
                     &connection,
+                    total_count,
                 )
                 .await?;
                 let connection = connection_output(

--- a/crates/torii/graphql/src/object/model_data.rs
+++ b/crates/torii/graphql/src/object/model_data.rs
@@ -11,7 +11,7 @@ use super::inputs::InputObjectTrait;
 use super::{ObjectTrait, TypeMapping, ValueMapping};
 use crate::constants::{ENTITY_ID_COLUMN, ENTITY_TABLE, ID_COLUMN, INTERNAL_ENTITY_ID_KEY};
 use crate::mapping::ENTITY_TYPE_MAPPING;
-use crate::query::data::{count_rows, fetch_multiple_rows, fetch_page_info, fetch_single_row};
+use crate::query::data::{count_rows, fetch_multiple_rows, fetch_single_row};
 use crate::query::value_mapping_from_row;
 use crate::types::TypeData;
 use crate::utils::extract;
@@ -91,18 +91,7 @@ impl ObjectTrait for ModelDataObject {
                 let id_column = "event_id";
 
                 let total_count = count_rows(&mut conn, &type_name, &None, &filters).await?;
-                let data = fetch_multiple_rows(
-                    &mut conn,
-                    &type_name,
-                    id_column,
-                    &None,
-                    &order,
-                    &filters,
-                    &connection,
-                )
-                .await?;
-
-                let page_info = fetch_page_info(
+                let (data, page_info) = fetch_multiple_rows(
                     &mut conn,
                     &type_name,
                     id_column,

--- a/crates/torii/graphql/src/query/data.rs
+++ b/crates/torii/graphql/src/query/data.rs
@@ -1,3 +1,4 @@
+use async_graphql::connection::PageInfo;
 use sqlx::pool::PoolConnection;
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Result, Sqlite};
@@ -90,6 +91,26 @@ pub async fn fetch_multiple_rows(
     }
 
     sqlx::query(&query).fetch_all(conn).await
+}
+
+pub async fn fetch_page_info(
+    conn: &mut PoolConnection<Sqlite>,
+    table_name: &str,
+    id_column: &str,
+    keys: &Option<Vec<String>>,
+    order: &Option<Order>,
+    filters: &Option<Vec<Filter>>,
+    connection: &ConnectionArguments,
+) -> Result<PageInfo> {
+    // TODO: fetch real page info data from sqlx
+    let page_info = PageInfo {
+        has_previous_page: false,
+        has_next_page: false,
+        start_cursor: None,
+        end_cursor: None,
+    };
+
+    Ok(page_info)
 }
 
 fn handle_cursor(

--- a/crates/torii/graphql/src/query/order.rs
+++ b/crates/torii/graphql/src/query/order.rs
@@ -15,8 +15,8 @@ pub struct Order {
 
 #[derive(AsRefStr, Debug, EnumString)]
 pub enum CursorDirection {
-    #[strum(serialize = "<")]
+    #[strum(serialize = "<=")]
     After,
-    #[strum(serialize = ">")]
+    #[strum(serialize = ">=")]
     Before,
 }

--- a/crates/torii/graphql/src/tests/entities_test.rs
+++ b/crates/torii/graphql/src/tests/entities_test.rs
@@ -137,11 +137,10 @@ mod tests {
         assert_eq!(connection.edges.first().unwrap(), three);
         assert_eq!(connection.edges.last().unwrap(), four);
 
-        let page_info = connection.page_info.take().unwrap();
-        assert_eq!(page_info.has_previous_page, true);
-        assert_eq!(page_info.has_next_page, true);
-        assert_eq!(page_info.start_cursor.unwrap(), three.cursor);
-        assert_eq!(page_info.end_cursor.unwrap(), four.cursor);
+        assert!(connection.page_info.has_previous_page);
+        assert!(connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor.unwrap(), three.cursor);
+        assert_eq!(connection.page_info.end_cursor.unwrap(), four.cursor);
 
         let entities =
             entities_query(&schema, &format!("(first: 3, after: \"{}\")", three.cursor)).await;
@@ -150,11 +149,10 @@ mod tests {
         assert_eq!(connection.edges.first().unwrap(), four);
         assert_eq!(connection.edges.last().unwrap(), six);
 
-        let page_info = connection.page_info.take().unwrap();
-        assert_eq!(page_info.has_previous_page, true);
-        assert_eq!(page_info.has_next_page, true);
-        assert_eq!(page_info.start_cursor.unwrap(), four.cursor);
-        assert_eq!(page_info.end_cursor.unwrap(), six.cursor);
+        assert!(connection.page_info.has_previous_page);
+        assert!(connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor.unwrap(), four.cursor);
+        assert_eq!(connection.page_info.end_cursor.unwrap(), six.cursor);
 
         // cursor based backward pagination
         let entities =
@@ -164,11 +162,10 @@ mod tests {
         assert_eq!(connection.edges.first().unwrap(), six);
         assert_eq!(connection.edges.last().unwrap(), five);
 
-        let page_info = connection.page_info.take().unwrap();
-        assert_eq!(page_info.has_previous_page, true);
-        assert_eq!(page_info.has_next_page, true);
-        assert_eq!(page_info.start_cursor.unwrap(), six.cursor);
-        assert_eq!(page_info.end_cursor.unwrap(), five.cursor);
+        assert!(connection.page_info.has_previous_page);
+        assert!(connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor.unwrap(), six.cursor);
+        assert_eq!(connection.page_info.end_cursor.unwrap(), five.cursor);
 
         let entities =
             entities_query(&schema, &format!("(last: 3, before: \"{}\")", six.cursor)).await;
@@ -177,11 +174,10 @@ mod tests {
         assert_eq!(connection.edges.first().unwrap(), five);
         assert_eq!(connection.edges.last().unwrap(), three);
 
-        let page_info = connection.page_info.take().unwrap();
-        assert_eq!(page_info.has_previous_page, true);
-        assert_eq!(page_info.has_next_page, true);
-        assert_eq!(page_info.start_cursor.unwrap(), five.cursor);
-        assert_eq!(page_info.end_cursor.unwrap(), three.cursor);
+        assert!(connection.page_info.has_previous_page);
+        assert!(connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor.unwrap(), five.cursor);
+        assert_eq!(connection.page_info.end_cursor.unwrap(), three.cursor);
 
         let empty_entities = entities_query(
             &schema,
@@ -194,11 +190,10 @@ mod tests {
         let connection: Connection<Entity> = serde_json::from_value(empty_entities).unwrap();
         assert_eq!(connection.edges.len(), 0);
 
-        let page_info = connection.page_info.take().unwrap();
-        assert_eq!(page_info.has_previous_page, false);
-        assert_eq!(page_info.has_next_page, false);
-        assert_eq!(page_info.start_cursor, None);
-        assert_eq!(page_info.end_cursor, None);
+        assert!(!connection.page_info.has_previous_page);
+        assert!(!connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor, None);
+        assert_eq!(connection.page_info.end_cursor, None);
 
         // offset/limit based pagination
         let entities = entities_query(&schema, "(limit: 2)").await;
@@ -206,19 +201,31 @@ mod tests {
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(connection.edges.first().unwrap(), one);
         assert_eq!(connection.edges.last().unwrap(), two);
-        assert!(connection.page_info.is_null());
+
+        assert!(!connection.page_info.has_previous_page);
+        assert!(connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor, None);
+        assert_eq!(connection.page_info.end_cursor, None);
 
         let entities = entities_query(&schema, "(limit: 3, offset: 2)").await;
         let connection: Connection<Entity> = serde_json::from_value(entities).unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(connection.edges.first().unwrap(), three);
         assert_eq!(connection.edges.last().unwrap(), five);
-        assert!(connection.page_info.is_null());
+
+        assert!(connection.page_info.has_previous_page);
+        assert!(connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor, None);
+        assert_eq!(connection.page_info.end_cursor, None);
 
         let empty_entities = entities_query(&schema, "(limit: 1, offset: 20)").await;
         let connection: Connection<Entity> = serde_json::from_value(empty_entities).unwrap();
         assert_eq!(connection.edges.len(), 0);
-        assert!(connection.page_info.is_null());
+
+        assert!(!connection.page_info.has_previous_page);
+        assert!(!connection.page_info.has_next_page);
+        assert_eq!(connection.page_info.start_cursor, None);
+        assert_eq!(connection.page_info.end_cursor, None);
 
         // entity model union
         let id = poseidon_hash_many(&[FieldElement::ZERO]);

--- a/crates/torii/graphql/src/tests/entities_test.rs
+++ b/crates/torii/graphql/src/tests/entities_test.rs
@@ -24,6 +24,12 @@ mod tests {
                   model_names
                 }}
               }}
+              page_info {{
+                has_previous_page
+                has_next_page
+                start_cursor
+                end_cursor
+              }}
             }}
           }}
         "#,
@@ -131,12 +137,24 @@ mod tests {
         assert_eq!(connection.edges.first().unwrap(), three);
         assert_eq!(connection.edges.last().unwrap(), four);
 
+        let page_info = connection.page_info.take().unwrap();
+        assert_eq!(page_info.has_previous_page, true);
+        assert_eq!(page_info.has_next_page, true);
+        assert_eq!(page_info.start_cursor.unwrap(), three.cursor);
+        assert_eq!(page_info.end_cursor.unwrap(), four.cursor);
+
         let entities =
             entities_query(&schema, &format!("(first: 3, after: \"{}\")", three.cursor)).await;
         let connection: Connection<Entity> = serde_json::from_value(entities).unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(connection.edges.first().unwrap(), four);
         assert_eq!(connection.edges.last().unwrap(), six);
+
+        let page_info = connection.page_info.take().unwrap();
+        assert_eq!(page_info.has_previous_page, true);
+        assert_eq!(page_info.has_next_page, true);
+        assert_eq!(page_info.start_cursor.unwrap(), four.cursor);
+        assert_eq!(page_info.end_cursor.unwrap(), six.cursor);
 
         // cursor based backward pagination
         let entities =
@@ -146,12 +164,24 @@ mod tests {
         assert_eq!(connection.edges.first().unwrap(), six);
         assert_eq!(connection.edges.last().unwrap(), five);
 
+        let page_info = connection.page_info.take().unwrap();
+        assert_eq!(page_info.has_previous_page, true);
+        assert_eq!(page_info.has_next_page, true);
+        assert_eq!(page_info.start_cursor.unwrap(), six.cursor);
+        assert_eq!(page_info.end_cursor.unwrap(), five.cursor);
+
         let entities =
             entities_query(&schema, &format!("(last: 3, before: \"{}\")", six.cursor)).await;
         let connection: Connection<Entity> = serde_json::from_value(entities).unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(connection.edges.first().unwrap(), five);
         assert_eq!(connection.edges.last().unwrap(), three);
+
+        let page_info = connection.page_info.take().unwrap();
+        assert_eq!(page_info.has_previous_page, true);
+        assert_eq!(page_info.has_next_page, true);
+        assert_eq!(page_info.start_cursor.unwrap(), five.cursor);
+        assert_eq!(page_info.end_cursor.unwrap(), three.cursor);
 
         let empty_entities = entities_query(
             &schema,
@@ -164,22 +194,31 @@ mod tests {
         let connection: Connection<Entity> = serde_json::from_value(empty_entities).unwrap();
         assert_eq!(connection.edges.len(), 0);
 
+        let page_info = connection.page_info.take().unwrap();
+        assert_eq!(page_info.has_previous_page, false);
+        assert_eq!(page_info.has_next_page, false);
+        assert_eq!(page_info.start_cursor, None);
+        assert_eq!(page_info.end_cursor, None);
+
         // offset/limit based pagination
         let entities = entities_query(&schema, "(limit: 2)").await;
         let connection: Connection<Entity> = serde_json::from_value(entities).unwrap();
         assert_eq!(connection.edges.len(), 2);
         assert_eq!(connection.edges.first().unwrap(), one);
         assert_eq!(connection.edges.last().unwrap(), two);
+        assert!(connection.page_info.is_null());
 
         let entities = entities_query(&schema, "(limit: 3, offset: 2)").await;
         let connection: Connection<Entity> = serde_json::from_value(entities).unwrap();
         assert_eq!(connection.edges.len(), 3);
         assert_eq!(connection.edges.first().unwrap(), three);
         assert_eq!(connection.edges.last().unwrap(), five);
+        assert!(connection.page_info.is_null());
 
         let empty_entities = entities_query(&schema, "(limit: 1, offset: 20)").await;
         let connection: Connection<Entity> = serde_json::from_value(empty_entities).unwrap();
         assert_eq!(connection.edges.len(), 0);
+        assert!(connection.page_info.is_null());
 
         // entity model union
         let id = poseidon_hash_many(&[FieldElement::ZERO]);

--- a/crates/torii/graphql/src/tests/metadata_test.rs
+++ b/crates/torii/graphql/src/tests/metadata_test.rs
@@ -33,6 +33,12 @@ mod tests {
               }
             }
           }
+          page_info {
+            has_previous_page
+            has_next_page
+            start_cursor
+            end_cursor
+          }
         }
       }
     "#;

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use async_graphql::dynamic::Schema;
-use async_graphql::MaybeUndefined;
 use dojo_test_utils::compiler::build_test_config;
 use dojo_test_utils::migration::prepare_migration;
 use dojo_test_utils::sequencer::{
@@ -41,7 +40,7 @@ use crate::schema::build_schema;
 pub struct Connection<T> {
     pub total_count: i64,
     pub edges: Vec<Edge<T>>,
-    pub page_info: MaybeUndefined<PageInfo>,
+    pub page_info: PageInfo,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use async_graphql::dynamic::Schema;
+use async_graphql::MaybeUndefined;
 use dojo_test_utils::compiler::build_test_config;
 use dojo_test_utils::migration::prepare_migration;
 use dojo_test_utils::sequencer::{
@@ -40,6 +41,7 @@ use crate::schema::build_schema;
 pub struct Connection<T> {
     pub total_count: i64,
     pub edges: Vec<Edge<T>>,
+    pub page_info: MaybeUndefined<PageInfo>,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
@@ -53,6 +55,16 @@ pub struct Entity {
     pub model_names: String,
     pub keys: Option<Vec<String>>,
     pub created_at: Option<String>,
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+// same as type from `async-graphql` but derive necessary traits
+// https://docs.rs/async-graphql/6.0.10/async_graphql/types/connection/struct.PageInfo.html
+pub struct PageInfo {
+    pub has_previous_page: bool,
+    pub has_next_page: bool,
+    pub start_cursor: Option<String>,
+    pub end_cursor: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/torii/graphql/src/tests/models_test.rs
+++ b/crates/torii/graphql/src/tests/models_test.rs
@@ -58,6 +58,12 @@ mod tests {
                     }}
                 }}
               }}
+              page_info {{
+                has_previous_page
+                has_next_page
+                start_cursor
+                end_cursor
+              }}
             }}
           }}
         "#,


### PR DESCRIPTION
This PR adds `pageInfo` fields in all connection object exposed by Torii in order to enable server side pagination.