### PR TITLE
refactor(katana): improve error handling

### DIFF
--- a/crates/katana/core/src/backend/mod.rs
+++ b/crates/katana/core/src/backend/mod.rs
@@ -95,7 +95,7 @@ impl Backend {
             );
 
             let blockchain = Blockchain::new_from_forked(
-                ForkedProvider::new(provider, forked_block_num.into()),
+                ForkedProvider::new(provider, forked_block_num.into()).unwrap(),
                 block.block_hash,
                 block.parent_hash,
                 &block_context,

--- a/crates/katana/core/src/sequencer_error.rs
+++ b/crates/katana/core/src/sequencer_error.rs
@@ -1,46 +1,26 @@
 use blockifier::execution::errors::EntryPointExecutionError;
-use blockifier::state::errors::StateError;
 use blockifier::transaction::errors::TransactionExecutionError;
 use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::contract::ContractAddress;
 use katana_primitives::event::ContinuationTokenError;
-use katana_primitives::transaction::TxHash;
-use starknet_api::StarknetApiError;
+use katana_provider::error::ProviderError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SequencerError {
     #[error("Block {0:?} not found.")]
     BlockNotFound(BlockIdOrTag),
-    #[error("Contract address {0:?} not found.")]
+    #[error("Contract address {0} not found.")]
     ContractNotFound(ContractAddress),
-    #[error("State update for block {0:?} not found.")]
-    StateUpdateNotFound(BlockIdOrTag),
     #[error("State for block {0:?} not found.")]
     StateNotFound(BlockIdOrTag),
-    #[error("Transaction with {0} hash not found.")]
-    TxnNotFound(TxHash),
-    #[error(transparent)]
-    State(#[from] StateError),
     #[error(transparent)]
     TransactionExecution(#[from] TransactionExecutionError),
-    #[error("Error converting {from} into {to}: {message}")]
-    ConversionError { from: String, to: String, message: String },
-    #[error(transparent)]
-    StarknetApi(#[from] StarknetApiError),
     #[error(transparent)]
     EntryPointExecution(#[from] EntryPointExecutionError),
     #[error("Wait for pending transactions.")]
     PendingTransactions,
-    #[error("Unsupported Transaction")]
-    UnsupportedTransaction,
     #[error(transparent)]
     ContinuationToken(#[from] ContinuationTokenError),
-    #[error("Error serializing state.")]
-    StateSerialization,
-    #[error("Required data unavailable")]
-    DataUnavailable,
-    #[error("Failed to decode state")]
-    FailedToDecodeStateDump,
     #[error(transparent)]
-    Other(#[from] anyhow::Error),
+    Provider(#[from] ProviderError),
 }

--- a/crates/katana/executor/src/blockifier/state.rs
+++ b/crates/katana/executor/src/blockifier/state.rs
@@ -7,6 +7,7 @@ use katana_primitives::contract::FlattenedSierraClass;
 use katana_primitives::FieldElement;
 use katana_provider::traits::contract::ContractClassProvider;
 use katana_provider::traits::state::StateProvider;
+use katana_provider::ProviderResult;
 use parking_lot::{Mutex, RawMutex, RwLock};
 use starknet_api::core::{ClassHash, CompiledClassHash, Nonce, PatriciaKey};
 use starknet_api::hash::StarkHash;
@@ -140,7 +141,7 @@ where
     fn class(
         &self,
         hash: katana_primitives::contract::ClassHash,
-    ) -> anyhow::Result<Option<katana_primitives::contract::CompiledContractClass>> {
+    ) -> ProviderResult<Option<katana_primitives::contract::CompiledContractClass>> {
         let Ok(class) = self.inner().get_compiled_contract_class(&ClassHash(hash.into())) else {
             return Ok(None);
         };
@@ -150,7 +151,7 @@ where
     fn compiled_class_hash_of_class_hash(
         &self,
         hash: katana_primitives::contract::ClassHash,
-    ) -> anyhow::Result<Option<katana_primitives::contract::CompiledClassHash>> {
+    ) -> ProviderResult<Option<katana_primitives::contract::CompiledClassHash>> {
         let Ok(hash) = self.inner().get_compiled_class_hash(ClassHash(hash.into())) else {
             return Ok(None);
         };
@@ -160,7 +161,7 @@ where
     fn sierra_class(
         &self,
         hash: katana_primitives::contract::ClassHash,
-    ) -> anyhow::Result<Option<FlattenedSierraClass>> {
+    ) -> ProviderResult<Option<FlattenedSierraClass>> {
         let class @ Some(_) = self.sierra_class().get(&hash).cloned() else {
             return Ok(None);
         };
@@ -176,7 +177,7 @@ where
         &self,
         address: katana_primitives::contract::ContractAddress,
         storage_key: katana_primitives::contract::StorageKey,
-    ) -> anyhow::Result<Option<katana_primitives::contract::StorageValue>> {
+    ) -> ProviderResult<Option<katana_primitives::contract::StorageValue>> {
         let Ok(value) =
             self.inner().get_storage_at(address.into(), StorageKey(patricia_key!(storage_key)))
         else {
@@ -188,7 +189,7 @@ where
     fn nonce(
         &self,
         address: katana_primitives::contract::ContractAddress,
-    ) -> anyhow::Result<Option<katana_primitives::contract::Nonce>> {
+    ) -> ProviderResult<Option<katana_primitives::contract::Nonce>> {
         let Ok(nonce) = self.inner().get_nonce_at(address.into()) else {
             return Ok(None);
         };
@@ -198,7 +199,7 @@ where
     fn class_hash_of_contract(
         &self,
         address: katana_primitives::contract::ContractAddress,
-    ) -> anyhow::Result<Option<katana_primitives::contract::ClassHash>> {
+    ) -> ProviderResult<Option<katana_primitives::contract::ClassHash>> {
         let Ok(hash) = self.inner().get_class_hash_at(address.into()) else {
             return Ok(None);
         };

--- a/crates/katana/rpc/rpc-types-builder/src/block.rs
+++ b/crates/katana/rpc/rpc-types-builder/src/block.rs
@@ -1,6 +1,6 @@
-use anyhow::Result;
 use katana_primitives::block::BlockHashOrNumber;
 use katana_provider::traits::block::{BlockHashProvider, BlockProvider, BlockStatusProvider};
+use katana_provider::ProviderResult;
 use katana_rpc_types::block::{BlockWithTxHashes, BlockWithTxs};
 
 /// A builder for building RPC block types.
@@ -19,7 +19,7 @@ impl<P> BlockBuilder<P>
 where
     P: BlockProvider + BlockHashProvider,
 {
-    pub fn build(self) -> Result<Option<BlockWithTxs>> {
+    pub fn build(self) -> ProviderResult<Option<BlockWithTxs>> {
         let Some(hash) = BlockHashProvider::block_hash_by_id(&self.provider, self.block_id)? else {
             return Ok(None);
         };
@@ -32,7 +32,7 @@ where
         Ok(Some(BlockWithTxs::new(hash, block, finality_status)))
     }
 
-    pub fn build_with_tx_hash(self) -> Result<Option<BlockWithTxHashes>> {
+    pub fn build_with_tx_hash(self) -> ProviderResult<Option<BlockWithTxHashes>> {
         let Some(hash) = BlockHashProvider::block_hash_by_id(&self.provider, self.block_id)? else {
             return Ok(None);
         };

--- a/crates/katana/rpc/rpc-types-builder/src/state_update.rs
+++ b/crates/katana/rpc/rpc-types-builder/src/state_update.rs
@@ -3,6 +3,7 @@ use katana_primitives::FieldElement;
 use katana_provider::traits::block::{BlockHashProvider, BlockNumberProvider};
 use katana_provider::traits::state::StateRootProvider;
 use katana_provider::traits::state_update::StateUpdateProvider;
+use katana_provider::ProviderResult;
 use katana_rpc_types::state_update::{StateDiff, StateUpdate};
 
 /// A builder for building RPC state update type.
@@ -22,7 +23,7 @@ where
     P: BlockHashProvider + BlockNumberProvider + StateRootProvider + StateUpdateProvider,
 {
     /// Builds a state update for the given block.
-    pub fn build(self) -> anyhow::Result<Option<StateUpdate>> {
+    pub fn build(self) -> ProviderResult<Option<StateUpdate>> {
         let Some(block_hash) = BlockHashProvider::block_hash_by_id(&self.provider, self.block_id)?
         else {
             return Ok(None);

--- a/crates/katana/rpc/src/starknet.rs
+++ b/crates/katana/rpc/src/starknet.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use jsonrpsee::core::{async_trait, Error};
 use katana_core::backend::contract::StarknetContract;
 use katana_core::sequencer::KatanaSequencer;
-use katana_core::sequencer_error::SequencerError;
 use katana_executor::blockifier::utils::EntryPointCall;
 use katana_primitives::block::{
     BlockHashOrNumber, BlockIdOrTag, FinalityStatus, GasPrices, PartialHeader,
@@ -58,10 +57,7 @@ impl StarknetApiServer for StarknetApi {
             .sequencer
             .nonce_at(block_id, contract_address.into())
             .await
-            .map_err(|e| match e {
-                SequencerError::StateNotFound(_) => StarknetApiError::BlockNotFound,
-                _ => StarknetApiError::UnexpectedError,
-            })?
+            .map_err(StarknetApiError::from)?
             .ok_or(StarknetApiError::ContractNotFound)?;
 
         Ok(nonce.into())
@@ -75,7 +71,7 @@ impl StarknetApiServer for StarknetApi {
         let tx = self
             .sequencer
             .transaction(&transaction_hash)
-            .map_err(|_| StarknetApiError::UnexpectedError)?
+            .map_err(StarknetApiError::from)?
             .ok_or(StarknetApiError::TxnHashNotFound)?;
         Ok(tx.into())
     }
@@ -84,7 +80,7 @@ impl StarknetApiServer for StarknetApi {
         let count = self
             .sequencer
             .block_tx_count(block_id)
-            .map_err(|_| StarknetApiError::UnexpectedError)?
+            .map_err(StarknetApiError::from)?
             .ok_or(StarknetApiError::BlockNotFound)?;
         Ok(count)
     }
@@ -97,17 +93,15 @@ impl StarknetApiServer for StarknetApi {
         let class_hash = self
             .sequencer
             .class_hash_at(block_id, contract_address.into())
-            .map_err(|_| StarknetApiError::UnexpectedError)?
+            .map_err(StarknetApiError::from)?
             .ok_or(StarknetApiError::ContractNotFound)?;
 
         self.class(block_id, class_hash).await
     }
 
     async fn block_hash_and_number(&self) -> Result<BlockHashAndNumber, Error> {
-        let hash_and_num_pair = self
-            .sequencer
-            .block_hash_and_number()
-            .map_err(|_| StarknetApiError::UnexpectedError)?;
+        let hash_and_num_pair =
+            self.sequencer.block_hash_and_number().map_err(StarknetApiError::from)?;
         Ok(hash_and_num_pair.into())
     }
 
@@ -121,7 +115,8 @@ impl StarknetApiServer for StarknetApi {
             let pending_state = self.sequencer.pending_state().expect("pending state should exist");
 
             let block_context = self.sequencer.backend.env.read().block.clone();
-            let latest_hash = BlockHashProvider::latest_hash(provider)?;
+            let latest_hash =
+                BlockHashProvider::latest_hash(provider).map_err(StarknetApiError::from)?;
 
             let gas_prices = GasPrices {
                 eth_gas_price: block_context.gas_prices.eth_l1_gas_price.try_into().unwrap(),
@@ -145,13 +140,13 @@ impl StarknetApiServer for StarknetApi {
             )))
         } else {
             let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                .map_err(|_| StarknetApiError::UnexpectedError)?
+                .map_err(StarknetApiError::from)?
                 .map(BlockHashOrNumber::Num)
                 .ok_or(StarknetApiError::BlockNotFound)?;
 
             katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
                 .build_with_tx_hash()
-                .map_err(|_| StarknetApiError::UnexpectedError)?
+                .map_err(StarknetApiError::from)?
                 .map(MaybePendingBlockWithTxHashes::Block)
                 .ok_or(Error::from(StarknetApiError::BlockNotFound))
         }
@@ -174,12 +169,12 @@ impl StarknetApiServer for StarknetApi {
             let provider = &self.sequencer.backend.blockchain.provider();
 
             let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                .map_err(|_| StarknetApiError::UnexpectedError)?
+                .map_err(StarknetApiError::from)?
                 .map(BlockHashOrNumber::Num)
                 .ok_or(StarknetApiError::BlockNotFound)?;
 
             TransactionProvider::transaction_by_block_and_idx(provider, block_num, index)
-                .map_err(|_| StarknetApiError::UnexpectedError)?
+                .map_err(StarknetApiError::from)?
         };
 
         Ok(tx.ok_or(StarknetApiError::InvalidTxnIndex)?.into())
@@ -195,7 +190,8 @@ impl StarknetApiServer for StarknetApi {
             let pending_state = self.sequencer.pending_state().expect("pending state should exist");
 
             let block_context = self.sequencer.backend.env.read().block.clone();
-            let latest_hash = BlockHashProvider::latest_hash(provider)?;
+            let latest_hash =
+                BlockHashProvider::latest_hash(provider).map_err(StarknetApiError::from)?;
 
             let gas_prices = GasPrices {
                 eth_gas_price: block_context.gas_prices.eth_l1_gas_price.try_into().unwrap(),
@@ -220,13 +216,13 @@ impl StarknetApiServer for StarknetApi {
             Ok(MaybePendingBlockWithTxs::Pending(PendingBlockWithTxs::new(header, transactions)))
         } else {
             let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                .map_err(|_| StarknetApiError::UnexpectedError)?
+                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
                 .map(BlockHashOrNumber::Num)
                 .ok_or(StarknetApiError::BlockNotFound)?;
 
             katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
                 .build()
-                .map_err(|_| StarknetApiError::UnexpectedError)?
+                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
                 .map(MaybePendingBlockWithTxs::Block)
                 .ok_or(Error::from(StarknetApiError::BlockNotFound))
         }
@@ -242,6 +238,7 @@ impl StarknetApiServer for StarknetApi {
             BlockIdOrTag::Tag(BlockTag::Latest) => BlockNumberProvider::latest_number(provider)
                 .map(BlockHashOrNumber::Num)
                 .map_err(|_| StarknetApiError::BlockNotFound)?,
+
             BlockIdOrTag::Tag(BlockTag::Pending) => {
                 return Err(StarknetApiError::BlockNotFound.into());
             }
@@ -249,7 +246,7 @@ impl StarknetApiServer for StarknetApi {
 
         katana_rpc_types_builder::StateUpdateBuilder::new(block_id, provider)
             .build()
-            .map_err(|_| StarknetApiError::UnexpectedError)?
+            .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
             .ok_or(Error::from(StarknetApiError::BlockNotFound))
     }
 
@@ -260,7 +257,7 @@ impl StarknetApiServer for StarknetApi {
         let provider = self.sequencer.backend.blockchain.provider();
         let receipt = ReceiptBuilder::new(transaction_hash, provider)
             .build()
-            .map_err(|_| StarknetApiError::UnexpectedError)?;
+            .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
 
         match receipt {
             Some(receipt) => Ok(MaybePendingTxReceipt::Receipt(receipt)),
@@ -294,11 +291,8 @@ impl StarknetApiServer for StarknetApi {
         let hash = self
             .sequencer
             .class_hash_at(block_id, contract_address.into())
-            .map_err(|e| match e {
-                SequencerError::BlockNotFound(_) => StarknetApiError::BlockNotFound,
-                _ => StarknetApiError::UnexpectedError,
-            })?
-            .ok_or(Error::from(StarknetApiError::ContractNotFound))?;
+            .map_err(StarknetApiError::from)?
+            .ok_or(StarknetApiError::ContractNotFound)?;
 
         Ok(hash.into())
     }
@@ -308,17 +302,13 @@ impl StarknetApiServer for StarknetApi {
         block_id: BlockIdOrTag,
         class_hash: FieldElement,
     ) -> Result<ContractClass, Error> {
-        let class = self.sequencer.class(block_id, class_hash).map_err(|e| match e {
-            SequencerError::BlockNotFound(_) => StarknetApiError::BlockNotFound,
-            _ => StarknetApiError::UnexpectedError,
-        })?;
-
+        let class = self.sequencer.class(block_id, class_hash).map_err(StarknetApiError::from)?;
         let Some(class) = class else { return Err(StarknetApiError::ClassHashNotFound.into()) };
 
         match class {
             StarknetContract::Legacy(c) => {
-                let contract =
-                    legacy_inner_to_rpc_class(c).map_err(|_| StarknetApiError::UnexpectedError)?;
+                let contract = legacy_inner_to_rpc_class(c)
+                    .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
                 Ok(contract)
             }
             StarknetContract::Sierra(c) => Ok(ContractClass::Sierra(c)),
@@ -343,10 +333,7 @@ impl StarknetApiServer for StarknetApi {
                 filter.result_page_request.chunk_size,
             )
             .await
-            .map_err(|e| match e {
-                SequencerError::BlockNotFound(_) => StarknetApiError::BlockNotFound,
-                _ => StarknetApiError::UnexpectedError,
-            })?;
+            .map_err(StarknetApiError::from)?;
 
         Ok(events)
     }
@@ -362,14 +349,7 @@ impl StarknetApiServer for StarknetApi {
             entry_point_selector: request.entry_point_selector,
         };
 
-        let res = self.sequencer.call(request, block_id).map_err(|e| match e {
-            SequencerError::BlockNotFound(_) => StarknetApiError::BlockNotFound,
-            SequencerError::ContractNotFound(_) => StarknetApiError::ContractNotFound,
-            SequencerError::EntryPointExecution(e) => {
-                StarknetApiError::ContractError { revert_error: e.to_string() }
-            }
-            _ => StarknetApiError::UnexpectedError,
-        })?;
+        let res = self.sequencer.call(request, block_id).map_err(StarknetApiError::from)?;
 
         Ok(res.into_iter().map(|v| v.into()).collect())
     }
@@ -380,13 +360,10 @@ impl StarknetApiServer for StarknetApi {
         key: FieldElement,
         block_id: BlockIdOrTag,
     ) -> Result<FeltAsHex, Error> {
-        let value = self.sequencer.storage_at(contract_address.into(), key, block_id).map_err(
-            |e| match e {
-                SequencerError::BlockNotFound(_) => StarknetApiError::BlockNotFound,
-                SequencerError::ContractNotFound(_) => StarknetApiError::ContractNotFound,
-                _ => StarknetApiError::UnexpectedError,
-            },
-        )?;
+        let value = self
+            .sequencer
+            .storage_at(contract_address.into(), key, block_id)
+            .map_err(StarknetApiError::from)?;
 
         Ok(value.into())
     }
@@ -445,13 +422,8 @@ impl StarknetApiServer for StarknetApi {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let res = self.sequencer.estimate_fee(transactions, block_id).map_err(|e| match e {
-            SequencerError::BlockNotFound(_) => StarknetApiError::BlockNotFound,
-            SequencerError::TransactionExecution(e) => {
-                StarknetApiError::ContractError { revert_error: e.to_string() }
-            }
-            _ => StarknetApiError::UnexpectedError,
-        })?;
+        let res =
+            self.sequencer.estimate_fee(transactions, block_id).map_err(StarknetApiError::from)?;
 
         Ok(res)
     }
@@ -470,13 +442,7 @@ impl StarknetApiServer for StarknetApi {
         let res = self
             .sequencer
             .estimate_fee(vec![tx], block_id)
-            .map_err(|e| match e {
-                SequencerError::BlockNotFound(_) => StarknetApiError::BlockNotFound,
-                SequencerError::TransactionExecution(e) => {
-                    StarknetApiError::ContractError { revert_error: e.to_string() }
-                }
-                _ => StarknetApiError::UnexpectedError,
-            })?
+            .map_err(StarknetApiError::from)?
             .pop()
             .expect("should have estimate result");
 
@@ -541,51 +507,55 @@ impl StarknetApiServer for StarknetApi {
         let provider = self.sequencer.backend.blockchain.provider();
 
         let tx_status = TransactionStatusProvider::transaction_status(provider, transaction_hash)
-            .map_err(|_| StarknetApiError::UnexpectedError)?;
+            .map_err(StarknetApiError::from)?;
 
         if let Some(status) = tx_status {
-            let receipt = ReceiptProvider::receipt_by_hash(provider, transaction_hash)
-                .map_err(|_| StarknetApiError::UnexpectedError)?
-                .ok_or(StarknetApiError::UnexpectedError)?;
-
-            let execution_status = if receipt.is_reverted() {
-                TransactionExecutionStatus::Reverted
-            } else {
-                TransactionExecutionStatus::Succeeded
-            };
-
-            Ok(match status {
-                FinalityStatus::AcceptedOnL1 => TransactionStatus::AcceptedOnL1(execution_status),
-                FinalityStatus::AcceptedOnL2 => TransactionStatus::AcceptedOnL2(execution_status),
-            })
-        } else {
-            let pending_state = self.sequencer.pending_state();
-            let state = pending_state.ok_or(StarknetApiError::TxnHashNotFound)?;
-            let executed_txs = state.executed_txs.read();
-
-            // attemps to find in the valid transactions list first (executed_txs)
-            // if not found, then search in the rejected transactions list (rejected_txs)
-            if let Some(is_reverted) = executed_txs
-                .iter()
-                .find(|(tx, _)| tx.hash == transaction_hash)
-                .map(|(_, rct)| rct.receipt.is_reverted())
+            if let Some(receipt) = ReceiptProvider::receipt_by_hash(provider, transaction_hash)
+                .map_err(StarknetApiError::from)?
             {
-                let exec_status = if is_reverted {
+                let execution_status = if receipt.is_reverted() {
                     TransactionExecutionStatus::Reverted
                 } else {
                     TransactionExecutionStatus::Succeeded
                 };
 
-                Ok(TransactionStatus::AcceptedOnL2(exec_status))
-            } else {
-                let rejected_txs = state.rejected_txs.read();
-
-                rejected_txs
-                    .iter()
-                    .find(|(tx, _)| tx.hash == transaction_hash)
-                    .map(|_| TransactionStatus::Rejected)
-                    .ok_or(Error::from(StarknetApiError::TxnHashNotFound))
+                return Ok(match status {
+                    FinalityStatus::AcceptedOnL1 => {
+                        TransactionStatus::AcceptedOnL1(execution_status)
+                    }
+                    FinalityStatus::AcceptedOnL2 => {
+                        TransactionStatus::AcceptedOnL2(execution_status)
+                    }
+                });
             }
+        }
+
+        let pending_state = self.sequencer.pending_state();
+        let state = pending_state.ok_or(StarknetApiError::TxnHashNotFound)?;
+        let executed_txs = state.executed_txs.read();
+
+        // attemps to find in the valid transactions list first (executed_txs)
+        // if not found, then search in the rejected transactions list (rejected_txs)
+        if let Some(is_reverted) = executed_txs
+            .iter()
+            .find(|(tx, _)| tx.hash == transaction_hash)
+            .map(|(_, rct)| rct.receipt.is_reverted())
+        {
+            let exec_status = if is_reverted {
+                TransactionExecutionStatus::Reverted
+            } else {
+                TransactionExecutionStatus::Succeeded
+            };
+
+            Ok(TransactionStatus::AcceptedOnL2(exec_status))
+        } else {
+            let rejected_txs = state.rejected_txs.read();
+
+            rejected_txs
+                .iter()
+                .find(|(tx, _)| tx.hash == transaction_hash)
+                .map(|_| TransactionStatus::Rejected)
+                .ok_or(Error::from(StarknetApiError::TxnHashNotFound))
         }
     }
 }

--- a/crates/katana/storage/db/src/error.rs
+++ b/crates/katana/storage/db/src/error.rs
@@ -1,42 +1,42 @@
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum DatabaseError {
-    #[error("failed to open an environment: {0}")]
+    #[error("failed to open db environment: {0}")]
     OpenEnv(libmdbx::Error),
 
     #[error(transparent)]
     Codec(#[from] CodecError),
 
-    #[error("failed to create table: {0}")]
+    #[error("failed to create db table: {0}")]
     CreateTable(libmdbx::Error),
 
-    #[error("failed to commit transaction: {0}")]
+    #[error("failed to commit db transaction: {0}")]
     Commit(libmdbx::Error),
 
-    #[error("failed to read: {0}")]
+    #[error("failed to read db: {0}")]
     Read(libmdbx::Error),
 
-    #[error("failed to write to table {table} with key {key:?}: {error}")]
+    #[error("failed to write to db table {table} with key {key:?}: {error}")]
     Write { error: libmdbx::Error, table: &'static str, key: Box<[u8]> },
 
-    #[error("failed to open database: {0}")]
+    #[error("failed to open db: {0}")]
     OpenDb(libmdbx::Error),
 
-    #[error("failed to retrieve database statistics: {0}")]
+    #[error("failed to retrieve db statistics: {0}")]
     Stat(libmdbx::Error),
 
-    #[error("failed to create cursor: {0}")]
+    #[error("failed to create db cursor: {0}")]
     CreateCursor(libmdbx::Error),
 
-    #[error("failed to create read-only transaction: {0}")]
+    #[error("failed to create read-only db transaction: {0}")]
     CreateROTx(libmdbx::Error),
 
-    #[error("failed to create a read-write transaction: {0}")]
+    #[error("failed to create a read-write db transaction: {0}")]
     CreateRWTx(libmdbx::Error),
 
-    #[error("failed to delete entry: {0}")]
+    #[error("failed to delete a db entry: {0}")]
     Delete(libmdbx::Error),
 
-    #[error("failed to clear database: {0}")]
+    #[error("failed to clear db: {0}")]
     Clear(libmdbx::Error),
 }
 

--- a/crates/katana/storage/provider/src/error.rs
+++ b/crates/katana/storage/provider/src/error.rs
@@ -1,0 +1,104 @@
+use katana_db::error::DatabaseError;
+use katana_primitives::block::BlockNumber;
+use katana_primitives::contract::{ClassHash, ContractAddress, StorageKey};
+use katana_primitives::transaction::TxNumber;
+
+use crate::providers::fork::backend::ForkedBackendError;
+
+/// Possible errors returned by the storage provider.
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    /// Error for anything related to parsing data.
+    #[error("Parsing error: {0}")]
+    ParsingError(String),
+
+    #[error("Missing latest block hash")]
+    MissingLatestBlockHash,
+
+    /// Error when the block hash is not found when it should be.
+    #[error("Missing block hash for block number {0}")]
+    MissingBlockHash(BlockNumber),
+
+    /// Error when the block header is not found when it should be.
+    #[error("Missing block header for block number {0}")]
+    MissingBlockHeader(BlockNumber),
+
+    /// Error when the block body is not found but the block exists.
+    #[error("Missing block transactions for block number {0}")]
+    MissingBlockTxs(BlockNumber),
+
+    /// Error when the block body indices are not found but the block exists.
+    #[error("Missing block body indices for block number {0}")]
+    MissingBlockBodyIndices(BlockNumber),
+
+    /// Error when the block status is not found but the block exists.
+    #[error("Missing block status for block number {0}")]
+    MissingBlockStatus(BlockNumber),
+
+    /// Error when a full transaction data is not found but its hash/number exists.
+    #[error("Missing transaction for tx number {0}")]
+    MissingTx(TxNumber),
+
+    /// Error when a transaction block number is not found but the transaction exists.
+    #[error("Missing transaction block number for tx number {0}")]
+    MissingTxBlock(TxNumber),
+
+    /// Error when a transaction hash is not found but the transaction exists.
+    #[error("Missing transaction hash for tx number {0}")]
+    MissingTxHash(TxNumber),
+
+    /// Error when a transaction receipt is not found but the transaction exists.
+    #[error("Missing transaction receipt for tx number {0}")]
+    MissingTxReceipt(TxNumber),
+
+    /// Error when a compiled class hash is not found but the class hash exists.
+    #[error("Missing compiled class hash for class hash {0:#x}")]
+    MissingCompiledClassHash(ClassHash),
+
+    /// Error when a contract class change entry is not found but the block number of when the
+    /// change happen exists in the class change list.
+    #[error("Missing contract class change entry")]
+    MissingContractClassChangeEntry {
+        /// The block number of when the change happen.
+        block: BlockNumber,
+        /// The updated contract address.
+        contract_address: ContractAddress,
+    },
+
+    /// Error when a contract nonce change entry is not found but the block number of when the
+    /// change happen exists in the nonce change list.
+    #[error(
+        "Missing contract nonce change entry for contract {contract_address} at block {block}"
+    )]
+    MissingContractNonceChangeEntry {
+        /// The block number of when the change happen.
+        block: BlockNumber,
+        /// The updated contract address.
+        contract_address: ContractAddress,
+    },
+
+    /// Error when a storage change entry is not found but the block number of when the change
+    /// happen exists in the storage change list.
+    #[error(
+        "Missing storage change entry for contract {contract_address} at block {block} for key \
+         {storage_key:#x}"
+    )]
+    MissingStorageChangeEntry {
+        /// The block number of when the change happen.
+        block: BlockNumber,
+        /// The updated contract address.
+        contract_address: ContractAddress,
+        /// The updated storage key.
+        storage_key: StorageKey,
+    },
+
+    /// Error returned by the database implementation.
+    #[error(transparent)]
+    Database(#[from] DatabaseError),
+
+    /// Error returned by a [ForkedBackend](crate::providers::fork::backend::ForkedBackend) used by
+    /// [ForkedProvider](crate::providers::fork::ForkedProvider).
+    #[cfg(feature = "fork")]
+    #[error(transparent)]
+    ForkedBackend(#[from] ForkedBackendError),
+}

--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -1,6 +1,5 @@
 use std::ops::{Range, RangeInclusive};
 
-use anyhow::Result;
 use katana_db::models::block::StoredBlockBodyIndices;
 use katana_primitives::block::{
     Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithTxHashes, FinalityStatus, Header,
@@ -19,6 +18,7 @@ use traits::contract::{ContractClassProvider, ContractClassWriter};
 use traits::state::{StateRootProvider, StateWriter};
 use traits::transaction::TransactionStatusProvider;
 
+pub mod error;
 pub mod providers;
 pub mod traits;
 
@@ -27,6 +27,9 @@ use crate::traits::contract::ContractInfoProvider;
 use crate::traits::state::{StateFactoryProvider, StateProvider};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{ReceiptProvider, TransactionProvider, TransactionsProviderExt};
+
+/// A result type for blockchain providers.
+pub type ProviderResult<T> = Result<T, error::ProviderError>;
 
 /// A blockchain provider that can be used to access the storage.
 ///
@@ -46,19 +49,25 @@ impl<Db> BlockProvider for BlockchainProvider<Db>
 where
     Db: BlockProvider,
 {
-    fn block(&self, id: BlockHashOrNumber) -> Result<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         self.provider.block(id)
     }
 
-    fn block_with_tx_hashes(&self, id: BlockHashOrNumber) -> Result<Option<BlockWithTxHashes>> {
+    fn block_with_tx_hashes(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<BlockWithTxHashes>> {
         self.provider.block_with_tx_hashes(id)
     }
 
-    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> Result<Vec<Block>> {
+    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> ProviderResult<Vec<Block>> {
         self.provider.blocks_in_range(range)
     }
 
-    fn block_body_indices(&self, id: BlockHashOrNumber) -> Result<Option<StoredBlockBodyIndices>> {
+    fn block_body_indices(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         self.provider.block_body_indices(id)
     }
 }
@@ -67,7 +76,7 @@ impl<Db> HeaderProvider for BlockchainProvider<Db>
 where
     Db: HeaderProvider,
 {
-    fn header(&self, id: BlockHashOrNumber) -> Result<Option<Header>> {
+    fn header(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Header>> {
         self.provider.header(id)
     }
 }
@@ -76,11 +85,11 @@ impl<Db> BlockNumberProvider for BlockchainProvider<Db>
 where
     Db: BlockNumberProvider,
 {
-    fn latest_number(&self) -> Result<BlockNumber> {
+    fn latest_number(&self) -> ProviderResult<BlockNumber> {
         self.provider.latest_number()
     }
 
-    fn block_number_by_hash(&self, hash: BlockHash) -> Result<Option<BlockNumber>> {
+    fn block_number_by_hash(&self, hash: BlockHash) -> ProviderResult<Option<BlockNumber>> {
         self.provider.block_number_by_hash(hash)
     }
 }
@@ -89,11 +98,11 @@ impl<Db> BlockHashProvider for BlockchainProvider<Db>
 where
     Db: BlockHashProvider,
 {
-    fn latest_hash(&self) -> Result<BlockHash> {
+    fn latest_hash(&self) -> ProviderResult<BlockHash> {
         self.provider.latest_hash()
     }
 
-    fn block_hash_by_num(&self, num: BlockNumber) -> Result<Option<BlockHash>> {
+    fn block_hash_by_num(&self, num: BlockNumber) -> ProviderResult<Option<BlockHash>> {
         self.provider.block_hash_by_num(num)
     }
 }
@@ -104,7 +113,7 @@ impl<Db> BlockStatusProvider for BlockchainProvider<Db>
 where
     Db: BlockStatusProvider,
 {
-    fn block_status(&self, id: BlockHashOrNumber) -> Result<Option<FinalityStatus>> {
+    fn block_status(&self, id: BlockHashOrNumber) -> ProviderResult<Option<FinalityStatus>> {
         self.provider.block_status(id)
     }
 }
@@ -118,7 +127,7 @@ where
         block: SealedBlockWithStatus,
         states: StateUpdatesWithDeclaredClasses,
         receipts: Vec<Receipt>,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.provider.insert_block_with_states_and_receipts(block, states, receipts)
     }
 }
@@ -127,14 +136,14 @@ impl<Db> TransactionProvider for BlockchainProvider<Db>
 where
     Db: TransactionProvider,
 {
-    fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TxWithHash>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
         self.provider.transaction_by_hash(hash)
     }
 
     fn transactions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> Result<Option<Vec<TxWithHash>>> {
+    ) -> ProviderResult<Option<Vec<TxWithHash>>> {
         self.provider.transactions_by_block(block_id)
     }
 
@@ -142,18 +151,21 @@ where
         &self,
         block_id: BlockHashOrNumber,
         idx: u64,
-    ) -> Result<Option<TxWithHash>> {
+    ) -> ProviderResult<Option<TxWithHash>> {
         self.provider.transaction_by_block_and_idx(block_id, idx)
     }
 
-    fn transaction_count_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<u64>> {
+    fn transaction_count_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<u64>> {
         self.provider.transaction_count_by_block(block_id)
     }
 
     fn transaction_block_num_and_hash(
         &self,
         hash: TxHash,
-    ) -> Result<Option<(BlockNumber, BlockHash)>> {
+    ) -> ProviderResult<Option<(BlockNumber, BlockHash)>> {
         TransactionProvider::transaction_block_num_and_hash(&self.provider, hash)
     }
 }
@@ -162,7 +174,7 @@ impl<Db> TransactionStatusProvider for BlockchainProvider<Db>
 where
     Db: TransactionStatusProvider,
 {
-    fn transaction_status(&self, hash: TxHash) -> Result<Option<FinalityStatus>> {
+    fn transaction_status(&self, hash: TxHash) -> ProviderResult<Option<FinalityStatus>> {
         TransactionStatusProvider::transaction_status(&self.provider, hash)
     }
 }
@@ -171,7 +183,7 @@ impl<Db> TransactionsProviderExt for BlockchainProvider<Db>
 where
     Db: TransactionsProviderExt,
 {
-    fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> Result<Vec<TxHash>> {
+    fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxHash>> {
         TransactionsProviderExt::transaction_hashes_in_range(&self.provider, range)
     }
 }
@@ -180,11 +192,14 @@ impl<Db> ReceiptProvider for BlockchainProvider<Db>
 where
     Db: ReceiptProvider,
 {
-    fn receipt_by_hash(&self, hash: TxHash) -> Result<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         self.provider.receipt_by_hash(hash)
     }
 
-    fn receipts_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Receipt>>> {
         self.provider.receipts_by_block(block_id)
     }
 }
@@ -196,7 +211,7 @@ where
     fn nonce(
         &self,
         address: ContractAddress,
-    ) -> Result<Option<katana_primitives::contract::Nonce>> {
+    ) -> ProviderResult<Option<katana_primitives::contract::Nonce>> {
         self.provider.nonce(address)
     }
 
@@ -204,11 +219,14 @@ where
         &self,
         address: ContractAddress,
         storage_key: StorageKey,
-    ) -> Result<Option<StorageValue>> {
+    ) -> ProviderResult<Option<StorageValue>> {
         self.provider.storage(address, storage_key)
     }
 
-    fn class_hash_of_contract(&self, address: ContractAddress) -> Result<Option<ClassHash>> {
+    fn class_hash_of_contract(
+        &self,
+        address: ContractAddress,
+    ) -> ProviderResult<Option<ClassHash>> {
         self.provider.class_hash_of_contract(address)
     }
 }
@@ -220,15 +238,15 @@ where
     fn compiled_class_hash_of_class_hash(
         &self,
         hash: ClassHash,
-    ) -> Result<Option<CompiledClassHash>> {
+    ) -> ProviderResult<Option<CompiledClassHash>> {
         self.provider.compiled_class_hash_of_class_hash(hash)
     }
 
-    fn class(&self, hash: ClassHash) -> Result<Option<CompiledContractClass>> {
+    fn class(&self, hash: ClassHash) -> ProviderResult<Option<CompiledContractClass>> {
         self.provider.class(hash)
     }
 
-    fn sierra_class(&self, hash: ClassHash) -> Result<Option<FlattenedSierraClass>> {
+    fn sierra_class(&self, hash: ClassHash) -> ProviderResult<Option<FlattenedSierraClass>> {
         self.provider.sierra_class(hash)
     }
 }
@@ -237,11 +255,14 @@ impl<Db> StateFactoryProvider for BlockchainProvider<Db>
 where
     Db: StateFactoryProvider,
 {
-    fn latest(&self) -> Result<Box<dyn StateProvider>> {
+    fn latest(&self) -> ProviderResult<Box<dyn StateProvider>> {
         self.provider.latest()
     }
 
-    fn historical(&self, block_id: BlockHashOrNumber) -> Result<Option<Box<dyn StateProvider>>> {
+    fn historical(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Box<dyn StateProvider>>> {
         self.provider.historical(block_id)
     }
 }
@@ -250,7 +271,7 @@ impl<Db> StateUpdateProvider for BlockchainProvider<Db>
 where
     Db: StateUpdateProvider,
 {
-    fn state_update(&self, block_id: BlockHashOrNumber) -> Result<Option<StateUpdates>> {
+    fn state_update(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<StateUpdates>> {
         self.provider.state_update(block_id)
     }
 }
@@ -259,7 +280,7 @@ impl<Db> ContractInfoProvider for BlockchainProvider<Db>
 where
     Db: ContractInfoProvider,
 {
-    fn contract(&self, address: ContractAddress) -> Result<Option<GenericContractInfo>> {
+    fn contract(&self, address: ContractAddress) -> ProviderResult<Option<GenericContractInfo>> {
         self.provider.contract(address)
     }
 }
@@ -268,7 +289,7 @@ impl<Db> StateRootProvider for BlockchainProvider<Db>
 where
     Db: StateRootProvider,
 {
-    fn state_root(&self, block_id: BlockHashOrNumber) -> Result<Option<FieldElement>> {
+    fn state_root(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<FieldElement>> {
         self.provider.state_root(block_id)
     }
 }
@@ -277,7 +298,7 @@ impl<Db> ContractClassWriter for BlockchainProvider<Db>
 where
     Db: ContractClassWriter,
 {
-    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> Result<()> {
+    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> ProviderResult<()> {
         self.provider.set_class(hash, class)
     }
 
@@ -285,11 +306,15 @@ where
         &self,
         hash: ClassHash,
         compiled_hash: CompiledClassHash,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.provider.set_compiled_class_hash_of_class_hash(hash, compiled_hash)
     }
 
-    fn set_sierra_class(&self, hash: ClassHash, sierra: FlattenedSierraClass) -> Result<()> {
+    fn set_sierra_class(
+        &self,
+        hash: ClassHash,
+        sierra: FlattenedSierraClass,
+    ) -> ProviderResult<()> {
         self.provider.set_sierra_class(hash, sierra)
     }
 }
@@ -303,7 +328,7 @@ where
         address: ContractAddress,
         storage_key: StorageKey,
         storage_value: StorageValue,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.provider.set_storage(address, storage_key, storage_value)
     }
 
@@ -311,7 +336,7 @@ where
         &self,
         address: ContractAddress,
         class_hash: ClassHash,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.provider.set_class_hash_of_contract(address, class_hash)
     }
 
@@ -319,7 +344,7 @@ where
         &self,
         address: ContractAddress,
         nonce: katana_primitives::contract::Nonce,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.provider.set_nonce(address, nonce)
     }
 }

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::{Range, RangeInclusive};
 
-use anyhow::Result;
 use katana_db::error::DatabaseError;
 use katana_db::mdbx::{self, DbEnv};
 use katana_db::models::block::StoredBlockBodyIndices;
@@ -35,6 +34,7 @@ use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 use katana_primitives::FieldElement;
 
+use crate::error::ProviderError;
 use crate::traits::block::{
     BlockHashProvider, BlockNumberProvider, BlockProvider, BlockStatusProvider, BlockWriter,
     HeaderProvider,
@@ -44,6 +44,7 @@ use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
     ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionsProviderExt,
 };
+use crate::ProviderResult;
 
 /// A provider implementation that uses a database as a backend.
 #[derive(Debug)]
@@ -57,11 +58,14 @@ impl DbProvider {
 }
 
 impl StateFactoryProvider for DbProvider {
-    fn latest(&self) -> Result<Box<dyn StateProvider>> {
+    fn latest(&self) -> ProviderResult<Box<dyn StateProvider>> {
         Ok(Box::new(self::state::LatestStateProvider::new(self.0.tx()?)))
     }
 
-    fn historical(&self, block_id: BlockHashOrNumber) -> Result<Option<Box<dyn StateProvider>>> {
+    fn historical(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Box<dyn StateProvider>>> {
         let block_number = match block_id {
             BlockHashOrNumber::Num(num) => {
                 let latest_num = self.latest_number()?;
@@ -83,14 +87,14 @@ impl StateFactoryProvider for DbProvider {
 }
 
 impl BlockNumberProvider for DbProvider {
-    fn block_number_by_hash(&self, hash: BlockHash) -> Result<Option<BlockNumber>> {
+    fn block_number_by_hash(&self, hash: BlockHash) -> ProviderResult<Option<BlockNumber>> {
         let db_tx = self.0.tx()?;
         let block_num = db_tx.get::<BlockNumbers>(hash)?;
         db_tx.commit()?;
         Ok(block_num)
     }
 
-    fn latest_number(&self) -> Result<BlockNumber> {
+    fn latest_number(&self) -> ProviderResult<BlockNumber> {
         let db_tx = self.0.tx()?;
         let total_blocks = db_tx.entries::<BlockNumbers>()? as u64;
         db_tx.commit()?;
@@ -99,16 +103,16 @@ impl BlockNumberProvider for DbProvider {
 }
 
 impl BlockHashProvider for DbProvider {
-    fn latest_hash(&self) -> Result<BlockHash> {
+    fn latest_hash(&self) -> ProviderResult<BlockHash> {
         let db_tx = self.0.tx()?;
         let total_blocks = db_tx.entries::<BlockNumbers>()? as u64;
         let latest_block = if total_blocks == 0 { 0 } else { total_blocks - 1 };
-        let latest_hash = db_tx.get::<BlockHashes>(latest_block)?.expect("block hash should exist");
+        let latest_hash = db_tx.get::<BlockHashes>(latest_block)?;
         db_tx.commit()?;
-        Ok(latest_hash)
+        latest_hash.ok_or(ProviderError::MissingLatestBlockHash)
     }
 
-    fn block_hash_by_num(&self, num: BlockNumber) -> Result<Option<BlockHash>> {
+    fn block_hash_by_num(&self, num: BlockNumber) -> ProviderResult<Option<BlockHash>> {
         let db_tx = self.0.tx()?;
         let block_hash = db_tx.get::<BlockHashes>(num)?;
         db_tx.commit()?;
@@ -117,7 +121,7 @@ impl BlockHashProvider for DbProvider {
 }
 
 impl HeaderProvider for DbProvider {
-    fn header(&self, id: BlockHashOrNumber) -> Result<Option<Header>> {
+    fn header(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Header>> {
         let db_tx = self.0.tx()?;
 
         let num = match id {
@@ -126,7 +130,8 @@ impl HeaderProvider for DbProvider {
         };
 
         if let Some(num) = num {
-            let header = db_tx.get::<Headers>(num)?.expect("should exist");
+            let header =
+                db_tx.get::<Headers>(num)?.ok_or(ProviderError::MissingBlockHeader(num))?;
             db_tx.commit()?;
             Ok(Some(header))
         } else {
@@ -136,7 +141,10 @@ impl HeaderProvider for DbProvider {
 }
 
 impl BlockProvider for DbProvider {
-    fn block_body_indices(&self, id: BlockHashOrNumber) -> Result<Option<StoredBlockBodyIndices>> {
+    fn block_body_indices(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         let db_tx = self.0.tx()?;
 
         let block_num = match id {
@@ -153,11 +161,13 @@ impl BlockProvider for DbProvider {
         }
     }
 
-    fn block(&self, id: BlockHashOrNumber) -> Result<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         let db_tx = self.0.tx()?;
 
         if let Some(header) = self.header(id)? {
-            let body = self.transactions_by_block(id)?.expect("should exist");
+            let res = self.transactions_by_block(id)?;
+            let body = res.ok_or(ProviderError::MissingBlockTxs(header.number))?;
+
             db_tx.commit()?;
             Ok(Some(Block { header, body }))
         } else {
@@ -165,7 +175,10 @@ impl BlockProvider for DbProvider {
         }
     }
 
-    fn block_with_tx_hashes(&self, id: BlockHashOrNumber) -> Result<Option<BlockWithTxHashes>> {
+    fn block_with_tx_hashes(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<BlockWithTxHashes>> {
         let db_tx = self.0.tx()?;
 
         let block_num = match id {
@@ -176,7 +189,9 @@ impl BlockProvider for DbProvider {
         let Some(block_num) = block_num else { return Ok(None) };
 
         if let Some(header) = db_tx.get::<Headers>(block_num)? {
-            let body_indices = db_tx.get::<BlockBodyIndices>(block_num)?.expect("should exist");
+            let res = db_tx.get::<BlockBodyIndices>(block_num)?;
+            let body_indices = res.ok_or(ProviderError::MissingBlockTxs(block_num))?;
+
             let body = self.transaction_hashes_in_range(Range::from(body_indices))?;
             let block = BlockWithTxHashes { header, body };
 
@@ -188,7 +203,7 @@ impl BlockProvider for DbProvider {
         }
     }
 
-    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> Result<Vec<Block>> {
+    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> ProviderResult<Vec<Block>> {
         let db_tx = self.0.tx()?;
 
         let total = range.end() - range.start() + 1;
@@ -196,7 +211,9 @@ impl BlockProvider for DbProvider {
 
         for num in range {
             if let Some(header) = db_tx.get::<Headers>(num)? {
-                let body_indices = db_tx.get::<BlockBodyIndices>(num)?.expect("should exist");
+                let res = db_tx.get::<BlockBodyIndices>(num)?;
+                let body_indices = res.ok_or(ProviderError::MissingBlockBodyIndices(num))?;
+
                 let body = self.transaction_in_range(Range::from(body_indices))?;
                 blocks.push(Block { header, body })
             }
@@ -208,7 +225,7 @@ impl BlockProvider for DbProvider {
 }
 
 impl BlockStatusProvider for DbProvider {
-    fn block_status(&self, id: BlockHashOrNumber) -> Result<Option<FinalityStatus>> {
+    fn block_status(&self, id: BlockHashOrNumber) -> ProviderResult<Option<FinalityStatus>> {
         let db_tx = self.0.tx()?;
 
         let block_num = match id {
@@ -217,7 +234,9 @@ impl BlockStatusProvider for DbProvider {
         };
 
         if let Some(block_num) = block_num {
-            let status = db_tx.get::<BlockStatusses>(block_num)?.expect("should exist");
+            let res = db_tx.get::<BlockStatusses>(block_num)?;
+            let status = res.ok_or(ProviderError::MissingBlockStatus(block_num))?;
+
             db_tx.commit()?;
             Ok(Some(status))
         } else {
@@ -227,7 +246,7 @@ impl BlockStatusProvider for DbProvider {
 }
 
 impl StateRootProvider for DbProvider {
-    fn state_root(&self, block_id: BlockHashOrNumber) -> Result<Option<FieldElement>> {
+    fn state_root(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<FieldElement>> {
         let db_tx = self.0.tx()?;
 
         let block_num = match block_id {
@@ -246,14 +265,14 @@ impl StateRootProvider for DbProvider {
 }
 
 impl StateUpdateProvider for DbProvider {
-    fn state_update(&self, block_id: BlockHashOrNumber) -> Result<Option<StateUpdates>> {
+    fn state_update(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<StateUpdates>> {
         // A helper function that iterates over all entries in a dupsort table and collects the
         // results into `V`. If `key` is not found, `V::default()` is returned.
         fn dup_entries<Tb, V, T>(
             db_tx: &mdbx::tx::TxRO,
             key: <Tb as Table>::Key,
-            f: impl FnMut(Result<KeyValue<Tb>, DatabaseError>) -> Result<T, DatabaseError>,
-        ) -> Result<V, DatabaseError>
+            f: impl FnMut(Result<KeyValue<Tb>, DatabaseError>) -> ProviderResult<T>,
+        ) -> ProviderResult<V>
         where
             Tb: DupSort + Debug,
             V: FromIterator<T> + Default,
@@ -261,7 +280,7 @@ impl StateUpdateProvider for DbProvider {
             Ok(db_tx
                 .cursor::<Tb>()?
                 .walk_dup(Some(key), None)?
-                .map(|walker| walker.map(f).collect::<Result<V, DatabaseError>>())
+                .map(|walker| walker.map(f).collect::<ProviderResult<V>>())
                 .transpose()?
                 .unwrap_or_default())
         }
@@ -294,8 +313,11 @@ impl StateUpdateProvider for DbProvider {
                 _,
             >(&db_tx, block_num, |entry| {
                 let (_, class_hash) = entry?;
-                let compiled_hash =
-                    db_tx.get::<CompiledClassHashes>(class_hash)?.expect("qed; must exist");
+
+                let compiled_hash = db_tx
+                    .get::<CompiledClassHashes>(class_hash)?
+                    .ok_or(ProviderError::MissingCompiledClassHash(class_hash))?;
+
                 Ok((class_hash, compiled_hash))
             })?;
 
@@ -306,7 +328,7 @@ impl StateUpdateProvider for DbProvider {
                     _,
                 >(&db_tx, block_num, |entry| {
                     let (_, ContractStorageEntry { key, value }) = entry?;
-                    Ok::<_, DatabaseError>((key.contract_address, (key.key, value)))
+                    Ok((key.contract_address, (key.key, value)))
                 })?;
 
                 let mut map: HashMap<_, HashMap<StorageKey, StorageValue>> = HashMap::new();
@@ -332,11 +354,12 @@ impl StateUpdateProvider for DbProvider {
 }
 
 impl TransactionProvider for DbProvider {
-    fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TxWithHash>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
         let db_tx = self.0.tx()?;
 
         if let Some(num) = db_tx.get::<TxNumbers>(hash)? {
-            let transaction = db_tx.get::<Transactions>(num)?.expect("transaction should exist");
+            let res = db_tx.get::<Transactions>(num)?;
+            let transaction = res.ok_or(ProviderError::MissingTx(num))?;
             let transaction = TxWithHash { hash, transaction };
             db_tx.commit()?;
 
@@ -349,7 +372,7 @@ impl TransactionProvider for DbProvider {
     fn transactions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> Result<Option<Vec<TxWithHash>>> {
+    ) -> ProviderResult<Option<Vec<TxWithHash>>> {
         if let Some(indices) = self.block_body_indices(block_id)? {
             Ok(Some(self.transaction_in_range(Range::from(indices))?))
         } else {
@@ -357,7 +380,7 @@ impl TransactionProvider for DbProvider {
         }
     }
 
-    fn transaction_in_range(&self, range: Range<TxNumber>) -> Result<Vec<TxWithHash>> {
+    fn transaction_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxWithHash>> {
         let db_tx = self.0.tx()?;
 
         let total = range.end - range.start;
@@ -365,7 +388,9 @@ impl TransactionProvider for DbProvider {
 
         for i in range {
             if let Some(transaction) = db_tx.get::<Transactions>(i)? {
-                let hash = db_tx.get::<TxHashes>(i)?.expect("should exist");
+                let res = db_tx.get::<TxHashes>(i)?;
+                let hash = res.ok_or(ProviderError::MissingTxHash(i))?;
+
                 transactions.push(TxWithHash { hash, transaction });
             };
         }
@@ -377,11 +402,15 @@ impl TransactionProvider for DbProvider {
     fn transaction_block_num_and_hash(
         &self,
         hash: TxHash,
-    ) -> Result<Option<(BlockNumber, BlockHash)>> {
+    ) -> ProviderResult<Option<(BlockNumber, BlockHash)>> {
         let db_tx = self.0.tx()?;
         if let Some(num) = db_tx.get::<TxNumbers>(hash)? {
-            let block_num = db_tx.get::<TxBlocks>(num)?.expect("should exist");
-            let block_hash = db_tx.get::<BlockHashes>(block_num)?.expect("should exist");
+            let block_num =
+                db_tx.get::<TxBlocks>(num)?.ok_or(ProviderError::MissingTxBlock(num))?;
+
+            let res = db_tx.get::<BlockHashes>(block_num)?;
+            let block_hash = res.ok_or(ProviderError::MissingBlockHash(num))?;
+
             db_tx.commit()?;
             Ok(Some((block_num, block_hash)))
         } else {
@@ -393,25 +422,32 @@ impl TransactionProvider for DbProvider {
         &self,
         block_id: BlockHashOrNumber,
         idx: u64,
-    ) -> Result<Option<TxWithHash>> {
+    ) -> ProviderResult<Option<TxWithHash>> {
         let db_tx = self.0.tx()?;
 
         match self.block_body_indices(block_id)? {
             // make sure the requested idx is within the range of the block tx count
             Some(indices) if idx < indices.tx_count => {
                 let num = indices.tx_offset + idx;
-                let hash = db_tx.get::<TxHashes>(num)?.expect("should exist");
-                let transaction = db_tx.get::<Transactions>(num)?.expect("should exist");
-                let transaction = TxWithHash { hash, transaction };
+
+                let res = db_tx.get::<TxHashes>(num)?;
+                let hash = res.ok_or(ProviderError::MissingTxHash(num))?;
+
+                let res = db_tx.get::<Transactions>(num)?;
+                let transaction = res.ok_or(ProviderError::MissingTx(num))?;
+
                 db_tx.commit()?;
-                Ok(Some(transaction))
+                Ok(Some(TxWithHash { hash, transaction }))
             }
 
             _ => Ok(None),
         }
     }
 
-    fn transaction_count_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<u64>> {
+    fn transaction_count_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<u64>> {
         let db_tx = self.0.tx()?;
         if let Some(indices) = self.block_body_indices(block_id)? {
             db_tx.commit()?;
@@ -423,7 +459,7 @@ impl TransactionProvider for DbProvider {
 }
 
 impl TransactionsProviderExt for DbProvider {
-    fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> Result<Vec<TxHash>> {
+    fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxHash>> {
         let db_tx = self.0.tx()?;
 
         let total = range.end - range.start;
@@ -441,11 +477,15 @@ impl TransactionsProviderExt for DbProvider {
 }
 
 impl TransactionStatusProvider for DbProvider {
-    fn transaction_status(&self, hash: TxHash) -> Result<Option<FinalityStatus>> {
+    fn transaction_status(&self, hash: TxHash) -> ProviderResult<Option<FinalityStatus>> {
         let db_tx = self.0.tx()?;
         if let Some(tx_num) = db_tx.get::<TxNumbers>(hash)? {
-            let block_num = db_tx.get::<TxBlocks>(tx_num)?.expect("should exist");
-            let status = db_tx.get::<BlockStatusses>(block_num)?.expect("should exist");
+            let res = db_tx.get::<TxBlocks>(tx_num)?;
+            let block_num = res.ok_or(ProviderError::MissingTxBlock(tx_num))?;
+
+            let res = db_tx.get::<BlockStatusses>(block_num)?;
+            let status = res.ok_or(ProviderError::MissingBlockStatus(block_num))?;
+
             db_tx.commit()?;
             Ok(Some(status))
         } else {
@@ -455,10 +495,13 @@ impl TransactionStatusProvider for DbProvider {
 }
 
 impl ReceiptProvider for DbProvider {
-    fn receipt_by_hash(&self, hash: TxHash) -> Result<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         let db_tx = self.0.tx()?;
         if let Some(num) = db_tx.get::<TxNumbers>(hash)? {
-            let receipt = db_tx.get::<katana_db::tables::Receipts>(num)?.expect("should exist");
+            let receipt = db_tx
+                .get::<katana_db::tables::Receipts>(num)?
+                .ok_or(ProviderError::MissingTxReceipt(num))?;
+
             db_tx.commit()?;
             Ok(Some(receipt))
         } else {
@@ -466,7 +509,10 @@ impl ReceiptProvider for DbProvider {
         }
     }
 
-    fn receipts_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Receipt>>> {
         if let Some(indices) = self.block_body_indices(block_id)? {
             let db_tx = self.0.tx()?;
             let mut receipts = Vec::with_capacity(indices.tx_count as usize);
@@ -492,8 +538,8 @@ impl BlockWriter for DbProvider {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithDeclaredClasses,
         receipts: Vec<Receipt>,
-    ) -> Result<()> {
-        self.0.update(move |db_tx| -> Result<()> {
+    ) -> ProviderResult<()> {
+        self.0.update(move |db_tx| -> ProviderResult<()> {
             let block_hash = block.block.header.hash;
             let block_number = block.block.header.header.number;
 

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -4,7 +4,6 @@ pub mod state;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use anyhow::Result;
 use katana_db::models::block::StoredBlockBodyIndices;
 use katana_primitives::block::{
     Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithTxHashes, FinalityStatus, Header,
@@ -20,7 +19,7 @@ use parking_lot::RwLock;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 
-use self::backend::{ForkedBackend, SharedStateProvider};
+use self::backend::{ForkedBackend, ForkedBackendError, SharedStateProvider};
 use self::state::ForkedStateDb;
 use super::in_memory::cache::{CacheDb, CacheStateDb};
 use super::in_memory::state::HistoricalStates;
@@ -34,6 +33,7 @@ use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
     ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionsProviderExt,
 };
+use crate::ProviderResult;
 
 pub struct ForkedProvider {
     // TODO: insert `ForkedBackend` into `CacheDb`
@@ -43,40 +43,46 @@ pub struct ForkedProvider {
 }
 
 impl ForkedProvider {
-    pub fn new(provider: Arc<JsonRpcClient<HttpTransport>>, block_id: BlockHashOrNumber) -> Self {
-        let backend = ForkedBackend::new_with_backend_thread(provider, block_id);
+    pub fn new(
+        provider: Arc<JsonRpcClient<HttpTransport>>,
+        block_id: BlockHashOrNumber,
+    ) -> Result<Self, ForkedBackendError> {
+        let backend = ForkedBackend::new_with_backend_thread(provider, block_id)?;
         let shared_provider = SharedStateProvider::new_with_backend(backend);
 
         let storage = RwLock::new(CacheDb::new(()));
         let state = Arc::new(CacheStateDb::new(shared_provider));
         let historical_states = RwLock::new(HistoricalStates::default());
 
-        Self { storage, state, historical_states }
+        Ok(Self { storage, state, historical_states })
     }
 }
 
 impl BlockHashProvider for ForkedProvider {
-    fn latest_hash(&self) -> Result<BlockHash> {
+    fn latest_hash(&self) -> ProviderResult<BlockHash> {
         Ok(self.storage.read().latest_block_hash)
     }
 
-    fn block_hash_by_num(&self, num: BlockNumber) -> Result<Option<BlockHash>> {
+    fn block_hash_by_num(&self, num: BlockNumber) -> ProviderResult<Option<BlockHash>> {
         Ok(self.storage.read().block_hashes.get(&num).cloned())
     }
 }
 
 impl BlockNumberProvider for ForkedProvider {
-    fn latest_number(&self) -> Result<BlockNumber> {
+    fn latest_number(&self) -> ProviderResult<BlockNumber> {
         Ok(self.storage.read().latest_block_number)
     }
 
-    fn block_number_by_hash(&self, hash: BlockHash) -> Result<Option<BlockNumber>> {
+    fn block_number_by_hash(&self, hash: BlockHash) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.storage.read().block_numbers.get(&hash).cloned())
     }
 }
 
 impl HeaderProvider for ForkedProvider {
-    fn header(&self, id: katana_primitives::block::BlockHashOrNumber) -> Result<Option<Header>> {
+    fn header(
+        &self,
+        id: katana_primitives::block::BlockHashOrNumber,
+    ) -> ProviderResult<Option<Header>> {
         match id {
             katana_primitives::block::BlockHashOrNumber::Num(num) => {
                 Ok(self.storage.read().block_headers.get(&num).cloned())
@@ -99,7 +105,7 @@ impl HeaderProvider for ForkedProvider {
 }
 
 impl BlockStatusProvider for ForkedProvider {
-    fn block_status(&self, id: BlockHashOrNumber) -> Result<Option<FinalityStatus>> {
+    fn block_status(&self, id: BlockHashOrNumber) -> ProviderResult<Option<FinalityStatus>> {
         let num = match id {
             BlockHashOrNumber::Num(num) => num,
             BlockHashOrNumber::Hash(hash) => {
@@ -114,7 +120,7 @@ impl BlockStatusProvider for ForkedProvider {
 }
 
 impl BlockProvider for ForkedProvider {
-    fn block(&self, id: BlockHashOrNumber) -> Result<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         let block_num = match id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -131,7 +137,10 @@ impl BlockProvider for ForkedProvider {
         Ok(Some(Block { header, body }))
     }
 
-    fn block_with_tx_hashes(&self, id: BlockHashOrNumber) -> Result<Option<BlockWithTxHashes>> {
+    fn block_with_tx_hashes(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<BlockWithTxHashes>> {
         let Some(header) = self.header(id)? else {
             return Ok(None);
         };
@@ -142,7 +151,7 @@ impl BlockProvider for ForkedProvider {
         Ok(Some(katana_primitives::block::BlockWithTxHashes { header, body: tx_hashes }))
     }
 
-    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> Result<Vec<Block>> {
+    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> ProviderResult<Vec<Block>> {
         let mut blocks = Vec::new();
         for num in range {
             if let Some(block) = self.block(BlockHashOrNumber::Num(num))? {
@@ -152,7 +161,10 @@ impl BlockProvider for ForkedProvider {
         Ok(blocks)
     }
 
-    fn block_body_indices(&self, id: BlockHashOrNumber) -> Result<Option<StoredBlockBodyIndices>> {
+    fn block_body_indices(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         let block_num = match id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -169,7 +181,7 @@ impl BlockProvider for ForkedProvider {
 }
 
 impl TransactionProvider for ForkedProvider {
-    fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TxWithHash>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
         let tx = self.storage.read().transaction_numbers.get(&hash).and_then(|num| {
             let transaction = self.storage.read().transactions.get(*num as usize).cloned()?;
             let hash = self.storage.read().transaction_hashes.get(num).copied()?;
@@ -181,7 +193,7 @@ impl TransactionProvider for ForkedProvider {
     fn transactions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> Result<Option<Vec<TxWithHash>>> {
+    ) -> ProviderResult<Option<Vec<TxWithHash>>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -218,7 +230,7 @@ impl TransactionProvider for ForkedProvider {
         &self,
         block_id: BlockHashOrNumber,
         idx: u64,
-    ) -> Result<Option<TxWithHash>> {
+    ) -> ProviderResult<Option<TxWithHash>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -246,7 +258,10 @@ impl TransactionProvider for ForkedProvider {
         Ok(tx)
     }
 
-    fn transaction_count_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<u64>> {
+    fn transaction_count_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<u64>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -264,7 +279,7 @@ impl TransactionProvider for ForkedProvider {
     fn transaction_block_num_and_hash(
         &self,
         hash: TxHash,
-    ) -> Result<Option<(BlockNumber, BlockHash)>> {
+    ) -> ProviderResult<Option<(BlockNumber, BlockHash)>> {
         let storage_read = self.storage.read();
 
         let Some(number) = storage_read.transaction_numbers.get(&hash) else { return Ok(None) };
@@ -276,7 +291,10 @@ impl TransactionProvider for ForkedProvider {
 }
 
 impl TransactionsProviderExt for ForkedProvider {
-    fn transaction_hashes_in_range(&self, range: std::ops::Range<TxNumber>) -> Result<Vec<TxHash>> {
+    fn transaction_hashes_in_range(
+        &self,
+        range: std::ops::Range<TxNumber>,
+    ) -> ProviderResult<Vec<TxHash>> {
         let mut hashes = Vec::new();
         for num in range {
             if let Some(hash) = self.storage.read().transaction_hashes.get(&num).cloned() {
@@ -288,7 +306,7 @@ impl TransactionsProviderExt for ForkedProvider {
 }
 
 impl TransactionStatusProvider for ForkedProvider {
-    fn transaction_status(&self, hash: TxHash) -> Result<Option<FinalityStatus>> {
+    fn transaction_status(&self, hash: TxHash) -> ProviderResult<Option<FinalityStatus>> {
         let tx_block = self
             .storage
             .read()
@@ -306,7 +324,7 @@ impl TransactionStatusProvider for ForkedProvider {
 }
 
 impl ReceiptProvider for ForkedProvider {
-    fn receipt_by_hash(&self, hash: TxHash) -> Result<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         let receipt = self
             .storage
             .read()
@@ -316,7 +334,10 @@ impl ReceiptProvider for ForkedProvider {
         Ok(receipt)
     }
 
-    fn receipts_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Receipt>>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -339,7 +360,7 @@ impl StateRootProvider for ForkedProvider {
     fn state_root(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> Result<Option<katana_primitives::FieldElement>> {
+    ) -> ProviderResult<Option<katana_primitives::FieldElement>> {
         let state_root = self.block_number_by_id(block_id)?.and_then(|num| {
             self.storage.read().block_headers.get(&num).map(|header| header.state_root)
         });
@@ -348,7 +369,7 @@ impl StateRootProvider for ForkedProvider {
 }
 
 impl StateUpdateProvider for ForkedProvider {
-    fn state_update(&self, block_id: BlockHashOrNumber) -> Result<Option<StateUpdates>> {
+    fn state_update(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<StateUpdates>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -361,11 +382,14 @@ impl StateUpdateProvider for ForkedProvider {
 }
 
 impl StateFactoryProvider for ForkedProvider {
-    fn latest(&self) -> Result<Box<dyn StateProvider>> {
+    fn latest(&self) -> ProviderResult<Box<dyn StateProvider>> {
         Ok(Box::new(self::state::LatestStateProvider(Arc::clone(&self.state))))
     }
 
-    fn historical(&self, block_id: BlockHashOrNumber) -> Result<Option<Box<dyn StateProvider>>> {
+    fn historical(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Box<dyn StateProvider>>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.block_number_by_hash(hash)?,
@@ -391,7 +415,7 @@ impl BlockWriter for ForkedProvider {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithDeclaredClasses,
         receipts: Vec<Receipt>,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         let mut storage = self.storage.write();
 
         let block_hash = block.block.header.hash;
@@ -441,12 +465,16 @@ impl BlockWriter for ForkedProvider {
 }
 
 impl ContractClassWriter for ForkedProvider {
-    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> Result<()> {
+    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> ProviderResult<()> {
         self.state.shared_contract_classes.compiled_classes.write().insert(hash, class);
         Ok(())
     }
 
-    fn set_sierra_class(&self, hash: ClassHash, sierra: FlattenedSierraClass) -> Result<()> {
+    fn set_sierra_class(
+        &self,
+        hash: ClassHash,
+        sierra: FlattenedSierraClass,
+    ) -> ProviderResult<()> {
         self.state.shared_contract_classes.sierra_classes.write().insert(hash, sierra);
         Ok(())
     }
@@ -455,7 +483,7 @@ impl ContractClassWriter for ForkedProvider {
         &self,
         hash: ClassHash,
         compiled_hash: CompiledClassHash,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.compiled_class_hashes.write().insert(hash, compiled_hash);
         Ok(())
     }
@@ -467,7 +495,7 @@ impl StateWriter for ForkedProvider {
         address: ContractAddress,
         storage_key: katana_primitives::contract::StorageKey,
         storage_value: katana_primitives::contract::StorageValue,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.storage.write().entry(address).or_default().insert(storage_key, storage_value);
         Ok(())
     }
@@ -476,7 +504,7 @@ impl StateWriter for ForkedProvider {
         &self,
         address: ContractAddress,
         class_hash: ClassHash,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.contract_state.write().entry(address).or_default().class_hash = class_hash;
         Ok(())
     }
@@ -485,7 +513,7 @@ impl StateWriter for ForkedProvider {
         &self,
         address: ContractAddress,
         nonce: katana_primitives::contract::Nonce,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.contract_state.write().entry(address).or_default().nonce = nonce;
         Ok(())
     }

--- a/crates/katana/storage/provider/src/providers/in_memory/mod.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/mod.rs
@@ -4,7 +4,6 @@ pub mod state;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
-use anyhow::Result;
 use katana_db::models::block::StoredBlockBodyIndices;
 use katana_primitives::block::{
     Block, BlockHash, BlockHashOrNumber, BlockNumber, BlockWithTxHashes, FinalityStatus, Header,
@@ -30,6 +29,7 @@ use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
     ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionsProviderExt,
 };
+use crate::ProviderResult;
 
 pub struct InMemoryProvider {
     storage: RwLock<CacheDb<()>>,
@@ -53,27 +53,30 @@ impl Default for InMemoryProvider {
 }
 
 impl BlockHashProvider for InMemoryProvider {
-    fn latest_hash(&self) -> Result<BlockHash> {
+    fn latest_hash(&self) -> ProviderResult<BlockHash> {
         Ok(self.storage.read().latest_block_hash)
     }
 
-    fn block_hash_by_num(&self, num: BlockNumber) -> Result<Option<BlockHash>> {
+    fn block_hash_by_num(&self, num: BlockNumber) -> ProviderResult<Option<BlockHash>> {
         Ok(self.storage.read().block_hashes.get(&num).cloned())
     }
 }
 
 impl BlockNumberProvider for InMemoryProvider {
-    fn latest_number(&self) -> Result<BlockNumber> {
+    fn latest_number(&self) -> ProviderResult<BlockNumber> {
         Ok(self.storage.read().latest_block_number)
     }
 
-    fn block_number_by_hash(&self, hash: BlockHash) -> Result<Option<BlockNumber>> {
+    fn block_number_by_hash(&self, hash: BlockHash) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.storage.read().block_numbers.get(&hash).cloned())
     }
 }
 
 impl HeaderProvider for InMemoryProvider {
-    fn header(&self, id: katana_primitives::block::BlockHashOrNumber) -> Result<Option<Header>> {
+    fn header(
+        &self,
+        id: katana_primitives::block::BlockHashOrNumber,
+    ) -> ProviderResult<Option<Header>> {
         match id {
             katana_primitives::block::BlockHashOrNumber::Num(num) => {
                 Ok(self.storage.read().block_headers.get(&num).cloned())
@@ -96,7 +99,7 @@ impl HeaderProvider for InMemoryProvider {
 }
 
 impl BlockStatusProvider for InMemoryProvider {
-    fn block_status(&self, id: BlockHashOrNumber) -> Result<Option<FinalityStatus>> {
+    fn block_status(&self, id: BlockHashOrNumber) -> ProviderResult<Option<FinalityStatus>> {
         let num = match id {
             BlockHashOrNumber::Num(num) => num,
             BlockHashOrNumber::Hash(hash) => {
@@ -111,7 +114,7 @@ impl BlockStatusProvider for InMemoryProvider {
 }
 
 impl BlockProvider for InMemoryProvider {
-    fn block(&self, id: BlockHashOrNumber) -> Result<Option<Block>> {
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>> {
         let block_num = match id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -128,7 +131,10 @@ impl BlockProvider for InMemoryProvider {
         Ok(Some(Block { header, body }))
     }
 
-    fn block_with_tx_hashes(&self, id: BlockHashOrNumber) -> Result<Option<BlockWithTxHashes>> {
+    fn block_with_tx_hashes(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<BlockWithTxHashes>> {
         let Some(header) = self.header(id)? else {
             return Ok(None);
         };
@@ -139,7 +145,7 @@ impl BlockProvider for InMemoryProvider {
         Ok(Some(katana_primitives::block::BlockWithTxHashes { header, body: tx_hashes }))
     }
 
-    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> Result<Vec<Block>> {
+    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> ProviderResult<Vec<Block>> {
         let mut blocks = Vec::new();
         for num in range {
             if let Some(block) = self.block(BlockHashOrNumber::Num(num))? {
@@ -149,7 +155,10 @@ impl BlockProvider for InMemoryProvider {
         Ok(blocks)
     }
 
-    fn block_body_indices(&self, id: BlockHashOrNumber) -> Result<Option<StoredBlockBodyIndices>> {
+    fn block_body_indices(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>> {
         let block_num = match id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -166,7 +175,7 @@ impl BlockProvider for InMemoryProvider {
 }
 
 impl TransactionProvider for InMemoryProvider {
-    fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TxWithHash>> {
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
         let tx = self.storage.read().transaction_numbers.get(&hash).and_then(|num| {
             let transaction = self.storage.read().transactions.get(*num as usize)?.clone();
             let hash = *self.storage.read().transaction_hashes.get(num)?;
@@ -178,7 +187,7 @@ impl TransactionProvider for InMemoryProvider {
     fn transactions_by_block(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> Result<Option<Vec<TxWithHash>>> {
+    ) -> ProviderResult<Option<Vec<TxWithHash>>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -215,7 +224,7 @@ impl TransactionProvider for InMemoryProvider {
         &self,
         block_id: BlockHashOrNumber,
         idx: u64,
-    ) -> Result<Option<TxWithHash>> {
+    ) -> ProviderResult<Option<TxWithHash>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -243,7 +252,10 @@ impl TransactionProvider for InMemoryProvider {
         Ok(tx)
     }
 
-    fn transaction_count_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<u64>> {
+    fn transaction_count_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<u64>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -261,7 +273,7 @@ impl TransactionProvider for InMemoryProvider {
     fn transaction_block_num_and_hash(
         &self,
         hash: TxHash,
-    ) -> Result<Option<(BlockNumber, BlockHash)>> {
+    ) -> ProviderResult<Option<(BlockNumber, BlockHash)>> {
         let storage_read = self.storage.read();
 
         let Some(number) = storage_read.transaction_numbers.get(&hash) else { return Ok(None) };
@@ -273,7 +285,10 @@ impl TransactionProvider for InMemoryProvider {
 }
 
 impl TransactionsProviderExt for InMemoryProvider {
-    fn transaction_hashes_in_range(&self, range: std::ops::Range<TxNumber>) -> Result<Vec<TxHash>> {
+    fn transaction_hashes_in_range(
+        &self,
+        range: std::ops::Range<TxNumber>,
+    ) -> ProviderResult<Vec<TxHash>> {
         let mut hashes = Vec::new();
         for num in range {
             if let Some(hash) = self.storage.read().transaction_hashes.get(&num).cloned() {
@@ -285,7 +300,7 @@ impl TransactionsProviderExt for InMemoryProvider {
 }
 
 impl TransactionStatusProvider for InMemoryProvider {
-    fn transaction_status(&self, hash: TxHash) -> Result<Option<FinalityStatus>> {
+    fn transaction_status(&self, hash: TxHash) -> ProviderResult<Option<FinalityStatus>> {
         let tx_block = self
             .storage
             .read()
@@ -303,7 +318,7 @@ impl TransactionStatusProvider for InMemoryProvider {
 }
 
 impl ReceiptProvider for InMemoryProvider {
-    fn receipt_by_hash(&self, hash: TxHash) -> Result<Option<Receipt>> {
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
         let receipt = self
             .storage
             .read()
@@ -313,7 +328,10 @@ impl ReceiptProvider for InMemoryProvider {
         Ok(receipt)
     }
 
-    fn receipts_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<Vec<Receipt>>> {
+    fn receipts_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Receipt>>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -333,7 +351,7 @@ impl ReceiptProvider for InMemoryProvider {
 }
 
 impl StateUpdateProvider for InMemoryProvider {
-    fn state_update(&self, block_id: BlockHashOrNumber) -> Result<Option<StateUpdates>> {
+    fn state_update(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<StateUpdates>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
@@ -346,11 +364,14 @@ impl StateUpdateProvider for InMemoryProvider {
 }
 
 impl StateFactoryProvider for InMemoryProvider {
-    fn latest(&self) -> Result<Box<dyn StateProvider>> {
+    fn latest(&self) -> ProviderResult<Box<dyn StateProvider>> {
         Ok(Box::new(LatestStateProvider(Arc::clone(&self.state))))
     }
 
-    fn historical(&self, block_id: BlockHashOrNumber) -> Result<Option<Box<dyn StateProvider>>> {
+    fn historical(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Box<dyn StateProvider>>> {
         let block_num = match block_id {
             BlockHashOrNumber::Num(num) => Some(num),
             BlockHashOrNumber::Hash(hash) => self.block_number_by_hash(hash)?,
@@ -374,7 +395,7 @@ impl StateRootProvider for InMemoryProvider {
     fn state_root(
         &self,
         block_id: BlockHashOrNumber,
-    ) -> Result<Option<katana_primitives::FieldElement>> {
+    ) -> ProviderResult<Option<katana_primitives::FieldElement>> {
         let state_root = self.block_number_by_id(block_id)?.and_then(|num| {
             self.storage.read().block_headers.get(&num).map(|header| header.state_root)
         });
@@ -388,7 +409,7 @@ impl BlockWriter for InMemoryProvider {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithDeclaredClasses,
         receipts: Vec<Receipt>,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         let mut storage = self.storage.write();
 
         let block_hash = block.block.header.hash;
@@ -438,12 +459,16 @@ impl BlockWriter for InMemoryProvider {
 }
 
 impl ContractClassWriter for InMemoryProvider {
-    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> Result<()> {
+    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> ProviderResult<()> {
         self.state.shared_contract_classes.compiled_classes.write().insert(hash, class);
         Ok(())
     }
 
-    fn set_sierra_class(&self, hash: ClassHash, sierra: FlattenedSierraClass) -> Result<()> {
+    fn set_sierra_class(
+        &self,
+        hash: ClassHash,
+        sierra: FlattenedSierraClass,
+    ) -> ProviderResult<()> {
         self.state.shared_contract_classes.sierra_classes.write().insert(hash, sierra);
         Ok(())
     }
@@ -452,7 +477,7 @@ impl ContractClassWriter for InMemoryProvider {
         &self,
         hash: ClassHash,
         compiled_hash: CompiledClassHash,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.compiled_class_hashes.write().insert(hash, compiled_hash);
         Ok(())
     }
@@ -464,7 +489,7 @@ impl StateWriter for InMemoryProvider {
         address: ContractAddress,
         storage_key: katana_primitives::contract::StorageKey,
         storage_value: katana_primitives::contract::StorageValue,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.storage.write().entry(address).or_default().insert(storage_key, storage_value);
         Ok(())
     }
@@ -473,7 +498,7 @@ impl StateWriter for InMemoryProvider {
         &self,
         address: ContractAddress,
         class_hash: ClassHash,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.contract_state.write().entry(address).or_default().class_hash = class_hash;
         Ok(())
     }
@@ -482,7 +507,7 @@ impl StateWriter for InMemoryProvider {
         &self,
         address: ContractAddress,
         nonce: katana_primitives::contract::Nonce,
-    ) -> Result<()> {
+    ) -> ProviderResult<()> {
         self.state.contract_state.write().entry(address).or_default().nonce = nonce;
         Ok(())
     }

--- a/crates/katana/storage/provider/src/traits/block.rs
+++ b/crates/katana/storage/provider/src/traits/block.rs
@@ -1,6 +1,5 @@
 use std::ops::RangeInclusive;
 
-use anyhow::Result;
 use katana_db::models::block::StoredBlockBodyIndices;
 use katana_primitives::block::{
     Block, BlockHash, BlockHashOrNumber, BlockIdOrTag, BlockNumber, BlockTag, BlockWithTxHashes,
@@ -10,11 +9,12 @@ use katana_primitives::receipt::Receipt;
 use katana_primitives::state::StateUpdatesWithDeclaredClasses;
 
 use super::transaction::{TransactionProvider, TransactionsProviderExt};
+use crate::ProviderResult;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait BlockIdReader: BlockNumberProvider + Send + Sync {
     /// Converts the block tag into its block number.
-    fn convert_block_id(&self, id: BlockIdOrTag) -> Result<Option<BlockNumber>> {
+    fn convert_block_id(&self, id: BlockIdOrTag) -> ProviderResult<Option<BlockNumber>> {
         match id {
             BlockIdOrTag::Number(number) => Ok(Some(number)),
             BlockIdOrTag::Hash(hash) => BlockNumberProvider::block_number_by_hash(self, hash),
@@ -34,7 +34,7 @@ pub trait BlockIdReader: BlockNumberProvider + Send + Sync {
     }
 
     /// Retrieves the pending block number and hash.
-    fn pending_block_id(&self) -> Result<Option<(BlockNumber, BlockHash)>> {
+    fn pending_block_id(&self) -> ProviderResult<Option<(BlockNumber, BlockHash)>> {
         Ok(None) // Returns `None` for now
     }
 }
@@ -44,13 +44,13 @@ pub trait BlockHashProvider: Send + Sync {
     /// Retrieves the latest block hash.
     ///
     /// There should always be at least one block (genesis) in the chain.
-    fn latest_hash(&self) -> Result<BlockHash>;
+    fn latest_hash(&self) -> ProviderResult<BlockHash>;
 
     /// Retrieves the block hash given its id.
-    fn block_hash_by_num(&self, num: BlockNumber) -> Result<Option<BlockHash>>;
+    fn block_hash_by_num(&self, num: BlockNumber) -> ProviderResult<Option<BlockHash>>;
 
     /// Retrieves the block hash given its id.
-    fn block_hash_by_id(&self, id: BlockHashOrNumber) -> Result<Option<BlockHash>> {
+    fn block_hash_by_id(&self, id: BlockHashOrNumber) -> ProviderResult<Option<BlockHash>> {
         match id {
             BlockHashOrNumber::Hash(hash) => Ok(Some(hash)),
             BlockHashOrNumber::Num(number) => self.block_hash_by_num(number),
@@ -63,13 +63,13 @@ pub trait BlockNumberProvider: Send + Sync {
     /// Retrieves the latest block number.
     ///
     /// There should always be at least one block (genesis) in the chain.
-    fn latest_number(&self) -> Result<BlockNumber>;
+    fn latest_number(&self) -> ProviderResult<BlockNumber>;
 
     /// Retrieves the block number given its id.
-    fn block_number_by_hash(&self, hash: BlockHash) -> Result<Option<BlockNumber>>;
+    fn block_number_by_hash(&self, hash: BlockHash) -> ProviderResult<Option<BlockNumber>>;
 
     /// Retrieves the block number given its id.
-    fn block_number_by_id(&self, id: BlockHashOrNumber) -> Result<Option<BlockNumber>> {
+    fn block_number_by_id(&self, id: BlockHashOrNumber) -> ProviderResult<Option<BlockNumber>> {
         match id {
             BlockHashOrNumber::Num(number) => Ok(Some(number)),
             BlockHashOrNumber::Hash(hash) => self.block_number_by_hash(hash),
@@ -80,13 +80,13 @@ pub trait BlockNumberProvider: Send + Sync {
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait HeaderProvider: Send + Sync {
     /// Retrieves the latest header by its block id.
-    fn header(&self, id: BlockHashOrNumber) -> Result<Option<Header>>;
+    fn header(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Header>>;
 
-    fn header_by_hash(&self, hash: BlockHash) -> Result<Option<Header>> {
+    fn header_by_hash(&self, hash: BlockHash) -> ProviderResult<Option<Header>> {
         self.header(hash.into())
     }
 
-    fn header_by_number(&self, number: BlockNumber) -> Result<Option<Header>> {
+    fn header_by_number(&self, number: BlockNumber) -> ProviderResult<Option<Header>> {
         self.header(number.into())
     }
 }
@@ -94,7 +94,7 @@ pub trait HeaderProvider: Send + Sync {
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait BlockStatusProvider: Send + Sync {
     /// Retrieves the finality status of a block.
-    fn block_status(&self, id: BlockHashOrNumber) -> Result<Option<FinalityStatus>>;
+    fn block_status(&self, id: BlockHashOrNumber) -> ProviderResult<Option<FinalityStatus>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]
@@ -109,24 +109,30 @@ pub trait BlockProvider:
     + Sync
 {
     /// Returns a block by its id.
-    fn block(&self, id: BlockHashOrNumber) -> Result<Option<Block>>;
+    fn block(&self, id: BlockHashOrNumber) -> ProviderResult<Option<Block>>;
 
     /// Returns a block with only the transaction hashes.
-    fn block_with_tx_hashes(&self, id: BlockHashOrNumber) -> Result<Option<BlockWithTxHashes>>;
+    fn block_with_tx_hashes(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<BlockWithTxHashes>>;
 
     /// Returns all available blocks in the given range.
-    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> Result<Vec<Block>>;
+    fn blocks_in_range(&self, range: RangeInclusive<u64>) -> ProviderResult<Vec<Block>>;
 
     /// Returns the block body indices of a block.
-    fn block_body_indices(&self, id: BlockHashOrNumber) -> Result<Option<StoredBlockBodyIndices>>;
+    fn block_body_indices(
+        &self,
+        id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<StoredBlockBodyIndices>>;
 
     /// Returns the block based on its hash.
-    fn block_by_hash(&self, hash: BlockHash) -> Result<Option<Block>> {
+    fn block_by_hash(&self, hash: BlockHash) -> ProviderResult<Option<Block>> {
         self.block(hash.into())
     }
 
     /// Returns the block based on its number.
-    fn block_by_number(&self, number: BlockNumber) -> Result<Option<Block>> {
+    fn block_by_number(&self, number: BlockNumber) -> ProviderResult<Option<Block>> {
         self.block(number.into())
     }
 }
@@ -139,5 +145,5 @@ pub trait BlockWriter: Send + Sync {
         block: SealedBlockWithStatus,
         states: StateUpdatesWithDeclaredClasses,
         receipts: Vec<Receipt>,
-    ) -> Result<()>;
+    ) -> ProviderResult<()>;
 }

--- a/crates/katana/storage/provider/src/traits/contract.rs
+++ b/crates/katana/storage/provider/src/traits/contract.rs
@@ -1,13 +1,14 @@
-use anyhow::Result;
 use katana_primitives::contract::{
     ClassHash, CompiledClassHash, CompiledContractClass, ContractAddress, FlattenedSierraClass,
     GenericContractInfo,
 };
 
+use crate::ProviderResult;
+
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait ContractInfoProvider: Send + Sync {
     /// Returns the contract information given its address.
-    fn contract(&self, address: ContractAddress) -> Result<Option<GenericContractInfo>>;
+    fn contract(&self, address: ContractAddress) -> ProviderResult<Option<GenericContractInfo>>;
 }
 
 /// A provider trait for retrieving contract class related information.
@@ -17,13 +18,13 @@ pub trait ContractClassProvider: Send + Sync {
     fn compiled_class_hash_of_class_hash(
         &self,
         hash: ClassHash,
-    ) -> Result<Option<CompiledClassHash>>;
+    ) -> ProviderResult<Option<CompiledClassHash>>;
 
     /// Returns the compiled class definition of a contract class given its class hash.
-    fn class(&self, hash: ClassHash) -> Result<Option<CompiledContractClass>>;
+    fn class(&self, hash: ClassHash) -> ProviderResult<Option<CompiledContractClass>>;
 
     /// Retrieves the Sierra class definition of a contract class given its class hash.
-    fn sierra_class(&self, hash: ClassHash) -> Result<Option<FlattenedSierraClass>>;
+    fn sierra_class(&self, hash: ClassHash) -> ProviderResult<Option<FlattenedSierraClass>>;
 }
 
 // TEMP: added mainly for compatibility reason. might be removed in the future.
@@ -34,11 +35,12 @@ pub trait ContractClassWriter: Send + Sync {
         &self,
         hash: ClassHash,
         compiled_hash: CompiledClassHash,
-    ) -> Result<()>;
+    ) -> ProviderResult<()>;
 
     /// Returns the compiled class definition of a contract class given its class hash.
-    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> Result<()>;
+    fn set_class(&self, hash: ClassHash, class: CompiledContractClass) -> ProviderResult<()>;
 
     /// Retrieves the Sierra class definition of a contract class given its class hash.
-    fn set_sierra_class(&self, hash: ClassHash, sierra: FlattenedSierraClass) -> Result<()>;
+    fn set_sierra_class(&self, hash: ClassHash, sierra: FlattenedSierraClass)
+    -> ProviderResult<()>;
 }

--- a/crates/katana/storage/provider/src/traits/env.rs
+++ b/crates/katana/storage/provider/src/traits/env.rs
@@ -1,8 +1,9 @@
-use anyhow::Result;
 use katana_primitives::block::BlockHashOrNumber;
 use katana_primitives::env::BlockEnv;
 
+use crate::ProviderResult;
+
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait BlockEnvProvider: Send + Sync {
-    fn env_at(&self, block_id: BlockHashOrNumber) -> Result<BlockEnv>;
+    fn env_at(&self, block_id: BlockHashOrNumber) -> ProviderResult<BlockEnv>;
 }

--- a/crates/katana/storage/provider/src/traits/state.rs
+++ b/crates/katana/storage/provider/src/traits/state.rs
@@ -1,47 +1,51 @@
-use anyhow::Result;
 use katana_primitives::block::BlockHashOrNumber;
 use katana_primitives::contract::{ClassHash, ContractAddress, Nonce, StorageKey, StorageValue};
 use katana_primitives::FieldElement;
 
 use super::contract::ContractClassProvider;
+use crate::ProviderResult;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateRootProvider: Send + Sync {
     /// Retrieves the state root of a block.
-    fn state_root(&self, block_id: BlockHashOrNumber) -> Result<Option<FieldElement>>;
+    fn state_root(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<FieldElement>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateProvider: ContractClassProvider + Send + Sync {
     /// Returns the nonce of a contract.
-    fn nonce(&self, address: ContractAddress) -> Result<Option<Nonce>>;
+    fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>>;
 
     /// Returns the value of a contract storage.
     fn storage(
         &self,
         address: ContractAddress,
         storage_key: StorageKey,
-    ) -> Result<Option<StorageValue>>;
+    ) -> ProviderResult<Option<StorageValue>>;
 
     /// Returns the class hash of a contract.
-    fn class_hash_of_contract(&self, address: ContractAddress) -> Result<Option<ClassHash>>;
+    fn class_hash_of_contract(&self, address: ContractAddress)
+    -> ProviderResult<Option<ClassHash>>;
 }
 
 /// A type which can create [`StateProvider`] for states at a particular block.
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateFactoryProvider: Send + Sync {
     /// Returns a state provider for retrieving the latest state.
-    fn latest(&self) -> Result<Box<dyn StateProvider>>;
+    fn latest(&self) -> ProviderResult<Box<dyn StateProvider>>;
 
     /// Returns a state provider for retrieving historical state at the given block.
-    fn historical(&self, block_id: BlockHashOrNumber) -> Result<Option<Box<dyn StateProvider>>>;
+    fn historical(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Box<dyn StateProvider>>>;
 }
 
 // TEMP: added mainly for compatibility reason. it might be removed in the future.
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateWriter: Send + Sync {
     /// Sets the nonce of a contract.
-    fn set_nonce(&self, address: ContractAddress, nonce: Nonce) -> Result<()>;
+    fn set_nonce(&self, address: ContractAddress, nonce: Nonce) -> ProviderResult<()>;
 
     /// Sets the value of a contract storage.
     fn set_storage(
@@ -49,12 +53,12 @@ pub trait StateWriter: Send + Sync {
         address: ContractAddress,
         storage_key: StorageKey,
         storage_value: StorageValue,
-    ) -> Result<()>;
+    ) -> ProviderResult<()>;
 
     /// Sets the class hash of a contract.
     fn set_class_hash_of_contract(
         &self,
         address: ContractAddress,
         class_hash: ClassHash,
-    ) -> Result<()>;
+    ) -> ProviderResult<()>;
 }

--- a/crates/katana/storage/provider/src/traits/state_update.rs
+++ b/crates/katana/storage/provider/src/traits/state_update.rs
@@ -1,9 +1,10 @@
-use anyhow::Result;
 use katana_primitives::block::BlockHashOrNumber;
 use katana_primitives::state::StateUpdates;
+
+use crate::ProviderResult;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait StateUpdateProvider: Send + Sync {
     /// Returns the state update at the given block.
-    fn state_update(&self, block_id: BlockHashOrNumber) -> Result<Option<StateUpdates>>;
+    fn state_update(&self, block_id: BlockHashOrNumber) -> ProviderResult<Option<StateUpdates>>;
 }

--- a/crates/katana/storage/provider/src/traits/transaction.rs
+++ b/crates/katana/storage/provider/src/traits/transaction.rs
@@ -1,37 +1,43 @@
 use std::ops::Range;
 
-use anyhow::Result;
 use katana_primitives::block::{BlockHash, BlockHashOrNumber, BlockNumber, FinalityStatus};
 use katana_primitives::receipt::Receipt;
 use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
 
+use crate::ProviderResult;
+
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait TransactionProvider: Send + Sync {
     /// Returns a transaction given its hash.
-    fn transaction_by_hash(&self, hash: TxHash) -> Result<Option<TxWithHash>>;
+    fn transaction_by_hash(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>>;
 
     /// Returns all the transactions for a given block.
-    fn transactions_by_block(&self, block_id: BlockHashOrNumber)
-    -> Result<Option<Vec<TxWithHash>>>;
+    fn transactions_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<TxWithHash>>>;
 
     /// Returns the transaction at the given block and its exact index in the block.
     fn transaction_by_block_and_idx(
         &self,
         block_id: BlockHashOrNumber,
         idx: u64,
-    ) -> Result<Option<TxWithHash>>;
+    ) -> ProviderResult<Option<TxWithHash>>;
 
     /// Returns the total number of transactions in a block.
-    fn transaction_count_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<u64>>;
+    fn transaction_count_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<u64>>;
 
     /// Returns the block number and hash of a transaction.
     fn transaction_block_num_and_hash(
         &self,
         hash: TxHash,
-    ) -> Result<Option<(BlockNumber, BlockHash)>>;
+    ) -> ProviderResult<Option<(BlockNumber, BlockHash)>>;
 
     /// Retrieves all the transactions at the given range.
-    fn transaction_in_range(&self, _range: Range<TxNumber>) -> Result<Vec<TxWithHash>> {
+    fn transaction_in_range(&self, _range: Range<TxNumber>) -> ProviderResult<Vec<TxWithHash>> {
         todo!()
     }
 }
@@ -39,20 +45,23 @@ pub trait TransactionProvider: Send + Sync {
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait TransactionsProviderExt: TransactionProvider + Send + Sync {
     /// Retrieves the tx hashes for the given range of tx numbers.
-    fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> Result<Vec<TxHash>>;
+    fn transaction_hashes_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxHash>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait TransactionStatusProvider: Send + Sync {
     /// Retrieves the finality status of a transaction.
-    fn transaction_status(&self, hash: TxHash) -> Result<Option<FinalityStatus>>;
+    fn transaction_status(&self, hash: TxHash) -> ProviderResult<Option<FinalityStatus>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait ReceiptProvider: Send + Sync {
     /// Returns the transaction receipt given a transaction hash.
-    fn receipt_by_hash(&self, hash: TxHash) -> Result<Option<Receipt>>;
+    fn receipt_by_hash(&self, hash: TxHash) -> ProviderResult<Option<Receipt>>;
 
     /// Returns all the receipts for a given block.
-    fn receipts_by_block(&self, block_id: BlockHashOrNumber) -> Result<Option<Vec<Receipt>>>;
+    fn receipts_by_block(
+        &self,
+        block_id: BlockHashOrNumber,
+    ) -> ProviderResult<Option<Vec<Receipt>>>;
 }

--- a/crates/katana/storage/provider/tests/fixtures.rs
+++ b/crates/katana/storage/provider/tests/fixtures.rs
@@ -51,7 +51,8 @@ pub fn fork_provider(
     #[default(0)] block_num: u64,
 ) -> BlockchainProvider<ForkedProvider> {
     let provider = JsonRpcClient::new(HttpTransport::new(Url::parse(rpc).unwrap()));
-    let provider = ForkedProvider::new(Arc::new(provider), BlockHashOrNumber::Num(block_num));
+    let provider =
+        ForkedProvider::new(Arc::new(provider), BlockHashOrNumber::Num(block_num)).unwrap();
     BlockchainProvider::new(provider)
 }
 
@@ -60,7 +61,7 @@ pub fn fork_provider_with_spawned_fork_network(
     #[default(0)] block_num: u64,
 ) -> BlockchainProvider<ForkedProvider> {
     let provider =
-        ForkedProvider::new(FORKED_PROVIDER.1.clone(), BlockHashOrNumber::Num(block_num));
+        ForkedProvider::new(FORKED_PROVIDER.1.clone(), BlockHashOrNumber::Num(block_num)).unwrap();
     BlockchainProvider::new(provider)
 }
 


### PR DESCRIPTION
This PR adds initial error handling improvement. The idea is to not rely on `anyhow` on lib level and 

- Typed error for `katana-providers` replacing `anyhow`.
- Removed unused variants in `SequencerError` enum.
- Turn `UnexpectedError` variant of `StarknetApiError` into a struct with a `reason` field.