### PR TITLE
feat(sozo): wait for tx to be accepted

### DIFF
--- a/crates/sozo/src/commands/auth.rs
+++ b/crates/sozo/src/commands/auth.rs
@@ -6,6 +6,7 @@ use starknet::core::types::FieldElement;
 
 use super::options::account::AccountOptions;
 use super::options::starknet::StarknetOptions;
+use super::options::transaction::TransactionOptions;
 use super::options::world::WorldOptions;
 use crate::ops::auth;
 
@@ -33,6 +34,9 @@ pub enum AuthCommand {
 
         #[command(flatten)]
         account: AccountOptions,
+
+        #[command(flatten)]
+        transaction: TransactionOptions,
     },
 }
 

--- a/crates/sozo/src/commands/execute.rs
+++ b/crates/sozo/src/commands/execute.rs
@@ -6,6 +6,7 @@ use starknet::core::types::FieldElement;
 
 use super::options::account::AccountOptions;
 use super::options::starknet::StarknetOptions;
+use super::options::transaction::TransactionOptions;
 use crate::ops::execute;
 
 #[derive(Debug, Args)]
@@ -29,6 +30,9 @@ pub struct ExecuteArgs {
 
     #[command(flatten)]
     pub account: AccountOptions,
+
+    #[command(flatten)]
+    pub transaction: TransactionOptions,
 }
 
 impl ExecuteArgs {

--- a/crates/sozo/src/commands/options/account.rs
+++ b/crates/sozo/src/commands/options/account.rs
@@ -42,7 +42,7 @@ impl AccountOptions {
         env_metadata: Option<&Environment>,
     ) -> Result<SingleOwnerAccount<P, LocalWallet>>
     where
-        P: Provider + Send + Sync + 'static,
+        P: Provider + Send + Sync,
     {
         let account_address = self.account_address(env_metadata)?;
         let signer = self.signer(env_metadata)?;

--- a/crates/sozo/src/commands/options/transaction.rs
+++ b/crates/sozo/src/commands/options/transaction.rs
@@ -11,6 +11,13 @@ pub struct TransactionOptions {
                        the estimated fee which will be used as the max fee for the transaction. \
                        (max_fee = estimated_fee * multiplier)")]
     pub fee_estimate_multiplier: Option<f64>,
+
+    #[arg(short, long)]
+    #[arg(help = "Wait until the transaction is accepted by the sequencer, returning the receipt.")]
+    #[arg(long_help = "Wait until the transaction is accepted by the sequencer, returning the \
+                       receipt. This will poll the transaction status until it gets accepted or \
+                       rejected by the sequencer.")]
+    pub wait: bool,
 }
 
 impl From<TransactionOptions> for TxConfig {

--- a/crates/sozo/src/commands/register.rs
+++ b/crates/sozo/src/commands/register.rs
@@ -6,6 +6,7 @@ use starknet::core::types::FieldElement;
 
 use super::options::account::AccountOptions;
 use super::options::starknet::StarknetOptions;
+use super::options::transaction::TransactionOptions;
 use super::options::world::WorldOptions;
 use crate::ops::register;
 
@@ -33,6 +34,9 @@ pub enum RegisterCommand {
 
         #[command(flatten)]
         account: AccountOptions,
+
+        #[command(flatten)]
+        transaction: TransactionOptions,
     },
 }
 

--- a/crates/sozo/src/ops/auth.rs
+++ b/crates/sozo/src/ops/auth.rs
@@ -2,16 +2,17 @@ use anyhow::{Context, Result};
 use dojo_world::contracts::cairo_utils;
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::metadata::Environment;
+use dojo_world::utils::TransactionWaiter;
 
 use crate::commands::auth::AuthCommand;
 
 pub async fn execute(command: AuthCommand, env_metadata: Option<Environment>) -> Result<()> {
     match command {
-        AuthCommand::Writer { model, contract, world, starknet, account } => {
+        AuthCommand::Writer { model, contract, world, starknet, account, transaction } => {
             let world_address = world.address(env_metadata.as_ref())?;
             let provider = starknet.provider(env_metadata.as_ref())?;
 
-            let account = account.account(provider, env_metadata.as_ref()).await?;
+            let account = account.account(&provider, env_metadata.as_ref()).await?;
             let world = WorldContract::new(world_address, &account);
 
             let res = world
@@ -20,7 +21,12 @@ pub async fn execute(command: AuthCommand, env_metadata: Option<Environment>) ->
                 .await
                 .with_context(|| "Failed to send transaction")?;
 
-            println!("Transaction: {:#x}", res.transaction_hash);
+            if transaction.wait {
+                let receipt = TransactionWaiter::new(res.transaction_hash, &provider).await?;
+                println!("{}", serde_json::to_string_pretty(&receipt)?);
+            } else {
+                println!("Transaction hash: {:#x}", res.transaction_hash);
+            }
         }
     }
 

--- a/crates/sozo/src/ops/migration/migration_test.rs
+++ b/crates/sozo/src/ops/migration/migration_test.rs
@@ -88,7 +88,7 @@ async fn migrate_with_small_fee_multiplier_will_fail() {
             &ws,
             &migration,
             &account,
-            Some(TransactionOptions { fee_estimate_multiplier: Some(0.2f64) }),
+            Some(TransactionOptions { fee_estimate_multiplier: Some(0.2f64), wait: false }),
         )
         .await
         .is_err()

--- a/crates/sozo/src/ops/register.rs
+++ b/crates/sozo/src/ops/register.rs
@@ -1,17 +1,18 @@
 use anyhow::{Context, Result};
 use dojo_world::contracts::WorldContract;
 use dojo_world::metadata::Environment;
+use dojo_world::utils::TransactionWaiter;
 use starknet::accounts::Account;
 
 use crate::commands::register::RegisterCommand;
 
 pub async fn execute(command: RegisterCommand, env_metadata: Option<Environment>) -> Result<()> {
     match command {
-        RegisterCommand::Model { models, world, starknet, account } => {
+        RegisterCommand::Model { models, world, starknet, account, transaction } => {
             let world_address = world.address(env_metadata.as_ref())?;
             let provider = starknet.provider(env_metadata.as_ref())?;
 
-            let account = account.account(provider, env_metadata.as_ref()).await?;
+            let account = account.account(&provider, env_metadata.as_ref()).await?;
             let world = WorldContract::new(world_address, &account);
 
             let calls = models
@@ -25,7 +26,12 @@ pub async fn execute(command: RegisterCommand, env_metadata: Option<Environment>
                 .await
                 .with_context(|| "Failed to send transaction")?;
 
-            println!("Models registered at transaction: {:#x}", res.transaction_hash)
+            if transaction.wait {
+                let receipt = TransactionWaiter::new(res.transaction_hash, &provider).await?;
+                println!("{}", serde_json::to_string_pretty(&receipt)?);
+            } else {
+                println!("Transaction hash: {:#x}", res.transaction_hash);
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
This PR adds `--wait` cli flags for `sozo` commands that involve sending a tx (`auth`, `execute`, and `register`). 

The flag is used to wait on the tx that is sent from the command. Waiting the transaction until it is executed/rejected by the sequencer.

Running the commands with `--wait` enable would return the tx receipt (in JSON) as the command output as opposed to just the tx hash (if `--wait` is omitted)