### PR TITLE
fix(katana-provider): handle not found err as `None`

### DIFF
--- a/crates/katana/storage/provider/src/providers/fork/backend.rs
+++ b/crates/katana/storage/provider/src/providers/fork/backend.rs
@@ -415,10 +415,18 @@ impl ContractClassProvider for SharedStateProvider {
             return Ok(hash.cloned());
         }
 
-        let compiled_hash = self.0.do_get_compiled_class_hash(hash)?;
-        self.0.compiled_class_hashes.write().insert(hash, compiled_hash);
-
-        Ok(Some(hash))
+        if let Some(hash) =
+            handle_contract_or_class_not_found_err(self.0.do_get_compiled_class_hash(hash))
+                .map_err(|e| {
+                    error!(target: "forked_backend", "error while fetching compiled class hash for class hash {hash:#x}: {e}");
+                    e
+                })?
+        {
+            self.0.compiled_class_hashes.write().insert(hash, hash);
+            Ok(Some(hash))
+        } else {
+            Ok(None)
+        }
     }
 
     fn class(&self, hash: ClassHash) -> Result<Option<CompiledContractClass>> {


### PR DESCRIPTION
When requesting compiled class hash from the forked network, if the request response is `ClassHashNotFound` error, then treat that as a `None` value.