### PR TITLE
Change model query field to camel case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-world-abigen"
-version = "0.1.0"
+version = "0.4.4"
 dependencies = [
  "cairo-lang-starknet",
  "camino",

--- a/crates/torii/graphql/src/schema.rs
+++ b/crates/torii/graphql/src/schema.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_graphql::dynamic::{
     Field, Object, Scalar, Schema, Subscription, SubscriptionField, Union,
 };
+use convert_case::{Case, Casing};
 use sqlx::SqlitePool;
 use torii_core::types::Model;
 
@@ -126,7 +127,7 @@ async fn build_objects(pool: &SqlitePool) -> Result<(Vec<Box<dyn ObjectTrait>>, 
         let type_mapping = type_mapping_query(&mut conn, &model.id).await?;
 
         if !type_mapping.is_empty() {
-            let field_name = model.name.to_lowercase();
+            let field_name = model.name.to_case(Case::Camel);
             let type_name = model.name;
 
             union = union.possible_type(&type_name);

--- a/crates/torii/graphql/src/tests/models_ordering_test.rs
+++ b/crates/torii/graphql/src/tests/models_ordering_test.rs
@@ -23,7 +23,7 @@ mod tests {
                     createdAt
                 }}
               }}
-              pageInfo{{
+              pageInfo {{
                 startCursor
                 hasPreviousPage
                 hasNextPage

--- a/crates/torii/graphql/src/tests/models_test.rs
+++ b/crates/torii/graphql/src/tests/models_test.rs
@@ -318,6 +318,23 @@ mod tests {
         let connection: Connection<Record> = serde_json::from_value(records).unwrap();
         assert_eq!(connection.edges.len(), 0);
 
+        let result = run_graphql_query(
+            &schema,
+            r#"
+            {
+                recordSiblingModels {
+                    edges {
+                        node {
+                            __typename
+                        }
+                    }
+                }
+            }
+            "#,
+        )
+        .await;
+        assert!(result.get("recordSiblingModels").is_some());
+
         Ok(())
     }
 }


### PR DESCRIPTION
World explorer currently expects lower camel case model fields

<img width="1624" alt="Screenshot 2024-01-09 at 13 00 26" src="https://github.com/dojoengine/dojo/assets/8398372/9d23f7dd-048d-4cc7-99c9-aeb51e4f3cc6">
