### PR TITLE
refactor: improve `TransactionWaiter`

### DIFF
--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -6,20 +6,25 @@ use std::time::Duration;
 use futures::FutureExt;
 use starknet::core::types::{
     ExecutionResult, FieldElement, MaybePendingTransactionReceipt, PendingTransactionReceipt,
-    StarknetError, TransactionFinalityStatus, TransactionReceipt,
+    StarknetError, TransactionFinalityStatus, TransactionReceipt, TransactionStatus,
 };
 use starknet::providers::{Provider, ProviderError};
 use tokio::time::{Instant, Interval};
 
-type GetReceiptResult = Result<MaybePendingTransactionReceipt, ProviderError>;
-type GetReceiptFuture<'a> = Pin<Box<dyn Future<Output = GetReceiptResult> + Send + 'a>>;
+type GetTxStatusResult = Result<TransactionStatus, ProviderError>;
+type GetTxReceiptResult = Result<MaybePendingTransactionReceipt, ProviderError>;
+
+type GetTxStatusFuture<'a> = Pin<Box<dyn Future<Output = GetTxStatusResult> + Send + 'a>>;
+type GetTxReceiptFuture<'a> = Pin<Box<dyn Future<Output = GetTxReceiptResult> + Send + 'a>>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum TransactionWaitingError {
     #[error("request timed out")]
     Timeout,
-    #[error("transaction reverted due to failed execution: {0}")]
+    #[error("transaction reverted with reason: {0}")]
     TransactionReverted(String),
+    #[error("transaction rejected")]
+    TransactionRejected,
     #[error(transparent)]
     Provider(ProviderError),
 }
@@ -49,21 +54,19 @@ pub enum TransactionWaitingError {
 pub struct TransactionWaiter<'a, P: Provider> {
     /// The hash of the transaction to wait for.
     tx_hash: FieldElement,
-    /// The finality status to wait for.
+    /// The transaction finality status to wait for.
     ///
-    /// If set, the waiter will wait for the transaction to achieve this finality status.
-    /// Otherwise, the waiter will only wait for the transaction until it is included in the
-    /// _pending_ block.
-    finality_status: Option<TransactionFinalityStatus>,
+    /// If not set, then it will wait until it is `ACCEPTED_ON_L2` whether it is reverted or not.
+    tx_finality_status: Option<TransactionFinalityStatus>,
     /// A flag to indicate that the waited transaction must either be successfully executed or not.
     ///
-    /// If it's set to `true`, then the transaction execution status must be `SUCCEEDED` otherwise
+    /// If it's set to `true`, then the transaction execution result must be `SUCCEEDED` otherwise
     /// an error will be returned. However, if set to `false`, then the execution status will not
     /// be considered when waiting for the transaction, meaning `REVERTED` transaction will not
     /// return an error.
     must_succeed: bool,
     /// Poll the transaction every `interval` miliseconds. Miliseconds are used so that
-    /// we can be more precise with the polling interval. Defaults to 250ms.
+    /// we can be more precise with the polling interval. Defaults to 2.5 seconds.
     interval: Interval,
     /// The maximum amount of time to wait for the transaction to achieve the desired status. An
     /// error will be returned if it is unable to finish within the `timeout` duration. Defaults to
@@ -71,8 +74,10 @@ pub struct TransactionWaiter<'a, P: Provider> {
     timeout: Duration,
     /// The provider to use for polling the transaction.
     provider: &'a P,
+    /// The future that gets the transaction status.
+    tx_status_request_fut: Option<GetTxStatusFuture<'a>>,
     /// The future that gets the transaction receipt.
-    receipt_request_fut: Option<GetReceiptFuture<'a>>,
+    tx_receipt_request_fut: Option<GetTxReceiptFuture<'a>>,
     /// The time when the transaction waiter was first polled.
     started_at: Option<Instant>,
 }
