### PR TITLE
feat(sozo): update manifest for incomplete migration

### DIFF
--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -143,7 +143,7 @@ where
     match migration::apply_diff(ws, &target_dir, diff, name.clone(), world_address, account, None)
         .await
     {
-        Ok(address) => {
+        Ok((address, _)) => {
             config
                 .ui()
                 .print(format!("🎉 World at address {} updated!", format_args!("{:#x}", address)));

--- a/crates/dojo-world/src/migration/strategy.rs
+++ b/crates/dojo-world/src/migration/strategy.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
@@ -27,6 +27,15 @@ pub struct MigrationStrategy {
     pub base: Option<ClassMigration>,
     pub contracts: Vec<ContractMigration>,
     pub models: Vec<ClassMigration>,
+}
+
+#[derive(Debug, Default)]
+pub struct MigrationResult {
+    pub block_number: Option<u64>,
+    pub world: bool,
+    pub base: bool,
+    pub contracts: HashSet<String>,
+    pub models: HashSet<String>,
 }
 
 #[derive(Debug)]

--- a/crates/dojo-world/src/migration/strategy.rs
+++ b/crates/dojo-world/src/migration/strategy.rs
@@ -29,7 +29,7 @@ pub struct MigrationStrategy {
     pub models: Vec<ClassMigration>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct MigrationResult {
     pub block_number: Option<u64>,
     pub world: bool,

--- a/examples/spawn-and-move/manifests/deployments/KATANA.toml
+++ b/examples/spawn-and-move/manifests/deployments/KATANA.toml
@@ -24,21 +24,6 @@ name = "dojo_examples::actions::actions"
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x53672d63a83f40ab5f3aeec55d1541a98aa822f5b197a30fbbac28e6f98a7d8"
-name = "dojo_examples::models::position"
-
-[[models.members]]
-name = "player"
-type = "ContractAddress"
-key = true
-
-[[models.members]]
-name = "vec"
-type = "Vec2"
-key = false
-
-[[models]]
-kind = "DojoModel"
 class_hash = "0x764906a97ff3e532e82b154908b25711cdec1c692bf68e3aba2a3dd9964a15c"
 name = "dojo_examples::models::moves"
 
@@ -55,4 +40,19 @@ key = false
 [[models.members]]
 name = "last_direction"
 type = "Direction"
+key = false
+
+[[models]]
+kind = "DojoModel"
+class_hash = "0x53672d63a83f40ab5f3aeec55d1541a98aa822f5b197a30fbbac28e6f98a7d8"
+name = "dojo_examples::models::position"
+
+[[models.members]]
+name = "player"
+type = "ContractAddress"
+key = true
+
+[[models.members]]
+name = "vec"
+type = "Vec2"
 key = false


### PR DESCRIPTION
fix: DOJ-116, #1218 

High level idea is instead of returning the error that we get during migration, we capture the progress of migration in `MigrationResult` and update only update the manifest to contain only the parts which got successfully migrated