### PR TITLE
fix: remove old reference to submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "crates/katana/core/contracts/messaging/solidity/lib/forge-std"]
-	path = crates/katana/core/contracts/messaging/solidity/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "crates/katana/primitives/contracts/messaging/solidity/lib/forge-std"]
+	path = crates/katana/primitives/contracts/messaging/solidity/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "crates/katana/primitives/contracts/messaging/solidity/lib/forge-std"]
-	path = crates/katana/primitives/contracts/messaging/solidity/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
My git client (yeah I'm a git-gui-using-normie) complained about a submodule reference a non-existent folder, so decided to just remove the file altogether.