@@ -82,6 +87,7 @@ where
     P: Provider + Send,
 {
     const DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
+    /// Interval for use with 3rd party provider without burning the API rate limit.
     const DEFAULT_INTERVAL: Duration = Duration::from_millis(2500);
 
     pub fn new(tx: FieldElement, provider: &'a P) -> Self {
@@ -90,8 +96,9 @@ where
             tx_hash: tx,
             started_at: None,
             must_succeed: true,
-            finality_status: None,
-            receipt_request_fut: None,
+            tx_finality_status: None,
+            tx_status_request_fut: None,
+            tx_receipt_request_fut: None,
             timeout: Self::DEFAULT_TIMEOUT,
             interval: tokio::time::interval_at(
                 Instant::now() + Self::DEFAULT_INTERVAL,
@@ -105,12 +112,60 @@ where
         Self { interval: tokio::time::interval_at(Instant::now() + interval, interval), ..self }
     }
 
-    pub fn with_finality(self, status: TransactionFinalityStatus) -> Self {
-        Self { finality_status: Some(status), ..self }
+    pub fn with_tx_status(self, status: TransactionFinalityStatus) -> Self {
+        Self { tx_finality_status: Some(status), ..self }
     }
 
     pub fn with_timeout(self, timeout: Duration) -> Self {
         Self { timeout, ..self }
+    }
+
+    // Helper function to evaluate if the transaction receipt should be accepted yet or not, based
+    // on the waiter's parameters. Used in the `Future` impl.
+    fn evaluate_receipt_from_params(
+        receipt: MaybePendingTransactionReceipt,
+        expected_finality_status: Option<TransactionFinalityStatus>,
+        must_succeed: bool,
+    ) -> Option<Result<MaybePendingTransactionReceipt, TransactionWaitingError>> {
+        if !must_succeed {
+            return Some(Ok(receipt));
+        }
+
+        match &receipt {
+            MaybePendingTransactionReceipt::PendingReceipt(r) => {
+                if expected_finality_status.is_some() {
+                    return None;
+                }
+
+                match execution_status_from_pending_receipt(r) {
+                    ExecutionResult::Succeeded => Some(Ok(receipt)),
+                    ExecutionResult::Reverted { reason } => {
+                        Some(Err(TransactionWaitingError::TransactionReverted(reason.clone())))
+                    }
+                }
+            }
+
+            MaybePendingTransactionReceipt::Receipt(r) => {
+                if let Some(expected_status) = expected_finality_status {
+                    match finality_status_from_receipt(r) {
+                        TransactionFinalityStatus::AcceptedOnL2
+                            if expected_status == TransactionFinalityStatus::AcceptedOnL1 =>
+                        {
+                            None
+                        }
+
+                        _ => match execution_status_from_receipt(r) {
+                            ExecutionResult::Succeeded => Some(Ok(receipt)),
+                            ExecutionResult::Reverted { reason } => Some(Err(
+                                TransactionWaitingError::TransactionReverted(reason.clone()),
+                            )),
+                        },
+                    }
+                } else {
+                    Some(Ok(receipt))
+                }
+            }
+        }
     }
 }
 
@@ -134,53 +189,24 @@ where
                 }
             }
 
