### PR TITLE
feat(libp2p): command to wait for the relay to be ready

### DIFF
--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -101,6 +101,11 @@ impl Client {
         })
     }
 
+    /// Waits for the relay connection to be established.
+    pub async fn wait_for_connection(&mut self) -> Result<(), Error> {
+        self.relay_client.command_sender.wait_for_connection().await.map_err(Error::RelayClient)
+    }
+
     /// Subscribes to a topic.
     /// Returns true if the topic was subscribed to.
     /// Returns false if the topic was already subscribed to.

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -101,9 +101,9 @@ impl Client {
         })
     }
 
-    /// Waits for the relay connection to be established.
-    pub async fn wait_for_connection(&mut self) -> Result<(), Error> {
-        self.relay_client.command_sender.wait_for_connection().await.map_err(Error::RelayClient)
+    /// Waits for the relay to be ready and listening for messages.
+    pub async fn wait_for_relay(&mut self) -> Result<(), Error> {
+        self.relay_client.command_sender.wait_for_relay().await.map_err(Error::RelayClient)
     }
 
     /// Subscribes to a topic.

--- a/crates/torii/libp2p/src/client/mod.rs
+++ b/crates/torii/libp2p/src/client/mod.rs
@@ -193,6 +193,16 @@ impl CommandSender {
 
         rx.await.expect("Failed to receive response")
     }
+
+    pub async fn wait_for_connection(&mut self) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+
+        self.sender
+            .unbounded_send(Command::WaitForConnection(tx))
+            .expect("Failed to send command");
+
+        rx.await.expect("Failed to receive response")
+    }
 }
 
 impl EventLoop {

--- a/crates/torii/libp2p/src/client/mod.rs
+++ b/crates/torii/libp2p/src/client/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures::channel::oneshot;
 use futures::lock::Mutex;
-use futures::{select, FutureExt, StreamExt};
+use futures::{select, StreamExt};
 use libp2p::gossipsub::{self, IdentTopic, MessageId, TopicHash};
 use libp2p::swarm::{NetworkBehaviour, Swarm, SwarmEvent};
 use libp2p::{identify, identity, ping, Multiaddr, PeerId};

--- a/crates/torii/libp2p/src/client/mod.rs
+++ b/crates/torii/libp2p/src/client/mod.rs
@@ -263,9 +263,7 @@ impl EventLoop {
                                         tx.send(Ok(())).expect("Failed to send response");
                                     }
                                 }
-                                _ => {
-                                    info!(target: "torii::relay::client::gossipsub", event = ?event, "Unhandled behaviour event");
-                                }
+                                _ => {}
                             }
                         }
                         SwarmEvent::ConnectionClosed { cause: Some(cause), .. } => {
@@ -276,9 +274,7 @@ impl EventLoop {
                                 return;
                             }
                         }
