### PR TITLE
Check model exists on `sozo auth`

### DIFF
--- a/bin/sozo/src/ops/auth.rs
+++ b/bin/sozo/src/ops/auth.rs
@@ -31,7 +31,7 @@ pub async fn execute(command: AuthCommand, env_metadata: Option<Environment>) ->
                         let contract = get_contract_address(&world, mc.contract).await?;
                         calls.push(world.grant_writer_getcall(&mc.model, &contract.into()));
                     } else {
-                        println!("[WARN] Unknown model '{}' => IGNORED", model_name);
+                        println!("Unknown model '{}' => IGNORED", model_name);
                     }
                 }
 

--- a/bin/sozo/src/ops/auth.rs
+++ b/bin/sozo/src/ops/auth.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result};
 use dojo_world::contracts::world::WorldContract;
+use dojo_world::contracts::WorldContractReader;
 use dojo_world::metadata::Environment;
 use dojo_world::utils::TransactionWaiter;
 use starknet::accounts::Account;
+use starknet::core::types::{BlockId, BlockTag};
+use starknet::core::utils::parse_cairo_short_string;
 
 use super::get_contract_address;
 use crate::commands::auth::{AuthCommand, AuthKind, ResourceType};
@@ -16,25 +19,36 @@ pub async fn execute(command: AuthCommand, env_metadata: Option<Environment>) ->
 
                 let account = account.account(&provider, env_metadata.as_ref()).await?;
                 let world = WorldContract::new(world_address, &account);
+                let world_reader = WorldContractReader::new(world_address, &provider)
+                    .with_block(BlockId::Tag(BlockTag::Pending));
 
                 let mut calls = Vec::new();
 
                 for mc in models_contracts {
-                    let contract = get_contract_address(&world, mc.contract).await?;
-                    calls.push(world.grant_writer_getcall(&mc.model, &contract.into()));
+                    let model_name = parse_cairo_short_string(&mc.model)?;
+
+                    if world_reader.model_reader(&model_name).await.is_ok() {
+                        let contract = get_contract_address(&world, mc.contract).await?;
+                        calls.push(world.grant_writer_getcall(&mc.model, &contract.into()));
+                    } else {
+                        println!("[WARN] Unknown model '{}' => IGNORED", model_name);
+                    }
                 }
 
-                let res = account
-                    .execute(calls)
-                    .send()
-                    .await
-                    .with_context(|| "Failed to send transaction")?;
+                if !calls.is_empty() {
+                    let res = account
+                        .execute(calls)
+                        .send()
+                        .await
+                        .with_context(|| "Failed to send transaction")?;
 
-                if transaction.wait {
-                    let receipt = TransactionWaiter::new(res.transaction_hash, &provider).await?;
-                    println!("{}", serde_json::to_string_pretty(&receipt)?);
-                } else {
-                    println!("Transaction hash: {:#x}", res.transaction_hash);
+                    if transaction.wait {
+                        let receipt =
+                            TransactionWaiter::new(res.transaction_hash, &provider).await?;
+                        println!("{}", serde_json::to_string_pretty(&receipt)?);
+                    } else {
+                        println!("Transaction hash: {:#x}", res.transaction_hash);
+                    }
                 }
             }
             AuthKind::Owner { owners_resources } => {

--- a/crates/dojo-world/src/contracts/model.rs
+++ b/crates/dojo-world/src/contracts/model.rs
@@ -1,6 +1,6 @@
 pub use abigen::model::ModelContractReader;
 use async_trait::async_trait;
-use cainome::cairo_serde::Error as CainomeError;
+use cainome::cairo_serde::{ContractAddress, Error as CainomeError};
 use dojo_types::packing::{parse_ty, unpack, PackingError, ParseError};
 use dojo_types::primitive::PrimitiveError;
 use dojo_types::schema::Ty;
@@ -85,6 +85,12 @@ where
                 )) => ModelError::ModelNotFound,
                 err => err.into(),
             })?;
+
+        // World Cairo contract won't raise an error in case of unknown/unregistered
+        // model so raise an error here in case of Null address.
+        if contract_address == ContractAddress(FieldElement::ZERO) {
+            return Err(ModelError::ModelNotFound);
+        }
 
         let model_reader = ModelContractReader::new(contract_address.into(), world.provider());
 

--- a/crates/dojo-world/src/contracts/model.rs
+++ b/crates/dojo-world/src/contracts/model.rs
@@ -87,7 +87,7 @@ where
             })?;
 
         // World Cairo contract won't raise an error in case of unknown/unregistered
-        // model so raise an error here in case of Null address.
+        // model so raise an error here in case of zero address.
         if contract_address == ContractAddress(FieldElement::ZERO) {
             return Err(ModelError::ModelNotFound);
         }


### PR DESCRIPTION
Related to DOJ-216, https://github.com/dojoengine/dojo/issues/1628

Before granting write access to models with the `sozo auth grant writer` command, this PR verifies if the model name exists and if the provided address is the good one.

Note that:
- the issue also mentions the `sozo auth revoke` command but it is not implemented yet.
- I've added a new dependency to the `colored` package to add some colors in warning traces. This is done in a separate commit so easy to remove if not needed.