### PR TITLE
fix: ensure DevApi is also present in test sequencer

### DIFF
--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -43,7 +43,7 @@ impl TestSequencer {
                 port: 0,
                 host: "127.0.0.1".into(),
                 max_connections: 100,
-                apis: vec![ApiKind::Starknet, ApiKind::Katana],
+                apis: vec![ApiKind::Starknet, ApiKind::Katana, ApiKind::Dev],
             },
         )
         .await


### PR DESCRIPTION
Small fix to ensure test sequencer can use `DevApi` by default.