### PR TITLE
Fix(sozo): Improve sozo migration output

### DIFF
--- a/bin/sozo/src/ops/migration/mod.rs
+++ b/bin/sozo/src/ops/migration/mod.rs
@@ -486,7 +486,7 @@ where
 
     TransactionWaiter::new(transaction_hash, migrator.provider()).await?;
 
-    ui.print_sub(format!("All models are registered at: {transaction_hash:#x}"));
+    ui.print(format!("All models are registered at: {transaction_hash:#x}"));
 
     Ok(Some(RegisterOutput { transaction_hash, declare_output }))
 }

--- a/bin/sozo/src/ops/migration/mod.rs
+++ b/bin/sozo/src/ops/migration/mod.rs
@@ -486,8 +486,6 @@ where
 
     TransactionWaiter::new(transaction_hash, migrator.provider()).await?;
 
-    ui.print_header(format!("======================================================"));
-
     ui.print_sub(format!("All models are registered at: {transaction_hash:#x}"));
 
     Ok(Some(RegisterOutput { transaction_hash, declare_output }))

--- a/bin/sozo/src/ops/migration/mod.rs
+++ b/bin/sozo/src/ops/migration/mod.rs
@@ -486,7 +486,9 @@ where
 
     TransactionWaiter::new(transaction_hash, migrator.provider()).await?;
 
-    ui.print_sub(format!("Registered at: {transaction_hash:#x}"));
+    ui.print_header(format!("======================================================"));
+
+    ui.print_sub(format!("All models are registered at: {transaction_hash:#x}"));
 
     Ok(Some(RegisterOutput { transaction_hash, declare_output }))
 }


### PR DESCRIPTION
- Fixes  #1558 
Added an additional divider line between the initial messages and final model registration message to make it clearer.