### PR TITLE
fix: error on `world.model()` call gets mapped wrongly

### DIFF
--- a/crates/dojo-world/src/contracts/model.rs
+++ b/crates/dojo-world/src/contracts/model.rs
@@ -4,7 +4,7 @@ use cainome::cairo_serde::{ContractAddress, Error as CainomeError};
 use dojo_types::packing::{parse_ty, unpack, PackingError, ParseError};
 use dojo_types::primitive::PrimitiveError;
 use dojo_types::schema::Ty;
-use starknet::core::types::{FieldElement, StarknetError};
+use starknet::core::types::FieldElement;
 use starknet::core::utils::{
     cairo_short_string_to_felt, CairoShortStringToFeltError, ParseCairoShortStringError,
 };
@@ -79,12 +79,7 @@ where
         let name = cairo_short_string_to_felt(name)?;
 
         let (class_hash, contract_address) =
-            world.model(&name).block_id(world.block_id).call().await.map_err(|err| match err {
-                CainomeError::Provider(ProviderError::StarknetError(
-                    StarknetError::ContractNotFound,
-                )) => ModelError::ModelNotFound,
-                err => err.into(),
-            })?;
+            world.model(&name).block_id(world.block_id).call().await?;
 
         // World Cairo contract won't raise an error in case of unknown/unregistered
         // model so raise an error here in case of zero address.


### PR DESCRIPTION
Resolves #1660 

I've also added a check to make sure we react to the correct error in `sozo auth`. ref #1644 