### PR TITLE
fix(dojo-lang): ensure macro expansion does not depend on prelude

### DIFF
--- a/crates/dojo-lang/src/inline_macros/emit.rs
+++ b/crates/dojo-lang/src/inline_macros/emit.rs
@@ -24,8 +24,8 @@ impl InlineMacroExprPlugin for EmitMacro {
         let mut builder = PatchBuilder::new(db);
         builder.add_str(
             "{
-                let mut keys = Default::<array::Array>::default();
-                let mut data = Default::<array::Array>::default();",
+                let mut keys = Default::<core::array::Array>::default();
+                let mut data = Default::<core::array::Array>::default();",
         );
 
         let args = arg_list.arguments(db).elements(db);
@@ -44,7 +44,7 @@ impl InlineMacroExprPlugin for EmitMacro {
         let event = &args[1];
 
         builder.add_str(
-            "\n            starknet::Event::append_keys_and_data(@traits::Into::<_, Event>::into(",
+            "\n            starknet::Event::append_keys_and_data(@core::traits::Into::<_, Event>::into(",
         );
         builder.add_node(event.as_syntax_node());
         builder.add_str("), ref keys, ref data);");

--- a/crates/dojo-lang/src/inline_macros/emit.rs
+++ b/crates/dojo-lang/src/inline_macros/emit.rs
@@ -44,7 +44,8 @@ impl InlineMacroExprPlugin for EmitMacro {
         let event = &args[1];
 
         builder.add_str(
-            "\n            starknet::Event::append_keys_and_data(@core::traits::Into::<_, Event>::into(",
+            "\n            starknet::Event::append_keys_and_data(@core::traits::Into::<_, \
+             Event>::into(",
         );
         builder.add_node(event.as_syntax_node());
         builder.add_str("), ref keys, ref data);");

--- a/crates/dojo-lang/src/inline_macros/get.rs
+++ b/crates/dojo-lang/src/inline_macros/get.rs
@@ -110,7 +110,8 @@ impl InlineMacroExprPlugin for GetMacro {
                 "\n            let mut __{model}_layout__ = core::array::ArrayTrait::new();
                  dojo::database::introspect::Introspect::<{model}>::layout(ref __{model}_layout__);
                  let mut __{model}_layout_clone__ = __{model}_layout__.clone();
-                 let mut __{model}_layout_span__ = core::array::ArrayTrait::span(@__{model}_layout__);
+                 let mut __{model}_layout_span__ = \
+                 core::array::ArrayTrait::span(@__{model}_layout__);
                  let mut __{model}_layout_clone_span__ = \
                  core::array::ArrayTrait::span(@__{model}_layout_clone__);
                  let mut __{model}_values__ = {}.entity('{model}', __get_macro_keys__, 0_u8,
@@ -119,8 +120,10 @@ impl InlineMacroExprPlugin for GetMacro {
                  let mut __{model}_model__ = core::array::ArrayTrait::new();
                  core::array::serialize_array_helper(__get_macro_keys__, ref __{model}_model__);
                  core::array::serialize_array_helper(__{model}_values__, ref __{model}_model__);
-                 let mut __{model}_model_span__ = core::array::ArrayTrait::span(@__{model}_model__);
-                 let __{model} = core::option::OptionTrait::expect(core::serde::Serde::<{model}>::deserialize(
+                 let mut __{model}_model_span__ = \
+                 core::array::ArrayTrait::span(@__{model}_model__);
+                 let __{model} = \
+                 core::option::OptionTrait::expect(core::serde::Serde::<{model}>::deserialize(
                     ref __{model}_model_span__
                 ), '{deser_err_msg}');\n",
                 world.as_syntax_node().get_text(db),

--- a/crates/dojo-lang/src/inline_macros/get.rs
+++ b/crates/dojo-lang/src/inline_macros/get.rs
@@ -30,7 +30,7 @@ impl InlineMacroExprPlugin for GetMacro {
         let mut builder = PatchBuilder::new(db);
         builder.add_str(
             "{
-                let mut __get_macro_keys__ = array::ArrayTrait::new();\n",
+                let mut __get_macro_keys__ = core::array::ArrayTrait::new();\n",
         );
 
         let args = arg_list.arguments(db).elements(db);
@@ -78,8 +78,8 @@ impl InlineMacroExprPlugin for GetMacro {
         };
 
         builder.add_str(&format!(
-            "serde::Serde::serialize(@{args}, ref __get_macro_keys__);
-            let __get_macro_keys__ = array::ArrayTrait::span(@__get_macro_keys__);\n"
+            "core::serde::Serde::serialize(@{args}, ref __get_macro_keys__);
+            let __get_macro_keys__ = core::array::ArrayTrait::span(@__get_macro_keys__);\n"
         ));
 
         let mut system_reads = SYSTEM_READS.lock().unwrap();
@@ -107,20 +107,20 @@ impl InlineMacroExprPlugin for GetMacro {
             deser_err_msg.truncate(CAIRO_ERR_MSG_LEN);
 
             builder.add_str(&format!(
-                "\n            let mut __{model}_layout__ = array::ArrayTrait::new();
+                "\n            let mut __{model}_layout__ = core::array::ArrayTrait::new();
                  dojo::database::introspect::Introspect::<{model}>::layout(ref __{model}_layout__);
                  let mut __{model}_layout_clone__ = __{model}_layout__.clone();
-                 let mut __{model}_layout_span__ = array::ArrayTrait::span(@__{model}_layout__);
+                 let mut __{model}_layout_span__ = core::array::ArrayTrait::span(@__{model}_layout__);
                  let mut __{model}_layout_clone_span__ = \
-                 array::ArrayTrait::span(@__{model}_layout_clone__);
+                 core::array::ArrayTrait::span(@__{model}_layout_clone__);
                  let mut __{model}_values__ = {}.entity('{model}', __get_macro_keys__, 0_u8,
                  dojo::packing::calculate_packed_size(ref __{model}_layout_clone_span__),
                  __{model}_layout_span__);
-                 let mut __{model}_model__ = array::ArrayTrait::new();
-                 array::serialize_array_helper(__get_macro_keys__, ref __{model}_model__);
-                 array::serialize_array_helper(__{model}_values__, ref __{model}_model__);
-                 let mut __{model}_model_span__ = array::ArrayTrait::span(@__{model}_model__);
-                 let __{model} = option::OptionTrait::expect(serde::Serde::<{model}>::deserialize(
+                 let mut __{model}_model__ = core::array::ArrayTrait::new();
+                 core::array::serialize_array_helper(__get_macro_keys__, ref __{model}_model__);
+                 core::array::serialize_array_helper(__{model}_values__, ref __{model}_model__);
+                 let mut __{model}_model_span__ = core::array::ArrayTrait::span(@__{model}_model__);
+                 let __{model} = core::option::OptionTrait::expect(core::serde::Serde::<{model}>::deserialize(
                     ref __{model}_model_span__
                 ), '{deser_err_msg}');\n",
                 world.as_syntax_node().get_text(db),

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo_v240/Scarb.lock
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo_v240/Scarb.lock
@@ -10,11 +10,12 @@ dependencies = [
 
 [[package]]
 name = "dojo"
-version = "0.4.0-rc0"
+version = "0.4.0-rc1"
 dependencies = [
  "dojo_plugin",
 ]
 
 [[package]]
 name = "dojo_plugin"
-version = "0.4.0"
+version = "0.3.11"
+source = "git+https://github.com/dojoengine/dojo?tag=v0.3.11#1e651b5d4d3b79b14a7d8aa29a92062fcb9e6659"

--- a/crates/dojo-lang/src/model.rs
+++ b/crates/dojo-lang/src/model.rs
@@ -50,13 +50,13 @@ pub fn handle_model_struct(
 
         if m.ty == "felt252" {
             return Some(RewriteNode::Text(format!(
-                "array::ArrayTrait::append(ref serialized, *self.{});",
+                "core::array::ArrayTrait::append(ref serialized, *self.{});",
                 m.name
             )));
         }
 
         Some(RewriteNode::Text(format!(
-            "serde::Serde::serialize(self.{}, ref serialized);",
+            "core::serde::Serde::serialize(self.{}, ref serialized);",
             m.name
         )))
     };
@@ -81,23 +81,23 @@ pub fn handle_model_struct(
 
                 #[inline(always)]
                 fn keys(self: @$type_name$) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
+                    let mut serialized = core::array::ArrayTrait::new();
                     $serialized_keys$
-                    array::ArrayTrait::span(@serialized)
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn values(self: @$type_name$) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
+                    let mut serialized = core::array::ArrayTrait::new();
                     $serialized_values$
-                    array::ArrayTrait::span(@serialized)
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn layout(self: @$type_name$) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<$type_name$>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[inline(always)]
@@ -133,7 +133,7 @@ pub fn handle_model_struct(
 
                 #[external(v0)]
                 fn packed_size(self: @ContractState) -> usize {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<$type_name$>::layout(ref layout);
                     let mut layout_span = layout.span();
                     dojo::packing::calculate_packed_size(ref layout_span)
@@ -141,9 +141,9 @@ pub fn handle_model_struct(
 
                 #[external(v0)]
                 fn layout(self: @ContractState) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<$type_name$>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[external(v0)]

--- a/crates/dojo-lang/src/plugin_test_data/model
+++ b/crates/dojo-lang/src/plugin_test_data/model
@@ -756,23 +756,23 @@ impl PositionSerde of core::serde::Serde::<Position> {
 
                 #[inline(always)]
                 fn keys(self: @Position) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
-                    array::ArrayTrait::append(ref serialized, *self.id);
-                    array::ArrayTrait::span(@serialized)
+                    let mut serialized = core::array::ArrayTrait::new();
+                    core::array::ArrayTrait::append(ref serialized, *self.id);
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn values(self: @Position) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
-                    serde::Serde::serialize(self.v, ref serialized);
-                    array::ArrayTrait::span(@serialized)
+                    let mut serialized = core::array::ArrayTrait::new();
+                    core::serde::Serde::serialize(self.v, ref serialized);
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn layout(self: @Position) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Position>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[inline(always)]
@@ -838,7 +838,7 @@ impl PositionIntrospect<> of dojo::database::introspect::Introspect<Position<>> 
 
                 #[external(v0)]
                 fn packed_size(self: @ContractState) -> usize {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Position>::layout(ref layout);
                     let mut layout_span = layout.span();
                     dojo::packing::calculate_packed_size(ref layout_span)
@@ -846,9 +846,9 @@ impl PositionIntrospect<> of dojo::database::introspect::Introspect<Position<>> 
 
                 #[external(v0)]
                 fn layout(self: @ContractState) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Position>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[external(v0)]
@@ -875,23 +875,23 @@ impl RolesSerde of core::serde::Serde::<Roles> {
 
                 #[inline(always)]
                 fn keys(self: @Roles) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
+                    let mut serialized = core::array::ArrayTrait::new();
                     
-                    array::ArrayTrait::span(@serialized)
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn values(self: @Roles) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
-                    serde::Serde::serialize(self.role_ids, ref serialized);
-                    array::ArrayTrait::span(@serialized)
+                    let mut serialized = core::array::ArrayTrait::new();
+                    core::serde::Serde::serialize(self.role_ids, ref serialized);
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn layout(self: @Roles) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Roles>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[inline(always)]
@@ -953,7 +953,7 @@ impl RolesIntrospect<> of dojo::database::introspect::Introspect<Roles<>> {
 
                 #[external(v0)]
                 fn packed_size(self: @ContractState) -> usize {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Roles>::layout(ref layout);
                     let mut layout_span = layout.span();
                     dojo::packing::calculate_packed_size(ref layout_span)
@@ -961,9 +961,9 @@ impl RolesIntrospect<> of dojo::database::introspect::Introspect<Roles<>> {
 
                 #[external(v0)]
                 fn layout(self: @ContractState) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Roles>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[external(v0)]
@@ -996,23 +996,23 @@ impl PlayerSerde of core::serde::Serde::<Player> {
 
                 #[inline(always)]
                 fn keys(self: @Player) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
-                    array::ArrayTrait::append(ref serialized, *self.game);serde::Serde::serialize(self.player, ref serialized);
-                    array::ArrayTrait::span(@serialized)
+                    let mut serialized = core::array::ArrayTrait::new();
+                    core::array::ArrayTrait::append(ref serialized, *self.game);core::serde::Serde::serialize(self.player, ref serialized);
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn values(self: @Player) -> Span<felt252> {
-                    let mut serialized = ArrayTrait::new();
-                    array::ArrayTrait::append(ref serialized, *self.name);
-                    array::ArrayTrait::span(@serialized)
+                    let mut serialized = core::array::ArrayTrait::new();
+                    core::array::ArrayTrait::append(ref serialized, *self.name);
+                    core::array::ArrayTrait::span(@serialized)
                 }
 
                 #[inline(always)]
                 fn layout(self: @Player) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Player>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[inline(always)]
@@ -1082,7 +1082,7 @@ impl PlayerIntrospect<> of dojo::database::introspect::Introspect<Player<>> {
 
                 #[external(v0)]
                 fn packed_size(self: @ContractState) -> usize {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Player>::layout(ref layout);
                     let mut layout_span = layout.span();
                     dojo::packing::calculate_packed_size(ref layout_span)
@@ -1090,9 +1090,9 @@ impl PlayerIntrospect<> of dojo::database::introspect::Introspect<Player<>> {
 
                 #[external(v0)]
                 fn layout(self: @ContractState) -> Span<u8> {
-                    let mut layout = ArrayTrait::new();
+                    let mut layout = core::array::ArrayTrait::new();
                     dojo::database::introspect::Introspect::<Player>::layout(ref layout);
-                    array::ArrayTrait::span(@layout)
+                    core::array::ArrayTrait::span(@layout)
                 }
 
                 #[external(v0)]

--- a/crates/dojo-lang/src/plugin_test_data/print
+++ b/crates/dojo-lang/src/plugin_test_data/print
@@ -46,14 +46,14 @@ struct Position {
 }
 
 #[cfg(test)]
-impl PositionPrintImpl of debug::PrintTrait<Position> {
+impl PositionPrintImpl of core::debug::PrintTrait<Position> {
     fn print(self: Position) {
-        debug::PrintTrait::print('id');
-        debug::PrintTrait::print(self.id);
-        debug::PrintTrait::print('x');
-        debug::PrintTrait::print(self.x);
-        debug::PrintTrait::print('y');
-        debug::PrintTrait::print(self.y);
+        core::debug::PrintTrait::print('id');
+        core::debug::PrintTrait::print(self.id);
+        core::debug::PrintTrait::print('x');
+        core::debug::PrintTrait::print(self.x);
+        core::debug::PrintTrait::print('y');
+        core::debug::PrintTrait::print(self.y);
     }
 }
 
@@ -64,10 +64,10 @@ struct Roles {
 }
 
 #[cfg(test)]
-impl RolesPrintImpl of debug::PrintTrait<Roles> {
+impl RolesPrintImpl of core::debug::PrintTrait<Roles> {
     fn print(self: Roles) {
-        debug::PrintTrait::print('role_ids');
-        debug::PrintTrait::print(self.role_ids);
+        core::debug::PrintTrait::print('role_ids');
+        core::debug::PrintTrait::print(self.role_ids);
     }
 }
 
@@ -85,14 +85,14 @@ struct Player {
     name: felt252, 
 }
 #[cfg(test)]
-impl PlayerPrintImpl of debug::PrintTrait<Player> {
+impl PlayerPrintImpl of core::debug::PrintTrait<Player> {
     fn print(self: Player) {
-        debug::PrintTrait::print('game');
-        debug::PrintTrait::print(self.game);
-        debug::PrintTrait::print('player');
-        debug::PrintTrait::print(self.player);
-        debug::PrintTrait::print('name');
-        debug::PrintTrait::print(self.name);
+        core::debug::PrintTrait::print('game');
+        core::debug::PrintTrait::print(self.game);
+        core::debug::PrintTrait::print('player');
+        core::debug::PrintTrait::print(self.player);
+        core::debug::PrintTrait::print('name');
+        core::debug::PrintTrait::print(self.name);
     }
 }
 

--- a/crates/dojo-lang/src/print.rs
+++ b/crates/dojo-lang/src/print.rs
@@ -17,7 +17,7 @@ pub fn derive_print(db: &dyn SyntaxGroup, struct_ast: ItemStruct) -> RewriteNode
         .iter()
         .map(|m| {
             format!(
-                "debug::PrintTrait::print('{}'); debug::PrintTrait::print(self.{});",
+                "core::debug::PrintTrait::print('{}'); core::debug::PrintTrait::print(self.{});",
                 m.name(db).text(db).to_string(),
                 m.name(db).text(db).to_string()
             )
@@ -26,7 +26,7 @@ pub fn derive_print(db: &dyn SyntaxGroup, struct_ast: ItemStruct) -> RewriteNode
 
     RewriteNode::interpolate_patched(
         "#[cfg(test)]
-            impl $type_name$PrintImpl of debug::PrintTrait<$type_name$> {
+            impl $type_name$PrintImpl of core::debug::PrintTrait<$type_name$> {
                 fn print(self: $type_name$) {
                     $print$
                 }

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -2,6 +2,9 @@
 cairo-version = "2.4.0"
 name = "dojo_examples"
 version = "0.4.0-rc0"
+# Use the prelude with the less imports as possible
+# from corelib.
+edition = "2023_10"
 
 [cairo]
 sierra-replace-ids = true

--- a/examples/spawn-and-move/src/models.cairo
+++ b/examples/spawn-and-move/src/models.cairo
@@ -1,4 +1,4 @@
-use array::ArrayTrait;
+use core::array::ArrayTrait;
 use core::debug::PrintTrait;
 use starknet::ContractAddress;
 

--- a/examples/spawn-and-move/src/models.cairo
+++ b/examples/spawn-and-move/src/models.cairo
@@ -64,7 +64,7 @@ impl Vec2Impl of Vec2Trait {
 
 #[cfg(test)]
 mod tests {
-    use debug::PrintTrait;
+    use core::debug::PrintTrait;
     use super::{Position, Vec2, Vec2Trait};
 
     #[test]


### PR DESCRIPTION
In the new cairo version, two preludes are available. And one of them defines less modules. @notV4l reported this problem with a fresh init which default to the smallest prelude, which causes `sozo` build to fail due to un-resolved modules.

This PR fixes that, and makes the macros code as agnostic as possible from the prelude.

The `spawn-and-move` example now uses the new prelude too.
