### PR TITLE
feat: add [dojo::interface] attribute

### DIFF
--- a/crates/dojo-lang/src/contract.rs
+++ b/crates/dojo-lang/src/contract.rs
@@ -308,16 +308,17 @@ impl DojoContract {
                 {
                     let has_good_pos = (add_self && idx == 0) || (!add_self && idx == 1);
                     let has_good_name = name.eq(&"world".to_string());
-                    
+
                     if has_good_pos && has_good_name {
                         world_removed = true;
                         None
-                    }
-                    else {
+                    } else {
                         if !has_good_pos {
                             self.diagnostics.push(PluginDiagnostic {
                                 stable_ptr: param.stable_ptr().untyped(),
-                                message: "The IWorldDispatcher parameter must be the first parameter of the function (self excluded).".to_string(),
+                                message: "The IWorldDispatcher parameter must be the first \
+                                          parameter of the function (self excluded)."
+                                    .to_string(),
                                 severity: Severity::Error,
                             });
                         }
@@ -325,7 +326,8 @@ impl DojoContract {
                         if !has_good_name {
                             self.diagnostics.push(PluginDiagnostic {
                                 stable_ptr: param.stable_ptr().untyped(),
-                                message: "The IWorldDispatcher parameter must be named 'world'.".to_string(),
+                                message: "The IWorldDispatcher parameter must be named 'world'."
+                                    .to_string(),
                                 severity: Severity::Error,
                             });
                         }

--- a/crates/dojo-lang/src/interface.rs
+++ b/crates/dojo-lang/src/interface.rs
@@ -1,0 +1,151 @@
+use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
+use cairo_lang_defs::plugin::{
+    PluginDiagnostic, PluginGeneratedFile, PluginResult,
+};
+use cairo_lang_diagnostics::Severity;
+use cairo_lang_syntax::node::{ast, ids, Terminal, TypedSyntaxNode};
+use cairo_lang_syntax::node::db::SyntaxGroup;
+use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
+
+pub struct DojoInterface {
+    diagnostics: Vec<PluginDiagnostic>,
+}
+
+impl DojoInterface {
+    pub fn from_trait(db: &dyn SyntaxGroup, trait_ast: ast::ItemTrait) -> PluginResult {
+        let name = trait_ast.name(db).text(db);
+        let mut system = DojoInterface { diagnostics: vec![] };
+        let mut builder = PatchBuilder::new(db);
+
+        if let ast::MaybeTraitBody::Some(body) = trait_ast.body(db) {
+            let body_nodes: Vec<_> = body
+                .items(db)
+                .elements(db)
+                .iter()
+                .flat_map(|el| {
+                      if let ast::TraitItem::Function(fn_ast) = el {
+                        return system.rewrite_function(db, fn_ast.clone());
+                    }
+
+                    system.diagnostics.push(PluginDiagnostic {
+                        stable_ptr: el.stable_ptr().untyped(),
+                        message: "Anything other than functions is not supported in a dojo::interface".to_string(),
+                        severity: Severity::Error,
+                    });
+
+                    vec![]
+                })
+                .collect();
+
+            builder.add_modified(RewriteNode::interpolate_patched(
+                "
+                #[starknet::interface]
+                trait $name$<TContractState> {
+                    $body$
+                }
+                ",
+                &UnorderedHashMap::from([
+                    ("name".to_string(), RewriteNode::Text(name.to_string())),
+                    ("body".to_string(), RewriteNode::new_modified(body_nodes)),
+                ]),
+            ));
+        }
+        else {
+            // empty trait
+            builder.add_modified(RewriteNode::interpolate_patched(
+                "
+                #[starknet::interface]
+                trait $name$<TContractState> {}
+                ",
+                &UnorderedHashMap::from([
+                    ("name".to_string(), RewriteNode::Text(name.to_string())),
+                ]),
+            ));
+        }
+        
+        PluginResult {
+            code: Some(PluginGeneratedFile {
+                name: name.clone(),
+                content: builder.code,
+                aux_data: None,
+                code_mappings: builder.code_mappings,
+            }),
+            diagnostics: system.diagnostics,
+            remove_original_item: true,
+        }
+    }
+
+    /// Rewrites parameter list  by adding `self` parameter if missing.
+    ///
+    /// Reports an error in case of `ref self` as systems are supposed to be 100% stateless.
+    pub fn rewrite_parameters(
+        &mut self,
+        db: &dyn SyntaxGroup,
+        param_list: ast::ParamList,
+        diagnostic_item: ids::SyntaxStablePtrId
+    ) -> String {
+        let mut params = param_list.elements(db)
+            .iter()
+            .map(|e| e.as_syntax_node().get_text(db))
+            .collect::<Vec<_>>();
+
+        let mut need_to_add_self = true;
+        if !params.is_empty() {
+            let first_param = param_list.elements(db)[0].clone();
+            let param_name = first_param.name(db).text(db).to_string();
+
+            if param_name.eq(&"self".to_string()) {
+                let param_modifiers = first_param
+                    .modifiers(db).elements(db)
+                    .iter().map(|e|e.as_syntax_node().get_text(db).trim().to_string())
+                    .collect::<Vec<_>>();
+
+                let param_type = first_param
+                    .type_clause(db).ty(db).as_syntax_node()
+                    .get_text(db).trim().to_string();
+
+                if param_modifiers.contains(&"ref".to_string()) && param_type.eq(&"TContractState".to_string()) {
+                    self.diagnostics.push(PluginDiagnostic {
+                        stable_ptr: diagnostic_item,
+                        message: "Functions of dojo::interface cannot have `ref self` parameter.".to_string(),
+                        severity: Severity::Error,
+                    });
+
+                    need_to_add_self = false;
+                }
+
+                if param_type.eq(&"@TContractState".to_string()) {
+                    need_to_add_self = false;
+                }
+            }
+        };
+
+        if need_to_add_self {
+            params.insert(0, "self: @TContractState".to_string());
+        }
+
+        params.join(", ")
+    }
+
+    /// Rewrites function declaration by adding `self` parameter if missing,
+    pub fn rewrite_function(
+        &mut self,
+        db: &dyn SyntaxGroup,
+        fn_ast: ast::TraitItemFunction,
+    ) -> Vec<RewriteNode> {
+        let mut rewritten_fn = RewriteNode::from_ast(&fn_ast);
+        let rewritten_params = rewritten_fn
+            .modify_child(db, ast::TraitItemFunction::INDEX_DECLARATION)
+            .modify_child(db, ast::FunctionDeclaration::INDEX_SIGNATURE)
+            .modify_child(db, ast::FunctionSignature::INDEX_PARAMETERS);
+
+        rewritten_params.set_str(
+            self.rewrite_parameters(
+                db,
+                fn_ast.declaration(db).signature(db).parameters(db),
+                fn_ast.stable_ptr().untyped()
+            )
+        );
+        vec![rewritten_fn]
+    }
+}

--- a/crates/dojo-lang/src/lib.rs
+++ b/crates/dojo-lang/src/lib.rs
@@ -5,8 +5,8 @@
 //! Learn more at [dojoengine.gg](http://dojoengine.gg).
 pub mod compiler;
 pub mod contract;
-pub mod interface;
 pub mod inline_macros;
+pub mod interface;
 pub mod introspect;
 pub mod model;
 pub mod plugin;

--- a/crates/dojo-lang/src/lib.rs
+++ b/crates/dojo-lang/src/lib.rs
@@ -5,6 +5,7 @@
 //! Learn more at [dojoengine.gg](http://dojoengine.gg).
 pub mod compiler;
 pub mod contract;
+pub mod interface;
 pub mod inline_macros;
 pub mod introspect;
 pub mod model;

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -23,18 +23,18 @@ use smol_str::SmolStr;
 use url::Url;
 
 use crate::contract::DojoContract;
-use crate::interface::DojoInterface;
 use crate::inline_macros::array_cap::ArrayCapMacro;
 use crate::inline_macros::delete::DeleteMacro;
 use crate::inline_macros::emit::EmitMacro;
 use crate::inline_macros::get::GetMacro;
 use crate::inline_macros::set::SetMacro;
+use crate::interface::DojoInterface;
 use crate::introspect::{handle_introspect_enum, handle_introspect_struct};
 use crate::model::handle_model_struct;
 use crate::print::{handle_print_enum, handle_print_struct};
 
 const DOJO_CONTRACT_ATTR: &str = "dojo::contract";
-const DOJO_INTERFACE_ATTR:  &str = "dojo::interface";
+const DOJO_INTERFACE_ATTR: &str = "dojo::interface";
 const DOJO_PLUGIN_EXPAND_VAR_ENV: &str = "DOJO_PLUGIN_EXPAND";
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -23,6 +23,7 @@ use smol_str::SmolStr;
 use url::Url;
 
 use crate::contract::DojoContract;
+use crate::interface::DojoInterface;
 use crate::inline_macros::array_cap::ArrayCapMacro;
 use crate::inline_macros::delete::DeleteMacro;
 use crate::inline_macros::emit::EmitMacro;
@@ -33,6 +34,7 @@ use crate::model::handle_model_struct;
 use crate::print::{handle_print_enum, handle_print_struct};
 
 const DOJO_CONTRACT_ATTR: &str = "dojo::contract";
+const DOJO_INTERFACE_ATTR:  &str = "dojo::interface";
 const DOJO_PLUGIN_EXPAND_VAR_ENV: &str = "DOJO_PLUGIN_EXPAND";
 
 #[derive(Clone, Debug, PartialEq)]
@@ -96,6 +98,14 @@ impl BuiltinDojoPlugin {
     fn handle_mod(&self, db: &dyn SyntaxGroup, module_ast: ast::ItemModule) -> PluginResult {
         if module_ast.has_attr(db, DOJO_CONTRACT_ATTR) {
             return DojoContract::from_module(db, module_ast);
+        }
+
+        PluginResult::default()
+    }
+
+    fn handle_trait(&self, db: &dyn SyntaxGroup, trait_ast: ast::ItemTrait) -> PluginResult {
+        if trait_ast.has_attr(db, DOJO_INTERFACE_ATTR) {
+            return DojoInterface::from_trait(db, trait_ast);
         }
 
         PluginResult::default()
@@ -246,6 +256,7 @@ impl MacroPlugin for BuiltinDojoPlugin {
 
         match item_ast {
             ast::ModuleItem::Module(module_ast) => self.handle_mod(db, module_ast),
+            ast::ModuleItem::Trait(trait_ast) => self.handle_trait(db, trait_ast),
             ast::ModuleItem::Enum(enum_ast) => {
                 let aux_data = DojoAuxData::default();
                 let mut rewrite_nodes = vec![];

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -84,6 +84,26 @@ mod withcomponent {
         testcomponent2_event: testcomponent2::Event,
     }
 }
+#[dojo::interface]
+trait IEmptyTrait;
+
+#[dojo::interface]
+trait IActions {
+    // TODO
+    // it looks like there is a bug in trait parsing because if a value is set
+    // on a constant, this value appears alone in the trait...
+    const ONE: u8;
+
+    fn do_no_param();
+    fn do_no_param_but_self(self: @TContractState);
+    fn do_params(p1: dojo_examples::models::Direction, p2: u8);
+    fn do_params_and_self(self: @TContractState, p2: u8);
+    fn do_return_value(p1: u8) -> u16;
+    fn do_ref_self(ref self: TContractState);
+
+    #[my_attr]
+    fn do_with_attrs(p1: u8) -> u16;
+}
 
 //! > generated_cairo_code
 #[starknet::contract]
@@ -205,6 +225,16 @@ error: Unsupported attribute.
 #[starknet::component]
 ^********************^
 
+error: Anything other than functions is not supported in a dojo::interface
+ --> test_src/lib.cairo:89:5
+    const ONE: u8;
+    ^************^
+
+error: Functions of dojo::interface cannot have `ref self` parameter.
+ --> test_src/lib.cairo:96:5
+    fn do_ref_self(ref self: TContractState);
+    ^***************************************^
+
 error: Unsupported attribute.
  --> test_src/lib.cairo[spawn]:2:17
                 #[starknet::contract]
@@ -229,6 +259,11 @@ error: Unsupported attribute.
  --> test_src/lib.cairo[withcomponent]:2:17
                 #[starknet::contract]
                 ^*******************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:98:5
+    #[my_attr]
+    ^********^
 
 error: Unsupported attribute.
  --> test_src/lib.cairo:49:5
@@ -700,4 +735,22 @@ impl TestEventDrop of core::traits::Drop::<TestEvent>;
             }
 impl EventDrop of core::traits::Drop::<Event>;
             
+                }
+
+                #[starknet::interface]
+                trait IEmptyTrait<TContractState> {}
+
+                #[starknet::interface]
+                trait IActions<TContractState> {
+                    
+    fn do_no_param(self: @TContractState);
+    fn do_no_param_but_self(self: @TContractState);
+    fn do_params(self: @TContractState, p1: dojo_examples::models::Direction, p2: u8);
+    fn do_params_and_self(self: @TContractState, p2: u8);
+    fn do_return_value(self: @TContractState, p1: u8) -> u16;
+    fn do_ref_self(ref self: TContractState);
+
+    #[my_attr]
+    fn do_with_attrs(self: @TContractState, p1: u8) -> u16;
+
                 }

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -88,12 +88,17 @@ mod withcomponent {
 trait IEmptyTrait;
 
 #[dojo::interface]
-trait IActions {
+trait ITraitWithConstant {
     /// Even if it looks weird, the expected pattern for a constant in a trait is
     /// `const <name>: <type>;`
     /// See: https://github.com/starkware-libs/cairo/blob/600553d34a1af93ff7fb038ac677efdd3fd07010/crates/cairo-lang-parser/src/parser.rs#L835
     const ONE: u8;
 
+    fn do_no_param();
+}
+
+#[dojo::interface]
+trait INominalTrait {
     fn do_no_param();
     fn do_no_param_but_self(self: @TContractState);
     fn do_params(p1: dojo_examples::models::Direction, p2: u8);
@@ -267,7 +272,7 @@ error: Anything other than functions is not supported in a dojo::interface
     ^************^
 
 error: Functions of dojo::interface cannot have `ref self` parameter.
- --> test_src/lib.cairo:96:5
+ --> test_src/lib.cairo:101:5
     fn do_ref_self(ref self: TContractState);
     ^***************************************^
 
@@ -297,7 +302,7 @@ error: Unsupported attribute.
                 ^*******************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:98:5
+ --> test_src/lib.cairo:103:5
     #[my_attr]
     ^********^
 
@@ -542,17 +547,17 @@ error: Unsupported attribute.
                     ^**************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:110:5
+ --> test_src/lib.cairo:115:5
     #[external(v0)]
     ^*************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:116:5
+ --> test_src/lib.cairo:121:5
     #[external(v0)]
     ^*************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:122:5
+ --> test_src/lib.cairo:127:5
     #[external(v0)]
     ^*************^
 
@@ -832,9 +837,15 @@ impl EventDrop of core::traits::Drop::<Event>;
                 trait IEmptyTrait<TContractState> {}
 
                 #[starknet::interface]
-                trait IActions<TContractState> {
+                trait ITraitWithConstant<TContractState> {
                     
     fn do_no_param(self: @TContractState);
+
+                }
+
+                #[starknet::interface]
+                trait INominalTrait<TContractState> {
+                        fn do_no_param(self: @TContractState);
     fn do_no_param_but_self(self: @TContractState);
     fn do_params(self: @TContractState, p1: dojo_examples::models::Direction, p2: u8);
     fn do_params_and_self(self: @TContractState, p2: u8);

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -88,13 +88,16 @@ mod withcomponent {
 trait IEmptyTrait;
 
 #[dojo::interface]
-trait ITraitWithConstant {
+trait IFaultyTrait {
     /// Even if it looks weird, the expected pattern for a constant in a trait is
     /// `const <name>: <type>;`
     /// See: https://github.com/starkware-libs/cairo/blob/600553d34a1af93ff7fb038ac677efdd3fd07010/crates/cairo-lang-parser/src/parser.rs#L835
     const ONE: u8;
 
-    fn do_no_param();
+    fn do_ref_self(ref self: TContractState);
+
+    #[my_attr]
+    fn do_with_attrs(p1: u8) -> u16;
 }
 
 #[dojo::interface]
@@ -104,14 +107,80 @@ trait INominalTrait {
     fn do_params(p1: dojo_examples::models::Direction, p2: u8);
     fn do_params_and_self(self: @TContractState, p2: u8);
     fn do_return_value(p1: u8) -> u16;
-    fn do_ref_self(ref self: TContractState);
-
-    #[my_attr]
-    fn do_with_attrs(p1: u8) -> u16;
 }
 
 #[dojo::contract]
-mod MyContract {
+mod MyFaultyContract {
+
+    #[external(v0)]
+    fn do_with_ref_self(ref self: ContractState) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_several_world_dispatchers(
+        world: IWorldDispatcher,
+        vec: Vec2,
+        another_world: IWorldDispatcher
+    ) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_self_and_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_self_and_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[abi(embed_v0)]
+    impl ActionsImpl of IActions<ContractState> {
+        fn do_with_ref_self(ref self: ContractState) -> felt252 {
+            'land'
+        }
+
+        fn do_with_several_world_dispatchers(
+            world: IWorldDispatcher,
+            vec: Vec2,
+            another_world: IWorldDispatcher
+        ) -> felt252 {
+            'land'
+        }
+
+        fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+        fn do_with_self_and_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+        fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+        fn do_with_self_and_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+    }
+}
+
+#[dojo::contract]
+mod MyNominalContract {
 
     #[derive(Drop)]
     struct Action {
@@ -120,28 +189,45 @@ mod MyContract {
 
     #[external(v0)]
     #[computed]
-    fn tile_terrain(vec: Vec2) -> felt252 {
+    fn do(vec: Vec2) -> felt252 {
         'land'
     }
 
     #[external(v0)]
     #[computed]
-    fn tile_terrain_with_world(vec: Vec2, world: IWorldDispatcher) -> felt252 {
+    fn do_with_self(self: @ContractState, vec: Vec2) -> felt252 {
         'land'
     }
 
     #[external(v0)]
+    #[computed]
+    fn do_with_world_first(world: IWorldDispatcher, vec: Vec2) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    #[computed]
+    fn do_with_self_and_world_first(self: @ContractState, world: IWorldDispatcher, vec: Vec2) -> felt252 {
+        'land'
+    }
+
+    #[abi(embed_v0)]
     impl ActionsImpl of IActions<ContractState> {
-        fn spawn() {
+
+        fn do(vec: Vec2) -> felt252 {
+            'land'
         }
 
-        fn spawn_with_world(world: IWorldDispatcher) {
+        fn do_with_self(self: @ContractState, vec: Vec2) -> felt252 {
+            'land'
         }
 
-        fn move(direction: Direction) {
+        fn do_with_world_first(world: IWorldDispatcher, vec: Vec2) -> felt252 {
+            'land'
         }
 
-        fn move_with_world(world: IWorldDispatcher, direction: Direction) {
+        fn do_with_self_and_world_first(self: @ContractState, world: IWorldDispatcher, vec: Vec2) -> felt252 {
+            'land'
         }
     }
 }
@@ -272,9 +358,59 @@ error: Anything other than functions is not supported in a dojo::interface
     ^************^
 
 error: Functions of dojo::interface cannot have `ref self` parameter.
- --> test_src/lib.cairo:101:5
+ --> test_src/lib.cairo:91:5
     fn do_ref_self(ref self: TContractState);
     ^***************************************^
+
+error: Only one parameter of type IWorldDispatcher is allowed.
+ --> test_src/lib.cairo:114:5
+    #[external(v0)]
+    ^*************^
+
+error: The IWorldDispatcher parameter must be named 'world'.
+ --> test_src/lib.cairo:124:38
+    fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
+                                     ^*****************************^
+
+error: The IWorldDispatcher parameter must be named 'world'.
+ --> test_src/lib.cairo:129:69
+    fn do_with_self_and_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+                                                                    ^*****************************^
+
+error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+ --> test_src/lib.cairo:134:43
+    fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
+                                          ^*********************^
+
+error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+ --> test_src/lib.cairo:139:74
+    fn do_with_self_and_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+                                                                         ^*********************^
+
+error: Only one parameter of type IWorldDispatcher is allowed.
+ --> test_src/lib.cairo:149:9
+        fn do_with_several_world_dispatchers(
+        ^***********************************^
+
+error: The IWorldDispatcher parameter must be named 'world'.
+ --> test_src/lib.cairo:157:42
+        fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
+                                         ^*****************************^
+
+error: The IWorldDispatcher parameter must be named 'world'.
+ --> test_src/lib.cairo:161:73
+        fn do_with_self_and_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+                                                                        ^*****************************^
+
+error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+ --> test_src/lib.cairo:165:47
+        fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
+                                              ^*********************^
+
+error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+ --> test_src/lib.cairo:169:78
+        fn do_with_self_and_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+                                                                             ^*********************^
 
 error: Unsupported attribute.
  --> test_src/lib.cairo[spawn]:2:17
@@ -302,12 +438,17 @@ error: Unsupported attribute.
                 ^*******************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:103:5
+ --> test_src/lib.cairo:93:5
     #[my_attr]
     ^********^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo[MyContract]:2:17
+ --> test_src/lib.cairo[MyFaultyContract]:2:17
+                #[starknet::contract]
+                ^*******************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyNominalContract]:2:17
                 #[starknet::contract]
                 ^*******************^
 
@@ -527,52 +668,132 @@ error: Unsupported attribute.
                         ^*****^
 
 error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo[MyContract]:10:21
+ --> test_src/lib.cairo[MyFaultyContract]:10:21
                     component!(path: dojo::components::upgradeable::upgradeable, storage: upgradeable, event: UpgradeableEvent);
                     ^**********************************************************************************************************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo[MyContract]:12:21
+ --> test_src/lib.cairo[MyFaultyContract]:12:21
                     #[abi(embed_v0)]
                     ^**************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo[MyContract]:19:21
+ --> test_src/lib.cairo[MyFaultyContract]:19:21
                     #[abi(embed_v0)]
                     ^**************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo[MyContract]:26:21
+ --> test_src/lib.cairo[MyFaultyContract]:26:21
                     #[abi(embed_v0)]
                     ^**************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:115:5
+ --> test_src/lib.cairo:109:5
     #[external(v0)]
     ^*************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:121:5
+ --> test_src/lib.cairo:114:5
     #[external(v0)]
     ^*************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo:127:5
+ --> test_src/lib.cairo:123:5
     #[external(v0)]
     ^*************^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo[MyContract]:65:13
+ --> test_src/lib.cairo:128:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:133:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:138:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:143:5
+    #[abi(embed_v0)]
+    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyFaultyContract]:92:13
             #[event]
             ^******^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo[MyContract]:71:13
+ --> test_src/lib.cairo[MyFaultyContract]:98:13
             #[storage]
             ^********^
 
 error: Unsupported attribute.
- --> test_src/lib.cairo[MyContract]:74:17
+ --> test_src/lib.cairo[MyFaultyContract]:101:17
+                #[substorage(v0)]
+                ^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo[MyNominalContract]:10:21
+                    component!(path: dojo::components::upgradeable::upgradeable, storage: upgradeable, event: UpgradeableEvent);
+                    ^**********************************************************************************************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyNominalContract]:12:21
+                    #[abi(embed_v0)]
+                    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyNominalContract]:19:21
+                    #[abi(embed_v0)]
+                    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyNominalContract]:26:21
+                    #[abi(embed_v0)]
+                    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:184:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:190:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:196:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:202:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:208:5
+    #[abi(embed_v0)]
+    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyNominalContract]:83:13
+            #[event]
+            ^******^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyNominalContract]:89:13
+            #[storage]
+            ^********^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyNominalContract]:92:17
                 #[substorage(v0)]
                 ^***************^
 
@@ -837,9 +1058,12 @@ impl EventDrop of core::traits::Drop::<Event>;
                 trait IEmptyTrait<TContractState> {}
 
                 #[starknet::interface]
-                trait ITraitWithConstant<TContractState> {
+                trait IFaultyTrait<TContractState> {
                     
-    fn do_no_param(self: @TContractState);
+    fn do_ref_self(ref self: TContractState);
+
+    #[my_attr]
+    fn do_with_attrs(self: @TContractState, p1: u8) -> u16;
 
                 }
 
@@ -850,15 +1074,11 @@ impl EventDrop of core::traits::Drop::<Event>;
     fn do_params(self: @TContractState, p1: dojo_examples::models::Direction, p2: u8);
     fn do_params_and_self(self: @TContractState, p2: u8);
     fn do_return_value(self: @TContractState, p1: u8) -> u16;
-    fn do_ref_self(ref self: TContractState);
-
-    #[my_attr]
-    fn do_with_attrs(self: @TContractState, p1: u8) -> u16;
 
                 }
 
                 #[starknet::contract]
-                mod MyContract {
+                mod MyFaultyContract {
                     use dojo::world;
                     use dojo::world::IWorldDispatcher;
                     use dojo::world::IWorldDispatcherTrait;
@@ -868,7 +1088,111 @@ impl EventDrop of core::traits::Drop::<Event>;
                     #[abi(embed_v0)]
                     impl DojoResourceProviderImpl of IDojoResourceProvider<ContractState> {
                         fn dojo_resource(self: @ContractState) -> felt252 {
-                            'MyContract'
+                            'MyFaultyContract'
+                        }
+                    }
+
+                    #[abi(embed_v0)]
+                    impl WorldProviderImpl of IWorldProvider<ContractState> {
+                        fn world(self: @ContractState) -> IWorldDispatcher {
+                            self.world_dispatcher.read()
+                        }
+                    }
+
+                    #[abi(embed_v0)]
+                    impl UpgradableImpl = dojo::components::upgradeable::upgradeable::UpgradableImpl<ContractState>;
+
+                    
+    #[external(v0)]
+    fn do_with_ref_self(ref self: ContractState) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_several_world_dispatchers(
+self: @ContractState,         world: IWorldDispatcher,         vec: Vec2,         another_world: IWorldDispatcher
+    ) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_self_and_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    fn do_with_self_and_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[abi(embed_v0)]
+    impl ActionsImpl of IActions<ContractState> {
+        fn do_with_ref_self(ref self: ContractState) -> felt252 {
+            'land'
+        }
+
+        fn do_with_several_world_dispatchers(
+self: @ContractState,             world: IWorldDispatcher,             vec: Vec2,             another_world: IWorldDispatcher
+        ) -> felt252 {
+            'land'
+        }
+
+        fn do_with_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+        fn do_with_self_and_world_not_named_world(self: @ContractState, another_world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+        fn do_with_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+        fn do_with_self_and_world_not_first(self: @ContractState, vec: Vec2, world: IWorldDispatcher) -> felt252 {
+            'land'
+        }
+
+    }
+
+            #[event]
+            #[derive(Drop, starknet::Event)]
+            enum Event {
+                UpgradeableEvent: dojo::components::upgradeable::upgradeable::Event,
+            }
+            
+            #[storage]
+            struct Storage {
+                world_dispatcher: IWorldDispatcher,
+                #[substorage(v0)]
+                upgradeable: dojo::components::upgradeable::upgradeable::Storage,
+            }
+impl EventDrop of core::traits::Drop::<Event>;
+            
+                }
+
+                #[starknet::contract]
+                mod MyNominalContract {
+                    use dojo::world;
+                    use dojo::world::IWorldDispatcher;
+                    use dojo::world::IWorldDispatcherTrait;
+                    use dojo::world::IWorldProvider;
+                    use dojo::world::IDojoResourceProvider;
+
+                    #[abi(embed_v0)]
+                    impl DojoResourceProviderImpl of IDojoResourceProvider<ContractState> {
+                        fn dojo_resource(self: @ContractState) -> felt252 {
+                            'MyNominalContract'
                         }
                     }
 
@@ -890,31 +1214,49 @@ impl EventDrop of core::traits::Drop::<Event>;
 
     #[external(v0)]
     #[computed]
-    fn tile_terrain(self: @ContractState, vec: Vec2) -> felt252 {
+    fn do(self: @ContractState, vec: Vec2) -> felt252 {
         'land'
     }
 
     #[external(v0)]
     #[computed]
-    fn tile_terrain_with_world(self: @ContractState, vec: Vec2) -> felt252 {
+    fn do_with_self(self: @ContractState, vec: Vec2) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    #[computed]
+    fn do_with_world_first(self: @ContractState, vec: Vec2) -> felt252 {
 let world = self.world_dispatcher.read();
         'land'
     }
 
     #[external(v0)]
+    #[computed]
+    fn do_with_self_and_world_first(self: @ContractState, vec: Vec2) -> felt252 {
+let world = self.world_dispatcher.read();
+        'land'
+    }
+
+    #[abi(embed_v0)]
     impl ActionsImpl of IActions<ContractState> {
-        fn spawn(self: @ContractState) {
+
+        fn do(self: @ContractState, vec: Vec2) -> felt252 {
+            'land'
         }
 
-        fn spawn_with_world(self: @ContractState) {
+        fn do_with_self(self: @ContractState, vec: Vec2) -> felt252 {
+            'land'
+        }
+
+        fn do_with_world_first(self: @ContractState, vec: Vec2) -> felt252 {
 let world = self.world_dispatcher.read();
+            'land'
         }
 
-        fn move(self: @ContractState, direction: Direction) {
-        }
-
-        fn move_with_world(self: @ContractState, direction: Direction) {
+        fn do_with_self_and_world_first(self: @ContractState, vec: Vec2) -> felt252 {
 let world = self.world_dispatcher.read();
+            'land'
         }
     }
 

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -105,6 +105,42 @@ trait IActions {
     fn do_with_attrs(p1: u8) -> u16;
 }
 
+#[dojo::contract]
+mod MyContract {
+
+    #[derive(Drop)]
+    struct Action {
+        damage: u8
+    }
+
+    #[external(v0)]
+    #[computed]
+    fn tile_terrain(vec: Vec2) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    #[computed]
+    fn tile_terrain_with_world(vec: Vec2, world: IWorldDispatcher) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    impl ActionsImpl of IActions<ContractState> {
+        fn spawn() {
+        }
+
+        fn spawn_with_world(world: IWorldDispatcher) {
+        }
+
+        fn move(direction: Direction) {
+        }
+
+        fn move_with_world(world: IWorldDispatcher, direction: Direction) {
+        }
+    }
+}
+
 //! > generated_cairo_code
 #[starknet::contract]
 mod spawn {
@@ -264,6 +300,11 @@ error: Unsupported attribute.
  --> test_src/lib.cairo:98:5
     #[my_attr]
     ^********^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyContract]:2:17
+                #[starknet::contract]
+                ^*******************^
 
 error: Unsupported attribute.
  --> test_src/lib.cairo:49:5
@@ -480,6 +521,56 @@ error: Unsupported attribute.
                         #[flat]
                         ^*****^
 
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo[MyContract]:10:21
+                    component!(path: dojo::components::upgradeable::upgradeable, storage: upgradeable, event: UpgradeableEvent);
+                    ^**********************************************************************************************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyContract]:12:21
+                    #[abi(embed_v0)]
+                    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyContract]:19:21
+                    #[abi(embed_v0)]
+                    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyContract]:26:21
+                    #[abi(embed_v0)]
+                    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:110:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:116:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:122:5
+    #[external(v0)]
+    ^*************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyContract]:65:13
+            #[event]
+            ^******^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyContract]:71:13
+            #[storage]
+            ^********^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo[MyContract]:74:17
+                #[substorage(v0)]
+                ^***************^
+
 //! > expanded_cairo_code
 
 #[starknet::component]
@@ -522,7 +613,7 @@ mod testcomponent2 {
                         use traits::Into;
     use dojo::world::Context;
 
-    fn execute(ctx: Context, name: felt252) {
+    fn execute(self: @ContractState, ctx: Context, name: felt252) {
         return ();
     }
 
@@ -567,7 +658,7 @@ impl EventDrop of core::traits::Drop::<Event>;
                     #[abi(embed_v0)]
                     impl UpgradableImpl = dojo::components::upgradeable::upgradeable::UpgradableImpl<ContractState>;
 
-                        fn execute(value: felt252) -> felt252 {
+                        fn execute(self: @ContractState, value: felt252) -> felt252 {
         value
     }
 
@@ -615,7 +706,7 @@ impl EventDrop of core::traits::Drop::<Event>;
                         use traits::Into;
     use dojo::world::Context;
 
-    fn execute(ctx2: Context, name: felt252) {
+    fn execute(self: @ContractState, ctx2: Context, name: felt252) {
         return ();
     }
 
@@ -674,7 +765,7 @@ impl EventDrop of core::traits::Drop::<Event>;
     }
 
     #[abi(embed_v0)]
-    fn test(value: felt252) -> value {
+    fn test(self: @ContractState, value: felt252) -> value {
         value
     }
 
@@ -753,4 +844,82 @@ impl EventDrop of core::traits::Drop::<Event>;
     #[my_attr]
     fn do_with_attrs(self: @TContractState, p1: u8) -> u16;
 
+                }
+
+                #[starknet::contract]
+                mod MyContract {
+                    use dojo::world;
+                    use dojo::world::IWorldDispatcher;
+                    use dojo::world::IWorldDispatcherTrait;
+                    use dojo::world::IWorldProvider;
+                    use dojo::world::IDojoResourceProvider;
+
+                    #[abi(embed_v0)]
+                    impl DojoResourceProviderImpl of IDojoResourceProvider<ContractState> {
+                        fn dojo_resource(self: @ContractState) -> felt252 {
+                            'MyContract'
+                        }
+                    }
+
+                    #[abi(embed_v0)]
+                    impl WorldProviderImpl of IWorldProvider<ContractState> {
+                        fn world(self: @ContractState) -> IWorldDispatcher {
+                            self.world_dispatcher.read()
+                        }
+                    }
+
+                    #[abi(embed_v0)]
+                    impl UpgradableImpl = dojo::components::upgradeable::upgradeable::UpgradableImpl<ContractState>;
+
+                    
+    #[derive(Drop)]
+    struct Action {
+        damage: u8
+    }
+
+    #[external(v0)]
+    #[computed]
+    fn tile_terrain(self: @ContractState, vec: Vec2) -> felt252 {
+        'land'
+    }
+
+    #[external(v0)]
+    #[computed]
+    fn tile_terrain_with_world(self: @ContractState, vec: Vec2) -> felt252 {
+let world = self.world_dispatcher.read();
+        'land'
+    }
+
+    #[external(v0)]
+    impl ActionsImpl of IActions<ContractState> {
+        fn spawn(self: @ContractState) {
+        }
+
+        fn spawn_with_world(self: @ContractState) {
+let world = self.world_dispatcher.read();
+        }
+
+        fn move(self: @ContractState, direction: Direction) {
+        }
+
+        fn move_with_world(self: @ContractState, direction: Direction) {
+let world = self.world_dispatcher.read();
+        }
+    }
+
+            #[event]
+            #[derive(Drop, starknet::Event)]
+            enum Event {
+                UpgradeableEvent: dojo::components::upgradeable::upgradeable::Event,
+            }
+            
+            #[storage]
+            struct Storage {
+                world_dispatcher: IWorldDispatcher,
+                #[substorage(v0)]
+                upgradeable: dojo::components::upgradeable::upgradeable::Storage,
+            }
+impl ActionDrop of core::traits::Drop::<Action>;
+impl EventDrop of core::traits::Drop::<Event>;
+            
                 }

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -89,9 +89,9 @@ trait IEmptyTrait;
 
 #[dojo::interface]
 trait IActions {
-    // TODO
-    // it looks like there is a bug in trait parsing because if a value is set
-    // on a constant, this value appears alone in the trait...
+    /// Even if it looks weird, the expected pattern for a constant in a trait is
+    /// `const <name>: <type>;`
+    /// See: https://github.com/starkware-libs/cairo/blob/600553d34a1af93ff7fb038ac677efdd3fd07010/crates/cairo-lang-parser/src/parser.rs#L835
     const ONE: u8;
 
     fn do_no_param();

--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -1,15 +1,15 @@
 use dojo_examples::models::{Position, Vec2};
 
-#[starknet::interface]
-trait IActions<TContractState> {
-    fn spawn(self: @TContractState);
-    fn move(self: @TContractState, direction: dojo_examples::models::Direction);
+#[dojo::interface]
+trait IActions {
+    fn spawn();
+    fn move(direction: dojo_examples::models::Direction);
 }
 
-#[starknet::interface]
-trait IActionsComputed<TContractState> {
-    fn tile_terrain(self: @TContractState, vec: Vec2) -> felt252 ;
-    fn quadrant(self: @TContractState, pos: Position) -> u8;
+#[dojo::interface]
+trait IActionsComputed {
+    fn tile_terrain(vec: Vec2) -> felt252;
+    fn quadrant(pos: Position) -> u8;
 }
 
 #[dojo::contract]
@@ -36,12 +36,12 @@ mod actions {
     #[abi(embed_v0)]
     impl ActionsComputedImpl of IActionsComputed<ContractState> {
         #[computed]
-        fn tile_terrain(self: @ContractState, vec: Vec2) -> felt252 {
+        fn tile_terrain(vec: Vec2) -> felt252 {
             'land'
         }
 
         #[computed(Position)]
-        fn quadrant(self: @ContractState, pos: Position) -> u8 {
+        fn quadrant(pos: Position) -> u8 {
             // 10 is zero
             if pos.vec.x < 10 {
                 if pos.vec.y < 10 {
@@ -64,8 +64,7 @@ mod actions {
     #[abi(embed_v0)]
     impl ActionsImpl of IActions<ContractState> {
         // ContractState is defined by system decorator expansion
-        fn spawn(self: @ContractState) {
-            let world = self.world_dispatcher.read();
+        fn spawn(world: IWorldDispatcher) {
             let player = get_caller_address();
             let position = get!(world, player, (Position));
             let moves = get!(world, player, (Moves));
@@ -83,8 +82,7 @@ mod actions {
             );
         }
 
-        fn move(self: @ContractState, direction: Direction) {
-            let world = self.world_dispatcher.read();
+        fn move(direction: Direction, world: IWorldDispatcher) {
             let player = get_caller_address();
             let (mut position, mut moves) = get!(world, player, (Position, Moves));
             moves.remaining -= 1;

--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -1,4 +1,4 @@
-use dojo_examples::models::{Position, Vec2};
+use dojo_examples::models::{Direction, Position, Vec2};
 
 #[dojo::interface]
 trait IActions {
@@ -82,7 +82,7 @@ mod actions {
             );
         }
 
-        fn move(direction: Direction, world: IWorldDispatcher) {
+        fn move(world: IWorldDispatcher, direction: Direction) {
             let player = get_caller_address();
             let (mut position, mut moves) = get!(world, player, (Position, Moves));
             moves.remaining -= 1;

--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -3,7 +3,7 @@ use dojo_examples::models::{Position, Vec2};
 #[dojo::interface]
 trait IActions {
     fn spawn();
-    fn move(direction: dojo_examples::models::Direction);
+    fn move(direction: Direction);
 }
 
 #[dojo::interface]


### PR DESCRIPTION
Related to DOJ-132, https://github.com/dojoengine/dojo/issues/1458.

Add a new `[dojo::interface]` attribute which is expanded in `[starknet::interface]`, allowing the user to ignore `TContractState` type and `self` parameter.