### PR TITLE
fix(katana): search the inner state when sierra class not found in the cache

### DIFF
--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -248,7 +248,7 @@ impl IntervalBlockProducer {
         trace!(target: "miner", "created new block: {}", outcome.block_number);
 
         backend.update_block_env(&mut block_env);
-        pending_state.reset_state(new_state.into(), block_env, cfg_env);
+        pending_state.reset_state(StateRefDb(new_state), block_env, cfg_env);
 
         Ok(outcome)
     }
@@ -410,7 +410,7 @@ impl InstantBlockProducer {
         let block_context = block_context_from_envs(&block_env, &cfg_env);
 
         let latest_state = StateFactoryProvider::latest(backend.blockchain.provider())?;
-        let state = CachedStateWrapper::new(latest_state.into());
+        let state = CachedStateWrapper::new(StateRefDb(latest_state));
 
         let txs = transactions.iter().map(TxWithHash::from);
 

--- a/crates/katana/executor/src/blockifier/utils.rs
+++ b/crates/katana/executor/src/blockifier/utils.rs
@@ -66,7 +66,7 @@ pub fn estimate_fee(
     state: Box<dyn StateProvider>,
     validate: bool,
 ) -> Result<Vec<FeeEstimate>, TransactionExecutionError> {
-    let state = CachedStateWrapper::new(StateRefDb::from(state));
+    let state = CachedStateWrapper::new(StateRefDb(state));
     let results = TransactionExecutor::new(&state, &block_context, true, validate, transactions)
         .with_error_log()
         .execute();
@@ -94,7 +94,7 @@ pub fn raw_call(
     state: Box<dyn StateProvider>,
     initial_gas: u64,
 ) -> Result<CallInfo, TransactionExecutionError> {
-    let mut state = CachedState::new(StateRefDb::from(state), GlobalContractCache::default());
+    let mut state = CachedState::new(StateRefDb(state), GlobalContractCache::default());
     let mut state = CachedState::new(MutRefState::new(&mut state), GlobalContractCache::default());
 
     let call = CallEntryPoint {
@@ -235,7 +235,7 @@ pub(crate) fn pretty_print_resources(resources: &ResourcesMapping) -> String {
 }
 
 pub fn get_state_update_from_cached_state(
-    state: &CachedStateWrapper<StateRefDb>,
+    state: &CachedStateWrapper,
 ) -> StateUpdatesWithDeclaredClasses {
     let state_diff = state.inner().to_state_diff();
 


### PR DESCRIPTION
Fixes sierra class not found when queried from `CachedStateWrapper` even though it should exists. 

This bug is caused by the `ContractClassProvider::sierra_class` implementation of `CachedStateWrapper` where it returns immediately when the sierra class is not found in the `sierra_class` [mapping](https://github.com/dojoengine/dojo/blob/1d3ecb61e3d7f104398b276332ddaf9be4240c5f/crates/katana/executor/src/blockifier/state.rs#L98) of `CachedStateWrapper` (the map only stores sierra class that are declared in the current state, because the underlying `CacheState` doesn't store it).

https://github.com/dojoengine/dojo/blob/1d3ecb61e3d7f104398b276332ddaf9be4240c5f/crates/katana/executor/src/blockifier/state.rs#L161-L170

Essentially when you try to fetch a sierra class (in the pending state) that has been declared in the previous blocks, you would get `None` as currently it only tries to find it in the mapping and not in the underlying `StateProvider` that `CachedStateWrapper` wraps.

---

This is fixed in the new executor refactors in `dev/katana` branch.