### PR TITLE
Increase `katana` RPC request timeout from 2 -> 20 secs

### DIFF
--- a/crates/katana/rpc/src/lib.rs
+++ b/crates/katana/rpc/src/lib.rs
@@ -50,7 +50,7 @@ pub async fn spawn(sequencer: Arc<KatanaSequencer>, config: ServerConfig) -> Res
     let middleware = tower::ServiceBuilder::new()
         .layer(cors)
         .layer(ProxyGetRequestLayer::new("/", "health")?)
-        .timeout(Duration::from_secs(2));
+        .timeout(Duration::from_secs(20));
 
     let server = ServerBuilder::new()
         .set_logger(RpcLogger)


### PR DESCRIPTION
Refer to #1456 for full context.

The new timeout value has been chosen arbitrarily, I just thought it seems reasonable enough.