### PR TITLE
refactor(katana): update genesis with forked block

### DIFF
--- a/bin/katana/src/args.rs
+++ b/bin/katana/src/args.rs
@@ -12,7 +12,6 @@
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use clap::{Args, Parser, Subcommand};
 use clap_complete::Shell;
@@ -262,7 +261,7 @@ impl KatanaArgs {
                     .unwrap_or(DEFAULT_VALIDATE_MAX_STEPS),
             },
             db_dir: self.db_dir.clone(),
-            genesis: Arc::new(genesis),
+            genesis,
         }
     }
 }

--- a/crates/katana/core/src/backend/config.rs
+++ b/crates/katana/core/src/backend/config.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use ethers::types::U256;
 use katana_primitives::block::GasPrices;
@@ -21,7 +20,7 @@ pub struct StarknetConfig {
     pub fork_block_number: Option<u64>,
     pub disable_validate: bool,
     pub db_dir: Option<PathBuf>,
-    pub genesis: Arc<Genesis>,
+    pub genesis: Genesis,
 }
 
 impl StarknetConfig {
@@ -53,7 +52,7 @@ impl Default for StarknetConfig {
             env: Environment::default(),
             disable_validate: false,
             db_dir: None,
-            genesis: Arc::new(genesis),
+            genesis,
         }
     }
 }

--- a/crates/katana/core/src/backend/storage.rs
+++ b/crates/katana/core/src/backend/storage.rs
@@ -98,7 +98,6 @@ impl Blockchain {
         Self::new_with_genesis(provider, genesis)
     }
 
-    // TODO: make this function to just accept a `Header` created from the forked block.
     /// Builds a new blockchain with a forked block.
     pub fn new_from_forked(
         provider: impl Database,

--- a/crates/katana/core/tests/sequencer.rs
+++ b/crates/katana/core/tests/sequencer.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use ethers::types::U256;
 use katana_core::backend::config::{Environment, StarknetConfig};
 use katana_core::sequencer::{KatanaSequencer, SequencerConfig};
@@ -20,7 +18,7 @@ fn create_test_sequencer_config() -> (SequencerConfig, StarknetConfig) {
     (
         SequencerConfig { block_time: None, ..Default::default() },
         StarknetConfig {
-            genesis: Arc::new(genesis),
+            genesis,
             disable_fee: true,
             env: Environment::default(),
             ..Default::default()

--- a/crates/katana/primitives/src/block.rs
+++ b/crates/katana/primitives/src/block.rs
@@ -132,6 +132,15 @@ impl Block {
     pub fn seal_with_hash(self, hash: BlockHash) -> SealedBlock {
         SealedBlock { header: SealedHeader { hash, header: self.header }, body: self.body }
     }
+
+    /// Seals the block with a given block hash and status.
+    pub fn seal_with_hash_and_status(
+        self,
+        hash: BlockHash,
+        status: FinalityStatus,
+    ) -> SealedBlockWithStatus {
+        SealedBlockWithStatus { block: self.seal_with_hash(hash), status }
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Follow up from #1483 to integrate the genesis state when running in forking mode.

The genesis state is updated with the values from the forked block.