### PR TITLE
refactor: migrate spawn-and-move to new proposed syntax

### DIFF
--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -1,13 +1,13 @@
-#[starknet::interface]
-trait IActions<TContractState> {
-    fn spawn(self: @TContractState);
-    fn move(self: @TContractState, direction: dojo_examples::models::Direction);
+#[dojo::interface]
+trait IActions {
+    fn spawn();
+    fn move(direction: dojo_examples::models::Direction);
 }
 
 #[dojo::contract]
 mod actions {
     use super::IActions;
-    
+
     use starknet::{ContractAddress, get_caller_address};
     use dojo_examples::models::{Position, Moves, Direction, Vec2};
     use dojo_examples::utils::next_position;
@@ -26,13 +26,13 @@ mod actions {
 
     #[external(v0)]
     #[computed]
-    fn tile_terrain(self: @ContractState, vec: Vec2) -> felt252 {
+    fn tile_terrain(vec: Vec2) -> felt252 {
         'land'
     }
 
     #[external(v0)]
     #[computed(Position)]
-    fn quadrant(self: @ContractState, pos: Position) -> u8 {
+    fn quadrant(pos: Position) -> u8 {
         // 10 is zero
         if pos.vec.x < 10 {
             if pos.vec.y < 10 {
@@ -51,10 +51,8 @@ mod actions {
 
     // impl: implement functions specified in trait
     #[external(v0)]
-    impl ActionsImpl of IActions<ContractState> {
-        // ContractState is defined by system decorator expansion
-        fn spawn(self: @ContractState) {
-            let world = self.world_dispatcher.read();
+    impl ActionsImpl of IActions {
+        fn spawn(world: IWorldDispatcher) {
             let player = get_caller_address();
             let position = get!(world, player, (Position));
             let moves = get!(world, player, (Moves));
@@ -72,8 +70,7 @@ mod actions {
             );
         }
 
-        fn move(self: @ContractState, direction: Direction) {
-            let world = self.world_dispatcher.read();
+        fn move(world: IWorldDispatcher, direction: Direction) {
             let player = get_caller_address();
             let (mut position, mut moves) = get!(world, player, (Position, Moves));
             moves.remaining -= 1;


### PR DESCRIPTION
Initial commit migrating the spawn-and-move actions.cairo contract to a new proposed syntax