### PR TITLE
feat(sozo): add `--receipt` transaction option

### DIFF
--- a/bin/sozo/src/commands/options/transaction.rs
+++ b/bin/sozo/src/commands/options/transaction.rs
@@ -13,11 +13,20 @@ pub struct TransactionOptions {
     pub fee_estimate_multiplier: Option<f64>,
 
     #[arg(short, long)]
-    #[arg(help = "Wait until the transaction is accepted by the sequencer, returning the receipt.")]
+    #[arg(help = "Wait until the transaction is accepted by the sequencer, returning the status \
+                  and hash.")]
     #[arg(long_help = "Wait until the transaction is accepted by the sequencer, returning the \
-                       receipt. This will poll the transaction status until it gets accepted or \
-                       rejected by the sequencer.")]
+                       status and the hash. This will poll the transaction status until it gets \
+                       accepted or rejected by the sequencer.")]
     pub wait: bool,
+
+    #[arg(short, long)]
+    #[arg(
+        help = "If --wait is set, returns the full transaction receipt. Otherwise, it is a no-op."
+    )]
+    #[arg(long_help = "If --wait is set, returns the full transaction receipt. Otherwise, it is \
+                       a no-op.")]
+    pub receipt: bool,
 }
 
 impl From<TransactionOptions> for TxConfig {

--- a/bin/sozo/src/lib.rs
+++ b/bin/sozo/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod args;
 pub mod commands;
 pub mod ops;
+pub mod utils;

--- a/bin/sozo/src/ops/execute.rs
+++ b/bin/sozo/src/ops/execute.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result};
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::metadata::Environment;
-use dojo_world::utils::TransactionWaiter;
 use starknet::accounts::{Account, Call};
 use starknet::core::utils::get_selector_from_name;
 
 use super::get_contract_address;
 use crate::commands::execute::ExecuteArgs;
+use crate::utils::handle_transaction_result;
 
 pub async fn execute(args: ExecuteArgs, env_metadata: Option<Environment>) -> Result<()> {
     let ExecuteArgs { contract, entrypoint, calldata, starknet, world, account, transaction } =
@@ -29,12 +29,7 @@ pub async fn execute(args: ExecuteArgs, env_metadata: Option<Environment>) -> Re
         .await
         .with_context(|| "Failed to send transaction")?;
 
-    if transaction.wait {
-        let receipt = TransactionWaiter::new(res.transaction_hash, &provider).await?;
-        println!("{}", serde_json::to_string_pretty(&receipt)?);
-    } else {
-        println!("Transaction hash: {:#x}", res.transaction_hash);
-    }
+    handle_transaction_result(&provider, res, transaction.wait, transaction.receipt).await?;
 
     Ok(())
 }

--- a/bin/sozo/src/ops/migration/migration_test.rs
+++ b/bin/sozo/src/ops/migration/migration_test.rs
@@ -95,7 +95,11 @@ async fn migrate_with_small_fee_multiplier_will_fail() {
             &ws,
             &migration,
             &account,
-            Some(TransactionOptions { fee_estimate_multiplier: Some(0.2f64), wait: false }),
+            Some(TransactionOptions {
+                fee_estimate_multiplier: Some(0.2f64),
+                wait: false,
+                receipt: false
+            }),
         )
         .await
         .is_err()

--- a/bin/sozo/src/ops/register.rs
+++ b/bin/sozo/src/ops/register.rs
@@ -1,10 +1,10 @@
 use anyhow::{Context, Result};
 use dojo_world::contracts::WorldContract;
 use dojo_world::metadata::Environment;
-use dojo_world::utils::TransactionWaiter;
 use starknet::accounts::Account;
 
 use crate::commands::register::RegisterCommand;
+use crate::utils::handle_transaction_result;
 
 pub async fn execute(command: RegisterCommand, env_metadata: Option<Environment>) -> Result<()> {
     match command {
@@ -26,12 +26,8 @@ pub async fn execute(command: RegisterCommand, env_metadata: Option<Environment>
                 .await
                 .with_context(|| "Failed to send transaction")?;
 
-            if transaction.wait {
-                let receipt = TransactionWaiter::new(res.transaction_hash, &provider).await?;
-                println!("{}", serde_json::to_string_pretty(&receipt)?);
-            } else {
-                println!("Transaction hash: {:#x}", res.transaction_hash);
-            }
+            handle_transaction_result(&provider, res, transaction.wait, transaction.receipt)
+                .await?;
         }
     }
     Ok(())

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -12,7 +12,7 @@ pub async fn handle_transaction_result<P>(
 where
     P: Provider + Send,
 {
-    println!("\nTransaction hash: {:#x}", transaction_result.transaction_hash);
+    println!("Transaction hash: {:#x}", transaction_result.transaction_hash);
 
     if wait_for_tx {
         let receipt =

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use dojo_world::utils::{execution_status_from_maybe_pending_receipt, TransactionWaiter};
+use starknet::core::types::{ExecutionResult, InvokeTransactionResult};
+use starknet::providers::Provider;
+
+pub async fn handle_transaction_result<P>(
+    provider: P,
+    transaction_result: InvokeTransactionResult,
+    wait_for_tx: bool,
+    show_receipt: bool,
+) -> Result<()>
+where
+    P: Provider + Send,
+{
+    println!("\nTransaction hash: {:#x}", transaction_result.transaction_hash);
+
+    if wait_for_tx {
+        let receipt =
+            TransactionWaiter::new(transaction_result.transaction_hash, &provider).await?;
+
+        if show_receipt {
+            println!("Receipt:\n{}", serde_json::to_string_pretty(&receipt)?);
+        } else {
+            match execution_status_from_maybe_pending_receipt(&receipt) {
+                ExecutionResult::Succeeded => {
+                    println!("Status: OK");
+                }
+                ExecutionResult::Reverted { reason } => {
+                    println!("Status: REVERTED");
+                    println!("Reason:\n{}", reason);
+                }
+            };
+        }
+    }
+
+    Ok(())
+}

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -274,6 +274,18 @@ where
 }
 
 #[inline]
+pub fn execution_status_from_maybe_pending_receipt(
+    receipt: &MaybePendingTransactionReceipt,
+) -> &ExecutionResult {
+    match &receipt {
+        MaybePendingTransactionReceipt::PendingReceipt(r) => {
+            execution_status_from_pending_receipt(r)
+        }
+        MaybePendingTransactionReceipt::Receipt(r) => execution_status_from_receipt(r),
+    }
+}
+
+#[inline]
 fn execution_status_from_receipt(receipt: &TransactionReceipt) -> &ExecutionResult {
     match receipt {
         TransactionReceipt::Invoke(receipt) => &receipt.execution_result,


### PR DESCRIPTION
Related to DOJ-215, https://github.com/dojoengine/dojo/issues/1627.

Modify the `--wait` transaction option to show the execution status and the transaction hash only.
Then, add the `--receipt` transaction option to be used with the `--wait` flag to show the full
receipt after the transaction execution.