### PR TITLE
fix(torii): Added timezone informations to naive datetime strings

### DIFF
--- a/crates/torii/graphql/src/constants.rs
+++ b/crates/torii/graphql/src/constants.rs
@@ -1,3 +1,5 @@
+pub const DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%SZ";
+
 pub const DEFAULT_LIMIT: u64 = 10;
 pub const BOOLEAN_TRUE: i64 = 1;
 

--- a/crates/torii/graphql/src/object/entity.rs
+++ b/crates/torii/graphql/src/object/entity.rs
@@ -12,7 +12,9 @@ use torii_core::types::Entity;
 
 use super::inputs::keys_input::keys_argument;
 use super::{BasicObject, ResolvableObject, TypeMapping, ValueMapping};
-use crate::constants::{ENTITY_NAMES, ENTITY_TABLE, ENTITY_TYPE_NAME, EVENT_ID_COLUMN, ID_COLUMN};
+use crate::constants::{
+    DATETIME_FORMAT, ENTITY_NAMES, ENTITY_TABLE, ENTITY_TYPE_NAME, EVENT_ID_COLUMN, ID_COLUMN,
+};
 use crate::mapping::ENTITY_TYPE_MAPPING;
 use crate::object::{resolve_many, resolve_one};
 use crate::query::{type_mapping_query, value_mapping_from_row};
@@ -61,8 +63,10 @@ impl ResolvableObject for EntityObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![
-            SubscriptionField::new("entityUpdated", TypeRef::named_nn(self.type_name()), |ctx| {
+        Some(vec![SubscriptionField::new(
+            "entityUpdated",
+            TypeRef::named_nn(self.type_name()),
+            |ctx| {
                 SubscriptionFieldFuture::new(async move {
                     let id = match ctx.args.get("id") {
                         Some(id) => Some(id.string()?.to_string()),
@@ -79,9 +83,9 @@ impl ResolvableObject for EntityObject {
                         }
                     }))
                 })
-            })
-            .argument(InputValue::new("id", TypeRef::named(TypeRef::ID))),
-        ])
+            },
+        )
+        .argument(InputValue::new("id", TypeRef::named(TypeRef::ID)))])
     }
 }
 
@@ -94,11 +98,11 @@ impl EntityObject {
             (Name::new("eventId"), Value::from(entity.event_id)),
             (
                 Name::new("createdAt"),
-                Value::from(entity.created_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+                Value::from(entity.created_at.format(DATETIME_FORMAT).to_string()),
             ),
             (
                 Name::new("updatedAt"),
-                Value::from(entity.updated_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+                Value::from(entity.updated_at.format(DATETIME_FORMAT).to_string()),
             ),
         ])
     }

--- a/crates/torii/graphql/src/object/entity.rs
+++ b/crates/torii/graphql/src/object/entity.rs
@@ -63,10 +63,8 @@ impl ResolvableObject for EntityObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![SubscriptionField::new(
-            "entityUpdated",
-            TypeRef::named_nn(self.type_name()),
-            |ctx| {
+        Some(vec![
+            SubscriptionField::new("entityUpdated", TypeRef::named_nn(self.type_name()), |ctx| {
                 SubscriptionFieldFuture::new(async move {
                     let id = match ctx.args.get("id") {
                         Some(id) => Some(id.string()?.to_string()),
@@ -83,9 +81,9 @@ impl ResolvableObject for EntityObject {
                         }
                     }))
                 })
-            },
-        )
-        .argument(InputValue::new("id", TypeRef::named(TypeRef::ID)))])
+            })
+            .argument(InputValue::new("id", TypeRef::named(TypeRef::ID))),
+        ])
     }
 }
 

--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -44,17 +44,15 @@ impl ResolvableObject for EventObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![SubscriptionField::new(
-            "eventEmitted",
-            TypeRef::named_nn(self.type_name()),
-            |ctx| {
+        Some(vec![
+            SubscriptionField::new("eventEmitted", TypeRef::named_nn(self.type_name()), |ctx| {
                 SubscriptionFieldFuture::new(async move {
                     let input_keys = parse_keys_argument(&ctx)?;
                     Ok(EventObject::subscription_stream(input_keys))
                 })
-            },
-        )
-        .argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING)))])
+            })
+            .argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING))),
+        ])
     }
 }
 

--- a/crates/torii/graphql/src/object/event.rs
+++ b/crates/torii/graphql/src/object/event.rs
@@ -9,7 +9,7 @@ use torii_core::types::Event;
 
 use super::inputs::keys_input::{keys_argument, parse_keys_argument};
 use super::{resolve_many, BasicObject, ResolvableObject, TypeMapping};
-use crate::constants::{EVENT_NAMES, EVENT_TABLE, EVENT_TYPE_NAME, ID_COLUMN};
+use crate::constants::{DATETIME_FORMAT, EVENT_NAMES, EVENT_TABLE, EVENT_TYPE_NAME, ID_COLUMN};
 use crate::mapping::EVENT_TYPE_MAPPING;
 use crate::types::ValueMapping;
 
@@ -44,15 +44,17 @@ impl ResolvableObject for EventObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![
-            SubscriptionField::new("eventEmitted", TypeRef::named_nn(self.type_name()), |ctx| {
+        Some(vec![SubscriptionField::new(
+            "eventEmitted",
+            TypeRef::named_nn(self.type_name()),
+            |ctx| {
                 SubscriptionFieldFuture::new(async move {
                     let input_keys = parse_keys_argument(&ctx)?;
                     Ok(EventObject::subscription_stream(input_keys))
                 })
-            })
-            .argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING))),
-        ])
+            },
+        )
+        .argument(InputValue::new("keys", TypeRef::named_list(TypeRef::STRING)))])
     }
 }
 
