### PR TITLE
fix(dev): test build in `dojo-lang` doesn't detect models properly

### DIFF
--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -295,6 +295,9 @@ fn update_manifest(
         }
     }
 
+    &models.iter().for_each(|model| println!("Model: {}", model.0));
+    &contracts.iter().for_each(|contract| println!("Contract: {}", contract.0));
+
     computed.into_iter().for_each(|(contract, computed_value_entrypoint)| {
         let contract_data =
             contracts.get_mut(&contract).expect("Error: Computed value contract doesn't exist.");

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -284,6 +284,7 @@ fn update_manifest(
                 }
 
                 if let Some(dojo_aux_data) = aux_data.downcast_ref::<DojoAuxData>() {
+                    dbg!("found models!");
                     models.extend(get_dojo_model_artifacts(
                         db,
                         dojo_aux_data,
@@ -295,8 +296,8 @@ fn update_manifest(
         }
     }
 
-    &models.iter().for_each(|model| println!("Model: {}", model.0));
-    &contracts.iter().for_each(|contract| println!("Contract: {}", contract.0));
+    let _ = &models.iter().for_each(|model| println!("Model: {}", model.0));
+    let _ = &contracts.iter().for_each(|contract| println!("Contract: {}", contract.0));
 
     computed.into_iter().for_each(|(contract, computed_value_entrypoint)| {
         let contract_data =

--- a/crates/dojo-test-utils/src/compiler.rs
+++ b/crates/dojo-test-utils/src/compiler.rs
@@ -20,6 +20,8 @@ pub fn build_test_config(path: &str) -> anyhow::Result<Config> {
     let config_dir = TempDir::new().unwrap();
     let target_dir = TempDir::new().unwrap();
 
+    dbg!(&target_dir);
+
     let path = Utf8PathBuf::from_path_buf(path.into()).unwrap();
     Config::builder(path.canonicalize_utf8().unwrap())
         .global_cache_dir_override(Some(Utf8Path::from_path(cache_dir.path()).unwrap()))

--- a/crates/dojo-test-utils/src/compiler.rs
+++ b/crates/dojo-test-utils/src/compiler.rs
@@ -11,7 +11,7 @@ use scarb::ops;
 use scarb_ui::Verbosity;
 
 pub fn build_test_config(path: &str) -> anyhow::Result<Config> {
-    let mut compilers = CompilerRepository::empty();
+    let mut compilers = CompilerRepository::std();
     compilers.add(Box::new(DojoCompiler)).unwrap();
 
     let cairo_plugins = CairoPluginRepository::default();


### PR DESCRIPTION
to reproduce:

run below command which runs test build and print outs temporary directory where result `target` result goes:
> cargo test --package dojo-lang --lib -- compiler::test::test_compiler --exact --nocapture

run below command to do almost same thing but using sozo:
> cargo run --bin sozo -- --manifest-path examples/spawn-and-move/Scarb.toml build

compare `manifest.json` between them, the one generated in unit test doesn't contain models but models are part of `contracts`