### PR TITLE
chore: test on localhost

### DIFF
--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -36,7 +36,7 @@ impl TestSequencer {
             Arc::clone(&sequencer),
             ServerConfig {
                 port: 0,
-                host: "0.0.0.0".into(),
+                host: "127.0.0.1".into(),
                 max_connections: 100,
                 apis: vec![ApiKind::Starknet, ApiKind::Katana],
             },


### PR DESCRIPTION
Don't listen on all IP addresses when testing, but only 127.0.0.1

This also get's rid of the annoying "Do you want...accept incoming messages?" messages when testing on mac.
<img width="246" alt="image" src="https://github.com/dojoengine/dojo/assets/11048263/3e8d7d03-1e8c-4055-b59a-4ecf9855a448">
