### PR TITLE
Fix torii indexing models having >1 same nested types

### DIFF
--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -290,7 +290,7 @@ impl Sql {
                 }
 
                 let mut path_clone = path.clone();
-                path_clone.push(member.ty.name());
+                path_clone.push(member.name.clone());
 
                 self.build_register_queries_recursive(
                     &member.ty,
@@ -337,12 +337,13 @@ impl Sql {
                     columns.join(","),
                     placeholders.join(",")
                 );
+
                 self.query_queue.enqueue(statement, arguments);
 
                 for member in s.children.iter() {
                     if let Ty::Struct(_) = &member.ty {
                         let mut path_clone = path.clone();
-                        path_clone.push(member.ty.name());
+                        path_clone.push(member.name.clone());
 
                         self.build_set_entity_queries_recursive(
                             path_clone, event_id, entity_id, &member.ty,
@@ -353,7 +354,7 @@ impl Sql {
             Ty::Enum(e) => {
                 for child in e.options.iter() {
                     let mut path_clone = path.clone();
-                    path_clone.push(child.ty.name());
+                    path_clone.push(child.name.clone());
                     self.build_set_entity_queries_recursive(
                         path_clone, event_id, entity_id, &child.ty,
                     );

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -70,19 +70,20 @@ fn member_to_type_data(member: &ModelMember, nested_members: &[&ModelMember]) ->
     match member.type_enum.as_str() {
         "Primitive" => TypeData::Simple(TypeRef::named(&member.ty)),
         "Enum" => TypeData::Simple(TypeRef::named("Enum")),
-        _ => parse_nested_type(&member.model_id, &member.ty, nested_members),
+        _ => parse_nested_type(&member.model_id, &member.name, &member.ty, nested_members),
     }
 }
 
 fn parse_nested_type(
-    target_id: &str,
-    target_type: &str,
+    model_id: &str,
+    member_name: &str,
+    member_type: &str,
     nested_members: &[&ModelMember],
 ) -> TypeData {
     let nested_mapping: TypeMapping = nested_members
         .iter()
         .filter_map(|&member| {
-            if target_id == member.model_id && member.id.ends_with(target_type) {
+            if model_id == member.model_id && member.id.ends_with(member_name) {
                 let type_data = member_to_type_data(member, nested_members);
                 Some((Name::new(&member.name), type_data))
             } else {
@@ -90,7 +91,7 @@ fn parse_nested_type(
             }
         })
         .collect();
-    let namespaced = format!("{}_{}", target_id, target_type);
+    let namespaced = format!("{}_{}", model_id, member_type);
     TypeData::Nested((TypeRef::named(namespaced), nested_mapping))
 }
 

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -86,7 +86,9 @@ pub struct Record {
     pub type_contract_address: String,
     pub random_u8: u8,
     pub random_u128: String,
-    pub type_nested: Option<Nested>,
+    pub type_deeply_nested: Option<Nested>,
+    pub type_nested_one: Option<NestedMost>,
+    pub type_nested_two: Option<NestedMost>,
     pub entity: Option<Entity>,
 }
 
@@ -105,11 +107,11 @@ pub struct NestedMore {
     pub depth: String,
     pub type_number: u8,
     pub type_string: String,
-    pub type_nested_more_more: NestedMoreMore,
+    pub type_nested_most: NestedMost,
 }
 
 #[derive(Deserialize, Debug, PartialEq)]
-pub struct NestedMoreMore {
+pub struct NestedMost {
     pub __typename: String,
     pub depth: String,
     pub type_number: u8,

--- a/crates/torii/types-test/Scarb.lock
+++ b/crates/torii/types-test/Scarb.lock
@@ -15,7 +15,7 @@ source = "git+https://github.com/dojoengine/dojo?tag=v0.3.11#1e651b5d4d3b79b14a7
 
 [[package]]
 name = "types_test"
-version = "0.1.0"
+version = "0.4.1"
 dependencies = [
  "dojo",
 ]

--- a/crates/torii/types-test/src/contracts.cairo
+++ b/crates/torii/types-test/src/contracts.cairo
@@ -8,7 +8,7 @@ trait IRecords<TContractState> {
 #[dojo::contract]
 mod records {
     use starknet::{ContractAddress, get_caller_address};
-    use types_test::models::{Record, RecordSibling, Subrecord, Nested, NestedMore, NestedMoreMore, Depth};
+    use types_test::models::{Record, RecordSibling, Subrecord, Nested, NestedMore, NestedMost, Depth};
     use types_test::{seed, random};
     use super::IRecords;
 
@@ -40,7 +40,7 @@ mod records {
                 }
 
                 let type_felt: felt252 = record_idx.into();
-                let random_u8 = random(pedersen::pedersen(seed(), record_idx.into()), 0, 100)
+                let random_u8: u8 = random(pedersen::pedersen(seed(), record_idx.into()), 0, 100)
                     .try_into()
                     .unwrap();
                 let random_u128 = random(
@@ -72,7 +72,7 @@ mod records {
                             type_felt: record_idx.into(),
                             type_class_hash: type_felt.try_into().unwrap(),
                             type_contract_address: type_felt.try_into().unwrap(),
-                            type_nested: Nested {
+                            type_deeply_nested: Nested {
                                 depth: Depth::One,
                                 type_number: record_idx.into(),
                                 type_string: type_felt,
@@ -80,12 +80,22 @@ mod records {
                                     depth: Depth::Two,
                                     type_number: record_idx.into(),
                                     type_string: type_felt,
-                                    type_nested_more_more: NestedMoreMore {
+                                    type_nested_most: NestedMost {
                                         depth: Depth::Three,
                                         type_number: record_idx.into(),
                                         type_string: type_felt,
                                     }
                                 }
+                            },
+                            type_nested_one: NestedMost {
+                                depth: Depth::One,
+                                type_number: 1,
+                                type_string: 1,
+                            },
+                            type_nested_two: NestedMost {
+                                depth: Depth::One,
+                                type_number: 2,
+                                type_string: 2,
                             },
                             random_u8,
                             random_u128

--- a/crates/torii/types-test/src/models.cairo
+++ b/crates/torii/types-test/src/models.cairo
@@ -16,7 +16,9 @@ struct Record {
     type_felt: felt252,
     type_class_hash: ClassHash,
     type_contract_address: ContractAddress,
-    type_nested: Nested,
+    type_deeply_nested: Nested,
+    type_nested_one: NestedMost,
+    type_nested_two: NestedMost,
     random_u8: u8,
     random_u128: u128,
 }
@@ -41,11 +43,11 @@ struct NestedMore {
     depth: Depth,
     type_number: u8,
     type_string: felt252,
-    type_nested_more_more: NestedMoreMore,
+    type_nested_most: NestedMost,
 }
 
 #[derive(Copy, Drop, Serde, Introspect)]
-struct NestedMoreMore {
+struct NestedMost {
     depth: Depth,
     type_number: u8,
     type_string: felt252,


### PR DESCRIPTION
This PR changes the names of sqlite tables for nested members from
`{model_name}${type_name}${...}`
to
`{model_name}${member_name}${...}`

This creates a table for every nested member instead of only for distinct nested types which was causing conflicts between same nested members. Resolves issue [#1320](https://github.com/dojoengine/dojo/issues/1320)

However, this change affects model tables which are created dynamically and we don't currently have a robust way to apply migrations to these. So Slot deployed Toriis would require a restart and re-index the world.