### PR TITLE
fix(katana-core): crate can't be build without any feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6548,6 +6548,7 @@ dependencies = [
  "katana-provider",
  "lazy_static",
  "parking_lot 0.12.1",
+ "primitive-types",
  "rand",
  "serde",
  "serde_json",

--- a/crates/katana/core/Cargo.toml
+++ b/crates/katana/core/Cargo.toml
@@ -24,7 +24,7 @@ flate2.workspace = true
 futures.workspace = true
 lazy_static = "1.4.0"
 parking_lot.workspace = true
-primitive-types = { version = "0.12.2", features = [ "serde" ] }
+primitive-types = "0.12.2"
 rand = { version = "0.8.5", features = [ "small_rng" ] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/katana/core/Cargo.toml
+++ b/crates/katana/core/Cargo.toml
@@ -24,6 +24,7 @@ flate2.workspace = true
 futures.workspace = true
 lazy_static = "1.4.0"
 parking_lot.workspace = true
+primitive-types = { version = "0.12.2", features = [ "serde" ] }
 rand = { version = "0.8.5", features = [ "small_rng" ] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/katana/core/src/backend/config.rs
+++ b/crates/katana/core/src/backend/config.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use ethers::types::U256;
+use ::primitive_types::U256;
 use katana_primitives::block::GasPrices;
 use katana_primitives::chain::ChainId;
 use katana_primitives::env::BlockEnv;


### PR DESCRIPTION
Currently, compiling `katana-core` will fail if the `messaging` feature is not enabled because we're using the `ethers` outside of the feature's scope. We would want to allow using `katana-core` as is without any features enabled. This issue means that downstream crates that rely on `katana-core` would have to enable this feature even if they don't need it.

Use the `primitive-types` where the `U256` is being exported from, instead of relying on `ethers`, for usage outside of the `messaging` feature scope.

