### PR TITLE
Refactor torii grpc queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12441,6 +12441,7 @@ dependencies = [
  "lazy_static",
  "log",
  "once_cell",
+ "regex",
  "reqwest",
  "scarb",
  "scarb-ui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ tokio = { version = "1.32.0", features = [ "full" ] }
 toml = "0.7.4"
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "json" ] }
+regex = "1.10.3"
 url = { version = "2.4.0", features = [ "serde" ] }
 
 # server

--- a/crates/torii/client/src/client/subscription.rs
+++ b/crates/torii/client/src/client/subscription.rs
@@ -12,7 +12,7 @@ use starknet::core::types::{StateDiff, StateUpdate};
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_crypto::FieldElement;
 use torii_grpc::client::ModelDiffsStreaming;
-use torii_grpc::types::KeysClause;
+use torii_grpc::types::ModelDiffKeys;
 
 use crate::client::error::{Error, ParseError};
 use crate::client::storage::ModelStorage;
@@ -24,13 +24,13 @@ pub enum SubscriptionEvent {
 
 pub struct SubscribedModels {
     metadata: Arc<RwLock<WorldMetadata>>,
-    pub(crate) models_keys: RwLock<HashSet<KeysClause>>,
+    pub(crate) models_keys: RwLock<HashSet<ModelDiffKeys>>,
     /// All the relevant storage addresses derived from the subscribed models
     pub(crate) subscribed_storage_addresses: RwLock<HashSet<FieldElement>>,
 }
 
 impl SubscribedModels {
-    pub(crate) fn is_synced(&self, keys: &KeysClause) -> bool {
+    pub(crate) fn is_synced(&self, keys: &ModelDiffKeys) -> bool {
         self.models_keys.read().contains(keys)
     }
 
@@ -42,21 +42,21 @@ impl SubscribedModels {
         }
     }
 
-    pub(crate) fn add_models(&self, models_keys: Vec<KeysClause>) -> Result<(), Error> {
+    pub(crate) fn add_models(&self, models_keys: Vec<ModelDiffKeys>) -> Result<(), Error> {
         for keys in models_keys {
             Self::add_model(self, keys)?;
         }
         Ok(())
     }
 
-    pub(crate) fn remove_models(&self, entities_keys: Vec<KeysClause>) -> Result<(), Error> {
+    pub(crate) fn remove_models(&self, entities_keys: Vec<ModelDiffKeys>) -> Result<(), Error> {
         for keys in entities_keys {
             Self::remove_model(self, keys)?;
         }
         Ok(())
     }
 
-    pub(crate) fn add_model(&self, keys: KeysClause) -> Result<(), Error> {
+    pub(crate) fn add_model(&self, keys: ModelDiffKeys) -> Result<(), Error> {
         if !self.models_keys.write().insert(keys.clone()) {
             return Ok(());
         }
@@ -83,7 +83,7 @@ impl SubscribedModels {
         Ok(())
     }
 
-    pub(crate) fn remove_model(&self, keys: KeysClause) -> Result<(), Error> {
+    pub(crate) fn remove_model(&self, keys: ModelDiffKeys) -> Result<(), Error> {
         if !self.models_keys.write().remove(&keys) {
             return Ok(());
         }
@@ -247,7 +247,7 @@ mod tests {
     use parking_lot::RwLock;
     use starknet::core::utils::cairo_short_string_to_felt;
     use starknet::macros::felt;
-    use torii_grpc::types::KeysClause;
+    use torii_grpc::types::ModelDiffKeys;
 
     use crate::utils::compute_all_storage_addresses;
 
@@ -283,7 +283,7 @@ mod tests {
 
         let metadata = self::create_dummy_metadata();
 
-        let keys = KeysClause { model: model_name, keys };
+        let keys = ModelDiffKeys { model: model_name, keys };
 
         let subscribed_models = super::SubscribedModels::new(Arc::new(RwLock::new(metadata)));
         subscribed_models.add_models(vec![keys.clone()]).expect("able to add model");

--- a/crates/torii/core/Cargo.toml
+++ b/crates/torii/core/Cargo.toml
@@ -22,6 +22,7 @@ hex.workspace = true
 lazy_static.workspace = true
 log = "0.4.17"
 once_cell.workspace = true
+regex.workspace = true
 reqwest = { version = "0.11.22", features = [ "blocking", "rustls-tls" ], default-features = false }
 scarb-ui.workspace = true
 serde.workspace = true

--- a/crates/torii/core/src/cache.rs
+++ b/crates/torii/core/src/cache.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use dojo_types::schema::Ty;
 use sqlx::SqlitePool;
@@ -19,7 +19,7 @@ impl ModelCache {
         Self { pool, cache: RwLock::new(HashMap::new()) }
     }
 
-    pub async fn schemas(&self, models: Vec<&str>) -> Result<Vec<Ty>, Error> {
+    pub async fn schemas(&self, models: HashSet<&str>) -> Result<Vec<Ty>, Error> {
         let mut schemas = Vec::with_capacity(models.len());
         for model in models {
             schemas.push(self.schema(model).await?);

--- a/crates/torii/core/src/error.rs
+++ b/crates/torii/core/src/error.rs
@@ -39,6 +39,8 @@ pub enum QueryError {
     MissingParam(String),
     #[error("model not found: {0}")]
     ModelNotFound(String),
+    #[error("multiple entities found")]
+    MultipleEntities,
     #[error("exceeds sqlite `JOIN` limit (64)")]
     SqliteJoinLimit,
 }

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -73,29 +73,33 @@ message ModelDiff {
     repeated StorageDiff storage_diffs = 1;
 }
 
-message ModelUpdate {
+message ModelDiffKeys {
+    string model = 1;
+    repeated bytes keys = 2;
+}
+
+message ModelDiffUpdate {
     string block_hash = 1;
     ModelDiff model_diff = 2;
 }
 
-message Query {
-    Clause clause = 1;
+message EntityQuery {
+    EntityClause clause = 1;
     uint32 limit = 2;
     uint32 offset = 3;
 }
 
 message EventQuery {
-    EventKeysClause keys =1;
+    KeysClause keys =1;
     uint32 limit = 2;
     uint32 offset = 3;
 }
 
-message Clause {
+message EntityClause {
     oneof clause_type {
         HashedKeysClause hashed_keys = 1;
         KeysClause keys = 2;
-        MemberClause member = 3;
-        CompositeClause composite = 4;
+        ModelsClause models = 3;
     }
 }
 
@@ -103,13 +107,13 @@ message HashedKeysClause {
     repeated bytes hashed_keys = 1;
 }
 
-message EventKeysClause {
-    repeated bytes keys = 1;
+message KeysClause {
+    repeated bytes keys = 2;
 }
 
-message KeysClause {
-    string model = 1;
-    repeated bytes keys = 2;
+message ModelsClause {
+    repeated MemberClause members = 1;
+    LogicalOperator operator = 2;
 }
 
 message MemberClause {
@@ -117,12 +121,6 @@ message MemberClause {
     string member = 2;
     ComparisonOperator operator = 3;
     Value value = 4;
-}
-
-message CompositeClause {
-    string model = 1;
-    LogicalOperator operator = 2;
-    repeated Clause clauses = 3;
 }
 
 enum LogicalOperator {

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -8,8 +8,8 @@ service World {
     // Retrieves metadata about the World including all the registered components and systems.
     rpc WorldMetadata (MetadataRequest) returns (MetadataResponse);
    
-    // Subscribes to models updates.
-    rpc SubscribeModels (SubscribeModelsRequest) returns (stream SubscribeModelsResponse);
+    // Subscribes to models diff updates.
+    rpc SubscribeDiffs (SubscribeDiffsRequest) returns (stream SubscribeDiffsResponse);
 
     // Subscribe to entity updates.
     rpc SubscribeEntities (SubscribeEntitiesRequest) returns (stream SubscribeEntityResponse);
@@ -32,14 +32,14 @@ message MetadataResponse {
    types.WorldMetadata metadata = 1;
 }
 
-message SubscribeModelsRequest {
+message SubscribeDiffsRequest {
     // The list of model keys to subscribe to.
-    repeated types.KeysClause models_keys = 1;
+    repeated types.ModelDiffKeys models_keys = 1;
 }
 
-message SubscribeModelsResponse {
+message SubscribeDiffsResponse {
     // List of models that have been updated.
-    types.ModelUpdate model_update = 1;
+    types.ModelDiffUpdate model_update = 1;
 }
 
 message SubscribeEntitiesRequest {
@@ -52,7 +52,7 @@ message SubscribeEntityResponse {
 
 message RetrieveEntitiesRequest {
     // The entities to retrieve
-    types.Query query = 1;
+    types.EntityQuery query = 1;
 }
 
 message RetrieveEntitiesResponse {

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -97,10 +97,11 @@ impl Service {
                 "#;
                 let (model_names,): (String,) =
                     sqlx::query_as(models_query).bind(hashed_keys).fetch_one(&pool).await?;
-                let model_names: Vec<&str> = model_names.split(',').collect();
+                let model_names: HashSet<&str> = model_names.split(',').collect();
                 let schemas = cache.schemas(model_names).await?;
 
-                let entity_query = format!("{} WHERE entities.id = ?", build_sql_query(&schemas)?);
+                let entity_query =
+                    format!("{} WHERE entities.id = ?", build_sql_query(&schemas, None)?);
                 let row = sqlx::query(&entity_query).bind(hashed_keys).fetch_one(&pool).await?;
 
                 let models = schemas

--- a/crates/torii/grpc/src/server/subscriptions/model_diff.rs
+++ b/crates/torii/grpc/src/server/subscriptions/model_diff.rs
@@ -20,7 +20,7 @@ use tracing::{debug, error, trace};
 
 use super::error::SubscriptionError;
 use crate::proto;
-use crate::types::KeysClause;
+use crate::types::ModelDiffKeys;
 
 pub struct ModelMetadata {
     pub name: FieldElement,
@@ -29,7 +29,7 @@ pub struct ModelMetadata {
 
 pub struct ModelDiffRequest {
     pub model: ModelMetadata,
-    pub keys: proto::types::KeysClause,
+    pub keys: proto::types::ModelDiffKeys,
 }
 
 impl ModelDiffRequest {}
@@ -38,7 +38,7 @@ pub struct ModelDiffSubscriber {
     /// The storage addresses that the subscriber is interested in.
     storage_addresses: HashSet<FieldElement>,
     /// The channel to send the response back to the subscriber.
-    sender: Sender<Result<proto::world::SubscribeModelsResponse, tonic::Status>>,
+    sender: Sender<Result<proto::world::SubscribeDiffsResponse, tonic::Status>>,
 }
 
 #[derive(Default)]
@@ -50,7 +50,7 @@ impl StateDiffManager {
     pub async fn add_subscriber(
         &self,
         reqs: Vec<ModelDiffRequest>,
-    ) -> Result<Receiver<Result<proto::world::SubscribeModelsResponse, tonic::Status>>, Error> {
+    ) -> Result<Receiver<Result<proto::world::SubscribeDiffsResponse, tonic::Status>>, Error> {
         let id = rand::thread_rng().gen::<usize>();
 
         let (sender, receiver) = channel(1);
@@ -59,7 +59,7 @@ impl StateDiffManager {
         let storage_addresses = reqs
             .into_iter()
             .map(|req| {
-                let keys: KeysClause =
+                let keys: ModelDiffKeys =
                     req.keys.try_into().map_err(ParseError::FromByteSliceError)?;
 
                 let base = poseidon_hash_many(&[
@@ -162,7 +162,7 @@ where
                 })
                 .collect::<Vec<proto::types::StorageEntry>>();
 
-            let model_update = proto::types::ModelUpdate {
+            let model_update = proto::types::ModelDiffUpdate {
                 block_hash: format!("{:#x}", state_update.block_hash),
                 model_diff: Some(proto::types::ModelDiff {
                     storage_diffs: vec![proto::types::StorageDiff {
@@ -172,7 +172,7 @@ where
                 }),
             };
 
-            let resp = proto::world::SubscribeModelsResponse { model_update: Some(model_update) };
+            let resp = proto::world::SubscribeDiffsResponse { model_update: Some(model_update) };
 
             if sub.sender.send(Ok(resp)).await.is_err() {
                 closed_stream.push(*idx);


### PR DESCRIPTION
The gRPC entities endpoint supports three query clauses - HashedKeysClause, KeysClause, and MemberClause. Previously, the `MemberClause` could only filter one member of a single model. This PR renames it to `ModelsClause` and supports filtering multiple model members. 

Example:
```
  "query": {
      "clause": {
          "models": {
              "members": [
                  {
                      "member": "remaining",
                      "model": "Moves",
                      "operator": "GTE",
                      "value": {
                          "int_value": 0
                      }
                  },
                  {
                        "member": "player",
                        "model": "Position",
                        "operator": "EQ",
                        "value": {
                            "byte_value": "BhYoltHXqyBMfMrG3V+Onnwl7NWuT8tK0y5XeGu0bgM="
                        }
                    }
              ],
              "operator": "AND"
          }
      },
      "limit": 5,
      "offset": 0
  }
```
