### PR TITLE
refactor(katana-db): compress `SierraClass` as `JSON` for now

### DIFF
--- a/crates/katana/storage/db/src/codecs/mod.rs
+++ b/crates/katana/storage/db/src/codecs/mod.rs
@@ -2,7 +2,7 @@
 pub mod postcard;
 
 use katana_primitives::block::FinalityStatus;
-use katana_primitives::contract::ContractAddress;
+use katana_primitives::contract::{ContractAddress, SierraClass};
 use katana_primitives::FieldElement;
 
 use crate::error::CodecError;
@@ -71,6 +71,19 @@ macro_rules! impl_encode_and_decode_for_felts {
 
 impl_encode_and_decode_for_uints!(u64);
 impl_encode_and_decode_for_felts!(FieldElement, ContractAddress);
+
+impl Compress for SierraClass {
+    type Compressed = Vec<u8>;
+    fn compress(self) -> Self::Compressed {
+        serde_json::to_vec(&self).unwrap()
+    }
+}
+
+impl Decompress for SierraClass {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        serde_json::from_slice(bytes.as_ref()).map_err(|e| CodecError::Decode(e.to_string()))
+    }
+}
 
 impl Compress for FinalityStatus {
     type Compressed = [u8; 1];

--- a/crates/katana/storage/db/src/codecs/postcard.rs
+++ b/crates/katana/storage/db/src/codecs/postcard.rs
@@ -1,5 +1,5 @@
 use katana_primitives::block::{BlockNumber, Header};
-use katana_primitives::contract::{ContractAddress, GenericContractInfo, SierraClass};
+use katana_primitives::contract::{ContractAddress, GenericContractInfo};
 use katana_primitives::receipt::Receipt;
 use katana_primitives::transaction::Tx;
 use katana_primitives::FieldElement;
@@ -34,7 +34,6 @@ impl_compress_and_decompress_for_table_values!(
     Tx,
     Header,
     Receipt,
-    SierraClass,
     FieldElement,
     ContractAddress,
     Vec<BlockNumber>,


### PR DESCRIPTION
Currently the only type that can't be encoded using `postcard` is `SierraClass` as it serde impl is using `deserialize_any`. This PR adds `SierraClass`'s `Compress` and `Decompress` trait impls by parsing it as `JSON`. 