### PR TITLE
fix: ensure local manifest and remote manifest models are comparable

### DIFF
--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -24,7 +24,7 @@ starknet.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "950e487", features = ["abigen-rs"] }
+cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "950e487", features = [ "abigen-rs" ] }
 dojo-types = { path = "../dojo-types", optional = true }
 http = { version = "0.2.9", optional = true }
 ipfs-api-backend-hyper = { git = "https://github.com/ferristseng/rust-ipfs-api", rev = "af2c17f7b19ef5b9898f458d97a90055c3605633", features = [ "with-hyper-rustls" ], optional = true }

--- a/crates/dojo-world/src/migration/world_test.rs
+++ b/crates/dojo-world/src/migration/world_test.rs
@@ -26,13 +26,22 @@ fn no_diff_when_local_and_remote_are_equal() {
         ..Default::default()
     }];
 
+    let remote_models = vec![Model {
+        members: vec![],
+        name: "Model".into(),
+        class_hash: 11_u32.into(),
+        ..Default::default()
+    }];
+
     let local = Manifest {
         models,
         world: world_contract,
         executor: executor_contract,
         ..Default::default()
     };
-    let remote = local.clone();
+
+    let mut remote = local.clone();
+    remote.models = remote_models;
 
     let diff = WorldDiff::compute(local, Some(remote));
 
@@ -68,6 +77,21 @@ fn diff_when_local_and_remote_are_different() {
         },
     ];
 
+    let remote_models = vec![
+        Model {
+            members: vec![],
+            name: "Model".into(),
+            class_hash: felt!("0x11"),
+            ..Default::default()
+        },
+        Model {
+            members: vec![],
+            name: "Model2".into(),
+            class_hash: felt!("0x33"),
+            ..Default::default()
+        },
+    ];
+
     let contracts = vec![
         Contract {
             name: "dojo_mock::contracts::my_contract".into(),
@@ -92,9 +116,9 @@ fn diff_when_local_and_remote_are_different() {
     };
 
     let mut remote = local.clone();
+    remote.models = remote_models;
     remote.world.class_hash = 44_u32.into();
     remote.executor.class_hash = 55_u32.into();
-    remote.models[1].class_hash = 33_u32.into();
     remote.contracts[0].class_hash = felt!("0x1112");
 
     let diff = WorldDiff::compute(local, Some(remote));


### PR DESCRIPTION
Currently, the change to fully qualified name in the manifest has a discrepancy with the model name that is reported by the remote manifest built.

To fix that for the moment, the comparison is made with comparable model name.

Related to the PR #1362, if we use array of felts or `ByteArray`, we should then be able to get back to fully qualified comparison on both sides.

This fixes the `sozo migrate --world 0x...` where transactions are always sent as the migration detects changes, but there are not.