### PR TITLE
fix: scarb language server

### DIFF
--- a/crates/dojo-core/Scarb.lock
+++ b/crates/dojo-core/Scarb.lock
@@ -3,11 +3,11 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "0.3.6"
+version = "0.3.10"
 dependencies = [
  "dojo_plugin",
 ]
 
 [[package]]
 name = "dojo_plugin"
-version = "0.3.6"
+version = "0.3.10"

--- a/crates/dojo-core/Scarb.toml
+++ b/crates/dojo-core/Scarb.toml
@@ -5,5 +5,5 @@ name = "dojo"
 version = "0.3.10"
 
 [dependencies]
-dojo_plugin = "0.3.10"
+dojo_plugin = {path = "../dojo-lang"}
 starknet = "2.3.1"


### PR DESCRIPTION
registry is not support - says scarb
module not found - also scarb

dependencies direct versions are not supported yet (fetch from registry) this breaks code navigation and hints