### PR TITLE
Prepare release: v0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "benches"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap_builder",
@@ -2670,15 +2670,15 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dojo-core"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "dojo-examples-spawn-and-move"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "dojo-lang"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-language-server"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "cairo-lang-compiler",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-signers"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "starknet",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-test-utils"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-types"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-world"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "katana"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_matches",
  "clap",
@@ -5449,7 +5449,7 @@ dependencies = [
  "console",
  "katana-core",
  "katana-rpc",
- "metrics 0.4.1",
+ "metrics 0.4.2",
  "metrics-process",
  "serde_json",
  "starknet_api",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "katana-codecs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "katana-primitives",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "katana-codecs-derive"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5479,7 +5479,7 @@ dependencies = [
 
 [[package]]
 name = "katana-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "katana-db"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -5535,7 +5535,7 @@ dependencies = [
 
 [[package]]
 name = "katana-executor"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "katana-primitives"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "blockifier",
@@ -5569,7 +5569,7 @@ dependencies = [
 
 [[package]]
 name = "katana-provider"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -5591,7 +5591,7 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5623,7 +5623,7 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc-types"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -5636,7 +5636,7 @@ dependencies = [
 
 [[package]]
 name = "katana-rpc-types-builder"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "katana-executor",
@@ -5648,7 +5648,7 @@ dependencies = [
 
 [[package]]
 name = "katana-runner"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "home",
@@ -5939,7 +5939,7 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "hyper",
@@ -8608,7 +8608,7 @@ dependencies = [
 
 [[package]]
 name = "sozo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -9802,7 +9802,7 @@ dependencies = [
 
 [[package]]
 name = "torii-client"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "camino",
@@ -9828,7 +9828,7 @@ dependencies = [
 
 [[package]]
 name = "torii-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9864,7 +9864,7 @@ dependencies = [
 
 [[package]]
 name = "torii-graphql"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -9903,7 +9903,7 @@ dependencies = [
 
 [[package]]
 name = "torii-grpc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "crypto-bigint",
@@ -9942,7 +9942,7 @@ dependencies = [
 
 [[package]]
 name = "torii-server"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9961,7 +9961,7 @@ dependencies = [
  "hyper-reverse-proxy",
  "indexmap 1.9.3",
  "lazy_static",
- "metrics 0.4.1",
+ "metrics 0.4.2",
  "metrics-process",
  "scarb",
  "serde",
@@ -10229,7 +10229,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "types-test"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ edition = "2021"
 license = "Apache-2.0"
 license-file = "LICENSE"
 repository = "https://github.com/dojoengine/dojo/"
-version = "0.4.1"
+version = "0.4.2"
 
 [profile.performance]
 codegen-units = 1

--- a/crates/dojo-core/Scarb.lock
+++ b/crates/dojo-core/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "dojo_plugin",
 ]

--- a/crates/dojo-core/Scarb.toml
+++ b/crates/dojo-core/Scarb.toml
@@ -2,7 +2,7 @@
 cairo-version = "2.4.0"
 description = "The Dojo Core library for autonomous worlds."
 name = "dojo"
-version = "0.4.1"
+version = "0.4.2"
 
 [dependencies]
 dojo_plugin = { git = "https://github.com/dojoengine/dojo", tag = "v0.3.11" }

--- a/crates/torii/types-test/Scarb.lock
+++ b/crates/torii/types-test/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "dojo_plugin",
 ]

--- a/crates/torii/types-test/Scarb.toml
+++ b/crates/torii/types-test/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 cairo-version = "2.4.0"
 name = "types_test"
-version = "0.4.1"
+version = "0.4.2"
 
 [cairo]
 sierra-replace-ids = true

--- a/examples/spawn-and-move/Scarb.lock
+++ b/examples/spawn-and-move/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "dojo_plugin",
 ]

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 cairo-version = "2.4.0"
 name = "dojo_examples"
-version = "0.4.1"
+version = "0.4.2"
 # Use the prelude with the less imports as possible
 # from corelib.
 edition = "2023_10"


### PR DESCRIPTION
## 📦 Uncategorized

- Add prometheus exporter to Katana
   - PR: #1278
- Fix grpc entity id field name
   - PR: #1282
- Add prometheus exporter to Torii
   - PR: #1281
- refactor(katana): allow types to be deserializable from non self-describing formats
   - PR: #1277
- fix(katana): adjust the logic to select the from_address from blockifier
   - PR: #1279
- Added grpc ids clause
   - PR: #1280
- Update devcontainer image hash: 7d49bcd
   - PR: #1284
- Introduce `katana-codecs` for DB encoding
   - PR: #1285
- test(katana-db): add mdbx tests
   - PR: #1293
- Update devcontainer image hash: 630bd82
   - PR: #1291
- Add codecov preview to devcontainer
   - PR: #1294
- Update devcontainer image hash: 54f0635
   - PR: #1295
- fix(katana-core): add missing submodule file
   - PR: #1298
- feat(katana-rpc): add ContractErrorData when it applies
   - PR: #1297
- Benchmark contract class de/compression
   - PR: #1292
- Rename entity ids to hashed_keys in grpc
   - PR: #1286
- Update devcontainer image hash: f61e50c
   - PR: #1303
- Integrate code coverage
   - PR: #1296
- Add hurl to devcontainer
   - PR: #1306
- Update devcontainer image hash: f6a4b8a
   - PR: #1305
- Update ci to use devcontainer
   - PR: #1304
- Update devcontainer image hash: 2e8cd62
   - PR: #1307
- Prepare for cargo release
   - PR: #1308
- Update devcontainer image hash: 448ffda
   - PR: #1313
- Move types-test to torii root
   - PR: #1311
- Add types-test to cargo release
   - PR: #1314
- fix(katana-provider): handle not found err as `None`
   - PR: #1316
- Remove nightly releases
   - PR: #1315
- Torii grpc member clause query
   - PR: #1312
- test(katana-provider): more elaborate tests
   - PR: #1317