### PR TITLE
refactor(katana-primitives): make most fields for account/contract allocations optional

### DIFF
--- a/crates/katana/primitives/src/genesis/allocation.rs
+++ b/crates/katana/primitives/src/genesis/allocation.rs
@@ -6,7 +6,7 @@ use ethers::types::U256;
 use rand::rngs::SmallRng;
 use rand::{RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
-use starknet::core::serde::unsigned_field_element::UfeHex;
+use starknet::core::serde::unsigned_field_element::{UfeHex, UfeHexOption};
 use starknet::core::utils::get_contract_address;
 use starknet::signers::SigningKey;
 
@@ -34,15 +34,15 @@ impl GenesisAllocation {
     }
 
     /// Get the contract class hash.
-    pub fn class_hash(&self) -> ClassHash {
+    pub fn class_hash(&self) -> Option<ClassHash> {
         match self {
             Self::Contract(contract) => contract.class_hash,
-            Self::Account(account) => account.class_hash(),
+            Self::Account(account) => Some(account.class_hash()),
         }
     }
 
     /// Get the balance to be allocated to this contract.
-    pub fn balance(&self) -> U256 {
+    pub fn balance(&self) -> Option<U256> {
         match self {
             Self::Contract(contract) => contract.balance,
             Self::Account(account) => account.balance(),
@@ -92,7 +92,7 @@ impl GenesisAccountAlloc {
         }
     }
 
-    pub fn balance(&self) -> U256 {
+    pub fn balance(&self) -> Option<U256> {
         match self {
             Self::Account(account) => account.balance,
             Self::DevAccount(account) => account.balance,
@@ -126,10 +126,10 @@ impl GenesisAccountAlloc {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GenesisContractAlloc {
     /// The class hash of the contract.
-    #[serde_as(as = "UfeHex")]
-    pub class_hash: ClassHash,
+    #[serde_as(as = "UfeHexOption")]
+    pub class_hash: Option<ClassHash>,
     /// The amount of the fee token allocated to the contract.
-    pub balance: U256,
+    pub balance: Option<U256>,
     /// The initial nonce of the contract.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nonce: Option<FieldElement>,
@@ -168,7 +168,7 @@ impl DevGenesisAccount {
         balance: U256,
     ) -> (ContractAddress, Self) {
         let (addr, mut account) = Self::new(private_key, class_hash);
-        account.balance = balance;
+        account.balance = Some(balance);
         (addr, account)
     }
 }
@@ -184,7 +184,7 @@ pub struct GenesisAccount {
     #[serde_as(as = "UfeHex")]
     pub class_hash: ClassHash,
     /// The amount of the fee token allocated to the account.
-    pub balance: U256,
+    pub balance: Option<U256>,
     /// The initial nonce of the account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nonce: Option<FieldElement>,
@@ -211,7 +211,7 @@ impl GenesisAccount {
         balance: U256,
     ) -> (ContractAddress, Self) {
         let (address, account) = Self::new(public_key, class_hash);
-        (address, Self { balance, ..account })
+        (address, Self { balance: Some(balance), ..account })
     }
 }
 

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -128,7 +128,7 @@ pub struct UniversalDeployerConfigJson {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct GenesisContractJson {
-    pub class: ClassHash,
+    pub class: Option<ClassHash>,
     pub balance: Option<U256>,
     pub nonce: Option<FieldElement>,
     pub storage: Option<HashMap<StorageKey, StorageValue>>,
@@ -417,14 +417,15 @@ impl TryFrom<GenesisJson> for Genesis {
                 }
             };
 
-            let balance = account.balance.unwrap_or_default();
-            // increase the total supply of the fee token
-            fee_token.total_supply += balance;
+            // increase the total supply of the fee token if balance is given
+            if let Some(balance) = account.balance {
+                fee_token.total_supply += balance;
+            }
 
             allocations.insert(
                 address,
                 GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
-                    balance,
+                    balance: account.balance,
                     class_hash,
                     nonce: account.nonce,
                     storage: account.storage,
@@ -435,20 +436,22 @@ impl TryFrom<GenesisJson> for Genesis {
 
         for (address, contract) in value.contracts {
             // check that the class hash exists in the classes field
-            let class_hash = contract.class;
-            if !classes.contains_key(&contract.class) {
-                return Err(GenesisJsonError::MissingClass(class_hash));
+            if let Some(hash) = contract.class {
+                if !classes.contains_key(&hash) {
+                    return Err(GenesisJsonError::MissingClass(hash));
+                }
             }
 
-            let balance = contract.balance.unwrap_or_default();
-            // increase the total supply of the fee token
-            fee_token.total_supply += balance;
+            // increase the total supply of the fee token if balance is given
+            if let Some(balance) = contract.balance {
+                fee_token.total_supply += balance;
+            }
 
             allocations.insert(
                 address,
                 GenesisAllocation::Contract(GenesisContractAlloc {
-                    balance,
-                    class_hash,
+                    balance: contract.balance,
+                    class_hash: contract.class,
                     nonce: contract.nonce,
                     storage: contract.storage,
                 }),
@@ -569,34 +572,34 @@ mod tests {
     #[test]
     fn deserialize_from_json() {
         let file = File::open("./src/genesis/test-genesis.json").unwrap();
-        let genesis: GenesisJson = serde_json::from_reader(file).unwrap();
+        let json: GenesisJson = serde_json::from_reader(file).unwrap();
 
-        assert_eq!(genesis.number, 0);
-        assert_eq!(genesis.parent_hash, felt!("0x999"));
-        assert_eq!(genesis.timestamp, 5123512314u64);
-        assert_eq!(genesis.state_root, felt!("0x99"));
-        assert_eq!(genesis.gas_prices.eth, 1111);
-        assert_eq!(genesis.gas_prices.strk, 2222);
+        assert_eq!(json.number, 0);
+        assert_eq!(json.parent_hash, felt!("0x999"));
+        assert_eq!(json.timestamp, 5123512314u64);
+        assert_eq!(json.state_root, felt!("0x99"));
+        assert_eq!(json.gas_prices.eth, 1111);
+        assert_eq!(json.gas_prices.strk, 2222);
 
-        assert_eq!(genesis.fee_token.address, Some(ContractAddress::from(felt!("0x55"))));
-        assert_eq!(genesis.fee_token.name, String::from("ETHER"));
-        assert_eq!(genesis.fee_token.symbol, String::from("ETH"));
-        assert_eq!(genesis.fee_token.class, Some(felt!("0x8")));
-        assert_eq!(genesis.fee_token.decimals, 18);
+        assert_eq!(json.fee_token.address, Some(ContractAddress::from(felt!("0x55"))));
+        assert_eq!(json.fee_token.name, String::from("ETHER"));
+        assert_eq!(json.fee_token.symbol, String::from("ETH"));
+        assert_eq!(json.fee_token.class, Some(felt!("0x8")));
+        assert_eq!(json.fee_token.decimals, 18);
         assert_eq!(
-            genesis.fee_token.storage,
+            json.fee_token.storage,
             Some(HashMap::from([(felt!("0x111"), felt!("0x1")), (felt!("0x222"), felt!("0x2"))]))
         );
 
         assert_eq!(
-            genesis.universal_deployer.clone().unwrap().address,
+            json.universal_deployer.clone().unwrap().address,
             Some(ContractAddress::from(felt!(
                 "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
             )))
         );
-        assert_eq!(genesis.universal_deployer.unwrap().class, None);
+        assert_eq!(json.universal_deployer.unwrap().class, None);
         assert_eq!(
-            genesis.fee_token.storage,
+            json.fee_token.storage,
             Some(HashMap::from([(felt!("0x111"), felt!("0x1")), (felt!("0x222"), felt!("0x2")),]))
         );
 
@@ -606,27 +609,40 @@ mod tests {
         let acc_2 = ContractAddress::from(felt!(
             "0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114"
         ));
+        let acc_3 = ContractAddress::from(felt!(
+            "0x79156ecb3d8f084001bb498c95e37fa1c4b40dbb35a3ae47b77b1ad535edcb9"
+        ));
 
-        assert_eq!(genesis.accounts.len(), 2);
-        assert_eq!(genesis.accounts[&acc_1].public_key, felt!("0x1"));
+        assert_eq!(json.accounts.len(), 3);
+
+        assert_eq!(json.accounts[&acc_1].public_key, felt!("0x1"));
         assert_eq!(
-            genesis.accounts[&acc_1].balance,
+            json.accounts[&acc_1].balance,
             Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap())
         );
-        assert_eq!(genesis.accounts[&acc_1].nonce, Some(felt!("0x1")));
-        assert_eq!(genesis.accounts[&acc_1].class, Some(felt!("0x80085")));
+        assert_eq!(json.accounts[&acc_1].nonce, Some(felt!("0x1")));
+        assert_eq!(json.accounts[&acc_1].class, Some(felt!("0x80085")));
         assert_eq!(
-            genesis.accounts[&acc_1].storage,
+            json.accounts[&acc_1].storage,
             Some(HashMap::from([(felt!("0x1"), felt!("0x1")), (felt!("0x2"), felt!("0x2")),]))
         );
 
-        assert_eq!(genesis.accounts[&acc_2].public_key, felt!("0x2"));
+        assert_eq!(json.accounts[&acc_2].public_key, felt!("0x2"));
         assert_eq!(
-            genesis.accounts[&acc_2].balance,
+            json.accounts[&acc_2].balance,
             Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap())
         );
+        assert_eq!(json.accounts[&acc_3].nonce, None);
+        assert_eq!(json.accounts[&acc_2].class, None);
+        assert_eq!(json.accounts[&acc_2].storage, None);
 
-        assert_eq!(genesis.contracts.len(), 2);
+        assert_eq!(json.accounts[&acc_3].public_key, felt!("0x3"));
+        assert_eq!(json.accounts[&acc_3].balance, None);
+        assert_eq!(json.accounts[&acc_3].nonce, None);
+        assert_eq!(json.accounts[&acc_3].class, None);
+        assert_eq!(json.accounts[&acc_3].storage, None);
+
+        assert_eq!(json.contracts.len(), 3);
 
         let contract_1 = ContractAddress::from(felt!(
             "0x29873c310fbefde666dc32a1554fea6bb45eecc84f680f8a2b0a8fbb8cb89af"
@@ -634,23 +650,39 @@ mod tests {
         let contract_2 = ContractAddress::from(felt!(
             "0xe29882a1fcba1e7e10cad46212257fea5c752a4f9b1b1ec683c503a2cf5c8a"
         ));
+        let contract_3 = ContractAddress::from(felt!(
+            "0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c"
+        ));
 
         assert_eq!(
-            genesis.contracts[&contract_1].balance,
+            json.contracts[&contract_1].balance,
             Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap())
         );
-        assert_eq!(genesis.contracts[&contract_1].nonce, None);
-        assert_eq!(genesis.contracts[&contract_1].class, felt!("0x8"));
+        assert_eq!(json.contracts[&contract_1].nonce, None);
+        assert_eq!(json.contracts[&contract_1].class, Some(felt!("0x8")));
+        assert_eq!(
+            json.contracts[&contract_1].storage,
+            Some(HashMap::from([(felt!("0x1"), felt!("0x1")), (felt!("0x2"), felt!("0x2"))]))
+        );
 
         assert_eq!(
-            genesis.contracts[&contract_2].balance,
+            json.contracts[&contract_2].balance,
             Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap())
         );
-        assert_eq!(genesis.contracts[&contract_2].nonce, None);
-        assert_eq!(genesis.contracts[&contract_2].class, felt!("0x8"));
+        assert_eq!(json.contracts[&contract_2].nonce, None);
+        assert_eq!(json.contracts[&contract_2].class, None);
+        assert_eq!(json.contracts[&contract_2].storage, None);
+
+        assert_eq!(json.contracts[&contract_3].balance, None);
+        assert_eq!(json.contracts[&contract_3].nonce, None);
+        assert_eq!(json.contracts[&contract_3].class, None);
+        assert_eq!(
+            json.contracts[&contract_3].storage,
+            Some(HashMap::from([(felt!("0x1"), felt!("0x1"))]))
+        );
 
         assert_eq!(
-            genesis.classes,
+            json.classes,
             vec![
                 GenesisClassJson {
                     class_hash: Some(felt!("0x8")),
@@ -701,7 +733,7 @@ mod tests {
         let json = GenesisJson::load(path).unwrap();
         let actual_genesis = Genesis::try_from(json).unwrap();
 
-        let classes = HashMap::from([
+        let expected_classes = HashMap::from([
             (
                 felt!("0x07b3e05f48f0c69e4a65ce5e076a66271a527aff2c34ce1083ec6e1526997a69"),
                 GenesisClass {
@@ -746,7 +778,7 @@ mod tests {
             ),
         ]);
 
-        let fee_token = FeeTokenConfig {
+        let expected_fee_token = FeeTokenConfig {
             address: ContractAddress::from(felt!("0x55")),
             name: String::from("ETHER"),
             symbol: String::from("ETH"),
@@ -765,19 +797,25 @@ mod tests {
         let acc_2 = ContractAddress::from(felt!(
             "0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114"
         ));
+        let acc_3 = ContractAddress::from(felt!(
+            "0x79156ecb3d8f084001bb498c95e37fa1c4b40dbb35a3ae47b77b1ad535edcb9"
+        ));
         let contract_1 = ContractAddress::from(felt!(
             "0x29873c310fbefde666dc32a1554fea6bb45eecc84f680f8a2b0a8fbb8cb89af"
         ));
         let contract_2 = ContractAddress::from(felt!(
             "0xe29882a1fcba1e7e10cad46212257fea5c752a4f9b1b1ec683c503a2cf5c8a"
         ));
+        let contract_3 = ContractAddress::from(felt!(
+            "0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c"
+        ));
 
-        let allocations = BTreeMap::from([
+        let expected_allocations = BTreeMap::from([
             (
                 acc_1,
                 GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
                     public_key: felt!("0x1"),
-                    balance: U256::from_str("0xD3C21BCECCEDA1000000").unwrap(),
+                    balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                     nonce: Some(felt!("0x1")),
                     class_hash: felt!("0x80085"),
                     storage: Some(HashMap::from([
@@ -790,7 +828,17 @@ mod tests {
                 acc_2,
                 GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
                     public_key: felt!("0x2"),
-                    balance: U256::from_str("0xD3C21BCECCEDA1000000").unwrap(),
+                    balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
+                    class_hash: DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH,
+                    nonce: None,
+                    storage: None,
+                })),
+            ),
+            (
+                acc_3,
+                GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
+                    public_key: felt!("0x3"),
+                    balance: None,
                     class_hash: DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH,
                     nonce: None,
                     storage: None,
@@ -799,9 +847,9 @@ mod tests {
             (
                 contract_1,
                 GenesisAllocation::Contract(GenesisContractAlloc {
-                    balance: U256::from_str("0xD3C21BCECCEDA1000000").unwrap(),
+                    balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                     nonce: None,
-                    class_hash: felt!("0x8"),
+                    class_hash: Some(felt!("0x8")),
                     storage: Some(HashMap::from([
                         (felt!("0x1"), felt!("0x1")),
                         (felt!("0x2"), felt!("0x2")),
@@ -811,19 +859,28 @@ mod tests {
             (
                 contract_2,
                 GenesisAllocation::Contract(GenesisContractAlloc {
-                    balance: U256::from_str("0xD3C21BCECCEDA1000000").unwrap(),
+                    balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                     nonce: None,
-                    class_hash: felt!("0x8"),
+                    class_hash: None,
                     storage: None,
+                }),
+            ),
+            (
+                contract_3,
+                GenesisAllocation::Contract(GenesisContractAlloc {
+                    balance: None,
+                    nonce: None,
+                    class_hash: None,
+                    storage: Some(HashMap::from([(felt!("0x1"), felt!("0x1"))])),
                 }),
             ),
         ]);
 
         let expected_genesis = Genesis {
-            classes,
+            classes: expected_classes,
             number: 0,
-            fee_token,
-            allocations,
+            fee_token: expected_fee_token,
+            allocations: expected_allocations,
             timestamp: 5123512314u64,
             sequencer_address: ContractAddress::from(felt!("0x100")),
             state_root: felt!("0x99"),
@@ -946,7 +1003,7 @@ mod tests {
             )),
             GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
                 public_key: felt!("0x1"),
-                balance: U256::from_str("0xD3C21BCECCEDA1000000").unwrap(),
+                balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                 class_hash: DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH,
                 nonce: None,
                 storage: None,

--- a/crates/katana/primitives/src/genesis/test-genesis.json
+++ b/crates/katana/primitives/src/genesis/test-genesis.json
@@ -39,6 +39,9 @@
 		"0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114": {
 			"publicKey": "0x2",
 			"balance": "0xD3C21BCECCEDA1000000"
+		},
+		"0x79156ecb3d8f084001bb498c95e37fa1c4b40dbb35a3ae47b77b1ad535edcb9": {
+			"publicKey": "0x3"
 		}
 	},
 	"contracts": {
@@ -51,8 +54,12 @@
 			}
 		},
 		"0xe29882a1fcba1e7e10cad46212257fea5c752a4f9b1b1ec683c503a2cf5c8a": {
-			"class": "0x8",
 			"balance": "0xD3C21BCECCEDA1000000"
+		},
+		"0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c": {
+			"storage": {
+				"0x1": "0x1"
+			}
 		}
 	},
 	"classes": [

--- a/crates/katana/rpc/rpc-types/src/account.rs
+++ b/crates/katana/rpc/rpc-types/src/account.rs
@@ -28,7 +28,7 @@ impl Account {
             public_key: account.public_key(),
             private_key: account.private_key(),
             class_hash: account.class_hash(),
-            balance: account.balance(),
+            balance: account.balance().unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
Changed `nonce`, `balance`, `class`, and `storage` fields to optional for both account & contract allocations in the genesis config.

Implications: 
- contracts storage can be initialized even when the contract itself isn't deployed, ie. there is no longer a restriction by the genesis config where it only allows a contract to be allocated if it has a class hash (which is basically what defines a contract to be deployed, by having a class hash).

## Checklist

- [ ] integration test 