### PR TITLE
refactor(sozo): change priority order for arguments

### DIFF
--- a/crates/sozo/src/commands/options/account.rs
+++ b/crates/sozo/src/commands/options/account.rs
@@ -8,13 +8,17 @@ use starknet::core::types::FieldElement;
 use starknet::providers::Provider;
 use starknet::signers::{LocalWallet, SigningKey};
 
+use super::{
+    DOJO_ACCOUNT_ADDRESS_ENV_VAR, DOJO_KEYSTORE_PASSWORD_ENV_VAR, DOJO_PRIVATE_KEY_ENV_VAR,
+};
+
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Account options")]
 pub struct AccountOptions {
-    #[arg(long)]
+    #[arg(long, env = DOJO_ACCOUNT_ADDRESS_ENV_VAR)]
     pub account_address: Option<FieldElement>,
 
-    #[arg(long)]
+    #[arg(long, env = DOJO_PRIVATE_KEY_ENV_VAR)]
     #[arg(requires = "account_address")]
     #[arg(conflicts_with = "keystore_path")]
     #[arg(help_heading = "Signer options - RAW")]
@@ -27,7 +31,7 @@ pub struct AccountOptions {
     #[arg(help = "Use the keystore in the given folder or file.")]
     pub keystore_path: Option<String>,
 
-    #[arg(long = "password")]
+    #[arg(long = "password", env = DOJO_KEYSTORE_PASSWORD_ENV_VAR)]
     #[arg(value_name = "PASSWORD")]
     #[arg(requires = "keystore_path")]
     #[arg(help_heading = "Signer options - KEYSTORE")]
@@ -64,11 +68,8 @@ impl AccountOptions {
     }
 
     fn signer(&self, env_metadata: Option<&Environment>) -> Result<LocalWallet> {
-        if let Some(private_key) = self
-            .private_key
-            .as_deref()
-            .or_else(|| env_metadata.and_then(|env| env.private_key()))
-            .or(std::env::var("DOJO_PRIVATE_KEY").ok().as_deref())
+        if let Some(private_key) =
+            self.private_key.as_deref().or_else(|| env_metadata.and_then(|env| env.private_key()))
         {
             return Ok(LocalWallet::from_signing_key(SigningKey::from_secret_scalar(
                 FieldElement::from_str(private_key)?,
@@ -80,7 +81,6 @@ impl AccountOptions {
                 .keystore_password
                 .as_deref()
                 .or_else(|| env_metadata.and_then(|env| env.keystore_password()))
-                .or(std::env::var("DOJO_KEYSTORE_PASSWORD").ok().as_deref())
             {
                 return Ok(LocalWallet::from_signing_key(SigningKey::from_keystore(
                     path, password,
@@ -99,10 +99,7 @@ impl AccountOptions {
     fn account_address(&self, env_metadata: Option<&Environment>) -> Result<FieldElement> {
         if let Some(address) = self.account_address {
             Ok(address)
-        } else if let Some(address) = env_metadata
-            .and_then(|env| env.account_address())
-            .or(std::env::var("DOJO_ACCOUNT_ADDRESS").ok().as_deref())
-        {
+        } else if let Some(address) = env_metadata.and_then(|env| env.account_address()) {
             Ok(FieldElement::from_str(address)?)
         } else {
             Err(anyhow!(

--- a/crates/sozo/src/commands/options/mod.rs
+++ b/crates/sozo/src/commands/options/mod.rs
@@ -2,3 +2,8 @@ pub mod account;
 pub mod starknet;
 pub mod transaction;
 pub mod world;
+
+const STARKNET_RPC_URL_ENV_VAR: &str = "STARKNET_RPC_URL";
+const DOJO_PRIVATE_KEY_ENV_VAR: &str = "DOJO_PRIVATE_KEY";
+const DOJO_KEYSTORE_PASSWORD_ENV_VAR: &str = "DOJO_KEYSTORE_PASSWORD";
+const DOJO_ACCOUNT_ADDRESS_ENV_VAR: &str = "DOJO_ACCOUNT_ADDRESS";

--- a/crates/sozo/src/commands/options/starknet.rs
+++ b/crates/sozo/src/commands/options/starknet.rs
@@ -79,6 +79,6 @@ mod tests {
             ..Default::default()
         };
         let cmd = Command::parse_from([""]);
-        assert_eq!(cmd.options.url(Some(&env_metadata)).unwrap().as_str(), METADATA_RPC);
+        assert_eq!(cmd.options.url(Some(&env_metadata)).unwrap().as_str(), ENV_RPC);
     }
 }

--- a/crates/sozo/src/commands/options/starknet.rs
+++ b/crates/sozo/src/commands/options/starknet.rs
@@ -45,6 +45,7 @@ mod tests {
 
     const ENV_RPC: &str = "http://localhost:7474/";
     const METADATA_RPC: &str = "http://localhost:6060/";
+    const DEFAULT_RPC: &str = "http://localhost:5050/";
 
     #[derive(clap::Parser)]
     struct Command {
@@ -80,5 +81,12 @@ mod tests {
         };
         let cmd = Command::parse_from([""]);
         assert_eq!(cmd.options.url(Some(&env_metadata)).unwrap().as_str(), ENV_RPC);
+    }
+
+    #[test]
+    fn exists_in_neither() {
+        let env_metadata = dojo_world::metadata::Environment::default();
+        let cmd = Command::parse_from([""]);
+        assert_eq!(cmd.options.url(Some(&env_metadata)).unwrap().as_str(), DEFAULT_RPC);
     }
 }


### PR DESCRIPTION
fix: #1336

to be consistent with what we did for torii: https://github.com/dojoengine/dojo/pull/800, i think we should follow this priority, wdyt?

```
passed cli argument
Environment variable
Scarb.toml 's dojo.tool.env
```