### PR TITLE
fix(katana-core): add missing submodule file

### DIFF
--- a/crates/katana/core/contracts/messaging/solidity/.gitignore
+++ b/crates/katana/core/contracts/messaging/solidity/.gitignore
@@ -2,7 +2,6 @@
 cache/
 out/
 logs/
-lib/forge-std/
 
 # Ignores development broadcast logs
 !/broadcast


### PR DESCRIPTION
Add missing submodule file to run `forge install` without manual step in the `katana/core/contract/messaging/solidity` folder.