### PR TITLE
minor bugfixes

### DIFF
--- a/crates/katana/core/contracts/messaging/README.md
+++ b/crates/katana/core/contracts/messaging/README.md
@@ -73,7 +73,7 @@ Then you've to wait the message to be sent to L1, Katana will display it:
 |   payload    | [0x2]
 ```
 ```
-# Consume the messag previously sent. You can try to call it once and see the second one reverting.
+# Consume the message previously sent. You can try to call it once and see the second one reverting.
 make -sC solidity/ consume_msg payload="[2]"
 ```
 

--- a/crates/katana/core/contracts/messaging/README.md
+++ b/crates/katana/core/contracts/messaging/README.md
@@ -39,7 +39,7 @@ To test this scenario, you can use the associated Makefiles. But the flow is the
 How to run the scripts:
 
 -   Start Anvil in a terminal.
--   Start Katana in an other terminal on default port 5050 with the messaging configuration that is inside the:
+-   Start Katana in another terminal on default port 5050 with the messaging configuration that is inside the:
     `katana --messaging ~/dojo/crates/katana/core/contracts/messaging/anvil.messaging.json`
 -   Open an other terminal and `cd ~/dojo/crates/katana/core/contracts/messaging`.
 

--- a/crates/katana/core/contracts/messaging/solidity/README.md
+++ b/crates/katana/core/contracts/messaging/solidity/README.md
@@ -18,8 +18,8 @@ If a command in the makefile requires an argument, please use the associated `*_
 
 If you want to check the logs emitted by the contracts, run `cast logs`.
 
-Note, starknet core contract is expected at least 30k wei to work. So you must
-always send a value when calling a function that will send a message to L2.
+Note, the starknet core contract requires a minimum of 30k wei to work. 
+So you must always send a value when calling a function that will send a message to L2.
 
 If the message is not ready yet to be consumed, you should see an error like this
 using:

--- a/crates/katana/core/contracts/messaging/solidity/README.md
+++ b/crates/katana/core/contracts/messaging/solidity/README.md
@@ -14,7 +14,7 @@ You should now have a json file into `logs` folder with the deployed addresses.
 To interact with the node, you can use the Makefile for better UX.
 If you need more customization, please check the Makefile to see the commands.
 
-If a command in the makefile requires argument, please use the associated `*_usage`.
+If a command in the makefile requires an argument, please use the associated `*_usage`.
 
 If you want to check the logs emitted by the contracts, run `cast logs`.
 


### PR DESCRIPTION
Add "an" before "argument" for grammatical correctness, like "requires an argument".

"starknet core contract is expected at least 30k wei": For clarity, it could be "the starknet core contract requires a minimum of 30k wei".

Typo in "an other terminal": It should be "another terminal".

Minor Typo "messag": The word should be "message".

