### PR TITLE
Torii core store u64 primitive as string in db

### DIFF
--- a/crates/dojo-types/src/primitive.rs
+++ b/crates/dojo-types/src/primitive.rs
@@ -138,10 +138,11 @@ impl Primitive {
             Primitive::U8(_)
             | Primitive::U16(_)
             | Primitive::U32(_)
-            | Primitive::U64(_)
             | Primitive::USize(_)
             | Primitive::Bool(_) => SqlType::Integer,
-            Primitive::U128(_)
+
+            Primitive::U64(_)
+            | Primitive::U128(_)
             | Primitive::U256(_)
             | Primitive::ContractAddress(_)
             | Primitive::ClassHash(_)
@@ -160,11 +161,11 @@ impl Primitive {
             Primitive::U8(_)
             | Primitive::U16(_)
             | Primitive::U32(_)
-            | Primitive::U64(_)
             | Primitive::USize(_)
             | Primitive::Bool(_) => Ok(format!("{}", value[0])),
 
-            Primitive::U128(_)
+            Primitive::U64(_)
+            | Primitive::U128(_)
             | Primitive::ContractAddress(_)
             | Primitive::ClassHash(_)
             | Primitive::Felt252(_) => Ok(format!("0x{:064x}", value[0])),

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -239,8 +239,11 @@ pub fn map_row_to_ty(path: &str, struct_ty: &mut Struct, row: &SqliteRow) -> Res
                         primitive.set_u32(Some(value))?;
                     }
                     Primitive::U64(_) => {
-                        let value = row.try_get::<i64, &str>(&column_name)?;
-                        primitive.set_u64(Some(value as u64))?;
+                        let value = row.try_get::<String, &str>(&column_name)?;
+                        let hex_str = value.trim_start_matches("0x");
+                        primitive.set_u64(Some(
+                            u64::from_str_radix(hex_str, 16).map_err(ParseError::ParseIntError)?,
+                        ))?;
                     }
                     Primitive::U128(_) => {
                         let value = row.try_get::<String, &str>(&column_name)?;

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -89,7 +89,7 @@ pub struct Record {
     pub type_u8: u8,
     pub type_u16: u16,
     pub type_u32: u32,
-    pub type_u64: u64,
+    pub type_u64: String,
     pub type_u128: String,
     pub type_u256: String,
     pub type_bool: bool,

--- a/crates/torii/graphql/src/tests/models_test.rs
+++ b/crates/torii/graphql/src/tests/models_test.rs
@@ -198,10 +198,10 @@ mod tests {
 
         // where filter LT and GT
         let records =
-            records_model_query(&schema, "(where: { type_u32GT: 2, type_u64LT: 4 })").await;
+            records_model_query(&schema, "(where: { type_u32GT: 2, type_u16LT: 4 })").await;
         let connection: Connection<Record> = serde_json::from_value(records).unwrap();
         let first_record = connection.edges.first().unwrap();
-        assert_eq!(first_record.node.type_u64, 3);
+        assert_eq!(first_record.node.type_u16, 3);
 
         // NOTE: Server side is gonna parse "0x5" and "5" to hexadecimal format
         let felt_str_0x5 = "0x5";
@@ -219,6 +219,14 @@ mod tests {
         let connection: Connection<Record> = serde_json::from_value(records).unwrap();
         let first_record = connection.edges.first().unwrap();
         assert_eq!(first_record.node.type_class_hash, "0x5");
+
+        // where filter EQ on u64 (string)
+        let records =
+            records_model_query(&schema, &format!("(where: {{ type_u64: \"{}\" }})", felt_str_0x5))
+                .await;
+        let connection: Connection<Record> = serde_json::from_value(records).unwrap();
+        let first_record = connection.edges.first().unwrap();
+        assert_eq!(first_record.node.type_u64, "0x5");
 
         // where filter GTE on u128 (string)
         let records = records_model_query(

--- a/crates/torii/graphql/src/tests/subscription_test.rs
+++ b/crates/torii/graphql/src/tests/subscription_test.rs
@@ -35,7 +35,7 @@ mod tests {
                         "depth": "Zero",
                         "record_id": 0,
                         "typeU16": 1,
-                        "type_u64": 1,
+                        "type_u64": "0x1",
                         "typeBool": true,
                         "type_felt": format!("{:#x}", FieldElement::from(1u128)),
                         "typeContractAddress": format!("{:#x}", FieldElement::ONE)


### PR DESCRIPTION
Currently, cairo u64 types are indexed as integers in db, but sqlite treat integers as i64. Values above 2^63 - 1 are converted to floating point. This results in precision loss and also error querying grpc/graphql
```
2024-02-07T19:54:41.297884Z ERROR torii_grpc::server::subscriptions::entity: error when publishing entity update: error occurred while decoding column "Round$duelist_a.salt": mismatched types; Rust type `i64` (as SQL type `INTEGER`) is not compatible with SQL type `REAL` target="subscription"
```

This PR changes indexing u64 types to strings. This affects dynamically created tables which we don't have a good way to apply migration.