### PR TITLE
Compute entrypoints

### DIFF
--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::Path;
 
 use ::serde::{Deserialize, Serialize};
-use cairo_lang_starknet::abi;
+pub use cairo_lang_starknet::abi;
 use serde_with::serde_as;
 use smol_str::SmolStr;
 use starknet::core::serde::unsigned_field_element::UfeHex;

--- a/crates/torii/core/src/computed_values.rs
+++ b/crates/torii/core/src/computed_values.rs
@@ -1,0 +1,85 @@
+use std::collections::HashMap;
+
+use camino::Utf8PathBuf;
+use dojo_world::manifest::{abi, ComputedValueEntrypoint, Manifest};
+use starknet::core::utils::get_selector_from_name;
+use torii_core::types::ComputedValueCall;
+use tracing::error;
+
+pub fn function_input_output_from_abi(
+    computed_val_fn: &ComputedValueEntrypoint,
+    abi: &Option<abi::Contract>,
+) -> Result<(Vec<abi::Input>, Vec<abi::Output>), String> {
+    match abi {
+        Some(abi) => abi
+            .clone()
+            .into_iter()
+            .find_map(|i| {
+                if let abi::Item::Function(fn_item) = i {
+                    if fn_item.name != computed_val_fn.entrypoint {
+                        return None;
+                    }
+                    return Some(Ok((fn_item.inputs, fn_item.outputs)));
+                }
+                None
+            })
+            .unwrap(),
+        None => Err("Couldn't find the function in the ABI.".into()),
+    }
+}
+
+pub fn computed_value_entrypoints(
+    manifest_json: Option<Utf8PathBuf>,
+) -> HashMap<String, Vec<ComputedValueCall>> {
+    let mut computed_values: HashMap<String, Vec<ComputedValueCall>> = HashMap::new();
+    if let Some(manifest) = manifest_json {
+        match Manifest::load_from_path(manifest) {
+            Ok(manifest) => {
+                manifest.contracts.iter().for_each(|contract| {
+                    contract.computed.iter().for_each(|computed_val_fn| {
+                        let model_name = match computed_val_fn.model.clone() {
+                            Some(m_name) => m_name,
+                            None => "".into(),
+                        };
+
+                        match function_input_output_from_abi(computed_val_fn, &contract.abi) {
+                            Ok((input, output)) => {
+                                let contract_entrypoint = ComputedValueCall {
+                                    contract_name: computed_val_fn.contract.to_string(),
+                                    contract_address: contract.address.expect(&format!(
+                                        "Contract {} doesn't have an address.",
+                                        computed_val_fn.contract.to_string()
+                                    )),
+                                    entry_point: computed_val_fn.entrypoint.to_string(),
+                                    entry_point_selector: get_selector_from_name(
+                                        &computed_val_fn.entrypoint.to_string(),
+                                    )
+                                    .unwrap(),
+                                    input,
+                                    output,
+                                };
+                                match computed_values.get_mut(&model_name) {
+                                    Some(model_computed_values) => {
+                                        model_computed_values.push(contract_entrypoint);
+                                    }
+                                    None => {
+                                        computed_values
+                                            .insert(model_name, vec![contract_entrypoint]);
+                                    }
+                                };
+                            }
+                            Err(err) => {
+                                eprintln!("{err}");
+                            }
+                        }
+                    })
+                });
+            }
+            Err(err) => {
+                error!("Manifest error: \n{:?}", err);
+            }
+        }
+        // model
+    };
+    computed_values
+}

