### PR TITLE
Update model register and contract deploy apis to take preimage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-world-abigen"
-version = "0.1.0"
+version = "0.4.4"
 dependencies = [
  "cairo-lang-starknet",
  "camino",

--- a/crates/benches/contracts/src/actions.cairo
+++ b/crates/benches/contracts/src/actions.cairo
@@ -67,7 +67,6 @@ mod actions {
         name: felt252,
     }
 
-
     #[external(v0)]
     impl ActionsImpl of IActions<ContractState> {
         fn spawn(self: @ContractState) {

--- a/crates/dojo-core/src/base_test.cairo
+++ b/crates/dojo-core/src/base_test.cairo
@@ -41,7 +41,7 @@ fn deploy_world() -> IWorldDispatcher {
 fn test_upgrade_from_world() {
     let world = deploy_world();
 
-    let base_address = world.deploy_contract('salt', base::TEST_CLASS_HASH.try_into().unwrap());
+    let base_address = world.deploy_contract(array!['base'].span(), base::TEST_CLASS_HASH.try_into().unwrap());
     let new_class_hash: ClassHash = contract_upgrade::TEST_CLASS_HASH.try_into().unwrap();
 
     world.upgrade_contract(base_address, new_class_hash);
@@ -56,7 +56,7 @@ fn test_upgrade_from_world() {
 fn test_upgrade_direct() {
     let world = deploy_world();
 
-    let base_address = world.deploy_contract('salt', base::TEST_CLASS_HASH.try_into().unwrap());
+    let base_address = world.deploy_contract(array!['base'].span(), base::TEST_CLASS_HASH.try_into().unwrap());
     let new_class_hash: ClassHash = contract_upgrade::TEST_CLASS_HASH.try_into().unwrap();
 
     let upgradeable_dispatcher = IUpgradeableDispatcher { contract_address: base_address };

--- a/crates/dojo-core/src/database_test.cairo
+++ b/crates/dojo-core/src/database_test.cairo
@@ -8,7 +8,6 @@ use traits::{Into, TryInto};
 use starknet::syscalls::deploy_syscall;
 use starknet::class_hash::{Felt252TryIntoClassHash, ClassHash};
 use dojo::world::{IWorldDispatcher};
-use dojo::executor::executor;
 use dojo::database::{get, set, set_with_index, del, scan};
 use dojo::database::index::WhereCondition;
 

--- a/crates/dojo-core/src/model.cairo
+++ b/crates/dojo-core/src/model.cairo
@@ -1,5 +1,5 @@
 trait Model<T> {
-    fn name(self: @T) -> felt252;
+    fn name_hash(self: @T) -> felt252;
     fn keys(self: @T) -> Span<felt252>;
     fn values(self: @T) -> Span<felt252>;
     fn layout(self: @T) -> Span<u8>;
@@ -8,7 +8,7 @@ trait Model<T> {
 
 #[starknet::interface]
 trait IModel<T> {
-    fn name(self: @T) -> felt252;
+    fn name_hash(self: @T) -> felt252;
     fn layout(self: @T) -> Span<felt252>;
     fn schema(self: @T) -> Span<dojo::database::introspect::Member>;
 }

--- a/crates/dojo-core/src/test_utils.cairo
+++ b/crates/dojo-core/src/test_utils.cairo
@@ -47,6 +47,7 @@ fn spawn_test_world(models: Array<felt252>) -> IWorldDispatcher {
         executor::TEST_CLASS_HASH.try_into().unwrap(), 0, constructor_calldata.span(), false
     )
         .unwrap();
+
     // deploy world
     let (world_address, _) = deploy_syscall(
         world::TEST_CLASS_HASH.try_into().unwrap(),
@@ -63,7 +64,7 @@ fn spawn_test_world(models: Array<felt252>) -> IWorldDispatcher {
         if index == models.len() {
             break ();
         }
-        world.register_model((*models[index]).try_into().unwrap());
+        world.register_model(array![index.into()].span(), (*models[index]).try_into().unwrap());
         index += 1;
     };
 

--- a/crates/dojo-lang/src/inline_macros/delete.rs
+++ b/crates/dojo-lang/src/inline_macros/delete.rs
@@ -142,7 +142,7 @@ impl InlineMacroExprPlugin for DeleteMacro {
             builder.add_str(&format!(
                 "
                 let __delete_macro_value__ = {};
-                {}.delete_entity(dojo::model::Model::name(@__delete_macro_value__),
+                {}.delete_entity(dojo::model::Model::name_hash(@__delete_macro_value__),
                  dojo::model::Model::keys(@__delete_macro_value__),
                  dojo::model::Model::layout(@__delete_macro_value__));",
                 entity,

--- a/crates/dojo-lang/src/inline_macros/set.rs
+++ b/crates/dojo-lang/src/inline_macros/set.rs
@@ -156,7 +156,7 @@ impl InlineMacroExprPlugin for SetMacro {
             builder.add_str(&format!(
                 "
                 let __set_macro_value__ = {};
-                {}.set_entity(dojo::model::Model::name(@__set_macro_value__),
+                {}.set_entity(dojo::model::Model::name_hash(@__set_macro_value__),
                  dojo::model::Model::keys(@__set_macro_value__), 0_u8,
                  dojo::model::Model::values(@__set_macro_value__),
                  dojo::model::Model::layout(@__set_macro_value__));",

--- a/crates/dojo-lang/src/manifest_test_data/cairo_v240
+++ b/crates/dojo-lang/src/manifest_test_data/cairo_v240
@@ -8,7 +8,7 @@ test_compiler_cairo_v240
   "world": {
     "name": "dojo::world::world",
     "address": null,
-    "class_hash": "0x5ac623f0c96059936bd2d0904bdd31799e430fe08a0caff7a5f497260b16497",
+    "class_hash": "0x439034396f2e01cf02122b1816378fddfa33b92109f80642306a3bcddd18d8e",
     "abi": [
       {
         "type": "impl",
@@ -114,7 +114,7 @@ test_compiler_cairo_v240
             "name": "model",
             "inputs": [
               {
-                "name": "name",
+                "name": "name_hash",
                 "type": "core::felt252"
               }
             ],
@@ -130,6 +130,10 @@ test_compiler_cairo_v240
             "name": "register_model",
             "inputs": [
               {
+                "name": "name",
+                "type": "core::array::Span::<core::felt252>"
+              },
+              {
                 "name": "class_hash",
                 "type": "core::starknet::class_hash::ClassHash"
               }
@@ -142,8 +146,8 @@ test_compiler_cairo_v240
             "name": "deploy_contract",
             "inputs": [
               {
-                "name": "salt",
-                "type": "core::felt252"
+                "name": "name",
+                "type": "core::array::Span::<core::felt252>"
               },
               {
                 "name": "class_hash",
@@ -532,8 +536,8 @@ test_compiler_cairo_v240
         "kind": "struct",
         "members": [
           {
-            "name": "salt",
-            "type": "core::felt252",
+            "name": "name",
+            "type": "core::array::Span::<core::felt252>",
             "kind": "data"
           },
           {
@@ -601,7 +605,7 @@ test_compiler_cairo_v240
         "members": [
           {
             "name": "name",
-            "type": "core::felt252",
+            "type": "core::array::Span::<core::felt252>",
             "kind": "data"
           },
           {

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -8,7 +8,7 @@ test_manifest_file
   "world": {
     "name": "dojo::world::world",
     "address": null,
-    "class_hash": "0x5ac623f0c96059936bd2d0904bdd31799e430fe08a0caff7a5f497260b16497",
+    "class_hash": "0x439034396f2e01cf02122b1816378fddfa33b92109f80642306a3bcddd18d8e",
     "abi": [
       {
         "type": "impl",
@@ -114,7 +114,7 @@ test_manifest_file
             "name": "model",
             "inputs": [
               {
-                "name": "name",
+                "name": "name_hash",
                 "type": "core::felt252"
               }
             ],
@@ -130,6 +130,10 @@ test_manifest_file
             "name": "register_model",
             "inputs": [
               {
+                "name": "name",
+                "type": "core::array::Span::<core::felt252>"
+              },
+              {
                 "name": "class_hash",
                 "type": "core::starknet::class_hash::ClassHash"
               }
@@ -142,8 +146,8 @@ test_manifest_file
             "name": "deploy_contract",
             "inputs": [
               {
-                "name": "salt",
-                "type": "core::felt252"
+                "name": "name",
+                "type": "core::array::Span::<core::felt252>"
               },
               {
                 "name": "class_hash",
@@ -532,8 +536,8 @@ test_manifest_file
         "kind": "struct",
         "members": [
           {
-            "name": "salt",
-            "type": "core::felt252",
+            "name": "name",
+            "type": "core::array::Span::<core::felt252>",
             "kind": "data"
           },
           {
@@ -601,7 +605,7 @@ test_manifest_file
         "members": [
           {
             "name": "name",
-            "type": "core::felt252",
+            "type": "core::array::Span::<core::felt252>",
             "kind": "data"
           },
           {
@@ -1205,11 +1209,11 @@ test_manifest_file
     {
       "name": "dojo_examples::models::moves",
       "address": null,
-      "class_hash": "0x64495ca6dc1dc328972697b30468cea364bcb7452bbb6e4aaad3e4b3f190147",
+      "class_hash": "0x268a4fa3b20c32f89ca204c679e5b1080950aa07ab81f5735abb2fa1db7187c",
       "abi": [
         {
           "type": "function",
-          "name": "name",
+          "name": "name_hash",
           "inputs": [],
           "outputs": [
             {
@@ -1374,11 +1378,11 @@ test_manifest_file
     {
       "name": "dojo_examples::models::position",
       "address": null,
-      "class_hash": "0x4cd20d231b04405a77b184c115dc60637e186504fad7f0929bd76cbd09c10b",
+      "class_hash": "0x165b41f5633015dc37f000b24019e8cb32c06570d4b2baf026ca5b6b707940f",
       "abi": [
         {
           "type": "function",
-          "name": "name",
+          "name": "name_hash",
           "inputs": [],
           "outputs": [
             {

--- a/crates/dojo-lang/src/plugin_test_data/model
+++ b/crates/dojo-lang/src/plugin_test_data/model
@@ -802,7 +802,7 @@ impl PositionSerde of core::serde::Serde::<Position> {
 
             impl PositionModel of dojo::model::Model<Position> {
                 #[inline(always)]
-                fn name(self: @Position) -> felt252 {
+                fn name_hash(self: @Position) -> felt252 {
                     'Position'
                 }
 
@@ -879,8 +879,8 @@ impl PositionIntrospect<> of dojo::database::introspect::Introspect<Position<>> 
                 struct Storage {}
 
                 #[external(v0)]
-                fn name(self: @ContractState) -> felt252 {
-                    'Position'
+                fn name_hash(self: @ContractState) -> felt252 {
+                    0x7b7bd4fefed73494631bcd45cf49e26b9c08d0cf2eef498e296ae6a76c106e4
                 }
 
                 #[external(v0)]
@@ -921,7 +921,7 @@ impl RolesSerde of core::serde::Serde::<Roles> {
 
             impl RolesModel of dojo::model::Model<Roles> {
                 #[inline(always)]
-                fn name(self: @Roles) -> felt252 {
+                fn name_hash(self: @Roles) -> felt252 {
                     'Roles'
                 }
 
@@ -994,8 +994,8 @@ impl RolesIntrospect<> of dojo::database::introspect::Introspect<Roles<>> {
                 struct Storage {}
 
                 #[external(v0)]
-                fn name(self: @ContractState) -> felt252 {
-                    'Roles'
+                fn name_hash(self: @ContractState) -> felt252 {
+                    0xe7952dd4a6d8cadc01c549ea1f202191a0371fde8260f06166932e8b366c4a
                 }
 
                 #[external(v0)]
@@ -1036,7 +1036,7 @@ impl OnlyKeyModelSerde of core::serde::Serde::<OnlyKeyModel> {
 
             impl OnlyKeyModelModel of dojo::model::Model<OnlyKeyModel> {
                 #[inline(always)]
-                fn name(self: @OnlyKeyModel) -> felt252 {
+                fn name_hash(self: @OnlyKeyModel) -> felt252 {
                     'OnlyKeyModel'
                 }
 
@@ -1108,8 +1108,8 @@ impl OnlyKeyModelIntrospect<> of dojo::database::introspect::Introspect<OnlyKeyM
                 struct Storage {}
 
                 #[external(v0)]
-                fn name(self: @ContractState) -> felt252 {
-                    'OnlyKeyModel'
+                fn name_hash(self: @ContractState) -> felt252 {
+                    0xadf5de5b7ca949565c1ab1e99d5c3501b0f2694b919bf9df06177fca2daa3e
                 }
 
                 #[external(v0)]
@@ -1156,7 +1156,7 @@ impl PlayerSerde of core::serde::Serde::<Player> {
 
             impl PlayerModel of dojo::model::Model<Player> {
                 #[inline(always)]
-                fn name(self: @Player) -> felt252 {
+                fn name_hash(self: @Player) -> felt252 {
                     'Player'
                 }
 
@@ -1237,8 +1237,8 @@ impl PlayerIntrospect<> of dojo::database::introspect::Introspect<Player<>> {
                 struct Storage {}
 
                 #[external(v0)]
-                fn name(self: @ContractState) -> felt252 {
-                    'Player'
+                fn name_hash(self: @ContractState) -> felt252 {
+                    0x3ef60e19d392fb1385879854ee6baf68dae43234ef5932a2c8087825dd75585
                 }
 
                 #[external(v0)]

--- a/crates/dojo-lang/src/semantics/test_data/set
+++ b/crates/dojo-lang/src/semantics/test_data/set
@@ -148,7 +148,7 @@ Block(
                                 Value(
                                     FunctionCall(
                                         ExprFunctionCall {
-                                            function: test::HealthModel::name,
+                                            function: test::HealthModel::name_hash,
                                             args: [
                                                 Value(
                                                     Snapshot(

--- a/crates/dojo-world/src/contracts/abi/world.rs
+++ b/crates/dojo-world/src/contracts/abi/world.rs
@@ -109,7 +109,7 @@ abigen!(
         "name": "model",
         "inputs": [
           {
-            "name": "name",
+            "name": "name_hash",
             "type": "core::felt252"
           }
         ],
@@ -125,6 +125,10 @@ abigen!(
         "name": "register_model",
         "inputs": [
           {
+            "name": "name",
+            "type": "core::array::Span::<core::felt252>"
+          },
+          {
             "name": "class_hash",
             "type": "core::starknet::class_hash::ClassHash"
           }
@@ -137,8 +141,8 @@ abigen!(
         "name": "deploy_contract",
         "inputs": [
           {
-            "name": "salt",
-            "type": "core::felt252"
+            "name": "name",
+            "type": "core::array::Span::<core::felt252>"
           },
           {
             "name": "class_hash",
@@ -527,8 +531,8 @@ abigen!(
     "kind": "struct",
     "members": [
       {
-        "name": "salt",
-        "type": "core::felt252",
+        "name": "name",
+        "type": "core::array::Span::<core::felt252>",
         "kind": "data"
       },
       {
@@ -596,7 +600,7 @@ abigen!(
     "members": [
       {
         "name": "name",
-        "type": "core::felt252",
+        "type": "core::array::Span::<core::felt252>",
         "kind": "data"
       },
       {

--- a/crates/dojo-world/src/contracts/cairo_utils.rs
+++ b/crates/dojo-world/src/contracts/cairo_utils.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use http::uri::Uri;
 use starknet::core::types::FieldElement;
 use starknet::core::utils::cairo_short_string_to_felt;
+use starknet_crypto::poseidon_hash_many;
 
 pub fn str_to_felt(string: &str) -> Result<FieldElement> {
     cairo_short_string_to_felt(string).map_err(|e| {
@@ -9,18 +10,24 @@ pub fn str_to_felt(string: &str) -> Result<FieldElement> {
     })
 }
 
-pub fn encode_uri(uri: &str) -> Result<Vec<FieldElement>> {
-    let parsed: Uri =
-        uri.try_into().map_err(|e| anyhow!("Failed to encode URI `{}`: {}", uri, e))?;
-
-    Ok(parsed
-        .to_string()
-        .chars()
+pub fn str_to_felts(s: &str) -> Result<Vec<FieldElement>> {
+    Ok(s.chars()
         .collect::<Vec<_>>()
         .chunks(31)
         .map(|chunk| {
             let s: String = chunk.iter().collect();
-            cairo_short_string_to_felt(&s)
+            str_to_felt(&s)
         })
         .collect::<Result<Vec<_>, _>>()?)
+}
+
+pub fn encode_uri(uri: &str) -> Result<Vec<FieldElement>> {
+    let parsed: Uri =
+        uri.try_into().map_err(|e| anyhow!("Failed to encode URI `{}`: {}", uri, e))?;
+
+    str_to_felts(&parsed.to_string())
+}
+
+pub fn poseidon_hash_str(value: &str) -> Result<FieldElement> {
+    Ok(poseidon_hash_many(&str_to_felts(&value)?))
 }

--- a/crates/dojo-world/src/contracts/model_test.rs
+++ b/crates/dojo-world/src/contracts/model_test.rs
@@ -63,7 +63,7 @@ async fn test_model() {
     assert_eq!(
         position.class_hash(),
         FieldElement::from_hex_be(
-            "0x004cd20d231b04405a77b184c115dc60637e186504fad7f0929bd76cbd09c10b"
+            "0x02b233bba9a232a5e891c85eca9f67beedca7a12f9768729ff017bcb62d25c9d"
         )
         .unwrap()
     );

--- a/crates/sozo/src/commands/register.rs
+++ b/crates/sozo/src/commands/register.rs
@@ -1,3 +1,6 @@
+use anyhow::Error;
+use std::str::FromStr;
+
 use anyhow::Result;
 use clap::{Args, Subcommand};
 use dojo_world::metadata::dojo_metadata_from_workspace;
@@ -10,6 +13,29 @@ use super::options::transaction::TransactionOptions;
 use super::options::world::WorldOptions;
 use crate::ops::register;
 
+#[derive(Clone, Debug)]
+pub struct Model {
+    pub name: String,
+    pub class_hash: FieldElement,
+}
+
+impl FromStr for Model {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(',').collect();
+        if parts.len() != 2 {
+            return Err(Error::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Invalid input",
+            )));
+        }
+        let name = parts[0].to_string();
+        let class_hash = parts[1].parse()?;
+        Ok(Model { name, class_hash })
+    }
+}
+
 #[derive(Debug, Args)]
 pub struct RegisterArgs {
     #[command(subcommand)]
@@ -20,11 +46,11 @@ pub struct RegisterArgs {
 pub enum RegisterCommand {
     #[command(about = "Register a model to a world.")]
     Model {
-        #[arg(num_args = 1..)]
+        // #[arg(num_args = 1..)]
         #[arg(required = true)]
-        #[arg(value_name = "CLASS_HASH")]
-        #[arg(help = "The class hash of the models to register.")]
-        models: Vec<FieldElement>,
+        #[arg(value_name = "MODEL")]
+        #[arg(help = "A (name, class hash) tuple of the models to register.")]
+        models: Vec<Model>,
 
         #[command(flatten)]
         world: WorldOptions,

--- a/crates/sozo/src/ops/execute.rs
+++ b/crates/sozo/src/ops/execute.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use dojo_world::metadata::Environment;
-use dojo_world::migration::strategy::generate_salt;
+use dojo_world::migration::strategy::poseidon_hash_str;
 use dojo_world::utils::TransactionWaiter;
 use starknet::accounts::{Account, Call};
 use starknet::core::types::{BlockId, BlockTag, FieldElement, FunctionCall};
@@ -36,7 +36,7 @@ pub async fn execute(args: ExecuteArgs, env_metadata: Option<Environment>) -> Re
             .await?;
 
         get_contract_address(
-            generate_salt(&contract),
+            poseidon_hash_str(&contract),
             contract_class_hash[0],
             &[],
             FieldElement::from_hex_be(&world_address).unwrap(),

--- a/crates/sozo/src/ops/register.rs
+++ b/crates/sozo/src/ops/register.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use dojo_world::contracts::cairo_utils::str_to_felts;
 use dojo_world::contracts::WorldContract;
 use dojo_world::metadata::Environment;
 use dojo_world::utils::TransactionWaiter;
@@ -17,7 +18,12 @@ pub async fn execute(command: RegisterCommand, env_metadata: Option<Environment>
 
             let calls = models
                 .iter()
-                .map(|c| world.register_model_getcall(&(*c).into()))
+                .map(|m| {
+                    world.register_model_getcall(
+                        &str_to_felts(&m.name).unwrap(),
+                        &m.class_hash.into(),
+                    )
+                })
                 .collect::<Vec<_>>();
 
             let res = account


### PR DESCRIPTION
This change enables two things:
- Longer model / contract names which are necessary for namespacing and using fully qualified paths
- Emitting the full name in the event so it is available onchain through events