### PR TITLE
Added grpc ids clause

### DIFF
--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -74,10 +74,15 @@ message Query {
 
 message Clause {
     oneof clause_type {
-        KeysClause keys = 1;
-        MemberClause member = 2;
-        CompositeClause composite = 3;
+        IdsClause ids = 1;
+        KeysClause keys = 2;
+        MemberClause member = 3;
+        CompositeClause composite = 4;
     }
+}
+
+message IdsClause {
+    repeated bytes ids = 1;
 }
 
 message KeysClause {


### PR DESCRIPTION
Added an ids clause to grpc's retrieve entities endpoint. 
```
"query": {
    "clause": {
        "ids": {
            "ids": [
                "entity id in bytes"
            ]
        }
    },
    "limit": 1,
    "offset": 0
}
```

cc @Larkooo 