### PR TITLE
refactor(katana-provider): implement `transaction_in_range` for in-memory and fork providers

### DIFF
--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -170,6 +170,10 @@ where
     ) -> ProviderResult<Option<(BlockNumber, BlockHash)>> {
         TransactionProvider::transaction_block_num_and_hash(&self.provider, hash)
     }
+
+    fn transaction_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxWithHash>> {
+        self.provider.transaction_in_range(range)
+    }
 }
 
 impl<Db> TransactionStatusProvider for BlockchainProvider<Db>

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -1,7 +1,7 @@
 pub mod backend;
 pub mod state;
 
-use std::ops::RangeInclusive;
+use std::ops::{Range, RangeInclusive};
 use std::sync::Arc;
 
 use katana_db::models::block::StoredBlockBodyIndices;
@@ -196,36 +196,11 @@ impl TransactionProvider for ForkedProvider {
         &self,
         block_id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<TxWithHash>>> {
-        let block_num = match block_id {
-            BlockHashOrNumber::Num(num) => Some(num),
-            BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
-        };
-
-        let Some(StoredBlockBodyIndices { tx_offset, tx_count }) =
-            block_num.and_then(|num| self.storage.read().block_body_indices.get(&num).cloned())
-        else {
-            return Ok(None);
-        };
-
-        let offset = tx_offset as usize;
-        let count = tx_count as usize;
-
-        let txs = self
-            .storage
-            .read()
-            .transactions
-            .iter()
-            .enumerate()
-            .skip(offset)
-            .take(count)
-            .map(|(n, tx)| {
-                let hash =
-                    self.storage.read().transaction_hashes.get(&(n as u64)).cloned().unwrap();
-                TxWithHash { hash, transaction: tx.clone() }
-            })
-            .collect();
-
-        Ok(Some(txs))
+        if let Some(indices) = self.block_body_indices(block_id)? {
+            Ok(Some(self.transaction_in_range(Range::from(indices))?))
+        } else {
+            Ok(None)
+        }
     }
 
     fn transaction_by_block_and_idx(
@@ -289,6 +264,28 @@ impl TransactionProvider for ForkedProvider {
         let block_hash = storage_read.block_hashes.get(block_num).expect("block hash should exist");
 
         Ok(Some((*block_num, *block_hash)))
+    }
+
+    fn transaction_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxWithHash>> {
+        let start = range.start as usize;
+        let total = range.end as usize - start;
+
+        let txs = self
+            .storage
+            .read()
+            .transactions
+            .iter()
+            .enumerate()
+            .skip(start)
+            .take(total)
+            .map(|(n, tx)| {
+                let hash =
+                    self.storage.read().transaction_hashes.get(&(n as u64)).cloned().unwrap();
+                TxWithHash { hash, transaction: tx.clone() }
+            })
+            .collect::<Vec<TxWithHash>>();
+
+        Ok(txs)
     }
 }
 

--- a/crates/katana/storage/provider/src/traits/transaction.rs
+++ b/crates/katana/storage/provider/src/traits/transaction.rs
@@ -37,9 +37,7 @@ pub trait TransactionProvider: Send + Sync {
     ) -> ProviderResult<Option<(BlockNumber, BlockHash)>>;
 
     /// Retrieves all the transactions at the given range.
-    fn transaction_in_range(&self, _range: Range<TxNumber>) -> ProviderResult<Vec<TxWithHash>> {
-        todo!()
-    }
+    fn transaction_in_range(&self, range: Range<TxNumber>) -> ProviderResult<Vec<TxWithHash>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]

--- a/crates/katana/storage/provider/tests/block.rs
+++ b/crates/katana/storage/provider/tests/block.rs
@@ -4,6 +4,7 @@ use katana_primitives::block::{
 };
 use katana_primitives::env::BlockEnv;
 use katana_primitives::state::StateUpdatesWithDeclaredClasses;
+use katana_primitives::transaction::TxWithHash;
 use katana_provider::providers::db::DbProvider;
 use katana_provider::providers::fork::ForkedProvider;
 use katana_provider::providers::in_memory::InMemoryProvider;
@@ -62,6 +63,9 @@ where
         + BlockEnvProvider,
 {
     let blocks = generate_dummy_blocks_and_receipts(count);
+    let txs: Vec<TxWithHash> =
+        blocks.iter().flat_map(|(block, _)| block.block.body.clone()).collect();
+    let total_txs = txs.len() as u64;
 
     for (block, receipts) in &blocks {
         provider.insert_block_with_states_and_receipts(
@@ -74,7 +78,11 @@ where
         assert_eq!(provider.latest_hash().unwrap(), block.block.header.hash);
     }
 
+    let actual_transactions_in_range = provider.transaction_in_range(0..total_txs).unwrap();
     let actual_blocks_in_range = provider.blocks_in_range(0..=count)?;
+
+    assert_eq!(total_txs, actual_transactions_in_range.len() as u64);
+    assert_eq!(txs, actual_transactions_in_range);
 
     assert_eq!(actual_blocks_in_range.len(), count as usize);
     assert_eq!(


### PR DESCRIPTION
Refactor how block transactions are fetched in in-memory and fork providers by moving the implementation to `TransactionsProvider::transaction_in_range`, matching `DbProvider`'s implementation.