-                        evt => {
-                            info!(target: "torii::relay::client", event = ?evt, "Unhandled event");
-                        }
+                        _ => {}
                     }
                 },
             }

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -147,7 +147,7 @@ impl Relay {
                             let message = serde_json::from_slice::<ClientMessage>(&message.data);
                             if let Err(e) = message {
                                 info!(
-                                    target: "torii::relay::server",
+                                    target: "torii::relay::server::gossipsub",
                                     error = %e,
                                     "Failed to deserialize message"
                                 );
@@ -176,18 +176,34 @@ impl Relay {
                                     .as_bytes(),
                             ) {
                                 info!(
-                                    target: "torii::relay::server",
+                                    target: "torii::relay::server::gossipsub",
                                     error = %e,
                                     "Failed to publish message"
                                 );
                             }
+                        }
+                        ServerEvent::Gossipsub(gossipsub::Event::Subscribed { peer_id, topic }) => {
+                            info!(
+                                target: "torii::relay::server::gossipsub",
+                                peer_id = %peer_id,
+                                topic = %topic,
+                                "Subscribed to topic"
+                            );
+                        }
+                        ServerEvent::Gossipsub(gossipsub::Event::Unsubscribed { peer_id, topic }) => {
+                            info!(
+                                target: "torii::relay::server::gossipsub",
+                                peer_id = %peer_id,
+                                topic = %topic,
+                                "Unsubscribed from topic"
+                            );
                         }
                         ServerEvent::Identify(identify::Event::Received {
                             info: identify::Info { observed_addr, .. },
                             peer_id,
                         }) => {
                             info!(
-                                target: "torii::relay::server",
+                                target: "torii::relay::server::identify",
                                 peer_id = %peer_id,
                                 observed_addr = %observed_addr,
                                 "Received identify event"
@@ -196,7 +212,7 @@ impl Relay {
                         }
                         ServerEvent::Ping(ping::Event { peer, result, .. }) => {
                             info!(
-                                target: "torii::relay::server",
+                                target: "torii::relay::server::ping",
                                 peer_id = %peer,
                                 result = ?result,
                                 "Received ping event"

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -190,7 +190,10 @@ impl Relay {
                                 "Subscribed to topic"
                             );
                         }
-                        ServerEvent::Gossipsub(gossipsub::Event::Unsubscribed { peer_id, topic }) => {
+                        ServerEvent::Gossipsub(gossipsub::Event::Unsubscribed {
+                            peer_id,
+                            topic,
+                        }) => {
                             info!(
                                 target: "torii::relay::server::gossipsub",
                                 peer_id = %peer_id,

--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -26,19 +26,19 @@ mod test {
             .with_env_filter("torii::relay::client=debug,torii::relay::server=debug")
             .try_init();
         // Initialize the relay server
-        let mut relay_server: Relay = Relay::new(9090, 9091, None, None)?;
+        let mut relay_server: Relay = Relay::new(9900, 9901, None, None)?;
         tokio::spawn(async move {
             relay_server.run().await;
         });
 
         // Initialize the first client (listener)
-        let mut client = RelayClient::new("/ip4/127.0.0.1/tcp/9090".to_string())?;
+        let mut client = RelayClient::new("/ip4/127.0.0.1/tcp/9900".to_string())?;
         tokio::spawn(async move {
             client.event_loop.lock().await.run().await;
         });
 
         client.command_sender.subscribe("mawmaw".to_string()).await?;
-        sleep(Duration::from_secs(1)).await;
+        client.command_sender.wait_for_relay().await?;
         client.command_sender.publish("mawmaw".to_string(), "mimi".as_bytes().to_vec()).await?;
 
         let message_receiver = client.message_receiver.clone();
@@ -73,7 +73,7 @@ mod test {
         // Make sure the cert hash is correct - corresponding to the cert in the relay server
         let mut client = RelayClient::new(
             "/ip4/127.0.0.1/udp/9091/webrtc-direct/certhash/\
-             uEiD6v3wzt8XU3s3SqgNSBJPvn9E0VMVFm8-G0iSEsIIDxw"
+            uEiCAoeHQh49fCHDolECesXO0CPR7fpz0sv0PWVaIahzT4g"
                 .to_string(),
         )?;
 
@@ -81,15 +81,15 @@ mod test {
             client.event_loop.lock().await.run().await;
         });
 
-        // Give some time for the client to start up
-        let _ = wasm_timer::Delay::new(std::time::Duration::from_secs(10)).await;
+        client.command_sender.wait_for_connection().await?;
 
         client.command_sender.subscribe("mawmaw".to_string()).await?;
         let _ = wasm_timer::Delay::new(std::time::Duration::from_secs(1)).await;
         client.command_sender.publish("mawmaw".to_string(), "mimi".as_bytes().to_vec()).await?;
 
-        let timeout = wasm_timer::Delay::new(std::time::Duration::from_secs(5));
-        let message_future = client.message_receiver.next();
+        let timeout = wasm_timer::Delay::new(std::time::Duration::from_secs(2));
+        let mut message_future = client.message_receiver.lock().await;
+        let message_future = message_future.next();
 
         match select(message_future, timeout).await {
             Either::Left((Some(_message), _)) => {

--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -81,10 +81,8 @@ mod test {
             client.event_loop.lock().await.run().await;
         });
 
-        client.command_sender.wait_for_connection().await?;
-
         client.command_sender.subscribe("mawmaw".to_string()).await?;
-        let _ = wasm_timer::Delay::new(std::time::Duration::from_secs(1)).await;
+        client.command_sender.wait_for_relay().await?;
         client.command_sender.publish("mawmaw".to_string(), "mimi".as_bytes().to_vec()).await?;
 
         let timeout = wasm_timer::Delay::new(std::time::Duration::from_secs(2));

--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -73,7 +73,7 @@ mod test {
         // Make sure the cert hash is correct - corresponding to the cert in the relay server
         let mut client = RelayClient::new(
             "/ip4/127.0.0.1/udp/9091/webrtc-direct/certhash/\
-            uEiCAoeHQh49fCHDolECesXO0CPR7fpz0sv0PWVaIahzT4g"
+             uEiCAoeHQh49fCHDolECesXO0CPR7fpz0sv0PWVaIahzT4g"
                 .to_string(),
         )?;
 


### PR DESCRIPTION
adds a command for the client to wait for the relay server to be ready. in cases where the client wants to make sure the relay is listening before trying to publish a message