### PR TITLE
fix(sozo-migrate): change call request block to pending

### DIFF
--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -162,7 +162,7 @@ pub trait Deployable: Declarable + Sync {
                     calldata: vec![],
                     entry_point_selector: get_selector_from_name("base").unwrap(),
                 },
-                BlockId::Tag(BlockTag::Latest),
+                BlockId::Tag(BlockTag::Pending),
             )
             .await
             .map_err(MigrationError::Provider)?;


### PR DESCRIPTION
migration is done entirely on the pending block tag but the call request here was done against the latest block. 

might result in contract not found error bcs the migrated contract might still be in the pending block.