### PR TITLE
perf(katana-rpc): spawn blocking tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5611,6 +5611,7 @@ dependencies = [
  "katana-provider",
  "katana-rpc-types",
  "katana-rpc-types-builder",
+ "katana-tasks",
  "serde",
  "serde_json",
  "serde_with",
@@ -5659,6 +5660,16 @@ dependencies = [
  "starknet",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "katana-tasks"
+version = "0.5.0"
+dependencies = [
+ "futures",
+ "rayon",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -267,8 +267,9 @@ impl KatanaSequencer {
         self.backend.chain_id
     }
 
-    pub fn block_number(&self) -> BlockNumber {
-        BlockNumberProvider::latest_number(&self.backend.blockchain.provider()).unwrap()
+    pub fn block_number(&self) -> SequencerResult<BlockNumber> {
+        let num = BlockNumberProvider::latest_number(&self.backend.blockchain.provider())?;
+        Ok(num)
     }
 
     pub fn block_tx_count(&self, block_id: BlockIdOrTag) -> SequencerResult<Option<u64>> {
@@ -300,7 +301,7 @@ impl KatanaSequencer {
         Ok(count)
     }
 
-    pub async fn nonce_at(
+    pub fn nonce_at(
         &self,
         block_id: BlockIdOrTag,
         contract_address: ContractAddress,
@@ -352,7 +353,7 @@ impl KatanaSequencer {
         Ok(tx)
     }
 
-    pub async fn events(
+    pub fn events(
         &self,
         from_block: BlockIdOrTag,
         to_block: BlockIdOrTag,

--- a/crates/katana/rpc/Cargo.toml
+++ b/crates/katana/rpc/Cargo.toml
@@ -12,6 +12,7 @@ katana-primitives = { path = "../primitives" }
 katana-provider = { path = "../storage/provider" }
 katana-rpc-types = { path = "rpc-types" }
 katana-rpc-types-builder = { path = "rpc-types-builder" }
+katana-tasks = { path = "../tasks" }
 
 anyhow.workspace = true
 cairo-lang-starknet = "2.3.1"

--- a/crates/katana/rpc/src/starknet.rs
+++ b/crates/katana/rpc/src/starknet.rs
@@ -66,16 +66,7 @@ impl StarknetApi {
         T: Send + 'static,
     {
         let this = self.clone();
-        // create oneshot tokio channel
-        let (sender, receiver) = tokio::sync::oneshot::channel::<T>();
-        let _ = TokioTaskSpawner::new()
-            .unwrap()
-            .spawn_blocking(move || {
-                let res = func(this);
-                let _ = sender.send(res);
-            })
-            .await;
-        receiver.await.unwrap()
+        TokioTaskSpawner::new().unwrap().spawn_blocking(move || func(this)).await.unwrap()
     }
 }
 #[async_trait]

--- a/crates/katana/rpc/src/starknet.rs
+++ b/crates/katana/rpc/src/starknet.rs
@@ -29,23 +29,59 @@ use katana_rpc_types::transaction::{
 };
 use katana_rpc_types::{ContractClass, FeeEstimate, FeltAsHex, FunctionCall};
 use katana_rpc_types_builder::ReceiptBuilder;
+use katana_tasks::{BlockingTaskPool, TokioTaskSpawner};
 use starknet::core::types::{BlockTag, TransactionExecutionStatus, TransactionStatus};
 
 use crate::api::starknet::{StarknetApiError, StarknetApiServer};
 
+#[derive(Clone)]
 pub struct StarknetApi {
+    inner: Arc<StarknetApiInner>,
+}
+
+struct StarknetApiInner {
     sequencer: Arc<KatanaSequencer>,
+    blocking_task_pool: BlockingTaskPool,
 }
 
 impl StarknetApi {
     pub fn new(sequencer: Arc<KatanaSequencer>) -> Self {
-        Self { sequencer }
+        let blocking_task_pool =
+            BlockingTaskPool::new().expect("failed to create blocking task pool");
+        Self { inner: Arc::new(StarknetApiInner { sequencer, blocking_task_pool }) }
+    }
+
+    async fn on_cpu_blocking_task<F, T>(&self, func: F) -> T
+    where
+        F: FnOnce(Self) -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        let this = self.clone();
+        self.inner.blocking_task_pool.spawn(move || func(this)).await.unwrap()
+    }
+
+    async fn on_io_blocking_task<F, T>(&self, func: F) -> T
+    where
+        F: FnOnce(Self) -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        let this = self.clone();
+        // create oneshot tokio channel
+        let (sender, receiver) = tokio::sync::oneshot::channel::<T>();
+        let _ = TokioTaskSpawner::new()
+            .unwrap()
+            .spawn_blocking(move || {
+                let res = func(this);
+                let _ = sender.send(res);
+            })
+            .await;
+        receiver.await.unwrap()
     }
 }
 #[async_trait]
 impl StarknetApiServer for StarknetApi {
     async fn chain_id(&self) -> Result<FeltAsHex, Error> {
-        Ok(FieldElement::from(self.sequencer.chain_id()).into())
+        Ok(FieldElement::from(self.inner.sequencer.chain_id()).into())
     }
 
     async fn nonce(
@@ -53,36 +89,51 @@ impl StarknetApiServer for StarknetApi {
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
     ) -> Result<FeltAsHex, Error> {
-        let nonce = self
-            .sequencer
-            .nonce_at(block_id, contract_address.into())
-            .await
-            .map_err(StarknetApiError::from)?
-            .ok_or(StarknetApiError::ContractNotFound)?;
-
-        Ok(nonce.into())
+        self.on_io_blocking_task(move |this| {
+            let nonce = this
+                .inner
+                .sequencer
+                .nonce_at(block_id, contract_address.into())
+                .map_err(StarknetApiError::from)?
+                .ok_or(StarknetApiError::ContractNotFound)?;
+            Ok(nonce.into())
+        })
+        .await
     }
 
     async fn block_number(&self) -> Result<u64, Error> {
-        Ok(self.sequencer.block_number())
+        self.on_io_blocking_task(move |this| {
+            let block_number =
+                this.inner.sequencer.block_number().map_err(StarknetApiError::from)?;
+            Ok(block_number)
+        })
+        .await
     }
 
     async fn transaction_by_hash(&self, transaction_hash: FieldElement) -> Result<Tx, Error> {
-        let tx = self
-            .sequencer
-            .transaction(&transaction_hash)
-            .map_err(StarknetApiError::from)?
-            .ok_or(StarknetApiError::TxnHashNotFound)?;
-        Ok(tx.into())
+        self.on_io_blocking_task(move |this| {
+            let tx = this
+                .inner
+                .sequencer
+                .transaction(&transaction_hash)
+                .map_err(StarknetApiError::from)?
+                .ok_or(StarknetApiError::TxnHashNotFound)?;
+            Ok(tx.into())
+        })
+        .await
     }
 
     async fn block_transaction_count(&self, block_id: BlockIdOrTag) -> Result<u64, Error> {
-        let count = self
-            .sequencer
-            .block_tx_count(block_id)
-            .map_err(StarknetApiError::from)?
-            .ok_or(StarknetApiError::BlockNotFound)?;
-        Ok(count)
+        self.on_io_blocking_task(move |this| {
+            let count = this
+                .inner
+                .sequencer
+                .block_tx_count(block_id)
+                .map_err(StarknetApiError::from)?
+                .ok_or(StarknetApiError::BlockNotFound)?;
+            Ok(count)
+        })
+        .await
     }
 
     async fn class_at(
@@ -91,17 +142,22 @@ impl StarknetApiServer for StarknetApi {
         contract_address: FieldElement,
     ) -> Result<ContractClass, Error> {
         let class_hash = self
-            .sequencer
-            .class_hash_at(block_id, contract_address.into())
-            .map_err(StarknetApiError::from)?
-            .ok_or(StarknetApiError::ContractNotFound)?;
-
+            .on_io_blocking_task(move |this| {
+                this.inner
+                    .sequencer
+                    .class_hash_at(block_id, contract_address.into())
+                    .map_err(StarknetApiError::from)?
+                    .ok_or(StarknetApiError::ContractNotFound)
+            })
+            .await?;
         self.class(block_id, class_hash).await
     }
 
     async fn block_hash_and_number(&self) -> Result<BlockHashAndNumber, Error> {
-        let hash_and_num_pair =
-            self.sequencer.block_hash_and_number().map_err(StarknetApiError::from)?;
+        let hash_and_num_pair = self
+            .on_io_blocking_task(move |this| this.inner.sequencer.block_hash_and_number())
+            .await
+            .map_err(StarknetApiError::from)?;
         Ok(hash_and_num_pair.into())
     }
 
@@ -109,51 +165,53 @@ impl StarknetApiServer for StarknetApi {
         &self,
         block_id: BlockIdOrTag,
     ) -> Result<MaybePendingBlockWithTxHashes, Error> {
-        let provider = self.sequencer.backend.blockchain.provider();
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.sequencer.backend.blockchain.provider();
 
-        if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-            if let Some(pending_state) = self.sequencer.pending_state() {
-                let block_env = pending_state.block_envs.read().0.clone();
-                let latest_hash =
-                    BlockHashProvider::latest_hash(provider).map_err(StarknetApiError::from)?;
+            if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
+                if let Some(pending_state) = this.inner.sequencer.pending_state() {
+                    let block_env = pending_state.block_envs.read().0.clone();
+                    let latest_hash =
+                        BlockHashProvider::latest_hash(provider).map_err(StarknetApiError::from)?;
 
-                let gas_prices = GasPrices {
-                    eth: block_env.l1_gas_prices.eth,
-                    strk: block_env.l1_gas_prices.strk,
-                };
+                    let gas_prices = GasPrices {
+                        eth: block_env.l1_gas_prices.eth,
+                        strk: block_env.l1_gas_prices.strk,
+                    };
 
-                let header = PartialHeader {
-                    gas_prices,
-                    parent_hash: latest_hash,
-                    version: CURRENT_STARKNET_VERSION,
-                    timestamp: block_env.timestamp,
-                    sequencer_address: block_env.sequencer_address,
-                };
+                    let header = PartialHeader {
+                        gas_prices,
+                        parent_hash: latest_hash,
+                        version: CURRENT_STARKNET_VERSION,
+                        timestamp: block_env.timestamp,
+                        sequencer_address: block_env.sequencer_address,
+                    };
 
-                let transactions = pending_state
-                    .executed_txs
-                    .read()
-                    .iter()
-                    .map(|(tx, _)| tx.hash)
-                    .collect::<Vec<_>>();
+                    let transactions = pending_state
+                        .executed_txs
+                        .read()
+                        .iter()
+                        .map(|(tx, _)| tx.hash)
+                        .collect::<Vec<_>>();
 
-                return Ok(MaybePendingBlockWithTxHashes::Pending(PendingBlockWithTxHashes::new(
-                    header,
-                    transactions,
-                )));
+                    return Ok(MaybePendingBlockWithTxHashes::Pending(
+                        PendingBlockWithTxHashes::new(header, transactions),
+                    ));
+                }
             }
-        }
 
-        let block_num = BlockIdReader::convert_block_id(provider, block_id)
-            .map_err(StarknetApiError::from)?
-            .map(BlockHashOrNumber::Num)
-            .ok_or(StarknetApiError::BlockNotFound)?;
+            let block_num = BlockIdReader::convert_block_id(provider, block_id)
+                .map_err(StarknetApiError::from)?
+                .map(BlockHashOrNumber::Num)
+                .ok_or(StarknetApiError::BlockNotFound)?;
 
-        katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
-            .build_with_tx_hash()
-            .map_err(StarknetApiError::from)?
-            .map(MaybePendingBlockWithTxHashes::Block)
-            .ok_or(Error::from(StarknetApiError::BlockNotFound))
+            katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
+                .build_with_tx_hash()
+                .map_err(StarknetApiError::from)?
+                .map(MaybePendingBlockWithTxHashes::Block)
+                .ok_or(Error::from(StarknetApiError::BlockNotFound))
+        })
+        .await
     }
 
     async fn transaction_by_block_id_and_index(
@@ -161,133 +219,145 @@ impl StarknetApiServer for StarknetApi {
         block_id: BlockIdOrTag,
         index: u64,
     ) -> Result<Tx, Error> {
-        // TEMP: have to handle pending tag independently for now
-        let tx = if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-            let Some(pending_state) = self.sequencer.pending_state() else {
-                return Err(StarknetApiError::BlockNotFound.into());
+        self.on_io_blocking_task(move |this| {
+            // TEMP: have to handle pending tag independently for now
+            let tx = if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
+                let Some(pending_state) = this.inner.sequencer.pending_state() else {
+                    return Err(StarknetApiError::BlockNotFound.into());
+                };
+
+                let pending_txs = pending_state.executed_txs.read();
+                pending_txs.iter().nth(index as usize).map(|(tx, _)| tx.clone())
+            } else {
+                let provider = &this.inner.sequencer.backend.blockchain.provider();
+
+                let block_num = BlockIdReader::convert_block_id(provider, block_id)
+                    .map_err(StarknetApiError::from)?
+                    .map(BlockHashOrNumber::Num)
+                    .ok_or(StarknetApiError::BlockNotFound)?;
+
+                TransactionProvider::transaction_by_block_and_idx(provider, block_num, index)
+                    .map_err(StarknetApiError::from)?
             };
 
-            let pending_txs = pending_state.executed_txs.read();
-            pending_txs.iter().nth(index as usize).map(|(tx, _)| tx.clone())
-        } else {
-            let provider = &self.sequencer.backend.blockchain.provider();
-
-            let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                .map_err(StarknetApiError::from)?
-                .map(BlockHashOrNumber::Num)
-                .ok_or(StarknetApiError::BlockNotFound)?;
-
-            TransactionProvider::transaction_by_block_and_idx(provider, block_num, index)
-                .map_err(StarknetApiError::from)?
-        };
-
-        Ok(tx.ok_or(StarknetApiError::InvalidTxnIndex)?.into())
+            Ok(tx.ok_or(StarknetApiError::InvalidTxnIndex)?.into())
+        })
+        .await
     }
 
     async fn block_with_txs(
         &self,
         block_id: BlockIdOrTag,
     ) -> Result<MaybePendingBlockWithTxs, Error> {
-        let provider = self.sequencer.backend.blockchain.provider();
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.sequencer.backend.blockchain.provider();
 
-        if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-            if let Some(pending_state) = self.sequencer.pending_state() {
-                let block_env = pending_state.block_envs.read().0.clone();
-                let latest_hash =
-                    BlockHashProvider::latest_hash(provider).map_err(StarknetApiError::from)?;
+            if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
+                if let Some(pending_state) = this.inner.sequencer.pending_state() {
+                    let block_env = pending_state.block_envs.read().0.clone();
+                    let latest_hash =
+                        BlockHashProvider::latest_hash(provider).map_err(StarknetApiError::from)?;
 
-                let gas_prices = GasPrices {
-                    eth: block_env.l1_gas_prices.eth,
-                    strk: block_env.l1_gas_prices.strk,
-                };
+                    let gas_prices = GasPrices {
+                        eth: block_env.l1_gas_prices.eth,
+                        strk: block_env.l1_gas_prices.strk,
+                    };
 
-                let header = PartialHeader {
-                    gas_prices,
-                    parent_hash: latest_hash,
-                    version: CURRENT_STARKNET_VERSION,
-                    timestamp: block_env.timestamp,
-                    sequencer_address: block_env.sequencer_address,
-                };
+                    let header = PartialHeader {
+                        gas_prices,
+                        parent_hash: latest_hash,
+                        version: CURRENT_STARKNET_VERSION,
+                        timestamp: block_env.timestamp,
+                        sequencer_address: block_env.sequencer_address,
+                    };
 
-                let transactions = pending_state
-                    .executed_txs
-                    .read()
-                    .iter()
-                    .map(|(tx, _)| tx.clone())
-                    .collect::<Vec<_>>();
+                    let transactions = pending_state
+                        .executed_txs
+                        .read()
+                        .iter()
+                        .map(|(tx, _)| tx.clone())
+                        .collect::<Vec<_>>();
 
-                return Ok(MaybePendingBlockWithTxs::Pending(PendingBlockWithTxs::new(
-                    header,
-                    transactions,
-                )));
+                    return Ok(MaybePendingBlockWithTxs::Pending(PendingBlockWithTxs::new(
+                        header,
+                        transactions,
+                    )));
+                }
             }
-        }
 
-        let block_num = BlockIdReader::convert_block_id(provider, block_id)
-            .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-            .map(BlockHashOrNumber::Num)
-            .ok_or(StarknetApiError::BlockNotFound)?;
+            let block_num = BlockIdReader::convert_block_id(provider, block_id)
+                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
+                .map(BlockHashOrNumber::Num)
+                .ok_or(StarknetApiError::BlockNotFound)?;
 
-        katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
-            .build()
-            .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-            .map(MaybePendingBlockWithTxs::Block)
-            .ok_or(Error::from(StarknetApiError::BlockNotFound))
+            katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
+                .build()
+                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
+                .map(MaybePendingBlockWithTxs::Block)
+                .ok_or(Error::from(StarknetApiError::BlockNotFound))
+        })
+        .await
     }
 
     async fn state_update(&self, block_id: BlockIdOrTag) -> Result<StateUpdate, Error> {
-        let provider = self.sequencer.backend.blockchain.provider();
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.sequencer.backend.blockchain.provider();
 
-        let block_id = match block_id {
-            BlockIdOrTag::Number(num) => BlockHashOrNumber::Num(num),
-            BlockIdOrTag::Hash(hash) => BlockHashOrNumber::Hash(hash),
+            let block_id = match block_id {
+                BlockIdOrTag::Number(num) => BlockHashOrNumber::Num(num),
+                BlockIdOrTag::Hash(hash) => BlockHashOrNumber::Hash(hash),
 
-            BlockIdOrTag::Tag(BlockTag::Latest) => BlockNumberProvider::latest_number(provider)
-                .map(BlockHashOrNumber::Num)
-                .map_err(|_| StarknetApiError::BlockNotFound)?,
+                BlockIdOrTag::Tag(BlockTag::Latest) => BlockNumberProvider::latest_number(provider)
+                    .map(BlockHashOrNumber::Num)
+                    .map_err(|_| StarknetApiError::BlockNotFound)?,
 
-            BlockIdOrTag::Tag(BlockTag::Pending) => {
-                return Err(StarknetApiError::BlockNotFound.into());
-            }
-        };
+                BlockIdOrTag::Tag(BlockTag::Pending) => {
+                    return Err(StarknetApiError::BlockNotFound.into());
+                }
+            };
 
-        katana_rpc_types_builder::StateUpdateBuilder::new(block_id, provider)
-            .build()
-            .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-            .ok_or(Error::from(StarknetApiError::BlockNotFound))
+            katana_rpc_types_builder::StateUpdateBuilder::new(block_id, provider)
+                .build()
+                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
+                .ok_or(Error::from(StarknetApiError::BlockNotFound))
+        })
+        .await
     }
 
     async fn transaction_receipt(
         &self,
         transaction_hash: FieldElement,
     ) -> Result<MaybePendingTxReceipt, Error> {
-        let provider = self.sequencer.backend.blockchain.provider();
-        let receipt = ReceiptBuilder::new(transaction_hash, provider)
-            .build()
-            .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.sequencer.backend.blockchain.provider();
+            let receipt = ReceiptBuilder::new(transaction_hash, provider)
+                .build()
+                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
 
-        match receipt {
-            Some(receipt) => Ok(MaybePendingTxReceipt::Receipt(receipt)),
+            match receipt {
+                Some(receipt) => Ok(MaybePendingTxReceipt::Receipt(receipt)),
 
-            None => {
-                let pending_receipt = self.sequencer.pending_state().and_then(|s| {
-                    s.executed_txs
-                        .read()
-                        .iter()
-                        .find(|(tx, _)| tx.hash == transaction_hash)
-                        .map(|(_, rct)| rct.receipt.clone())
-                });
+                None => {
+                    let pending_receipt = this.inner.sequencer.pending_state().and_then(|s| {
+                        s.executed_txs
+                            .read()
+                            .iter()
+                            .find(|(tx, _)| tx.hash == transaction_hash)
+                            .map(|(_, rct)| rct.receipt.clone())
+                    });
 
-                let Some(pending_receipt) = pending_receipt else {
-                    return Err(StarknetApiError::TxnHashNotFound.into());
-                };
+                    let Some(pending_receipt) = pending_receipt else {
+                        return Err(StarknetApiError::TxnHashNotFound.into());
+                    };
 
-                Ok(MaybePendingTxReceipt::Pending(PendingTxReceipt::new(
-                    transaction_hash,
-                    pending_receipt,
-                )))
+                    Ok(MaybePendingTxReceipt::Pending(PendingTxReceipt::new(
+                        transaction_hash,
+                        pending_receipt,
+                    )))
+                }
             }
-        }
+        })
+        .await
     }
 
     async fn class_hash_at(
@@ -295,13 +365,16 @@ impl StarknetApiServer for StarknetApi {
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
     ) -> Result<FeltAsHex, Error> {
-        let hash = self
-            .sequencer
-            .class_hash_at(block_id, contract_address.into())
-            .map_err(StarknetApiError::from)?
-            .ok_or(StarknetApiError::ContractNotFound)?;
-
-        Ok(hash.into())
+        self.on_io_blocking_task(move |this| {
+            let hash = this
+                .inner
+                .sequencer
+                .class_hash_at(block_id, contract_address.into())
+                .map_err(StarknetApiError::from)?
+                .ok_or(StarknetApiError::ContractNotFound)?;
+            Ok(hash.into())
+        })
+        .await
     }
 
     async fn class(
@@ -309,40 +382,48 @@ impl StarknetApiServer for StarknetApi {
         block_id: BlockIdOrTag,
         class_hash: FieldElement,
     ) -> Result<ContractClass, Error> {
-        let class = self.sequencer.class(block_id, class_hash).map_err(StarknetApiError::from)?;
-        let Some(class) = class else { return Err(StarknetApiError::ClassHashNotFound.into()) };
+        self.on_io_blocking_task(move |this| {
+            let class =
+                this.inner.sequencer.class(block_id, class_hash).map_err(StarknetApiError::from)?;
+            let Some(class) = class else { return Err(StarknetApiError::ClassHashNotFound.into()) };
 
-        match class {
-            StarknetContract::Legacy(c) => {
-                let contract = legacy_inner_to_rpc_class(c)
-                    .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
-                Ok(contract)
+            match class {
+                StarknetContract::Legacy(c) => {
+                    let contract = legacy_inner_to_rpc_class(c)
+                        .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
+                    Ok(contract)
+                }
+                StarknetContract::Sierra(c) => Ok(ContractClass::Sierra(c)),
             }
-            StarknetContract::Sierra(c) => Ok(ContractClass::Sierra(c)),
-        }
+        })
+        .await
     }
 
     async fn events(&self, filter: EventFilterWithPage) -> Result<EventsPage, Error> {
-        let from_block = filter.event_filter.from_block.unwrap_or(BlockIdOrTag::Number(0));
-        let to_block = filter.event_filter.to_block.unwrap_or(BlockIdOrTag::Tag(BlockTag::Latest));
+        self.on_io_blocking_task(move |this| {
+            let from_block = filter.event_filter.from_block.unwrap_or(BlockIdOrTag::Number(0));
+            let to_block =
+                filter.event_filter.to_block.unwrap_or(BlockIdOrTag::Tag(BlockTag::Latest));
 
-        let keys = filter.event_filter.keys;
-        let keys = keys.filter(|keys| !(keys.len() == 1 && keys.is_empty()));
+            let keys = filter.event_filter.keys;
+            let keys = keys.filter(|keys| !(keys.len() == 1 && keys.is_empty()));
 
-        let events = self
-            .sequencer
-            .events(
-                from_block,
-                to_block,
-                filter.event_filter.address.map(|f| f.into()),
-                keys,
-                filter.result_page_request.continuation_token,
-                filter.result_page_request.chunk_size,
-            )
-            .await
-            .map_err(StarknetApiError::from)?;
+            let events = this
+                .inner
+                .sequencer
+                .events(
+                    from_block,
+                    to_block,
+                    filter.event_filter.address.map(|f| f.into()),
+                    keys,
+                    filter.result_page_request.continuation_token,
+                    filter.result_page_request.chunk_size,
+                )
+                .map_err(StarknetApiError::from)?;
 
-        Ok(events)
+            Ok(events)
+        })
+        .await
     }
 
     async fn call(
@@ -350,15 +431,18 @@ impl StarknetApiServer for StarknetApi {
         request: FunctionCall,
         block_id: BlockIdOrTag,
     ) -> Result<Vec<FeltAsHex>, Error> {
-        let request = EntryPointCall {
-            calldata: request.calldata,
-            contract_address: request.contract_address.into(),
-            entry_point_selector: request.entry_point_selector,
-        };
+        self.on_io_blocking_task(move |this| {
+            let request = EntryPointCall {
+                calldata: request.calldata,
+                contract_address: request.contract_address.into(),
+                entry_point_selector: request.entry_point_selector,
+            };
 
-        let res = self.sequencer.call(request, block_id).map_err(StarknetApiError::from)?;
-
-        Ok(res.into_iter().map(|v| v.into()).collect())
+            let res =
+                this.inner.sequencer.call(request, block_id).map_err(StarknetApiError::from)?;
+            Ok(res.into_iter().map(|v| v.into()).collect())
+        })
+        .await
     }
 
     async fn storage_at(
@@ -367,33 +451,40 @@ impl StarknetApiServer for StarknetApi {
         key: FieldElement,
         block_id: BlockIdOrTag,
     ) -> Result<FeltAsHex, Error> {
-        let value = self
-            .sequencer
-            .storage_at(contract_address.into(), key, block_id)
-            .map_err(StarknetApiError::from)?;
+        self.on_io_blocking_task(move |this| {
+            let value = this
+                .inner
+                .sequencer
+                .storage_at(contract_address.into(), key, block_id)
+                .map_err(StarknetApiError::from)?;
 
-        Ok(value.into())
+            Ok(value.into())
+        })
+        .await
     }
 
     async fn add_deploy_account_transaction(
         &self,
         deploy_account_transaction: BroadcastedDeployAccountTx,
     ) -> Result<DeployAccountTxResult, Error> {
-        if deploy_account_transaction.is_query {
-            return Err(StarknetApiError::UnsupportedTransactionVersion.into());
-        }
+        self.on_io_blocking_task(move |this| {
+            if deploy_account_transaction.is_query {
+                return Err(StarknetApiError::UnsupportedTransactionVersion.into());
+            }
 
-        let chain_id = self.sequencer.chain_id();
+            let chain_id = this.inner.sequencer.chain_id();
 
-        let tx = deploy_account_transaction.into_tx_with_chain_id(chain_id);
-        let contract_address = tx.contract_address;
+            let tx = deploy_account_transaction.into_tx_with_chain_id(chain_id);
+            let contract_address = tx.contract_address;
 
-        let tx = ExecutableTxWithHash::new(ExecutableTx::DeployAccount(tx));
-        let tx_hash = tx.hash;
+            let tx = ExecutableTxWithHash::new(ExecutableTx::DeployAccount(tx));
+            let tx_hash = tx.hash;
 
-        self.sequencer.add_transaction_to_pool(tx);
+            this.inner.sequencer.add_transaction_to_pool(tx);
 
-        Ok((tx_hash, contract_address).into())
+            Ok((tx_hash, contract_address).into())
+        })
+        .await
     }
 
     async fn estimate_fee(
@@ -401,38 +492,44 @@ impl StarknetApiServer for StarknetApi {
         request: Vec<BroadcastedTx>,
         block_id: BlockIdOrTag,
     ) -> Result<Vec<FeeEstimate>, Error> {
-        let chain_id = self.sequencer.chain_id();
+        self.on_cpu_blocking_task(move |this| {
+            let chain_id = this.inner.sequencer.chain_id();
 
-        let transactions = request
-            .into_iter()
-            .map(|tx| {
-                let tx = match tx {
-                    BroadcastedTx::Invoke(tx) => {
-                        let tx = tx.into_tx_with_chain_id(chain_id);
-                        ExecutableTxWithHash::new_query(ExecutableTx::Invoke(tx))
-                    }
+            let transactions = request
+                .into_iter()
+                .map(|tx| {
+                    let tx = match tx {
+                        BroadcastedTx::Invoke(tx) => {
+                            let tx = tx.into_tx_with_chain_id(chain_id);
+                            ExecutableTxWithHash::new_query(ExecutableTx::Invoke(tx))
+                        }
 
-                    BroadcastedTx::DeployAccount(tx) => {
-                        let tx = tx.into_tx_with_chain_id(chain_id);
-                        ExecutableTxWithHash::new_query(ExecutableTx::DeployAccount(tx))
-                    }
+                        BroadcastedTx::DeployAccount(tx) => {
+                            let tx = tx.into_tx_with_chain_id(chain_id);
+                            ExecutableTxWithHash::new_query(ExecutableTx::DeployAccount(tx))
+                        }
 
-                    BroadcastedTx::Declare(tx) => {
-                        let tx = tx
-                            .try_into_tx_with_chain_id(chain_id)
-                            .map_err(|_| StarknetApiError::InvalidContractClass)?;
-                        ExecutableTxWithHash::new_query(ExecutableTx::Declare(tx))
-                    }
-                };
+                        BroadcastedTx::Declare(tx) => {
+                            let tx = tx
+                                .try_into_tx_with_chain_id(chain_id)
+                                .map_err(|_| StarknetApiError::InvalidContractClass)?;
+                            ExecutableTxWithHash::new_query(ExecutableTx::Declare(tx))
+                        }
+                    };
 
-                Result::<ExecutableTxWithHash, StarknetApiError>::Ok(tx)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+                    Result::<ExecutableTxWithHash, StarknetApiError>::Ok(tx)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
-        let res =
-            self.sequencer.estimate_fee(transactions, block_id).map_err(StarknetApiError::from)?;
+            let res = this
+                .inner
+                .sequencer
+                .estimate_fee(transactions, block_id)
+                .map_err(StarknetApiError::from)?;
 
-        Ok(res)
+            Ok(res)
+        })
+        .await
     }
 
     async fn estimate_message_fee(
@@ -440,129 +537,143 @@ impl StarknetApiServer for StarknetApi {
         message: MsgFromL1,
         block_id: BlockIdOrTag,
     ) -> Result<FeeEstimate, Error> {
-        let chain_id = self.sequencer.chain_id();
+        self.on_cpu_blocking_task(move |this| {
+            let chain_id = this.inner.sequencer.chain_id();
 
-        let tx = message.into_tx_with_chain_id(chain_id);
-        let hash = tx.calculate_hash();
-        let tx: ExecutableTxWithHash = ExecutableTxWithHash { hash, transaction: tx.into() };
+            let tx = message.into_tx_with_chain_id(chain_id);
+            let hash = tx.calculate_hash();
+            let tx: ExecutableTxWithHash = ExecutableTxWithHash { hash, transaction: tx.into() };
 
-        let res = self
-            .sequencer
-            .estimate_fee(vec![tx], block_id)
-            .map_err(StarknetApiError::from)?
-            .pop()
-            .expect("should have estimate result");
+            let res = this
+                .inner
+                .sequencer
+                .estimate_fee(vec![tx], block_id)
+                .map_err(StarknetApiError::from)?
+                .pop()
+                .expect("should have estimate result");
 
-        Ok(res)
+            Ok(res)
+        })
+        .await
     }
 
     async fn add_declare_transaction(
         &self,
         declare_transaction: BroadcastedDeclareTx,
     ) -> Result<DeclareTxResult, Error> {
-        if declare_transaction.is_query() {
-            return Err(StarknetApiError::UnsupportedTransactionVersion.into());
-        }
+        self.on_io_blocking_task(move |this| {
+            if declare_transaction.is_query() {
+                return Err(StarknetApiError::UnsupportedTransactionVersion.into());
+            }
 
-        let chain_id = self.sequencer.chain_id();
+            let chain_id = this.inner.sequencer.chain_id();
 
-        // // validate compiled class hash
-        // let is_valid = declare_transaction
-        //     .validate_compiled_class_hash()
-        //     .map_err(|_| StarknetApiError::InvalidContractClass)?;
+            // // validate compiled class hash
+            // let is_valid = declare_transaction
+            //     .validate_compiled_class_hash()
+            //     .map_err(|_| StarknetApiError::InvalidContractClass)?;
 
-        // if !is_valid {
-        //     return Err(StarknetApiError::CompiledClassHashMismatch.into());
-        // }
+            // if !is_valid {
+            //     return Err(StarknetApiError::CompiledClassHashMismatch.into());
+            // }
 
-        let tx = declare_transaction
-            .try_into_tx_with_chain_id(chain_id)
-            .map_err(|_| StarknetApiError::InvalidContractClass)?;
+            let tx = declare_transaction
+                .try_into_tx_with_chain_id(chain_id)
+                .map_err(|_| StarknetApiError::InvalidContractClass)?;
 
-        let class_hash = tx.class_hash();
-        let tx = ExecutableTxWithHash::new(ExecutableTx::Declare(tx));
-        let tx_hash = tx.hash;
+            let class_hash = tx.class_hash();
+            let tx = ExecutableTxWithHash::new(ExecutableTx::Declare(tx));
+            let tx_hash = tx.hash;
 
-        self.sequencer.add_transaction_to_pool(tx);
+            this.inner.sequencer.add_transaction_to_pool(tx);
 
-        Ok((tx_hash, class_hash).into())
+            Ok((tx_hash, class_hash).into())
+        })
+        .await
     }
 
     async fn add_invoke_transaction(
         &self,
         invoke_transaction: BroadcastedInvokeTx,
     ) -> Result<InvokeTxResult, Error> {
-        if invoke_transaction.is_query {
-            return Err(StarknetApiError::UnsupportedTransactionVersion.into());
-        }
+        self.on_io_blocking_task(move |this| {
+            if invoke_transaction.is_query {
+                return Err(StarknetApiError::UnsupportedTransactionVersion.into());
+            }
 
-        let chain_id = self.sequencer.chain_id();
+            let chain_id = this.inner.sequencer.chain_id();
 
-        let tx = invoke_transaction.into_tx_with_chain_id(chain_id);
-        let tx = ExecutableTxWithHash::new(ExecutableTx::Invoke(tx));
-        let tx_hash = tx.hash;
+            let tx = invoke_transaction.into_tx_with_chain_id(chain_id);
+            let tx = ExecutableTxWithHash::new(ExecutableTx::Invoke(tx));
+            let tx_hash = tx.hash;
 
-        self.sequencer.add_transaction_to_pool(tx);
+            this.inner.sequencer.add_transaction_to_pool(tx);
 
-        Ok(tx_hash.into())
+            Ok(tx_hash.into())
+        })
+        .await
     }
 
     async fn transaction_status(
         &self,
         transaction_hash: TxHash,
     ) -> Result<TransactionStatus, Error> {
-        let provider = self.sequencer.backend.blockchain.provider();
+        self.on_io_blocking_task(move |this| {
+            let provider = this.inner.sequencer.backend.blockchain.provider();
 
-        let tx_status = TransactionStatusProvider::transaction_status(provider, transaction_hash)
-            .map_err(StarknetApiError::from)?;
+            let tx_status =
+                TransactionStatusProvider::transaction_status(provider, transaction_hash)
+                    .map_err(StarknetApiError::from)?;
 
-        if let Some(status) = tx_status {
-            if let Some(receipt) = ReceiptProvider::receipt_by_hash(provider, transaction_hash)
-                .map_err(StarknetApiError::from)?
+            if let Some(status) = tx_status {
+                if let Some(receipt) = ReceiptProvider::receipt_by_hash(provider, transaction_hash)
+                    .map_err(StarknetApiError::from)?
+                {
+                    let execution_status = if receipt.is_reverted() {
+                        TransactionExecutionStatus::Reverted
+                    } else {
+                        TransactionExecutionStatus::Succeeded
+                    };
+
+                    return Ok(match status {
+                        FinalityStatus::AcceptedOnL1 => {
+                            TransactionStatus::AcceptedOnL1(execution_status)
+                        }
+                        FinalityStatus::AcceptedOnL2 => {
+                            TransactionStatus::AcceptedOnL2(execution_status)
+                        }
+                    });
+                }
+            }
+
+            let pending_state = this.inner.sequencer.pending_state();
+            let state = pending_state.ok_or(StarknetApiError::TxnHashNotFound)?;
+            let executed_txs = state.executed_txs.read();
+
+            // attemps to find in the valid transactions list first (executed_txs)
+            // if not found, then search in the rejected transactions list (rejected_txs)
+            if let Some(is_reverted) = executed_txs
+                .iter()
+                .find(|(tx, _)| tx.hash == transaction_hash)
+                .map(|(_, rct)| rct.receipt.is_reverted())
             {
-                let execution_status = if receipt.is_reverted() {
+                let exec_status = if is_reverted {
                     TransactionExecutionStatus::Reverted
                 } else {
                     TransactionExecutionStatus::Succeeded
                 };
 
-                return Ok(match status {
-                    FinalityStatus::AcceptedOnL1 => {
-                        TransactionStatus::AcceptedOnL1(execution_status)
-                    }
-                    FinalityStatus::AcceptedOnL2 => {
-                        TransactionStatus::AcceptedOnL2(execution_status)
-                    }
-                });
-            }
-        }
-
-        let pending_state = self.sequencer.pending_state();
-        let state = pending_state.ok_or(StarknetApiError::TxnHashNotFound)?;
-        let executed_txs = state.executed_txs.read();
-
-        // attemps to find in the valid transactions list first (executed_txs)
-        // if not found, then search in the rejected transactions list (rejected_txs)
-        if let Some(is_reverted) = executed_txs
-            .iter()
-            .find(|(tx, _)| tx.hash == transaction_hash)
-            .map(|(_, rct)| rct.receipt.is_reverted())
-        {
-            let exec_status = if is_reverted {
-                TransactionExecutionStatus::Reverted
+                Ok(TransactionStatus::AcceptedOnL2(exec_status))
             } else {
-                TransactionExecutionStatus::Succeeded
-            };
+                let rejected_txs = state.rejected_txs.read();
 
-            Ok(TransactionStatus::AcceptedOnL2(exec_status))
-        } else {
-            let rejected_txs = state.rejected_txs.read();
-
-            rejected_txs
-                .iter()
-                .find(|(tx, _)| tx.hash == transaction_hash)
-                .map(|_| TransactionStatus::Rejected)
-                .ok_or(Error::from(StarknetApiError::TxnHashNotFound))
-        }
+                rejected_txs
+                    .iter()
+                    .find(|(tx, _)| tx.hash == transaction_hash)
+                    .map(|_| TransactionStatus::Rejected)
+                    .ok_or(Error::from(StarknetApiError::TxnHashNotFound))
+            }
+        })
+        .await
     }
 }

--- a/crates/katana/tasks/Cargo.toml
+++ b/crates/katana/tasks/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition.workspace = true
+name = "katana-tasks"
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futures.workspace = true
+rayon.workspace = true
+thiserror.workspace = true
+tokio.workspace = true

--- a/crates/katana/tasks/src/lib.rs
+++ b/crates/katana/tasks/src/lib.rs
@@ -86,10 +86,11 @@ impl<T> Future for BlockingTaskHandle<T> {
 /// thread-pool. This is mainly for executing expensive CPU-bound tasks. For spawing blocking
 /// IO-bound tasks, use [TokioTaskSpawner::spawn_blocking] instead.
 ///
-/// Refer to the [CPU-bound tasks and blocking code] section of the *tokio* docs for more
-/// information.
+/// Refer to the [CPU-bound tasks and blocking code] section of the *tokio* docs and this [blog
+/// post] for more information.
 ///
 /// [CPU-bound tasks and blocking code]: https://docs.rs/tokio/latest/tokio/index.html#cpu-bound-tasks-and-blocking-code
+/// [blog post]: https://ryhl.io/blog/async-what-is-blocking/
 #[derive(Debug, Clone)]
 pub struct BlockingTaskPool {
     pool: Arc<rayon::ThreadPool>,


### PR DESCRIPTION
Resolves https://github.com/dojoengine/dojo/issues/1448

Creates new crate under `katana`, `katana-tasks`, for managing spawning blocking tasks. RPC calls that mostly perform blocking tasks are now sent to their designated threadpools and won't block the async threads.

- `TokioTaskSpawner`: mainly for spawning blocking IO-bound tasks (ie reading from storage)
- `BlockingThreadPool`: mainly for spawning expensive CPU-bound tasks

Depends on #1455 because now the RPC requests (that used to block the thread before) have to wait for the blocking tasks to finish and thus may be idling for more than 2 seconds which will result in a connection timeout.

Doing `sozo migrate` on 2s timeout will failed when calling `/esimateFee` for estimating the World contract declare tx with error `connection closed before message completed`.

Raw error message from `sozo` against the new changes:
```console
Caused by:
    Failed to deploy world: Failed to migrate world: Migrator(Provider(Other(TransportError(Reqwest(reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("localhost")), port: Some(5050), path: "/", query: None, fragment: None }, source: hyper::Error(IncompleteMessage) })))))
```