### PR TITLE
update devcontainer config (resolves #1221)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,12 +2,12 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/rust
 {
 	"name": "Rust",
-	"image": "ghcr.io/dojoengine/dojo-dev:72f7bc2220f0438e435052f807e58c09b7b61cbe",
+	"image": "mcr.microsoft.com/devcontainers/rust:dev-bookworm",
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
 		"--security-opt",
 		"seccomp=unconfined"
-	],
+	], 
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
@@ -27,17 +27,12 @@
 				"mutantdino.resourcemonitor",
 				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
-				"serayuzgur.crates"
+				"serayuzgur.crates",
+				"starkware.cairo1"
 			]
 		}
 	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
-	// "postCreateCommand": ". scripts/startup.sh",
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode",
+	"postCreateCommand": "sudo apt-get update && sudo apt-get install -y protobuf-compiler && curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh",
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:/workspace/dojo/target/release"
 	}


### PR DESCRIPTION
**Changes**:
* switch base to bookworm
* add cairo1 vscode extension
* install scarb
* install protobuf-compiler

**Review Instructions**
- Ideal reviewer for this is someone who uses VSCode who can checkout this branch and spin up a devcontainer.
- Verify:
1. Cairo1 extension is preinstalled
2. Scarb is preinstalled by running: `scarb`
3. dev environment is ready to go: `cargo test`

@tarrencev Looking at the git logs for .devcontainer and you are the only one who has touched this in recent history that is still actively contributing. Are you able to checkout this branch in VSCode, let it load the .devcontainer, and verify the resulting container is ready to dev? 