### PR TITLE
Switch to dedicated IPFS gateway

### DIFF
--- a/crates/torii/core/src/processors/metadata_update.rs
+++ b/crates/torii/core/src/processors/metadata_update.rs
@@ -17,7 +17,7 @@ use tracing::{error, info};
 use super::EventProcessor;
 use crate::sql::Sql;
 
-const IPFS_URL: &str = "https://ipfs.io/ipfs/";
+const IPFS_URL: &str = "https://cartridge.infura-ipfs.io/ipfs/";
 const MAX_RETRY: u8 = 3;
 
 #[derive(Default)]


### PR DESCRIPTION
Pinning to `ipfs://` no longer seems to work. Switching to our dedicated IPFS gateway endpoint provided by Infura.