### PR TITLE
fix: retry on `TransactionHashNotFound` error

### DIFF
--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -65,12 +65,12 @@ pub struct TransactionWaiter<'a, P: Provider> {
     /// be considered when waiting for the transaction, meaning `REVERTED` transaction will not
     /// return an error.
     must_succeed: bool,
-    /// Poll the transaction every `interval` miliseconds. Miliseconds are used so that
+    /// Poll the transaction every `interval` milliseconds. Milliseconds are used so that
     /// we can be more precise with the polling interval. Defaults to 2.5 seconds.
     interval: Interval,
     /// The maximum amount of time to wait for the transaction to achieve the desired status. An
     /// error will be returned if it is unable to finish within the `timeout` duration. Defaults to
-    /// 60 seconds.
+    /// 300 seconds.
     timeout: Duration,
     /// The provider to use for polling the transaction.
     provider: &'a P,
@@ -240,6 +240,10 @@ where
                     }
 
                     Poll::Ready(res) => match res {
+                        Err(ProviderError::StarknetError(
+                            StarknetError::TransactionHashNotFound,
+                        )) => {}
+
                         Err(e) => {
                             return Poll::Ready(Err(TransactionWaitingError::Provider(e)));
                         }

--- a/crates/sozo/src/ops/migration/mod.rs
+++ b/crates/sozo/src/ops/migration/mod.rs
@@ -475,7 +475,7 @@ where
         .execute(calls)
         .send()
         .await
-        .map_err(|e| anyhow!("Failed to register models to World: {e}"))?;
+        .map_err(|e| anyhow!("Failed to register models to World: {e:?}"))?;
 
     TransactionWaiter::new(transaction_hash, migrator.provider()).await?;
 


### PR DESCRIPTION
related: #1340

we are only calling `get_transaction_receipt` after we get `Accepted_on_L2/Accepted_on_L1` from `get_transaction_status`, still rpc returns `TransactionHashNotFound` in which case we simply retry after sometime.