--- a/crates/torii/core/src/computed_values.rs
+++ b/crates/torii/core/src/computed_values.rs
@@ -52,10 +52,12 @@ pub fn computed_value_entrypoints(
                             Ok((input, output)) => {
                                 let contract_entrypoint = ComputedValueCall {
                                     contract_name: computed_val_fn.contract.to_string(),
-                                    contract_address: contract.address.expect(&format!(
-                                        "Contract {} doesn't have an address.",
-                                        computed_val_fn.contract.to_string()
-                                    )),
+                                    contract_address: contract.address.unwrap_or_else(|| {
+                                        panic!(
+                                            "Contract {} doesn't have an address.",
+                                            computed_val_fn.contract.to_string()
+                                        )
+                                    }),
                                     entry_point: computed_val_fn.entrypoint.to_string(),
                                     entry_point_selector: get_selector_from_name(
                                         &computed_val_fn.entrypoint.to_string(),

--- a/crates/torii/core/src/lib.rs
+++ b/crates/torii/core/src/lib.rs
@@ -4,6 +4,7 @@ use sqlx::FromRow;
 use crate::types::SQLFieldElement;
 
 pub mod cache;
+pub mod computed_values;
 pub mod engine;
 pub mod error;
 pub mod model;

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -140,7 +140,6 @@ impl Sql {
                     .fetch_one(&self.pool)
                     .await?;
 
-                println!("{entrypoint_registered:#?}",);
                 SimpleBroker::publish(entrypoint_registered);
             }
         }

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -7,14 +7,17 @@ use dojo_test_utils::sequencer::{
 };
 use dojo_world::contracts::world::WorldContractReader;
 use dojo_world::migration::strategy::MigrationStrategy;
+use reqwest::Url;
 use scarb::ops;
 use sozo::ops::migration::execute_strategy;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use starknet::core::types::{BlockId, BlockTag, Event, FieldElement};
+use starknet::macros::felt;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
 use tokio::sync::broadcast;
 
+use crate::computed_values::{call_computed_value, computed_value_entrypoints};
 use crate::engine::{Engine, EngineConfig, Processors};
 use crate::processors::register_model::RegisterModelProcessor;
 use crate::processors::store_set_record::StoreSetRecordProcessor;
@@ -121,4 +124,73 @@ async fn test_load_from_remote() {
     assert_eq!(keys, format!("{:#x}/", FieldElement::TWO));
     assert_eq!(data, format!("{:#x}/{:#x}/", FieldElement::TWO, FieldElement::THREE));
     assert_eq!(tx_hash, format!("{:#x}", FieldElement::THREE))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_compute_entrypoints() {
+    let options =
+        SqliteConnectOptions::from_str("sqlite::memory:").unwrap().create_if_missing(true);
+    let pool = SqlitePoolOptions::new().max_connections(5).connect_with(options).await.unwrap();
+    sqlx::migrate!("../migrations").run(&pool).await.unwrap();
+    let migration =
+        prepare_migration("../../../examples/spawn-and-move/target/dev".into()).unwrap();
+    let sequencer =
+        TestSequencer::start(SequencerConfig::default(), get_default_test_starknet_config()).await;
+    let provider = JsonRpcClient::new(HttpTransport::new(sequencer.url()));
+    let world = WorldContractReader::new(migration.world_address().unwrap(), &provider);
+
+    let mut db = Sql::new(pool.clone(), migration.world_address().unwrap()).await.unwrap();
+    let _ = bootstrap_engine(world, &mut db, &provider, migration, sequencer).await;
+
+    let computed_value_entrypoints = computed_value_entrypoints(Some(
+        "../../../examples/spawn-and-move/target/dev/manifest.json".into(),
+    ));
+
+    let _ = db.register_computed_value_entrypoints(computed_value_entrypoints).await.unwrap();
+
+    let values = call_computed_value(
+        "actions",
+        "tile_terrain",
+        vec![felt!("0"), felt!("0")],
+        pool,
+        &provider,
+    )
+    .await
+    .unwrap();
+
+    println!("{values:#?}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_raw_compute_entrypoints() {
+    let options =
+        SqliteConnectOptions::from_str("sqlite::memory:").unwrap().create_if_missing(true);
+    let pool = SqlitePoolOptions::new().max_connections(5).connect_with(options).await.unwrap();
+    sqlx::migrate!("../migrations").run(&pool).await.unwrap();
+    let migration =
+        prepare_migration("../../../examples/spawn-and-move/target/dev".into()).unwrap();
+
+    let url = Url::parse("http://127.0.0.1:5050").expect("Failed to parse URL");
+    let provider = JsonRpcClient::new(HttpTransport::new(url));
+    // let world = WorldContractReader::new(migration.world_address().unwrap(), &provider);
+
+    let mut db = Sql::new(pool.clone(), migration.world_address().unwrap()).await.unwrap();
+
+    let computed_value_entrypoints = computed_value_entrypoints(Some(
+        "../../../examples/spawn-and-move/target/dev/manifest.json".into(),
+    ));
+
+    let _ = db.register_computed_value_entrypoints(computed_value_entrypoints).await.unwrap();
+
+    let values = call_computed_value(
+        "actions",
+        "tile_terrain",
+        vec![felt!("0"), felt!("0")],
+        pool,
+        &provider,
+    )
+    .await
+    .unwrap();
+
+    println!("Result:\n{values:?}");
 }

--- a/crates/torii/core/src/types.rs
+++ b/crates/torii/core/src/types.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 
 use chrono::{DateTime, Utc};
+use dojo_world::manifest::abi;
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use starknet::core::types::FieldElement;
@@ -51,10 +52,30 @@ pub struct Model {
 
 #[derive(FromRow, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+pub struct ComputedValue {
+    pub id: String,
+    pub contract_name: String,
+    pub entrypoint: String,
+    pub contract_address: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(FromRow, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct Event {
     pub id: String,
     pub keys: String,
     pub data: String,
     pub transaction_hash: String,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComputedValueCall {
+    pub contract_name: String,
+    pub contract_address: FieldElement,
+    pub entry_point: String,
+    pub entry_point_selector: FieldElement,
+    pub input: Vec<abi::Input>,
+    pub output: Vec<abi::Output>,
 }

--- a/crates/torii/migrations/20230316154230_setup.sql
+++ b/crates/torii/migrations/20230316154230_setup.sql
@@ -31,6 +31,16 @@ CREATE TABLE models (
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
+CREATE TABLE computed_values (
+    id TEXT NOT NULL PRIMARY KEY, -- ID is contract_name::entrypoint
+    contract_name TEXT NOT NULL,
+    entrypoint TEXT NOT NULL,
+    contract_address TEXT NOT NULL,
+    input BLOB NOT NULL,
+    output BLOB NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE INDEX idx_models_created_at ON models (created_at);
 
 CREATE TABLE model_members(

--- a/crates/torii/server/src/cli.rs
+++ b/crates/torii/server/src/cli.rs
@@ -1,11 +1,10 @@
 mod proxy;
-mod utils;
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use camino::Utf8PathBuf;
 use clap::Parser;
 use dojo_world::contracts::world::WorldContractReader;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
@@ -41,7 +40,7 @@ struct Args {
 
     /// Path to build manifest.json file.
     #[arg(short, long, env = "DOJO_MANIFEST_PATH")]
-    pub manifest_json: Option<Utf8PathBuf>,
+    pub manifest_json: Option<PathBuf>,
 
     /// The rpc endpoint to use
     #[arg(long, default_value = "http://localhost:5050")]


### PR DESCRIPTION
The first barebones version.

The spec was getting a bit unwieldy, so started with a more functional but basic version.

Unwieldy version here:
https://github.com/shramee/dojo/tree/compute-val-component

This version includes-
1. Register the computed value entry points from manifest
2. Call computed values from contract name and entry point #1123

⚠️ Can we get the contract addresses in the manifest on `sozo build`?