### PR TITLE
fix: add dojo compiler pluging for `migrate`

### DIFF
--- a/crates/sozo/src/main.rs
+++ b/crates/sozo/src/main.rs
@@ -29,7 +29,9 @@ fn cli_main(args: SozoArgs) -> Result<()> {
     let cairo_plugins = CairoPluginRepository::default();
 
     match &args.command {
-        Commands::Build(_) | Commands::Dev(_) => compilers.add(Box::new(DojoCompiler)).unwrap(),
+        Commands::Build(_) | Commands::Dev(_) | Commands::Migrate(_) => {
+            compilers.add(Box::new(DojoCompiler)).unwrap()
+        }
         _ => {}
     }
 


### PR DESCRIPTION
fix: #1270 

- `sozo migrate` already supports using configuration from custom profiles
- but `sozo migrate` was failing because we where not adding dojo compiler plugin while running `migrate` subcommand