@@ -67,7 +69,7 @@ impl EventObject {
             (Name::new("transactionHash"), Value::from(event.transaction_hash)),
             (
                 Name::new("createdAt"),
-                Value::from(event.created_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+                Value::from(event.created_at.format(DATETIME_FORMAT).to_string()),
             ),
         ])
     }

--- a/crates/torii/graphql/src/object/model.rs
+++ b/crates/torii/graphql/src/object/model.rs
@@ -74,10 +74,8 @@ impl ResolvableObject for ModelObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![SubscriptionField::new(
-            "modelRegistered",
-            TypeRef::named_nn(self.type_name()),
-            |ctx| {
+        Some(vec![
+            SubscriptionField::new("modelRegistered", TypeRef::named_nn(self.type_name()), |ctx| {
                 {
                     SubscriptionFieldFuture::new(async move {
                         let id = match ctx.args.get("id") {
@@ -96,9 +94,9 @@ impl ResolvableObject for ModelObject {
                         }))
                     })
                 }
-            },
-        )
-        .argument(InputValue::new("id", TypeRef::named(TypeRef::ID)))])
+            })
+            .argument(InputValue::new("id", TypeRef::named(TypeRef::ID))),
+        ])
     }
 }
 

--- a/crates/torii/graphql/src/object/model.rs
+++ b/crates/torii/graphql/src/object/model.rs
@@ -9,8 +9,8 @@ use torii_core::types::Model;
 
 use super::{resolve_many, BasicObject, ResolvableObject, TypeMapping, ValueMapping};
 use crate::constants::{
-    ID_COLUMN, MODEL_NAMES, MODEL_ORDER_FIELD_TYPE_NAME, MODEL_ORDER_TYPE_NAME, MODEL_TABLE,
-    MODEL_TYPE_NAME, ORDER_ASC, ORDER_DESC, ORDER_DIR_TYPE_NAME,
+    DATETIME_FORMAT, ID_COLUMN, MODEL_NAMES, MODEL_ORDER_FIELD_TYPE_NAME, MODEL_ORDER_TYPE_NAME,
+    MODEL_TABLE, MODEL_TYPE_NAME, ORDER_ASC, ORDER_DESC, ORDER_DIR_TYPE_NAME,
 };
 use crate::mapping::MODEL_TYPE_MAPPING;
 use crate::object::resolve_one;
@@ -74,8 +74,10 @@ impl ResolvableObject for ModelObject {
     }
 
     fn subscriptions(&self) -> Option<Vec<SubscriptionField>> {
-        Some(vec![
-            SubscriptionField::new("modelRegistered", TypeRef::named_nn(self.type_name()), |ctx| {
+        Some(vec![SubscriptionField::new(
+            "modelRegistered",
+            TypeRef::named_nn(self.type_name()),
+            |ctx| {
                 {
                     SubscriptionFieldFuture::new(async move {
                         let id = match ctx.args.get("id") {
@@ -94,9 +96,9 @@ impl ResolvableObject for ModelObject {
                         }))
                     })
                 }
-            })
-            .argument(InputValue::new("id", TypeRef::named(TypeRef::ID))),
-        ])
+            },
+        )
+        .argument(InputValue::new("id", TypeRef::named(TypeRef::ID)))])
     }
 }
 
@@ -110,7 +112,7 @@ impl ModelObject {
             (Name::new("transactionHash"), Value::from(model.transaction_hash)),
             (
                 Name::new("createdAt"),
-                Value::from(model.created_at.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+                Value::from(model.created_at.format(DATETIME_FORMAT).to_string()),
             ),
         ])
     }

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -180,10 +180,10 @@ fn fetch_value(
             let mut value = row.try_get::<String, &str>(&column_name).map(Value::from)?;
             // add timezone to naive datetime strings
             if type_name == "DateTime" {
-                match add_timezone_to_naive_dt(value.to_string(), "\"%Y-%m-%d %H:%M:%S\"") {
-                    Some(dt) => value = dt,
-                    None => {}
-                };
+                let dt_format = "\"%Y-%m-%d %H:%M:%S\"";
+                if let Some(dt) = add_timezone_to_naive_dt(value.to_string(), dt_format) {
+                    value = dt
+                }
             }
             Ok(value)
         }

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -109,9 +109,9 @@ fn remove_hex_leading_zeros(value: Value) -> Value {
     }
 }
 
-fn add_timezone_to_naive_dt(value: &Value, initial_format: &str) -> Option<Value> {
-    if let Value::String(s) = value {
-        if let Ok(dt) = NaiveDateTime::parse_from_str(s, initial_format) {
+fn add_timezone_to_naive_dt(wrapped_dt: &Value, initial_format: &str) -> Option<Value> {
+    if let Value::String(naive_dt) = wrapped_dt {
+        if let Ok(dt) = NaiveDateTime::parse_from_str(naive_dt, initial_format) {
             let dt_with_timezone = Utc.from_utc_datetime(&dt);
             return Some(Value::String(dt_with_timezone.format(DATETIME_FORMAT).to_string()));
         }


### PR DESCRIPTION
Follow-up from: #1657 

# Problem

At the moment when returning date time with GraphQL, we don't have the timezone information in the date strings. 
This leads to complications when used by other clients: the timezone is set to the local one of the user instead of UTC and discrepancies will be observed.

The last PR only fixed this problem for GQL subscriptions - not for the queries. This has been addressed in this PR.

# Fix

Updated the file: `crates/torii/graphql/src/query/mod.rs`
by adding a function `add_timezone_to_naive_dt`.

Gives the right format:
![image](https://github.com/dojoengine/dojo/assets/22559023/699f2cba-838d-476f-9358-9113cbd34e20)
