### PR TITLE
refactor(katana): display genesis state properly on startup

### DIFF
--- a/crates/katana/core/src/backend/mod.rs
+++ b/crates/katana/core/src/backend/mod.rs
@@ -5,7 +5,6 @@ use katana_primitives::block::{
 };
 use katana_primitives::chain::ChainId;
 use katana_primitives::env::{BlockEnv, CfgEnv, FeeTokenAddressses};
-use katana_primitives::genesis::constant::DEFAULT_FEE_TOKEN_ADDRESS;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::StateUpdatesWithDeclaredClasses;
 use katana_primitives::transaction::TxWithHash;
@@ -202,7 +201,7 @@ impl Backend {
             validate_max_n_steps: self.config.env.validate_max_steps,
             max_recursion_depth: MAX_RECURSION_DEPTH,
             fee_token_addresses: FeeTokenAddressses {
-                eth: DEFAULT_FEE_TOKEN_ADDRESS,
+                eth: self.config.genesis.fee_token.address,
                 strk: Default::default(),
             },
         }

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -433,7 +433,9 @@ mod tests {
 
         assert_eq!(
             genesis.universal_deployer.clone().unwrap().address,
-            Some(ContractAddress::from(felt!("0x77")))
+            Some(ContractAddress::from(felt!(
+                "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
+            )))
         );
         assert_eq!(genesis.universal_deployer.unwrap().class, None);
 
@@ -636,7 +638,9 @@ mod tests {
             gas_prices: GasPrices { eth: 1111, strk: 2222 },
             universal_deployer: Some(UniversalDeployerConfig {
                 class_hash: DEFAULT_LEGACY_UDC_CLASS_HASH,
-                address: ContractAddress::from(felt!("0x77")),
+                address: ContractAddress::from(felt!(
+                    "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
+                )),
             }),
         };
 

--- a/crates/katana/primitives/src/genesis/test-genesis.json
+++ b/crates/katana/primitives/src/genesis/test-genesis.json
@@ -16,7 +16,7 @@
 		"class": "0x8"
 	},
 	"universalDeployer": {
-		"address": "0x77"
+		"address": "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
 	},
 	"accounts": {
 		"0x66efb28ac62686966ae85095ff3a772e014e7fbf56d4c5f6fac5606d4dde23a": {


### PR DESCRIPTION
Display the genesis state in the startup title according to the actual genesis config defined in the `Genesis` struct instead of just displaying the default values.