### PR TITLE
feat(sozo): propose multicall format for `sozo auth writer`

### DIFF
--- a/bin/sozo/src/commands/auth.rs
+++ b/bin/sozo/src/commands/auth.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 use dojo_world::metadata::dojo_metadata_from_workspace;
 use scarb::core::Config;
-use starknet::core::types::FieldElement;
 
 use super::options::account::AccountOptions;
 use super::options::starknet::StarknetOptions;
@@ -20,11 +19,13 @@ pub struct AuthArgs {
 pub enum AuthCommand {
     #[command(about = "Auth a system with the given calldata.")]
     Writer {
-        #[arg(help = "Name of the model to grant write access to.")]
-        model: String,
-
-        #[arg(help = "Address of the contract to grant writer access to.")]
-        contract: FieldElement,
+        #[arg(num_args = 1..)]
+        #[arg(required = true)]
+        #[arg(value_name = "model,contract_address")]
+        #[arg(help = "A list of models and contract address to grant write access to. Comma \
+                      separated values to indicate model name and contract address e.g. \
+                      model_name,0x1234 model_name,0x1111 ")]
+        models_contracts: Vec<String>,
 
         #[command(flatten)]
         world: WorldOptions,

--- a/bin/sozo/src/ops/auth.rs
+++ b/bin/sozo/src/ops/auth.rs
@@ -3,20 +3,44 @@ use dojo_world::contracts::cairo_utils;
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::metadata::Environment;
 use dojo_world::utils::TransactionWaiter;
+use starknet::accounts::Account;
+use starknet::core::types::FieldElement;
 
 use crate::commands::auth::AuthCommand;
 
 pub async fn execute(command: AuthCommand, env_metadata: Option<Environment>) -> Result<()> {
     match command {
-        AuthCommand::Writer { model, contract, world, starknet, account, transaction } => {
+        AuthCommand::Writer { models_contracts, world, starknet, account, transaction } => {
             let world_address = world.address(env_metadata.as_ref())?;
             let provider = starknet.provider(env_metadata.as_ref())?;
 
             let account = account.account(&provider, env_metadata.as_ref()).await?;
             let world = WorldContract::new(world_address, &account);
 
-            let res = world
-                .grant_writer(&cairo_utils::str_to_felt(&model)?, &contract.into())
+            let mut calls = vec![];
+
+            for mc in models_contracts {
+                let parts: Vec<&str> = mc.split(',').collect();
+
+                let (model, contract_part) = match parts.as_slice() {
+                    [model, contract] => (model.to_string(), *contract),
+                    _ => anyhow::bail!(
+                        "Model and contract address are expected to be comma separated: `sozo \
+                         auth writer model_name,0x1234`"
+                    ),
+                };
+
+                let contract = FieldElement::from_hex_be(contract_part)
+                    .map_err(|_| anyhow::anyhow!("Invalid contract address: {}", contract_part))?;
+
+                calls.push(
+                    world
+                        .grant_writer_getcall(&cairo_utils::str_to_felt(&model)?, &contract.into()),
+                );
+            }
+
+            let res = account
+                .execute(calls)
                 .send()
                 .await
                 .with_context(|| "Failed to send transaction")?;


### PR DESCRIPTION
Auth initialization can be a very long step on public network. Having multicall support here can help.

I'm not sure if the proposed format in this PR is the most appropriate, but it's easy to script:
```
sozo auth writer model1,0x1234 model2,01234 model2,0x111
```
Open to any other suggestion!