### PR TITLE
feat: add `ensure_abi` method into model generated contract

### DIFF
--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo_v240/Scarb.lock
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo_v240/Scarb.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "dojo"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "dojo_plugin",
 ]

--- a/crates/dojo-lang/src/manifest_test_data/manifest
+++ b/crates/dojo-lang/src/manifest_test_data/manifest
@@ -1205,7 +1205,7 @@ test_manifest_file
     {
       "name": "dojo_examples::models::moves",
       "address": null,
-      "class_hash": "0x64495ca6dc1dc328972697b30468cea364bcb7452bbb6e4aaad3e4b3f190147",
+      "class_hash": "0x1e13e74f3cb66e022c2b58a8ab7670a065d12d050446e20f736bd5bdc37c17e",
       "abi": [
         {
           "type": "function",
@@ -1358,6 +1358,62 @@ test_manifest_file
               "type": "dojo::database::introspect::Ty"
             }
           ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "enum",
+          "name": "dojo_examples::models::Direction",
+          "variants": [
+            {
+              "name": "None",
+              "type": "()"
+            },
+            {
+              "name": "Left",
+              "type": "()"
+            },
+            {
+              "name": "Right",
+              "type": "()"
+            },
+            {
+              "name": "Up",
+              "type": "()"
+            },
+            {
+              "name": "Down",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo_examples::models::Moves",
+          "members": [
+            {
+              "name": "player",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "remaining",
+              "type": "core::integer::u8"
+            },
+            {
+              "name": "last_direction",
+              "type": "dojo_examples::models::Direction"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "ensure_abi",
+          "inputs": [
+            {
+              "name": "model",
+              "type": "dojo_examples::models::Moves"
+            }
+          ],
+          "outputs": [],
           "state_mutability": "view"
         },
         {
@@ -1374,7 +1430,7 @@ test_manifest_file
     {
       "name": "dojo_examples::models::position",
       "address": null,
-      "class_hash": "0x4cd20d231b04405a77b184c115dc60637e186504fad7f0929bd76cbd09c10b",
+      "class_hash": "0x2a7df852d6ef0af662dad741b97b423ba0fb34a1483599781ac9e7f6822bc25",
       "abi": [
         {
           "type": "function",
@@ -1527,6 +1583,46 @@ test_manifest_file
               "type": "dojo::database::introspect::Ty"
             }
           ],
+          "state_mutability": "view"
+        },
+        {
+          "type": "struct",
+          "name": "dojo_examples::models::Vec2",
+          "members": [
+            {
+              "name": "x",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "y",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo_examples::models::Position",
+          "members": [
+            {
+              "name": "player",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "vec",
+              "type": "dojo_examples::models::Vec2"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "ensure_abi",
+          "inputs": [
+            {
+              "name": "model",
+              "type": "dojo_examples::models::Position"
+            }
+          ],
+          "outputs": [],
           "state_mutability": "view"
         },
         {

--- a/crates/dojo-lang/src/model.rs
+++ b/crates/dojo-lang/src/model.rs
@@ -157,6 +157,10 @@ pub fn handle_model_struct(
                 fn schema(self: @ContractState) -> dojo::database::introspect::Ty {
                     dojo::database::introspect::Introspect::<$type_name$>::ty()
                 }
+
+                #[external(v0)]
+                fn ensure_abi(self: @ContractState, model: $type_name$) {
+                }
             }
         ",
             &UnorderedHashMap::from([

--- a/crates/dojo-lang/src/plugin_test_data/model
+++ b/crates/dojo-lang/src/plugin_test_data/model
@@ -587,6 +587,11 @@ error: Unsupported attribute.
                 ^*************^
 
 error: Unsupported attribute.
+ --> test_src/lib.cairo[Position]:110:17
+                #[external(v0)]
+                ^*************^
+
+error: Unsupported attribute.
  --> test_src/lib.cairo[Roles]:73:17
                 #[storage]
                 ^********^
@@ -613,6 +618,11 @@ error: Unsupported attribute.
 
 error: Unsupported attribute.
  --> test_src/lib.cairo[Roles]:101:17
+                #[external(v0)]
+                ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[Roles]:106:17
                 #[external(v0)]
                 ^*************^
 
@@ -647,6 +657,11 @@ error: Unsupported attribute.
                 ^*************^
 
 error: Unsupported attribute.
+ --> test_src/lib.cairo[OnlyKeyModel]:105:17
+                #[external(v0)]
+                ^*************^
+
+error: Unsupported attribute.
  --> test_src/lib.cairo[Player]:81:17
                 #[storage]
                 ^********^
@@ -673,6 +688,11 @@ error: Unsupported attribute.
 
 error: Unsupported attribute.
  --> test_src/lib.cairo[Player]:109:17
+                #[external(v0)]
+                ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[Player]:114:17
                 #[external(v0)]
                 ^*************^
 
@@ -907,6 +927,10 @@ impl PositionIntrospect<> of dojo::database::introspect::Introspect<Position<>> 
                 fn schema(self: @ContractState) -> dojo::database::introspect::Ty {
                     dojo::database::introspect::Introspect::<Position>::ty()
                 }
+
+                #[external(v0)]
+                fn ensure_abi(self: @ContractState, model: Position) {
+                }
             }
 impl RolesSerde of core::serde::Serde::<Roles> {
     fn serialize(self: @Roles, ref output: core::array::Array<felt252>) {
@@ -1022,6 +1046,10 @@ impl RolesIntrospect<> of dojo::database::introspect::Introspect<Roles<>> {
                 fn schema(self: @ContractState) -> dojo::database::introspect::Ty {
                     dojo::database::introspect::Introspect::<Roles>::ty()
                 }
+
+                #[external(v0)]
+                fn ensure_abi(self: @ContractState, model: Roles) {
+                }
             }
 impl OnlyKeyModelSerde of core::serde::Serde::<OnlyKeyModel> {
     fn serialize(self: @OnlyKeyModel, ref output: core::array::Array<felt252>) {
@@ -1135,6 +1163,10 @@ impl OnlyKeyModelIntrospect<> of dojo::database::introspect::Introspect<OnlyKeyM
                 #[external(v0)]
                 fn schema(self: @ContractState) -> dojo::database::introspect::Ty {
                     dojo::database::introspect::Introspect::<OnlyKeyModel>::ty()
+                }
+
+                #[external(v0)]
+                fn ensure_abi(self: @ContractState, model: OnlyKeyModel) {
                 }
             }
 impl PlayerCopy of core::traits::Copy::<Player>;
@@ -1264,5 +1296,9 @@ impl PlayerIntrospect<> of dojo::database::introspect::Introspect<Player<>> {
                 #[external(v0)]
                 fn schema(self: @ContractState) -> dojo::database::introspect::Ty {
                     dojo::database::introspect::Introspect::<Player>::ty()
+                }
+
+                #[external(v0)]
+                fn ensure_abi(self: @ContractState, model: Player) {
                 }
             }

--- a/crates/dojo-world/src/contracts/model_test.rs
+++ b/crates/dojo-world/src/contracts/model_test.rs
@@ -63,7 +63,7 @@ async fn test_model() {
     assert_eq!(
         position.class_hash(),
         FieldElement::from_hex_be(
-            "0x004cd20d231b04405a77b184c115dc60637e186504fad7f0929bd76cbd09c10b"
+            "0x02a7df852d6ef0af662dad741b97b423ba0fb34a1483599781ac9e7f6822bc25"
         )
         .unwrap()
     );

--- a/examples/spawn-and-move/Scarb.lock
+++ b/examples/spawn-and-move/Scarb.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "dojo_examples"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "dojo",
 ]


### PR DESCRIPTION
When it comes to types, cairo compiler will strip out any ABI entry that is not directly related to an input or output of an entry point.

This causes a problem in the dojo stack where a model that is not directly used by a system is never present in the ABI.

The current PR solved this by adding a method into the model generated contract, `ensure_abi`, which takes the model type as input. Having this, we ensure that the type ABI entry associated to the model (and any inner type of the model) is always present at least once in the ABI of the model contract.

Of course, this type may be repeated in the ABI of a dojo contract that has system using it.

Having the ABI of all the models allows `dojo-bindgen` to generate, at compile time, the bindings for **every** models.