### PR TITLE
CI: remove codecov on main merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: ci
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: ci
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 env:
@@ -17,6 +20,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo llvm-cov nextest --all-features --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v3
+        if: github.event_name == 'pull_request'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo llvm-cov nextest --all-features --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v3
-        if: github.event_name == 'pull_request'
+        if: github.ref != 'refs/heads/main'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info


### PR DESCRIPTION
Currently, codecov reports are not always in adequation with the code being pushed in a PR.
Disabling on main merge, ensures that maintainers can evaluate a PR to be mergeable, even if the codecov report is not valid, without impacting the CI on the main branch.