### PR TITLE
fix: add flat to the event to be consistent with all world events

### DIFF
--- a/crates/dojo-core/src/base.cairo
+++ b/crates/dojo-core/src/base.cairo
@@ -13,6 +13,7 @@ mod base {
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
+        #[flat]
         UpgradeableEvent: upgradeable_component::Event
     }
 

--- a/crates/dojo-core/src/base_test.cairo
+++ b/crates/dojo-core/src/base_test.cairo
@@ -107,7 +107,7 @@ mod invalid_model {
     impl InvalidModelName of super::INameOnly<ContractState> {
         fn name(self: @ContractState) -> felt252 {
             // Pre-computed address of a contract deployed through the world.
-            0x742c3d09472a40914dedcbd609788fd547bde613d6c4d4c2f15d41f4e241f25
+            0x7b6cc67bb03efdf091487465df2037cad74111d8b616536b013e70da7491a30
         }
     }
 }

--- a/crates/torii/types-test/manifests/base/base.toml
+++ b/crates/torii/types-test/manifests/base/base.toml
@@ -1,3 +1,3 @@
 kind = "Class"
-class_hash = "0x794d5ed2f7eb970f92e0ed9be8f73bbbdf18f7db2a9a296fa12c2d9c33e6ab3"
+class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 name = "dojo::base::base"

--- a/crates/torii/types-test/manifests/base/contracts/records.toml
+++ b/crates/torii/types-test/manifests/base/contracts/records.toml
@@ -1,5 +1,5 @@
 kind = "DojoContract"
-class_hash = "0x6bf304cbc4a410fdc4cd877a7dfdaddb0678b596b7c5018dd2d926fbfdce5f9"
+class_hash = "0x5f0a221b80b5667c20574d62953f99eb6ddf7d351f531a9f0c56f96adb0d48b"
 abi = "abis/base/contracts/records.json"
 reads = []
 writes = []

--- a/crates/torii/types-test/manifests/base/models/record.toml
+++ b/crates/torii/types-test/manifests/base/models/record.toml
@@ -1,5 +1,5 @@
 kind = "DojoModel"
-class_hash = "0x143f14424c28802a649bbd45dfc4213794b5ec98700fe959597c2daeb2c5937"
+class_hash = "0x134456282bbaf00e0895ff43f286af8d490202baf6279d2b05be9bc0c05f059"
 name = "types_test::models::record"
 
 [[members]]

--- a/crates/torii/types-test/manifests/base/models/record_sibling.toml
+++ b/crates/torii/types-test/manifests/base/models/record_sibling.toml
@@ -1,5 +1,5 @@
 kind = "DojoModel"
-class_hash = "0x7660a792b6d4e2c6790ff6df004cc1f903343ed7ccd8ea3da57e6163b05126b"
+class_hash = "0x4e92336e21ac7970b9bd9f4e294705f7864c0b29f53fdbf42ff7a9d7f0a53f3"
 name = "types_test::models::record_sibling"
 
 [[members]]

--- a/crates/torii/types-test/manifests/base/models/subrecord.toml
+++ b/crates/torii/types-test/manifests/base/models/subrecord.toml
@@ -1,5 +1,5 @@
 kind = "DojoModel"
-class_hash = "0xf7a5bcc533f76d67c228de4583d2460538bb98900ad073c61c4ab18023b1ef"
+class_hash = "0x7a47c3a9c8509a1d4a0379e50799eba7b173db6e41961341fe3f856a51d627"
 name = "types_test::models::subrecord"
 
 [[members]]

--- a/crates/torii/types-test/manifests/base/world.toml
+++ b/crates/torii/types-test/manifests/base/world.toml
@@ -1,3 +1,3 @@
 kind = "Class"
-class_hash = "0x5ad96ceea29160aa7305bb078d1ade41f73b487363ae12778dbea6393cc00b2"
+class_hash = "0x799bc4e9da10bfb3dd88e6f223c9cfbf7745435cd14f5d69675ea448e578cd"
 name = "dojo::world::world"

--- a/examples/spawn-and-move/manifests/base/base.toml
+++ b/examples/spawn-and-move/manifests/base/base.toml
@@ -1,3 +1,3 @@
 kind = "Class"
-class_hash = "0x4861487b5a2c1fad2559e88ad1fa7e9a278ed5718adac7fdc89c7a716685d63"
+class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 name = "dojo::base::base"

--- a/examples/spawn-and-move/manifests/deployments/KATANA.toml
+++ b/examples/spawn-and-move/manifests/deployments/KATANA.toml
@@ -1,18 +1,18 @@
 [world]
 kind = "Contract"
-class_hash = "0x5ad96ceea29160aa7305bb078d1ade41f73b487363ae12778dbea6393cc00b2"
-address = "0xc26dfdc00af6798af8add1ee5d99a716ce9a5766d81218c4fd675ab9889dc4"
+class_hash = "0x799bc4e9da10bfb3dd88e6f223c9cfbf7745435cd14f5d69675ea448e578cd"
+address = "0x1385f25d20a724edc9c7b3bd9636c59af64cbaf9fcd12f33b3af96b2452f295"
 name = "dojo::world::world"
 
 [base]
 kind = "Class"
-class_hash = "0x794d5ed2f7eb970f92e0ed9be8f73bbbdf18f7db2a9a296fa12c2d9c33e6ab3"
+class_hash = "0x679177a2cb757694ac4f326d01052ff0963eac0bc2a17116a2b87badcdf6f76"
 name = "dojo::base::base"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x4bc39aa90510ea204e24910cc18e2fe9027292b49d465ca1d1832e41752b840"
-class_hash = "0x2a1c4999d12c32667739532ef820d68ab01db6bed62ea3fd2da08e4d36cca63"
+address = "0x3539c9b89b08095ba914653fb0f20e55d4b172a415beade611bc260b346d0f7"
+class_hash = "0xd43bce39922ec3857da231e3bb5c365c29f837c6dce322e4d61dfae83a4c18"
 abi = "abis/deployments/KATANA/contracts/actions.json"
 reads = [
     "Moves",
@@ -24,22 +24,7 @@ name = "dojo_examples::actions::actions"
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x53672d63a83f40ab5f3aeec55d1541a98aa822f5b197a30fbbac28e6f98a7d8"
-name = "dojo_examples::models::position"
-
-[[models.members]]
-name = "player"
-type = "ContractAddress"
-key = true
-
-[[models.members]]
-name = "vec"
-type = "Vec2"
-key = false
-
-[[models]]
-kind = "DojoModel"
-class_hash = "0x764906a97ff3e532e82b154908b25711cdec1c692bf68e3aba2a3dd9964a15c"
+class_hash = "0x511fbd833938f5c4b743eea1e67605a125d7ff60e8a09e8dc227ad2fb59ca54"
 name = "dojo_examples::models::moves"
 
 [[models.members]]
@@ -55,4 +40,19 @@ key = false
 [[models.members]]
 name = "last_direction"
 type = "Direction"
+key = false
+
+[[models]]
+kind = "DojoModel"
+class_hash = "0xb33ae053213ccb2a57967ffc4411901f3efab24781ca867adcd0b90f2fece5"
+name = "dojo_examples::models::position"
+
+[[models.members]]
+name = "player"
+type = "ContractAddress"
+key = true
+
+[[models.members]]
+name = "vec"
+type = "Vec2"
 key = false


### PR DESCRIPTION
Currently the `Upgraded` events contains two keys, due to the use of a component.
To ensure `sozo event` correct parsing and consistency with the world events, using the `#[flat]` attribute exposes only the `Upgraded` event selector.