### PR TITLE
Torii client/grpc rename subscription

### DIFF
--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -56,14 +56,14 @@ message StorageDiff {
     repeated StorageEntry storage_entries = 2;
 }
 
-message EntityDiff {
+message ModelDiff {
     // Storage diffs
     repeated StorageDiff storage_diffs = 1;
 }
 
-message EntityUpdate {
+message ModelUpdate {
     string block_hash = 1;
-    EntityDiff entity_diff = 2;
+    ModelDiff model_diff = 2;
 }
 
 message Query {

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -9,10 +9,10 @@ service World {
     rpc WorldMetadata (MetadataRequest) returns (MetadataResponse);
    
      
-    // Subscribes to entities updates.
-    rpc SubscribeEntities (SubscribeEntitiesRequest) returns (stream SubscribeEntitiesResponse);
+    // Subscribes to models updates.
+    rpc SubscribeModels (SubscribeModelsRequest) returns (stream SubscribeModelsResponse);
 
-    // Retrieve entity
+    // Retrieve entities
     rpc RetrieveEntities (RetrieveEntitiesRequest) returns (RetrieveEntitiesResponse);
 }
 
@@ -27,14 +27,14 @@ message MetadataResponse {
    types.WorldMetadata metadata = 1;
 }
 
-message SubscribeEntitiesRequest {
-    // The list of entity keys to subscribe to.
-    repeated types.KeysClause entities_keys = 1;
+message SubscribeModelsRequest {
+    // The list of model keys to subscribe to.
+    repeated types.KeysClause models_keys = 1;
 }
 
-message SubscribeEntitiesResponse {
-    // List of entities that have been updated.
-    types.EntityUpdate entity_update = 1;
+message SubscribeModelsResponse {
+    // List of models that have been updated.
+    types.ModelUpdate model_update = 1;
 }
 
 message RetrieveEntitiesRequest {

--- a/crates/torii/grpc/src/server/subscription.rs
+++ b/crates/torii/grpc/src/server/subscription.rs
@@ -51,7 +51,7 @@ pub struct Subscriber {
     /// The storage addresses that the subscriber is interested in.
     storage_addresses: HashSet<FieldElement>,
     /// The channel to send the response back to the subscriber.
-    sender: Sender<Result<proto::world::SubscribeEntitiesResponse, tonic::Status>>,
+    sender: Sender<Result<proto::world::SubscribeModelsResponse, tonic::Status>>,
 }
 
 #[derive(Default)]
@@ -63,8 +63,7 @@ impl SubscriberManager {
     pub(super) async fn add_subscriber(
         &self,
         reqs: Vec<SubscribeRequest>,
-    ) -> Result<Receiver<Result<proto::world::SubscribeEntitiesResponse, tonic::Status>>, Error>
-    {
+    ) -> Result<Receiver<Result<proto::world::SubscribeModelsResponse, tonic::Status>>, Error> {
         let id = rand::thread_rng().gen::<usize>();
 
         let (sender, receiver) = channel(1);
@@ -173,9 +172,9 @@ where
                 })
                 .collect::<Vec<proto::types::StorageEntry>>();
 
-            let entity_update = proto::types::EntityUpdate {
+            let model_update = proto::types::ModelUpdate {
                 block_hash: format!("{:#x}", state_update.block_hash),
-                entity_diff: Some(proto::types::EntityDiff {
+                model_diff: Some(proto::types::ModelDiff {
                     storage_diffs: vec![proto::types::StorageDiff {
                         address: format!("{contract_address:#x}"),
                         storage_entries: relevant_storage_entries,
@@ -183,8 +182,7 @@ where
                 }),
             };
 
-            let resp =
-                proto::world::SubscribeEntitiesResponse { entity_update: Some(entity_update) };
+            let resp = proto::world::SubscribeModelsResponse { model_update: Some(model_update) };
 
             if sub.sender.send(Ok(resp)).await.is_err() {
                 closed_stream.push(*idx);

--- a/crates/torii/grpc/src/types.rs
+++ b/crates/torii/grpc/src/types.rs
@@ -376,9 +376,9 @@ impl TryFrom<proto::types::StorageDiff> for ContractStorageDiffItem {
     }
 }
 
-impl TryFrom<proto::types::EntityDiff> for StateDiff {
+impl TryFrom<proto::types::ModelDiff> for StateDiff {
     type Error = FromStrError;
-    fn try_from(value: proto::types::EntityDiff) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::types::ModelDiff) -> Result<Self, Self::Error> {
         Ok(Self {
             nonces: vec![],
             declared_classes: vec![],
@@ -394,14 +394,14 @@ impl TryFrom<proto::types::EntityDiff> for StateDiff {
     }
 }
 
-impl TryFrom<proto::types::EntityUpdate> for StateUpdate {
+impl TryFrom<proto::types::ModelUpdate> for StateUpdate {
     type Error = FromStrError;
-    fn try_from(value: proto::types::EntityUpdate) -> Result<Self, Self::Error> {
+    fn try_from(value: proto::types::ModelUpdate) -> Result<Self, Self::Error> {
         Ok(Self {
             new_root: FieldElement::ZERO,
             old_root: FieldElement::ZERO,
             block_hash: FieldElement::from_str(&value.block_hash)?,
-            state_diff: value.entity_diff.expect("must have").try_into()?,
+            state_diff: value.model_diff.expect("must have").try_into()?,
         })
     }
 }


### PR DESCRIPTION
The `subscribe_entities` endpoint seems to be returning individual model updates, so renaming it to `subscribe_models`. Will implement `subscribe_entities` to return entities + associated models in format like `retrieve_entities` endpoint. 