### PR TITLE
fix: ensure correct model detection via interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,6 +2969,7 @@ dependencies = [
  "cainome 0.1.5 (git+https://github.com/cartridge-gg/cainome?tag=v0.2.2)",
  "camino",
  "convert_case 0.6.0",
+ "dojo-test-utils",
  "serde",
  "serde_json",
  "starknet",

--- a/crates/dojo-bindgen/Cargo.toml
+++ b/crates/dojo-bindgen/Cargo.toml
@@ -16,7 +16,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 
 # Some issue with CI on windows, need to be investigated.
-# https://github.com/dojoengine/dojo/actions/runs/7548423990/job/20550444492?pr=1425#step:6:1644
-dojo-test-utils = { path = "../dojo-test-utils", features = [ "build-examples" ] }
+# https://github.com/dojoengine/dojo/actions/runs/7736050751/job/21092743552?pr=1501#step:6:249
+# dojo-test-utils = { path = "../dojo-test-utils", features = [ "build-examples" ] }
 
 cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.2.2" }

--- a/crates/dojo-bindgen/Cargo.toml
+++ b/crates/dojo-bindgen/Cargo.toml
@@ -17,6 +17,6 @@ thiserror.workspace = true
 
 # Some issue with CI on windows, need to be investigated.
 # https://github.com/dojoengine/dojo/actions/runs/7548423990/job/20550444492?pr=1425#step:6:1644
-#dojo-test-utils = { path = "../dojo-test-utils", features = [ "build-examples" ] }
+dojo-test-utils = { path = "../dojo-test-utils", features = [ "build-examples" ] }
 
 cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.2.2" }

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -250,7 +250,7 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
 
     let mut funcs_counts = 0;
 
-    for functions in &tokens.interfaces.values() {
+    for functions in tokens.interfaces.values() {
         for f in functions {
             if expected_funcs.contains(&f.to_function().expect("Function expected").name.as_str()) {
                 funcs_counts += 1;

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -250,7 +250,7 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
 
     let mut funcs_counts = 0;
 
-    for (_, functions) in &tokens.interfaces {
+    for functions in &tokens.interfaces.values() {
         for f in functions {
             if expected_funcs.contains(&f.to_function().expect("Function expected").name.as_str()) {
                 funcs_counts += 1;

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -261,86 +261,87 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
     funcs_counts == expected_funcs.len()
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// Uncomment tests once windows issue is solved.
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-    #[test]
-    fn is_system_contract_ok() {
-        let file_name = "dojo_examples::actions::actions.json";
-        let file_content = include_str!(
-            "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
-        );
+//     #[test]
+//     fn is_system_contract_ok() {
+//         let file_name = "dojo_examples::actions::actions.json";
+//         let file_content = include_str!(
+//             "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
+//         );
 
-        assert!(is_systems_contract(file_name, file_content));
-    }
+//         assert!(is_systems_contract(file_name, file_content));
+//     }
 
-    #[test]
-    fn is_system_contract_ignore_dojo_files() {
-        let file_name = "dojo::world::world.json";
-        let file_content = "";
-        assert!(!is_systems_contract(file_name, file_content));
+//     #[test]
+//     fn is_system_contract_ignore_dojo_files() {
+//         let file_name = "dojo::world::world.json";
+//         let file_content = "";
+//         assert!(!is_systems_contract(file_name, file_content));
 
-        let file_name = "manifest.json";
-        assert!(!is_systems_contract(file_name, file_content));
-    }
+//         let file_name = "manifest.json";
+//         assert!(!is_systems_contract(file_name, file_content));
+//     }
 
-    #[test]
-    fn test_is_system_contract_ignore_models() {
-        let file_name = "dojo_examples::models::position.json";
-        let file_content = include_str!(
-            "test_data/spawn-and-move/target/dev/dojo_examples::models::position.json"
-        );
-        assert!(!is_systems_contract(file_name, file_content));
-    }
+//     #[test]
+//     fn test_is_system_contract_ignore_models() {
+//         let file_name = "dojo_examples::models::position.json";
+//         let file_content = include_str!(
+//             "test_data/spawn-and-move/target/dev/dojo_examples::models::position.json"
+//         );
+//         assert!(!is_systems_contract(file_name, file_content));
+//     }
 
-    #[test]
-    fn model_name_from_artifact_filename_ok() {
-        let file_name = "dojo_examples::models::position.json";
-        assert_eq!(model_name_from_artifact_filename(file_name), Some("position".to_string()));
-    }
+//     #[test]
+//     fn model_name_from_artifact_filename_ok() {
+//         let file_name = "dojo_examples::models::position.json";
+//         assert_eq!(model_name_from_artifact_filename(file_name), Some("position".to_string()));
+//     }
 
-    #[test]
-    fn is_model_contract_ok() {
-        let file_content =
-            include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
-        let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
+//     #[test]
+//     fn is_model_contract_ok() {
+//         let file_content =
+//             include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
+//         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
 
-        assert!(is_model_contract(&tokens));
-    }
+//         assert!(is_model_contract(&tokens));
+//     }
 
-    #[test]
-    fn is_model_contract_ignore_systems() {
-        let file_content = include_str!(
-            "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
-        );
-        let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
+//     #[test]
+//     fn is_model_contract_ignore_systems() {
+//         let file_content = include_str!(
+//             "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
+//         );
+//         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
 
-        assert!(!is_model_contract(&tokens));
-    }
+//         assert!(!is_model_contract(&tokens));
+//     }
 
-    #[test]
-    fn is_model_contract_ignore_dojo_files() {
-        let file_content =
-            include_str!("test_data/spawn-and-move/target/dev/dojo::world::world.json");
-        let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
+//     #[test]
+//     fn is_model_contract_ignore_dojo_files() {
+//         let file_content =
+//             include_str!("test_data/spawn-and-move/target/dev/dojo::world::world.json");
+//         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
 
-        assert!(!is_model_contract(&tokens));
-    }
+//         assert!(!is_model_contract(&tokens));
+//     }
 
-    #[test]
-    fn gather_data_ok() {
-        let data = gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))
-            .unwrap();
+//     #[test]
+//     fn gather_data_ok() {
+//         let data = gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))
+//             .unwrap();
 
-        assert_eq!(data.models.len(), 2);
+//         assert_eq!(data.models.len(), 2);
 
-        let pos = data.models.get("Position").unwrap();
-        assert_eq!(pos.name, "Position");
-        assert_eq!(pos.qualified_path, "dojo_examples::models::Position");
+//         let pos = data.models.get("Position").unwrap();
+//         assert_eq!(pos.name, "Position");
+//         assert_eq!(pos.qualified_path, "dojo_examples::models::Position");
 
-        let moves = data.models.get("Moves").unwrap();
-        assert_eq!(moves.name, "Moves");
-        assert_eq!(moves.qualified_path, "dojo_examples::models::Moves");
-    }
-}
+//         let moves = data.models.get("Moves").unwrap();
+//         assert_eq!(moves.name, "Moves");
+//         assert_eq!(moves.qualified_path, "dojo_examples::models::Moves");
+//     }
+// }

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -304,7 +304,8 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
 //     #[test]
 //     fn is_model_contract_ok() {
 //         let file_content =
-//             include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
+//             
+// include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
 //         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
 
 //         assert!(is_model_contract(&tokens));
@@ -331,8 +332,9 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
 
 //     #[test]
 //     fn gather_data_ok() {
-//         let data = gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))
-//             .unwrap();
+//         let data =
+// gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))             
+// .unwrap();
 
 //         assert_eq!(data.models.len(), 2);
 

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -250,97 +250,97 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
 
     let mut funcs_counts = 0;
 
-    // This hashmap is not that good at devex level.. one must check the
-    // code to know the keys.
-    for f in &tokens.functions {
-        if expected_funcs.contains(&f.to_function().expect("Function expected").name.as_str()) {
-            funcs_counts += 1;
+    for (_, functions) in &tokens.interfaces {
+        for f in functions {
+            if expected_funcs.contains(&f.to_function().expect("Function expected").name.as_str()) {
+                funcs_counts += 1;
+            }
         }
     }
 
     funcs_counts == expected_funcs.len()
 }
 
-// #[cfg(test)]
-// mod tests {
-// use super::*;
-//
-// #[test]
-// fn is_system_contract_ok() {
-// let file_name = "dojo_examples::actions::actions.json";
-// let file_content = include_str!(
-// "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
-// );
-//
-// assert!(is_systems_contract(file_name, file_content));
-// }
-//
-// #[test]
-// fn is_system_contract_ignore_dojo_files() {
-// let file_name = "dojo::world::world.json";
-// let file_content = "";
-// assert!(!is_systems_contract(file_name, file_content));
-//
-// let file_name = "manifest.json";
-// assert!(!is_systems_contract(file_name, file_content));
-// }
-//
-// #[test]
-// fn test_is_system_contract_ignore_models() {
-// let file_name = "dojo_examples::models::position.json";
-// let file_content = include_str!(
-// "test_data/spawn-and-move/target/dev/dojo_examples::models::position.json"
-// );
-// assert!(!is_systems_contract(file_name, file_content));
-// }
-//
-// #[test]
-// fn model_name_from_artifact_filename_ok() {
-// let file_name = "dojo_examples::models::position.json";
-// assert_eq!(model_name_from_artifact_filename(file_name), Some("position".to_string()));
-// }
-//
-// #[test]
-// fn is_model_contract_ok() {
-// let file_content =
-// include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
-// let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
-//
-// assert!(is_model_contract(&tokens));
-// }
-//
-// #[test]
-// fn is_model_contract_ignore_systems() {
-// let file_content = include_str!(
-// "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
-// );
-// let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
-//
-// assert!(!is_model_contract(&tokens));
-// }
-//
-// #[test]
-// fn is_model_contract_ignore_dojo_files() {
-// let file_content =
-// include_str!("test_data/spawn-and-move/target/dev/dojo::world::world.json");
-// let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
-//
-// assert!(!is_model_contract(&tokens));
-// }
-//
-// #[test]
-// fn gather_data_ok() {
-// let data = gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))
-// .unwrap();
-//
-// assert_eq!(data.models.len(), 2);
-//
-// let pos = data.models.get("Position").unwrap();
-// assert_eq!(pos.name, "Position");
-// assert_eq!(pos.qualified_path, "dojo_examples::models::Position");
-//
-// let moves = data.models.get("Moves").unwrap();
-// assert_eq!(moves.name, "Moves");
-// assert_eq!(moves.qualified_path, "dojo_examples::models::Moves");
-// }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_system_contract_ok() {
+        let file_name = "dojo_examples::actions::actions.json";
+        let file_content = include_str!(
+            "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
+        );
+
+        assert!(is_systems_contract(file_name, file_content));
+    }
+
+    #[test]
+    fn is_system_contract_ignore_dojo_files() {
+        let file_name = "dojo::world::world.json";
+        let file_content = "";
+        assert!(!is_systems_contract(file_name, file_content));
+
+        let file_name = "manifest.json";
+        assert!(!is_systems_contract(file_name, file_content));
+    }
+
+    #[test]
+    fn test_is_system_contract_ignore_models() {
+        let file_name = "dojo_examples::models::position.json";
+        let file_content = include_str!(
+            "test_data/spawn-and-move/target/dev/dojo_examples::models::position.json"
+        );
+        assert!(!is_systems_contract(file_name, file_content));
+    }
+
+    #[test]
+    fn model_name_from_artifact_filename_ok() {
+        let file_name = "dojo_examples::models::position.json";
+        assert_eq!(model_name_from_artifact_filename(file_name), Some("position".to_string()));
+    }
+
+    #[test]
+    fn is_model_contract_ok() {
+        let file_content =
+            include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
+        let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
+
+        assert!(is_model_contract(&tokens));
+    }
+
+    #[test]
+    fn is_model_contract_ignore_systems() {
+        let file_content = include_str!(
+            "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
+        );
+        let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
+
+        assert!(!is_model_contract(&tokens));
+    }
+
+    #[test]
+    fn is_model_contract_ignore_dojo_files() {
+        let file_content =
+            include_str!("test_data/spawn-and-move/target/dev/dojo::world::world.json");
+        let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
+
+        assert!(!is_model_contract(&tokens));
+    }
+
+    #[test]
+    fn gather_data_ok() {
+        let data = gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))
+            .unwrap();
+
+        assert_eq!(data.models.len(), 2);
+
+        let pos = data.models.get("Position").unwrap();
+        assert_eq!(pos.name, "Position");
+        assert_eq!(pos.qualified_path, "dojo_examples::models::Position");
+
+        let moves = data.models.get("Moves").unwrap();
+        assert_eq!(moves.name, "Moves");
+        assert_eq!(moves.qualified_path, "dojo_examples::models::Moves");
+    }
+}

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -304,7 +304,7 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
 //     #[test]
 //     fn is_model_contract_ok() {
 //         let file_content =
-//             
+//
 // include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
 //         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
 
@@ -333,7 +333,7 @@ fn is_model_contract(tokens: &TokenizedAbi) -> bool {
 //     #[test]
 //     fn gather_data_ok() {
 //         let data =
-// gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))             
+// gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))
 // .unwrap();
 
 //         assert_eq!(data.models.len(), 2);


### PR DESCRIPTION
With the change to `abi(embed_v0)`, an interface must be used to expose function.
This PR fixes the detection of model, which were relying on functions instead of interface.

We need to anticipate related change in cainome when `external(v0)` will be deprecated.