### PR TITLE
fix(katana): non-query-version fee estimates

### DIFF
--- a/crates/katana/primitives/src/transaction.rs
+++ b/crates/katana/primitives/src/transaction.rs
@@ -87,12 +87,12 @@ impl ExecutableTxWithHash {
         Self { hash, transaction }
     }
 
-    pub fn new_query(transaction: ExecutableTx) -> Self {
+    pub fn new_query(transaction: ExecutableTx, is_query: bool) -> Self {
         let hash = match &transaction {
             ExecutableTx::L1Handler(tx) => tx.calculate_hash(),
-            ExecutableTx::Invoke(tx) => tx.calculate_hash(true),
-            ExecutableTx::Declare(tx) => tx.calculate_hash(true),
-            ExecutableTx::DeployAccount(tx) => tx.calculate_hash(true),
+            ExecutableTx::Invoke(tx) => tx.calculate_hash(is_query),
+            ExecutableTx::Declare(tx) => tx.calculate_hash(is_query),
+            ExecutableTx::DeployAccount(tx) => tx.calculate_hash(is_query),
         };
         Self { hash, transaction }
     }

--- a/crates/katana/rpc/rpc/src/starknet.rs
+++ b/crates/katana/rpc/rpc/src/starknet.rs
@@ -481,20 +481,26 @@ impl StarknetApiServer for StarknetApi {
                 .map(|tx| {
                     let tx = match tx {
                         BroadcastedTx::Invoke(tx) => {
+                            let is_query = tx.is_query();
                             let tx = tx.into_tx_with_chain_id(chain_id);
-                            ExecutableTxWithHash::new_query(ExecutableTx::Invoke(tx))
+                            ExecutableTxWithHash::new_query(ExecutableTx::Invoke(tx), is_query)
                         }
 
                         BroadcastedTx::DeployAccount(tx) => {
+                            let is_query = tx.is_query();
                             let tx = tx.into_tx_with_chain_id(chain_id);
-                            ExecutableTxWithHash::new_query(ExecutableTx::DeployAccount(tx))
+                            ExecutableTxWithHash::new_query(
+                                ExecutableTx::DeployAccount(tx),
+                                is_query,
+                            )
                         }
 
                         BroadcastedTx::Declare(tx) => {
+                            let is_query = tx.is_query();
                             let tx = tx
                                 .try_into_tx_with_chain_id(chain_id)
                                 .map_err(|_| StarknetApiError::InvalidContractClass)?;
-                            ExecutableTxWithHash::new_query(ExecutableTx::Declare(tx))
+                            ExecutableTxWithHash::new_query(ExecutableTx::Declare(tx), is_query)
                         }
                     };
 


### PR DESCRIPTION
Katana incorrectly assumes that all `starknet_estimateFee` requests are query-versioned, and hence arrives at wrong transaction hashes when clients attempt to estimate with non-query transactions. As of this writing, both Argent X and Braavos use non-query requests for 'DEPLOY_ACCOUNT' fee estimation. This bug prevents these wallets from being used on Katana networks.