### PR TITLE
refactor(katana-rpc): isolate dev JSON RPC API from `katana` namespace

### DIFF
--- a/bin/katana/src/args.rs
+++ b/bin/katana/src/args.rs
@@ -212,12 +212,10 @@ impl KatanaArgs {
     }
 
     pub fn server_config(&self) -> ServerConfig {
-        let mut apis = vec![ApiKind::Starknet];
+        let mut apis = vec![ApiKind::Starknet, ApiKind::Katana];
         // only enable `katana` API in dev mode
         if self.dev {
             apis.push(ApiKind::Dev);
-        } else {
-            apis.push(ApiKind::Katana);
         }
 
         ServerConfig {

--- a/bin/katana/src/args.rs
+++ b/bin/katana/src/args.rs
@@ -215,6 +215,8 @@ impl KatanaArgs {
         let mut apis = vec![ApiKind::Starknet];
         // only enable `katana` API in dev mode
         if self.dev {
+            apis.push(ApiKind::Dev);
+        } else {
             apis.push(ApiKind::Katana);
         }
 

--- a/crates/katana/rpc/rpc-api/src/dev.rs
+++ b/crates/katana/rpc/rpc-api/src/dev.rs
@@ -9,7 +9,7 @@ pub trait DevApi {
     async fn generate_block(&self) -> RpcResult<()>;
 
     #[method(name = "nextBlockTimestamp")]
-    async fn next_block_timestamp(&self) -> RpcResult<u64>;
+    async fn next_block_timestamp(&self) -> RpcResult<()>;
 
     #[method(name = "setNextBlockTimestamp")]
     async fn set_next_block_timestamp(&self, timestamp: u64) -> RpcResult<()>;

--- a/crates/katana/rpc/rpc-api/src/dev.rs
+++ b/crates/katana/rpc/rpc-api/src/dev.rs
@@ -1,0 +1,27 @@
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+use katana_primitives::FieldElement;
+
+#[cfg_attr(not(feature = "client"), rpc(server, namespace = "dev"))]
+#[cfg_attr(feature = "client", rpc(client, server, namespace = "dev"))]
+pub trait DevApi {
+    #[method(name = "generateBlock")]
+    async fn generate_block(&self) -> RpcResult<()>;
+
+    #[method(name = "nextBlockTimestamp")]
+    async fn next_block_timestamp(&self) -> RpcResult<u64>;
+
+    #[method(name = "setNextBlockTimestamp")]
+    async fn set_next_block_timestamp(&self, timestamp: u64) -> RpcResult<()>;
+
+    #[method(name = "increaseNextBlockTimestamp")]
+    async fn increase_next_block_timestamp(&self, timestamp: u64) -> RpcResult<()>;
+
+    #[method(name = "setStorageAt")]
+    async fn set_storage_at(
+        &self,
+        contract_address: FieldElement,
+        key: FieldElement,
+        value: FieldElement,
+    ) -> RpcResult<()>;
+}

--- a/crates/katana/rpc/rpc-api/src/katana.rs
+++ b/crates/katana/rpc/rpc-api/src/katana.rs
@@ -1,31 +1,10 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
-use katana_primitives::FieldElement;
 use katana_rpc_types::account::Account;
 
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "katana"))]
 #[cfg_attr(feature = "client", rpc(client, server, namespace = "katana"))]
 pub trait KatanaApi {
-    #[method(name = "generateBlock")]
-    async fn generate_block(&self) -> RpcResult<()>;
-
-    #[method(name = "nextBlockTimestamp")]
-    async fn next_block_timestamp(&self) -> RpcResult<u64>;
-
-    #[method(name = "setNextBlockTimestamp")]
-    async fn set_next_block_timestamp(&self, timestamp: u64) -> RpcResult<()>;
-
-    #[method(name = "increaseNextBlockTimestamp")]
-    async fn increase_next_block_timestamp(&self, timestamp: u64) -> RpcResult<()>;
-
     #[method(name = "predeployedAccounts")]
     async fn predeployed_accounts(&self) -> RpcResult<Vec<Account>>;
-
-    #[method(name = "setStorageAt")]
-    async fn set_storage_at(
-        &self,
-        contract_address: FieldElement,
-        key: FieldElement,
-        value: FieldElement,
-    ) -> RpcResult<()>;
 }

--- a/crates/katana/rpc/rpc-api/src/lib.rs
+++ b/crates/katana/rpc/rpc-api/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod dev;
 pub mod katana;
 pub mod starknet;
 
@@ -6,4 +7,5 @@ pub mod starknet;
 pub enum ApiKind {
     Starknet,
     Katana,
+    Dev,
 }

--- a/crates/katana/rpc/rpc/src/dev.rs
+++ b/crates/katana/rpc/rpc/src/dev.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use jsonrpsee::core::{async_trait, Error};
+use katana_core::sequencer::KatanaSequencer;
+use katana_primitives::FieldElement;
+use katana_rpc_api::dev::DevApiServer;
+use katana_rpc_types::error::katana::KatanaApiError;
+
+pub struct DevApiImpl {
+    sequencer: Arc<KatanaSequencer>,
+}
+
+impl DevApiImpl {
+    pub fn new(sequencer: Arc<KatanaSequencer>) -> Self {
+        Self { sequencer }
+    }
+}
+
+#[async_trait]
+impl DevApiServer for DevApiImpl {
+    async fn generate_block(&self) -> Result<(), Error> {
+        self.sequencer.block_producer().force_mine();
+        Ok(())
+    }
+
+    async fn next_block_timestamp(&self) -> Result<u64, Error> {
+        // Ok(self.sequencer.backend().env.read().block.block_timestamp.0)
+        unimplemented!()
+    }
+
+    async fn set_next_block_timestamp(&self, timestamp: u64) -> Result<(), Error> {
+        self.sequencer
+            .set_next_block_timestamp(timestamp)
+            .map_err(|_| Error::from(KatanaApiError::FailedToChangeNextBlockTimestamp))
+    }
+
+    async fn increase_next_block_timestamp(&self, timestamp: u64) -> Result<(), Error> {
+        self.sequencer
+            .increase_next_block_timestamp(timestamp)
+            .map_err(|_| Error::from(KatanaApiError::FailedToChangeNextBlockTimestamp))
+    }
+
+    async fn set_storage_at(
+        &self,
+        _contract_address: FieldElement,
+        _key: FieldElement,
+        _value: FieldElement,
+    ) -> Result<(), Error> {
+        // self.sequencer
+        //     .set_storage_at(contract_address.into(), key, value)
+        //     .await
+        //     .map_err(|_| Error::from(KatanaApiError::FailedToUpdateStorage))
+        Ok(())
+    }
+}

--- a/crates/katana/rpc/rpc/src/dev.rs
+++ b/crates/katana/rpc/rpc/src/dev.rs
@@ -6,26 +6,26 @@ use katana_primitives::FieldElement;
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_types::error::katana::KatanaApiError;
 
-pub struct DevApiImpl {
+pub struct DevApi {
     sequencer: Arc<KatanaSequencer>,
 }
 
-impl DevApiImpl {
+impl DevApi {
     pub fn new(sequencer: Arc<KatanaSequencer>) -> Self {
         Self { sequencer }
     }
 }
 
 #[async_trait]
-impl DevApiServer for DevApiImpl {
+impl DevApiServer for DevApi {
     async fn generate_block(&self) -> Result<(), Error> {
         self.sequencer.block_producer().force_mine();
         Ok(())
     }
 
-    async fn next_block_timestamp(&self) -> Result<u64, Error> {
+    async fn next_block_timestamp(&self) -> Result<(), Error> {
         // Ok(self.sequencer.backend().env.read().block.block_timestamp.0)
-        unimplemented!()
+        Ok(())
     }
 
     async fn set_next_block_timestamp(&self, timestamp: u64) -> Result<(), Error> {

--- a/crates/katana/rpc/rpc/src/katana.rs
+++ b/crates/katana/rpc/rpc/src/katana.rs
@@ -2,10 +2,8 @@ use std::sync::Arc;
 
 use jsonrpsee::core::{async_trait, Error};
 use katana_core::sequencer::KatanaSequencer;
-use katana_primitives::FieldElement;
 use katana_rpc_api::katana::KatanaApiServer;
 use katana_rpc_types::account::Account;
-use katana_rpc_types::error::katana::KatanaApiError;
 
 pub struct KatanaApi {
     sequencer: Arc<KatanaSequencer>,
@@ -19,28 +17,6 @@ impl KatanaApi {
 
 #[async_trait]
 impl KatanaApiServer for KatanaApi {
-    async fn generate_block(&self) -> Result<(), Error> {
-        self.sequencer.block_producer().force_mine();
-        Ok(())
-    }
-
-    async fn next_block_timestamp(&self) -> Result<u64, Error> {
-        // Ok(self.sequencer.backend().env.read().block.block_timestamp.0)
-        unimplemented!()
-    }
-
-    async fn set_next_block_timestamp(&self, timestamp: u64) -> Result<(), Error> {
-        self.sequencer
-            .set_next_block_timestamp(timestamp)
-            .map_err(|_| Error::from(KatanaApiError::FailedToChangeNextBlockTimestamp))
-    }
-
-    async fn increase_next_block_timestamp(&self, timestamp: u64) -> Result<(), Error> {
-        self.sequencer
-            .increase_next_block_timestamp(timestamp)
-            .map_err(|_| Error::from(KatanaApiError::FailedToChangeNextBlockTimestamp))
-    }
-
     async fn predeployed_accounts(&self) -> Result<Vec<Account>, Error> {
         Ok(self
             .sequencer
@@ -50,18 +26,5 @@ impl KatanaApiServer for KatanaApi {
             .accounts()
             .map(|e| Account::new(*e.0, e.1))
             .collect())
-    }
-
-    async fn set_storage_at(
-        &self,
-        _contract_address: FieldElement,
-        _key: FieldElement,
-        _value: FieldElement,
-    ) -> Result<(), Error> {
-        // self.sequencer
-        //     .set_storage_at(contract_address.into(), key, value)
-        //     .await
-        //     .map_err(|_| Error::from(KatanaApiError::FailedToUpdateStorage))
-        Ok(())
     }
 }

--- a/crates/katana/rpc/rpc/src/lib.rs
+++ b/crates/katana/rpc/rpc/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod dev;
 pub mod katana;
 pub mod starknet;
 
@@ -34,6 +35,9 @@ pub async fn spawn(sequencer: Arc<KatanaSequencer>, config: ServerConfig) -> Res
                 methods.merge(StarknetApi::new(sequencer.clone()).into_rpc())?;
             }
             ApiKind::Katana => {
+                methods.merge(KatanaApi::new(sequencer.clone()).into_rpc())?;
+            }
+            ApiKind::Dev => {
                 methods.merge(KatanaApi::new(sequencer.clone()).into_rpc())?;
             }
         }

--- a/crates/katana/rpc/rpc/src/lib.rs
+++ b/crates/katana/rpc/rpc/src/lib.rs
@@ -17,11 +17,13 @@ use jsonrpsee::tracing::debug;
 use jsonrpsee::types::Params;
 use jsonrpsee::RpcModule;
 use katana_core::sequencer::KatanaSequencer;
+use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::katana::KatanaApiServer;
 use katana_rpc_api::starknet::StarknetApiServer;
 use katana_rpc_api::ApiKind;
 use tower_http::cors::{Any, CorsLayer};
 
+use crate::dev::DevApi;
 use crate::katana::KatanaApi;
 use crate::starknet::StarknetApi;
 
@@ -38,7 +40,7 @@ pub async fn spawn(sequencer: Arc<KatanaSequencer>, config: ServerConfig) -> Res
                 methods.merge(KatanaApi::new(sequencer.clone()).into_rpc())?;
             }
             ApiKind::Dev => {
-                methods.merge(KatanaApi::new(sequencer.clone()).into_rpc())?;
+                methods.merge(DevApi::new(sequencer.clone()).into_rpc())?;
             }
         }
     }


### PR DESCRIPTION
issue #1537 

Task 

- [x] 1.katana/rpc/rpc-api defines the method and it's namespace, create a new namespace called dev.
- [x] 2.The implementation must go under katana/rpc/rpc.
- [x] 3.No new types should be introduced into katana/rpc/rpc-types for now.
 