### PR TITLE
Bump `blockifier` rev for supporting higher fee transfer gas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.5.0-dev.0"
-source = "git+https://github.com/dojoengine/blockifier?rev=8860946#886094680ea5ead4ba1227f46172e02468901488"
+source = "git+https://github.com/dojoengine/blockifier?rev=d38b979#d38b9790cf36261d06e1409d98f0105cbc09d8e2"
 dependencies = [
  "ark-ec",
  "ark-ff 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ wasm-tonic = { version = "0.9.2", default-features = false, features = [ "codege
 wasm-tonic-build = { version = "0.9.2", default-features = false, features = [ "prost" ], package = "tonic-build" }
 
 [patch."https://github.com/starkware-libs/blockifier"]
-blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "8860946" }
+blockifier = { git = "https://github.com/dojoengine/blockifier", rev = "d38b979" }
 
 [patch.crates-io]
 cairo-felt = { git = "https://github.com/dojoengine/cairo-rs.git", rev = "1031381" }


### PR DESCRIPTION
If you specified the Dojo ERC20 as the fee token in the genesis config, fee transfer would fail with `run out of gas` error. This is the new change added in the new bump:

https://github.com/dojoengine/blockifier/blob/d38b9790cf36261d06e1409d98f0105cbc09d8e2/crates/blockifier/src/transaction/account_transaction.rs#L334-L336

Mainly an issue during the Realms world deployment bcs its using dojo erc20 as the fee token which performs more computation in the `transfer` method (the function used by the sequencer for the transaction fee transfer) compared to the default katana fee token.