### PR TITLE
fix: [torii/graphql] Added timezone information to timestamps strings

### DIFF
--- a/crates/torii/graphql/src/object/entity.rs
+++ b/crates/torii/graphql/src/object/entity.rs
@@ -94,11 +94,11 @@ impl EntityObject {
             (Name::new("eventId"), Value::from(entity.event_id)),
             (
                 Name::new("createdAt"),
-                Value::from(entity.created_at.format("%Y-%m-%d %H:%M:%S").to_string()),
+                Value::from(entity.created_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
             ),
             (
                 Name::new("updatedAt"),
-                Value::from(entity.updated_at.format("%Y-%m-%d %H:%M:%S").to_string()),
+                Value::from(entity.updated_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
             ),
         ])
     }

--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -67,7 +67,7 @@ impl EventObject {
             (Name::new("transactionHash"), Value::from(event.transaction_hash)),
             (
                 Name::new("createdAt"),
-                Value::from(event.created_at.format("%Y-%m-%d %H:%M:%S").to_string()),
+                Value::from(event.created_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
             ),
         ])
     }

--- a/crates/torii/graphql/src/object/model.rs
+++ b/crates/torii/graphql/src/object/model.rs
@@ -110,7 +110,7 @@ impl ModelObject {
             (Name::new("transactionHash"), Value::from(model.transaction_hash)),
             (
                 Name::new("createdAt"),
-                Value::from(model.created_at.format("%Y-%m-%d %H:%M:%S").to_string()),
+                Value::from(model.created_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
             ),
         ])
     }


### PR DESCRIPTION
## Problem

At the moment, when returning dates from `created_at` or `updated_at` with GraphQL, we don't store timezone informations.

This leads to complications when used by other clients: the timezone is set to the local one of the user instead of UTC and discrepancies will be observed.
Example in this issue: https://github.com/cartridge-gg/internal/issues/1270 - the bug observed here comes from this.

## Fix

Simply added UTC timezone info in the strings:
```typescript
"%Y-%m-%d %H:%M:%S"
// becomes
"%Y-%m-%dT%H:%M:%SZ"
```

## Another possible solution

It is also possible to not update Torii at all and just update the clients, but I think it's a good addition here.
I'm just not 100% sure if this changes won't break something somewhere else.

Let me know what you think!