### PR TITLE
fix(dojo-lang): ensure a model has at least one attribute that is not a key

### DIFF
--- a/crates/dojo-lang/src/introspect.rs
+++ b/crates/dojo-lang/src/introspect.rs
@@ -279,6 +279,14 @@ fn handle_introspect_internal(
         size.push(format!("{}", size_precompute));
     }
 
+    if size.is_empty() {
+        panic!(
+            "The model `{}` has only keys, ensure you have at least one field without the #[key] \
+             attribute.",
+            name
+        );
+    }
+
     RewriteNode::interpolate_patched(
         "
 impl $name$Introspect<$generics$> of \


### PR DESCRIPTION
Currently, a model that has only keys produces the following error:
```
error: Unexpected return type. Expected: "core::integer::u32", found: "()".
 --> /mnt/data/dojo-starter/src/models.cairo[Multi]:39:24
    fn size() -> usize {
                       ^

error: Compilation failed.
```

This PR aims at panicking explaining to the user what's happening.
From my understanding, it is not useful to have a model without any field in the database.