-            if let Some(mut flush) = this.receipt_request_fut.take() {
-                match flush.poll_unpin(cx) {
+            if let Some(mut fut) = this.tx_status_request_fut.take() {
+                match fut.poll_unpin(cx) {
                     Poll::Ready(res) => match res {
-                        Ok(receipt) => match &receipt {
-                            MaybePendingTransactionReceipt::PendingReceipt(r) => {
-                                if this.finality_status.is_none() {
-                                    if this.must_succeed {
-                                        let res = match execution_status_from_pending_receipt(r) {
-                                            ExecutionResult::Succeeded => Ok(receipt),
-                                            ExecutionResult::Reverted { reason } => {
-                                                Err(TransactionWaitingError::TransactionReverted(
-                                                    reason.clone(),
-                                                ))
-                                            }
-                                        };
-                                        return Poll::Ready(res);
-                                    }
-
-                                    return Poll::Ready(Ok(receipt));
-                                }
+                        Ok(status) => match status {
+                            TransactionStatus::AcceptedOnL2(_)
+                            | TransactionStatus::AcceptedOnL1(_) => {
+                                this.tx_receipt_request_fut = Some(Box::pin(
+                                    this.provider.get_transaction_receipt(this.tx_hash),
+                                ));
                             }
 
-                            MaybePendingTransactionReceipt::Receipt(r) => {
-                                if let Some(finality_status) = this.finality_status {
-                                    match finality_status_from_receipt(r) {
-                                        status if status == finality_status => {
-                                            if this.must_succeed {
-                                                let res = match execution_status_from_receipt(r) {
-                                                    ExecutionResult::Succeeded => Ok(receipt),
-                                                    ExecutionResult::Reverted { reason } => {
-                                                        Err(TransactionWaitingError::TransactionReverted(
-                                                            reason.clone(),
-                                                        ))
-                                                    }
-                                                };
-                                                return Poll::Ready(res);
-                                            }
-
-                                            return Poll::Ready(Ok(receipt));
-                                        }
-
-                                        _ => {}
-                                    }
-                                } else {
-                                    return Poll::Ready(Ok(receipt));
-                                }
+                            TransactionStatus::Rejected => {
+                                return Poll::Ready(Err(
+                                    TransactionWaitingError::TransactionRejected,
+                                ));
                             }
+
+                            TransactionStatus::Received => {}
                         },
 
                         Err(ProviderError::StarknetError(
@@ -193,15 +219,40 @@ where
                     },
 
                     Poll::Pending => {
-                        this.receipt_request_fut = Some(flush);
+                        this.tx_status_request_fut = Some(fut);
                         return Poll::Pending;
                     }
                 }
             }
 
+            if let Some(mut fut) = this.tx_receipt_request_fut.take() {
+                match fut.poll_unpin(cx) {
+                    Poll::Pending => {
+                        this.tx_receipt_request_fut = Some(fut);
+                        return Poll::Pending;
+                    }
+
+                    Poll::Ready(res) => match res {
+                        Err(e) => {
+                            return Poll::Ready(Err(TransactionWaitingError::Provider(e)));
+                        }
+
+                        Ok(receipt) => {
+                            if let Some(res) = Self::evaluate_receipt_from_params(
+                                receipt,
+                                this.tx_finality_status,
+                                this.must_succeed,
+                            ) {
+                                return Poll::Ready(res);
+                            }
+                        }
+                    },
+                }
+            }
+
             if this.interval.poll_tick(cx).is_ready() {
-                this.receipt_request_fut =
-                    Some(Box::pin(this.provider.get_transaction_receipt(this.tx_hash)));
+                this.tx_status_request_fut =
+                    Some(Box::pin(this.provider.get_transaction_status(this.tx_hash)));
             } else {
                 break;
             }
@@ -260,23 +311,228 @@ mod tests {
     use dojo_test_utils::sequencer::{
         get_default_test_starknet_config, SequencerConfig, TestSequencer,
     };
-    use starknet::core::types::FieldElement;
+    use starknet::core::types::{
+        ExecutionResources, ExecutionResult, FieldElement, InvokeTransactionReceipt,
+        MaybePendingTransactionReceipt, TransactionFinalityStatus, TransactionReceipt,
+    };
     use starknet::providers::jsonrpc::HttpTransport;
     use starknet::providers::JsonRpcClient;
 
     use super::{Duration, TransactionWaiter};
 
-    #[tokio::test]
-    async fn should_timeout_on_nonexistant_transaction() {
+    async fn create_test_sequencer() -> (TestSequencer, JsonRpcClient<HttpTransport>) {
         let sequencer =
             TestSequencer::start(SequencerConfig::default(), get_default_test_starknet_config())
                 .await;
         let provider = JsonRpcClient::new(HttpTransport::new(sequencer.url()));
+        (sequencer, provider)
+    }
+
+    fn mock_receipt_with_status(
+        finality_status: TransactionFinalityStatus,
+        execution_result: ExecutionResult,
+    ) -> TransactionReceipt {
+        let execution_resources = ExecutionResources {
+            steps: 0,
+            memory_holes: None,
+            ec_op_builtin_applications: 0,
+            ecdsa_builtin_applications: 0,
+            keccak_builtin_applications: 0,
+            bitwise_builtin_applications: 0,
+            pedersen_builtin_applications: 0,
+            poseidon_builtin_applications: 0,
+            range_check_builtin_applications: 0,
+        };
+
+        TransactionReceipt::Invoke(InvokeTransactionReceipt {
+            finality_status,
+            execution_result,
+            execution_resources,
+            events: Default::default(),
+            actual_fee: Default::default(),
+            block_hash: Default::default(),
+            block_number: Default::default(),
+            messages_sent: Default::default(),
+            transaction_hash: Default::default(),
+        })
+    }
+
+    #[tokio::test]
+    async fn should_timeout_on_nonexistant_transaction() {
+        let (_sequencer, provider) = create_test_sequencer().await;
+
         assert_matches!(
             TransactionWaiter::new(FieldElement::from_hex_be("0x1234").unwrap(), &provider)
                 .with_timeout(Duration::from_secs(1))
                 .await,
             Err(super::TransactionWaitingError::Timeout)
         );
+    }
+
+    #[test]
+    fn wait_for_no_finality_status() {
+        let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+            TransactionFinalityStatus::AcceptedOnL2,
+            ExecutionResult::Succeeded,
+        ));
+
+        assert_eq!(
+            TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                receipt.clone(),
+                None,
+                false
+            )
+            .unwrap()
+            .unwrap(),
+            receipt
+        );
+    }
+
+    #[test]
+    fn wait_for_finality_status_with_no_succeed() {
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL2,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert_eq!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt.clone(),
+                    Some(TransactionFinalityStatus::AcceptedOnL2),
+                    false
+                )
+                .unwrap()
+                .unwrap(),
+                receipt
+            )
+        }
+
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL2,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert_eq!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt.clone(),
+                    Some(TransactionFinalityStatus::AcceptedOnL1),
+                    false,
+                )
+                .unwrap()
+                .unwrap(),
+                receipt
+            );
+        }
+
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL1,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert_eq!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt.clone(),
+                    Some(TransactionFinalityStatus::AcceptedOnL2),
+                    false
+                )
+                .unwrap()
+                .unwrap(),
+                receipt
+            )
+        }
+
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL1,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert_eq!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt.clone(),
+                    Some(TransactionFinalityStatus::AcceptedOnL1),
+                    false
+                )
+                .unwrap()
+                .unwrap(),
+                receipt
+            )
+        }
+    }
+
+    #[test]
+    fn wait_for_finality_status_with_must_succeed() {
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL2,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert_eq!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt.clone(),
+                    Some(TransactionFinalityStatus::AcceptedOnL2),
+                    true
+                )
+                .unwrap()
+                .unwrap(),
+                receipt
+            )
+        }
+
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL2,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt,
+                    Some(TransactionFinalityStatus::AcceptedOnL1),
+                    true,
+                )
+                .is_none()
+            );
+        }
+
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL1,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert_eq!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt.clone(),
+                    Some(TransactionFinalityStatus::AcceptedOnL2),
+                    true
+                )
+                .unwrap()
+                .unwrap(),
+                receipt
+            )
+        }
+
+        {
+            let receipt = MaybePendingTransactionReceipt::Receipt(mock_receipt_with_status(
+                TransactionFinalityStatus::AcceptedOnL1,
+                ExecutionResult::Succeeded,
+            ));
+
+            assert_eq!(
+                TransactionWaiter::<JsonRpcClient<HttpTransport>>::evaluate_receipt_from_params(
+                    receipt.clone(),
+                    Some(TransactionFinalityStatus::AcceptedOnL1),
+                    true
+                )
+                .unwrap()
+                .unwrap(),
+                receipt
+            )
+        }
     }
 }


### PR DESCRIPTION
This PR improves the `TransactionWaiter` type by using `getTransactionStatus` endpoint when querying for the tx status before requesting for its receipt. Which means the waiter should now be able to handle transaction with `REJECTED` / `RECEIVED` status.