### PR TITLE
feat: store contract abi and source in contract metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11135,6 +11135,7 @@ dependencies = [
  "dojo-types",
  "dojo-world",
  "futures",
+ "ipfs-api-backend-hyper",
  "katana-runner",
  "notify",
  "notify-debouncer-mini",

--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -199,7 +199,7 @@ impl DevArgs {
         let env_metadata = if config.manifest_path().exists() {
             let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
 
-            dojo_metadata_from_workspace(&ws).and_then(|inner| inner.env().cloned())
+            dojo_metadata_from_workspace(&ws).env().cloned()
         } else {
             None
         };

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -129,7 +129,7 @@ impl MigrateArgs {
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
 
         let env_metadata = if config.manifest_path().exists() {
-            dojo_metadata_from_workspace(&ws).and_then(|inner| inner.env().cloned())
+            dojo_metadata_from_workspace(&ws).env().cloned()
         } else {
             None
         };

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -25,7 +25,7 @@ pub fn load_metadata_from_config(config: &Config) -> Result<Option<Environment>,
     let env_metadata = if config.manifest_path().exists() {
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
 
-        dojo_metadata_from_workspace(&ws).and_then(|inner| inner.env().cloned())
+        dojo_metadata_from_workspace(&ws).env().cloned()
     } else {
         None
     };

--- a/crates/dojo-lang/Cargo.toml
+++ b/crates/dojo-lang/Cargo.toml
@@ -16,6 +16,7 @@ cairo-lang-debug.workspace = true
 cairo-lang-defs.workspace = true
 cairo-lang-diagnostics.workspace = true
 cairo-lang-filesystem.workspace = true
+cairo-lang-formatter.workspace = true
 cairo-lang-lowering.workspace = true
 cairo-lang-parser.workspace = true
 cairo-lang-plugins.workspace = true
@@ -50,7 +51,6 @@ tracing.workspace = true
 url = "2.2.2"
 
 [dev-dependencies]
-cairo-lang-formatter.workspace = true
 cairo-lang-semantic.workspace = true
 cairo-lang-test-utils.workspace = true
 dojo-test-utils = { path = "../dojo-test-utils" }

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::Write;
 use std::iter::zip;
 use std::ops::DerefMut;
 
@@ -8,13 +9,14 @@ use cairo_lang_defs::db::DefsGroup;
 use cairo_lang_defs::ids::{ModuleId, ModuleItemId};
 use cairo_lang_filesystem::db::FilesGroup;
 use cairo_lang_filesystem::ids::{CrateId, CrateLongId};
+use cairo_lang_formatter::format_string;
 use cairo_lang_semantic::db::SemanticGroup;
 use cairo_lang_starknet::abi;
 use cairo_lang_starknet::contract::{find_contracts, ContractDeclaration};
 use cairo_lang_starknet::contract_class::{compile_prepared_db, ContractClass};
 use cairo_lang_starknet::plugin::aux_data::StarkNetContractAuxData;
 use cairo_lang_utils::UpcastMut;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use convert_case::{Case, Casing};
 use dojo_world::manifest::{
     AbiFormat, Class, ComputedValueEntrypoint, DojoContract, DojoModel, Manifest, ManifestMethods,
@@ -45,6 +47,8 @@ pub const ABIS_DIR: &str = "abis";
 
 pub const CONTRACTS_DIR: &str = "contracts";
 pub const MODELS_DIR: &str = "models";
+
+pub const SOURCES_DIR: &str = "src";
 
 pub(crate) const LOG_TARGET: &str = "dojo_lang::compiler";
 
@@ -87,6 +91,8 @@ impl Compiler for DojoCompiler {
     ) -> Result<()> {
         let props: Props = unit.target().props()?;
         let target_dir = unit.target_dir(ws);
+        let sources_dir = target_dir.child(Utf8Path::new(SOURCES_DIR));
+
         let compiler_config = build_compiler_config(&unit, ws);
 
         let mut main_crate_ids = collect_main_crate_ids(&unit, db);
@@ -118,11 +124,31 @@ impl Compiler for DojoCompiler {
 
         for (decl, class) in zip(contracts, classes) {
             let contract_full_path = decl.module_id().full_path(db.upcast_mut());
-            let file_name = format!("{contract_full_path}.json");
 
-            let mut file = target_dir.open_rw(file_name.clone(), "output file", ws.config())?;
-            serde_json::to_writer_pretty(file.deref_mut(), &class)
-                .with_context(|| format!("failed to serialize contract: {contract_full_path}"))?;
+            // save expanded contract source file
+            if let Ok(file_id) = db.module_main_file(decl.module_id()) {
+                if let Some(file_content) = db.file_content(file_id) {
+                    let src_file_name = format!("{contract_full_path}.cairo").replace("::", "_");
+
+                    let mut file =
+                        sources_dir.open_rw(src_file_name.clone(), "source file", ws.config())?;
+                    file.write(format_string(db, file_content.to_string()).as_bytes())
+                        .with_context(|| {
+                            format!("failed to serialize contract source: {contract_full_path}")
+                        })?;
+                } else {
+                    return Err(anyhow!("failed to get source file content: {contract_full_path}"));
+                }
+            } else {
+                return Err(anyhow!("failed to get source file: {contract_full_path}"));
+            }
+
+            // save JSON artifact file
+            let file_name = format!("{contract_full_path}.json");
+            let mut file = target_dir.open_rw(file_name.clone(), "class file", ws.config())?;
+            serde_json::to_writer_pretty(file.deref_mut(), &class).with_context(|| {
+                format!("failed to serialize contract artifact: {contract_full_path}")
+            })?;
 
             let class_hash = compute_class_hash_of_contract_class(&class).with_context(|| {
                 format!("problem computing class hash for contract `{contract_full_path}`")

--- a/crates/dojo-test-utils/src/compiler.rs
+++ b/crates/dojo-test-utils/src/compiler.rs
@@ -11,25 +11,40 @@ use scarb::ops;
 use scarb_ui::Verbosity;
 
 pub fn build_test_config(path: &str) -> anyhow::Result<Config> {
+    build_full_test_config(path, true)
+}
+
+pub fn build_full_test_config(path: &str, override_dirs: bool) -> anyhow::Result<Config> {
     let mut compilers = CompilerRepository::empty();
     compilers.add(Box::new(DojoCompiler)).unwrap();
 
     let cairo_plugins = CairoPluginRepository::default();
-
-    let cache_dir = TempDir::new().unwrap();
-    let config_dir = TempDir::new().unwrap();
-    let target_dir = TempDir::new().unwrap();
-
     let path = Utf8PathBuf::from_path_buf(path.into()).unwrap();
-    Config::builder(path.canonicalize_utf8().unwrap())
-        .global_cache_dir_override(Some(Utf8Path::from_path(cache_dir.path()).unwrap()))
-        .global_config_dir_override(Some(Utf8Path::from_path(config_dir.path()).unwrap()))
-        .target_dir_override(Some(Utf8Path::from_path(target_dir.path()).unwrap().to_path_buf()))
-        .ui_verbosity(Verbosity::Verbose)
-        .log_filter_directive(env::var_os("SCARB_LOG"))
-        .compilers(compilers)
-        .cairo_plugins(cairo_plugins.into())
-        .build()
+
+    if override_dirs {
+        let cache_dir = TempDir::new().unwrap();
+        let config_dir = TempDir::new().unwrap();
+        let target_dir = TempDir::new().unwrap();
+
+        Config::builder(path.canonicalize_utf8().unwrap())
+            .global_cache_dir_override(Some(Utf8Path::from_path(cache_dir.path()).unwrap()))
+            .global_config_dir_override(Some(Utf8Path::from_path(config_dir.path()).unwrap()))
+            .target_dir_override(Some(
+                Utf8Path::from_path(target_dir.path()).unwrap().to_path_buf(),
+            ))
+            .ui_verbosity(Verbosity::Verbose)
+            .log_filter_directive(env::var_os("SCARB_LOG"))
+            .compilers(compilers)
+            .cairo_plugins(cairo_plugins.into())
+            .build()
+    } else {
+        Config::builder(path.canonicalize_utf8().unwrap())
+            .ui_verbosity(Verbosity::Verbose)
+            .log_filter_directive(env::var_os("SCARB_LOG"))
+            .compilers(compilers)
+            .cairo_plugins(cairo_plugins.into())
+            .build()
+    }
 }
 
 pub fn corelib() -> PathBuf {

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -3,24 +3,144 @@ use std::io::Cursor;
 use std::path::PathBuf;
 
 use anyhow::Result;
+use camino::Utf8PathBuf;
 use ipfs_api_backend_hyper::{IpfsApi, IpfsClient, TryFromUri};
 use scarb::core::{ManifestMetadata, Workspace};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
 use url::Url;
 
+use crate::manifest::{BaseManifest, WORLD_CONTRACT_NAME};
+
 #[cfg(test)]
 #[path = "metadata_test.rs"]
 mod test;
 
-pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> Option<Metadata> {
-    Some(ws.current_package().ok()?.manifest.metadata.dojo())
+pub const IPFS_CLIENT_URL: &str = "https://ipfs.infura.io:5001";
+pub const IPFS_USERNAME: &str = "2EBrzr7ZASQZKH32sl2xWauXPSA";
+pub const IPFS_PASSWORD: &str = "12290b883db9138a8ae3363b6739d220";
+
+// copy constants from dojo-lang to avoid circular dependency
+pub const MANIFESTS_DIR: &str = "manifests";
+pub const ABIS_DIR: &str = "abis";
+pub const SOURCES_DIR: &str = "src";
+pub const BASE_DIR: &str = "base";
+
+fn build_artifact_from_name(
+    source_dir: &Utf8PathBuf,
+    abi_dir: &Utf8PathBuf,
+    element_name: &str,
+) -> ArtifactMetadata {
+    let sanitized_name = element_name.replace("::", "_");
+    let abi_file = abi_dir.join(format!("{sanitized_name}.json"));
+    let src_file = source_dir.join(format!("{sanitized_name}.cairo"));
+
+    ArtifactMetadata {
+        abi: if abi_file.exists() { Some(Uri::File(abi_file.into_std_path_buf())) } else { None },
+        source: if src_file.exists() {
+            Some(Uri::File(src_file.into_std_path_buf()))
+        } else {
+            None
+        },
+    }
 }
 
+/// Build world metadata with data read from the project configuration.
+///
+/// # Arguments
+///
+/// * `project_metadata` - The project metadata.
+///
+/// # Returns
+///
+/// A [`WorldMetadata`] object initialized with project metadata.
+pub fn project_to_world_metadata(project_metadata: Option<ProjectWorldMetadata>) -> WorldMetadata {
+    if let Some(m) = project_metadata {
+        WorldMetadata {
+            name: m.name,
+            description: m.description,
+            cover_uri: m.cover_uri,
+            icon_uri: m.icon_uri,
+            website: m.website,
+            socials: m.socials,
+            ..Default::default()
+        }
+    } else {
+        WorldMetadata {
+            name: None,
+            description: None,
+            cover_uri: None,
+            icon_uri: None,
+            website: None,
+            socials: None,
+            ..Default::default()
+        }
+    }
+}
+
+/// Collect metadata from the project configuration and from the workspace.
+///
+/// # Arguments
+/// `ws`: the workspace.
+///
+/// # Returns
+/// A [`DojoMetadata`] object containing all Dojo metadata.
+pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> DojoMetadata {
+    let profile = ws.config().profile();
+
+    let manifest_dir = ws.manifest_path().parent().unwrap().to_path_buf();
+    let manifest_dir = manifest_dir.join(MANIFESTS_DIR).join(profile.as_str());
+    let target_dir = ws.target_dir().path_existent().unwrap();
+    let sources_dir = target_dir.join(profile.as_str()).join(SOURCES_DIR);
+    let abis_dir = manifest_dir.join(ABIS_DIR).join(BASE_DIR);
+
+    let project_metadata = ws.current_package().unwrap().manifest.metadata.dojo();
+    let mut dojo_metadata =
+        DojoMetadata { env: project_metadata.env.clone(), ..Default::default() };
+
+    let world_artifact = build_artifact_from_name(&sources_dir, &abis_dir, WORLD_CONTRACT_NAME);
+
+    // inialize Dojo world metadata with world metadata coming from project configuration
+    dojo_metadata.world = project_to_world_metadata(project_metadata.world);
+    dojo_metadata.world.artifacts = world_artifact;
+
+    // load models and contracts metadata
+    if manifest_dir.join(BASE_DIR).exists() {
+        if let Ok(manifest) = BaseManifest::load_from_path(&manifest_dir.join(BASE_DIR)) {
+            for model in manifest.models {
+                let name = model.name.to_string();
+                dojo_metadata.artifacts.insert(
+                    name.clone(),
+                    build_artifact_from_name(&sources_dir, &abis_dir.join("models"), &name),
+                );
+            }
+
+            for contract in manifest.contracts {
+                let name = contract.name.to_string();
+                dojo_metadata.artifacts.insert(
+                    name.clone(),
+                    build_artifact_from_name(&sources_dir, &abis_dir.join("contracts"), &name),
+                );
+            }
+        }
+    }
+
+    dojo_metadata
+}
+
+/// Metadata coming from project configuration (Scarb.toml)
 #[derive(Default, Deserialize, Debug, Clone)]
-pub struct Metadata {
-    pub world: Option<WorldMetadata>,
+pub struct ProjectMetadata {
+    pub world: Option<ProjectWorldMetadata>,
     pub env: Option<Environment>,
+}
+
+/// Metadata collected from the project configuration and the Dojo workspace
+#[derive(Default, Deserialize, Debug, Clone)]
+pub struct DojoMetadata {
+    pub world: WorldMetadata,
+    pub env: Option<Environment>,
+    pub artifacts: HashMap<String, ArtifactMetadata>,
 }
 
 #[derive(Debug)]
@@ -76,6 +196,18 @@ impl Uri {
     }
 }
 
+/// World metadata coming from the project configuration (Scarb.toml)
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+pub struct ProjectWorldMetadata {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub cover_uri: Option<Uri>,
+    pub icon_uri: Option<Uri>,
+    pub website: Option<Url>,
+    pub socials: Option<HashMap<String, String>>,
+}
+
+/// World metadata collected from the project configuration and the Dojo workspace
 #[derive(Default, Serialize, Deserialize, Debug, Clone)]
 pub struct WorldMetadata {
     pub name: Option<String>,
@@ -84,6 +216,14 @@ pub struct WorldMetadata {
     pub icon_uri: Option<Uri>,
     pub website: Option<Url>,
     pub socials: Option<HashMap<String, String>>,
+    pub artifacts: ArtifactMetadata,
+}
+
+/// Metadata Artifacts collected for one Dojo element (world, model, contract...)
+#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+pub struct ArtifactMetadata {
+    pub abi: Option<Uri>,
+    pub source: Option<Uri>,
 }
 
 #[derive(Default, Deserialize, Clone, Debug)]
@@ -122,7 +262,7 @@ impl Environment {
     }
 }
 
-impl WorldMetadata {
+impl ProjectWorldMetadata {
     pub fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }
@@ -135,8 +275,8 @@ impl WorldMetadata {
 impl WorldMetadata {
     pub async fn upload(&self) -> Result<String> {
         let mut meta = self.clone();
-        let client = IpfsClient::from_str("https://ipfs.infura.io:5001")?
-            .with_credentials("2EBrzr7ZASQZKH32sl2xWauXPSA", "12290b883db9138a8ae3363b6739d220");
+        let client =
+            IpfsClient::from_str(IPFS_CLIENT_URL)?.with_credentials(IPFS_USERNAME, IPFS_PASSWORD);
 
         if let Some(Uri::File(icon)) = &self.icon_uri {
             let icon_data = std::fs::read(icon)?;
@@ -152,6 +292,20 @@ impl WorldMetadata {
             meta.cover_uri = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
         };
 
+        if let Some(Uri::File(abi)) = &self.artifacts.abi {
+            let abi_data = std::fs::read(abi)?;
+            let reader = Cursor::new(abi_data);
+            let response = client.add(reader).await?;
+            meta.artifacts.abi = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
+        };
+
+        if let Some(Uri::File(source)) = &self.artifacts.source {
+            let source_data = std::fs::read(source)?;
+            let reader = Cursor::new(source_data);
+            let response = client.add(reader).await?;
+            meta.artifacts.source = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
+        };
+
         let serialized = json!(meta).to_string();
         let reader = Cursor::new(serialized);
         let response = client.add(reader).await?;
@@ -160,26 +314,51 @@ impl WorldMetadata {
     }
 }
 
-impl Metadata {
+impl ArtifactMetadata {
+    pub async fn upload(&self) -> Result<String> {
+        let mut meta = self.clone();
+        let client =
+            IpfsClient::from_str(IPFS_CLIENT_URL)?.with_credentials(IPFS_USERNAME, IPFS_PASSWORD);
+
+        if let Some(Uri::File(abi)) = &self.abi {
+            let abi_data = std::fs::read(abi)?;
+            let reader = Cursor::new(abi_data);
+            let response = client.add(reader).await?;
+            meta.abi = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
+        };
+
+        if let Some(Uri::File(source)) = &self.source {
+            let source_data = std::fs::read(source)?;
+            let reader = Cursor::new(source_data);
+            let response = client.add(reader).await?;
+            meta.source = Some(Uri::Ipfs(format!("ipfs://{}", response.hash)))
+        };
+
+        let serialized = json!(meta).to_string();
+        let reader = Cursor::new(serialized);
+        let response = client.add(reader).await?;
+
+        Ok(response.hash)
+    }
+}
+
+impl DojoMetadata {
     pub fn env(&self) -> Option<&Environment> {
         self.env.as_ref()
     }
-
-    pub fn world(&self) -> Option<&WorldMetadata> {
-        self.world.as_ref()
-    }
 }
+
 trait MetadataExt {
-    fn dojo(&self) -> Metadata;
+    fn dojo(&self) -> ProjectMetadata;
 }
 
 impl MetadataExt for ManifestMetadata {
-    fn dojo(&self) -> Metadata {
+    fn dojo(&self) -> ProjectMetadata {
         self.tool_metadata
             .as_ref()
             .and_then(|e| e.get("dojo"))
             .cloned()
-            .map(|v| v.try_into::<Metadata>().unwrap_or_default())
+            .map(|v| v.try_into::<ProjectMetadata>().unwrap_or_default())
             .unwrap_or_default()
     }
 }

--- a/crates/dojo-world/src/metadata_test_data/abi.json
+++ b/crates/dojo-world/src/metadata_test_data/abi.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "impl",
+    "name": "WorldProviderImpl",
+    "interface_name": "dojo::world::IWorldProvider"
+  },
+  {
+    "type": "struct",
+    "name": "dojo::world::IWorldDispatcher",
+    "members": [
+      {
+        "name": "contract_address",
+        "type": "core::starknet::contract_address::ContractAddress"
+      }
+    ]
+  }
+]

--- a/crates/dojo-world/src/metadata_test_data/source.cairo
+++ b/crates/dojo-world/src/metadata_test_data/source.cairo
@@ -1,0 +1,79 @@
+use starknet::ContractAddress;
+
+#[derive(Serde, Copy, Drop, Introspect)]
+enum Direction {
+    None,
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+impl DirectionIntoFelt252 of Into<Direction, felt252> {
+    fn into(self: Direction) -> felt252 {
+        match self {
+            Direction::None => 0,
+            Direction::Left => 1,
+            Direction::Right => 2,
+            Direction::Up => 3,
+            Direction::Down => 4,
+        }
+    }
+}
+
+#[derive(Model, Copy, Drop, Serde)]
+struct Moves {
+    #[key]
+    player: ContractAddress,
+    remaining: u8,
+    last_direction: Direction
+}
+
+#[derive(Copy, Drop, Serde, Introspect)]
+struct Vec2 {
+    x: u32,
+    y: u32
+}
+
+#[derive(Model, Copy, Drop, Serde)]
+struct Position {
+    #[key]
+    player: ContractAddress,
+    vec: Vec2,
+}
+
+trait Vec2Trait {
+    fn is_zero(self: Vec2) -> bool;
+    fn is_equal(self: Vec2, b: Vec2) -> bool;
+}
+
+impl Vec2Impl of Vec2Trait {
+    fn is_zero(self: Vec2) -> bool {
+        if self.x - self.y == 0 {
+            return true;
+        }
+        false
+    }
+
+    fn is_equal(self: Vec2, b: Vec2) -> bool {
+        self.x == b.x && self.y == b.y
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Position, Vec2, Vec2Trait};
+
+    #[test]
+    #[available_gas(100000)]
+    fn test_vec_is_zero() {
+        assert(Vec2Trait::is_zero(Vec2 { x: 0, y: 0 }), 'not zero');
+    }
+
+    #[test]
+    #[available_gas(100000)]
+    fn test_vec_is_equal() {
+        let position = Vec2 { x: 420, y: 0 };
+        assert(position.is_equal(Vec2 { x: 420, y: 0 }), 'not equal');
+    }
+}

--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -51,6 +51,7 @@ pub struct UpgradeOutput {
 pub struct RegisterOutput {
     pub transaction_hash: FieldElement,
     pub declare_output: Vec<DeclareOutput>,
+    pub registered_model_names: Vec<String>,
 }
 
 #[derive(Debug, Error)]

--- a/crates/sozo/ops/Cargo.toml
+++ b/crates/sozo/ops/Cargo.toml
@@ -49,5 +49,6 @@ cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.2.2" }
 [dev-dependencies]
 assert_fs = "1.0.10"
 dojo-test-utils = { workspace = true, features = [ "build-examples" ] }
+ipfs-api-backend-hyper = { git = "https://github.com/ferristseng/rust-ipfs-api", rev = "af2c17f7b19ef5b9898f458d97a90055c3605633", features = [ "with-hyper-rustls" ] }
 katana-runner.workspace = true
 snapbox = "0.4.6"

--- a/crates/sozo/ops/src/tests/migration.rs
+++ b/crates/sozo/ops/src/tests/migration.rs
@@ -1,0 +1,496 @@
+use std::str;
+
+use camino::Utf8Path;
+use dojo_lang::compiler::{BASE_DIR, MANIFESTS_DIR};
+use dojo_test_utils::compiler::build_full_test_config;
+use dojo_test_utils::sequencer::{
+    get_default_test_starknet_config, SequencerConfig, StarknetConfig, TestSequencer,
+};
+use dojo_world::contracts::WorldContractReader;
+use dojo_world::manifest::{BaseManifest, DeploymentManifest, WORLD_CONTRACT_NAME};
+use dojo_world::metadata::{
+    dojo_metadata_from_workspace, ArtifactMetadata, DojoMetadata, Uri, WorldMetadata,
+    IPFS_CLIENT_URL, IPFS_PASSWORD, IPFS_USERNAME,
+};
+use dojo_world::migration::strategy::prepare_for_migration;
+use dojo_world::migration::world::WorldDiff;
+use dojo_world::migration::TxConfig;
+use futures::TryStreamExt;
+use ipfs_api_backend_hyper::{HyperBackend, IpfsApi, IpfsClient, TryFromUri};
+use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};
+use starknet::core::chain_id;
+use starknet::core::types::{BlockId, BlockTag};
+use starknet::core::utils::{get_selector_from_name, parse_cairo_short_string};
+use starknet::macros::felt;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
+use starknet::signers::{LocalWallet, SigningKey};
+use starknet_crypto::FieldElement;
+
+use super::setup::{load_config, setup_migration, setup_ws};
+use crate::migration::{execute_strategy, upload_metadata};
+use crate::utils::get_contract_address_from_reader;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn migrate_with_auto_mine() {
+    let config = load_config();
+    let ws = setup_ws(&config);
+
+    let mut migration = setup_migration().unwrap();
+
+    let sequencer =
+        TestSequencer::start(SequencerConfig::default(), get_default_test_starknet_config()).await;
+
+    let mut account = sequencer.account();
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+    execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+
+    sequencer.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn migrate_with_block_time() {
+    let config = load_config();
+    let ws = setup_ws(&config);
+
+    let mut migration = setup_migration().unwrap();
+
+    let sequencer = TestSequencer::start(
+        SequencerConfig { block_time: Some(1000), ..Default::default() },
+        get_default_test_starknet_config(),
+    )
+    .await;
+
+    let mut account = sequencer.account();
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+    execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+    sequencer.stop().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn migrate_with_small_fee_multiplier_will_fail() {
+    let config = load_config();
+    let ws = setup_ws(&config);
+
+    let mut migration = setup_migration().unwrap();
+
+    let sequencer = TestSequencer::start(
+        Default::default(),
+        StarknetConfig { disable_fee: false, ..Default::default() },
+    )
+    .await;
+
+    let account = SingleOwnerAccount::new(
+        JsonRpcClient::new(HttpTransport::new(sequencer.url())),
+        LocalWallet::from_signing_key(SigningKey::from_secret_scalar(
+            sequencer.raw_account().private_key,
+        )),
+        sequencer.raw_account().account_address,
+        chain_id::TESTNET,
+        ExecutionEncoding::New,
+    );
+
+    assert!(
+        execute_strategy(
+            &ws,
+            &mut migration,
+            &account,
+            Some(TxConfig { fee_estimate_multiplier: Some(0.2f64), wait: false, receipt: false }),
+        )
+        .await
+        .is_err()
+    );
+    sequencer.stop().unwrap();
+}
+
+#[test]
+fn migrate_world_without_seed_will_fail() {
+    let profile_name = "dev";
+    let base = "../../../examples/spawn-and-move";
+    let target_dir = format!("{}/target/dev", base);
+    let manifest = BaseManifest::load_from_path(
+        &Utf8Path::new(base).to_path_buf().join(MANIFESTS_DIR).join(profile_name).join(BASE_DIR),
+    )
+    .unwrap();
+    let world = WorldDiff::compute(manifest, None);
+    let res = prepare_for_migration(None, None, &Utf8Path::new(&target_dir).to_path_buf(), world);
+    assert!(res.is_err_and(|e| e.to_string().contains("Missing seed for World deployment.")))
+}
+
+#[tokio::test]
+async fn migration_from_remote() {
+    let config = load_config();
+    let ws = setup_ws(&config);
+
+    let base = "../../../examples/spawn-and-move";
+    let target_dir = format!("{}/target/dev", base);
+
+    let sequencer =
+        TestSequencer::start(SequencerConfig::default(), get_default_test_starknet_config()).await;
+
+    let account = SingleOwnerAccount::new(
+        JsonRpcClient::new(HttpTransport::new(sequencer.url())),
+        LocalWallet::from_signing_key(SigningKey::from_secret_scalar(
+            sequencer.raw_account().private_key,
+        )),
+        sequencer.raw_account().account_address,
+        chain_id::TESTNET,
+        ExecutionEncoding::New,
+    );
+
+    let profile_name = ws.current_profile().unwrap().to_string();
+
+    let manifest = BaseManifest::load_from_path(
+        &Utf8Path::new(base).to_path_buf().join(MANIFESTS_DIR).join(&profile_name).join(BASE_DIR),
+    )
+    .unwrap();
+
+    let world = WorldDiff::compute(manifest, None);
+
+    let mut migration = prepare_for_migration(
+        None,
+        Some(felt!("0x12345")),
+        &Utf8Path::new(&target_dir).to_path_buf(),
+        world,
+    )
+    .unwrap();
+
+    execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+
+    let local_manifest = BaseManifest::load_from_path(
+        &Utf8Path::new(base).to_path_buf().join(MANIFESTS_DIR).join(&profile_name).join(BASE_DIR),
+    )
+    .unwrap();
+
+    let remote_manifest = DeploymentManifest::load_from_remote(
+        JsonRpcClient::new(HttpTransport::new(sequencer.url())),
+        migration.world_address().unwrap(),
+    )
+    .await
+    .unwrap();
+
+    sequencer.stop().unwrap();
+
+    assert_eq!(local_manifest.world.inner.class_hash, remote_manifest.world.inner.class_hash);
+    assert_eq!(local_manifest.models.len(), remote_manifest.models.len());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn migrate_with_metadata() {
+    let config = build_full_test_config("../../../examples/spawn-and-move/Scarb.toml", false)
+        .unwrap_or_else(|c| panic!("Error loading config: {c:?}"));
+    let ws = setup_ws(&config);
+
+    let mut migration = setup_migration().unwrap();
+
+    let sequencer =
+        TestSequencer::start(SequencerConfig::default(), get_default_test_starknet_config()).await;
+
+    let mut account = sequencer.account();
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+    let output = execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+
+    let res = upload_metadata(&ws, &account, output.clone()).await;
+    assert!(res.is_ok());
+
+    let provider = sequencer.provider();
+    let world_reader = WorldContractReader::new(output.world_address, &provider);
+
+    let client = IpfsClient::from_str(IPFS_CLIENT_URL)
+        .unwrap_or_else(|_| panic!("Unable to initialize the IPFS Client"))
+        .with_credentials(IPFS_USERNAME, IPFS_PASSWORD);
+
+    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+
+    // check world metadata
+    let resource = world_reader.metadata(&FieldElement::ZERO).call().await.unwrap();
+    let element_name = WORLD_CONTRACT_NAME.to_string();
+
+    let full_uri = get_and_check_metadata_uri(&element_name, &resource.metadata_uri);
+    let resource_bytes = get_ipfs_resource_data(&client, &element_name, &full_uri).await;
+
+    let metadata = resource_bytes_to_world_metadata(&resource_bytes, &element_name);
+
+    assert_eq!(metadata.name, dojo_metadata.world.name, "");
+    assert_eq!(metadata.description, dojo_metadata.world.description, "");
+    assert_eq!(metadata.cover_uri, dojo_metadata.world.cover_uri, "");
+    assert_eq!(metadata.icon_uri, dojo_metadata.world.icon_uri, "");
+    assert_eq!(metadata.website, dojo_metadata.world.website, "");
+    assert_eq!(metadata.socials, dojo_metadata.world.socials, "");
+
+    check_artifact_fields(
+        &client,
+        &metadata.artifacts,
+        &dojo_metadata.world.artifacts,
+        &element_name,
+    )
+    .await;
+
+    // check model metadata
+    for m in migration.models {
+        let selector = get_selector_from_name(&m.diff.name).unwrap();
+        check_artifact_metadata(&client, &world_reader, selector, &m.diff.name, &dojo_metadata)
+            .await;
+    }
+
+    // check contract metadata
+    for c in migration.contracts {
+        let contract_address =
+            get_contract_address_from_reader(&world_reader, c.diff.name.clone()).await.unwrap();
+        check_artifact_metadata(
+            &client,
+            &world_reader,
+            contract_address,
+            &c.diff.name,
+            &dojo_metadata,
+        )
+        .await;
+    }
+}
+
+/// Get the hash from a IPFS URI
+///
+/// # Arguments
+///
+/// * `uri` - a full IPFS URI
+///
+/// # Returns
+///
+/// A [`String`] containing the hash from the URI.
+fn get_hash_from_uri(uri: &str) -> String {
+    let hash = match uri.strip_prefix("ipfs://") {
+        Some(s) => s.to_string(),
+        None => uri.to_owned(),
+    };
+    match hash.strip_suffix('/') {
+        Some(s) => s.to_string(),
+        None => hash,
+    }
+}
+
+/// Check a metadata field which refers to a file.
+///
+/// # Arguments
+///
+/// * `client` - a IPFS client.
+/// * `uri` - the IPFS URI of the abi field.
+/// * `expected_uri` - the URI of the expected file.
+/// * `field_name` - the field name.
+/// * `element_name` - the fully qualified name of the element linked to this field.
+async fn check_file_field(
+    client: &HyperBackend,
+    uri: &Uri,
+    expected_uri: &Uri,
+    field_name: String,
+    element_name: &String,
+) {
+    if let Uri::Ipfs(uri) = uri {
+        let resource_data = get_ipfs_resource_data(client, element_name, uri).await;
+        assert!(
+            !resource_data.is_empty(),
+            "{field_name} IPFS artifact for {} is empty",
+            element_name
+        );
+
+        if let Uri::File(f) = expected_uri {
+            let file_content = std::fs::read_to_string(f).unwrap();
+            let resource_content = std::str::from_utf8(&resource_data).unwrap_or_else(|_| {
+                panic!(
+                    "Unable to stringify resource data for field '{}' of {}",
+                    field_name, element_name
+                )
+            });
+
+            assert!(
+                file_content.eq(&resource_content),
+                "local '{field_name}' content differs from the one uploaded on IPFS for {}",
+                element_name
+            );
+        } else {
+            panic!(
+                "The field '{field_name}' of {} is not a file (Should never happen !)",
+                element_name
+            );
+        }
+    } else {
+        panic!("The '{field_name}' field is not an IPFS artifact for {}", element_name);
+    }
+}
+
+/// Convert resource bytes to a ArtifactMetadata object.
+///
+/// # Arguments
+///
+/// * `raw_data` - resource data as bytes.
+/// * `element_name` - name of the element linked to this resource.
+///
+/// # Returns
+///
+/// A [`ArtifactMetadata`] object.
+fn resource_bytes_to_metadata(raw_data: &[u8], element_name: &String) -> ArtifactMetadata {
+    let data = std::str::from_utf8(raw_data)
+        .unwrap_or_else(|_| panic!("Unable to stringify raw metadata for {}", element_name));
+    serde_json::from_str(data)
+        .unwrap_or_else(|_| panic!("Unable to deserialize metadata for {}", element_name))
+}
+
+/// Convert resource bytes to a WorldMetadata object.
+///
+/// # Arguments
+///
+/// * `raw_data` - resource data as bytes.
+/// * `element_name` - name of the element linked to this resource.
+///
+/// # Returns
+///
+/// A [`WorldMetadata`] object.
+fn resource_bytes_to_world_metadata(raw_data: &[u8], element_name: &String) -> WorldMetadata {
+    let data = std::str::from_utf8(raw_data)
+        .unwrap_or_else(|_| panic!("Unable to stringify raw metadata for {}", element_name));
+    serde_json::from_str(data)
+        .unwrap_or_else(|_| panic!("Unable to deserialize metadata for {}", element_name))
+}
+
+/// Read the content of a resource identified by its IPFS URI.
+///
+/// # Arguments
+///
+/// * `client` - a IPFS client.
+/// * `element_name` - the name of the element (model or contract) linked to this artifact.
+/// * `uri` - the IPFS resource URI.
+///
+/// # Returns
+///
+/// A [`Vec<u8>`] containing the resource content as bytes.
+async fn get_ipfs_resource_data(
+    client: &HyperBackend,
+    element_name: &String,
+    uri: &String,
+) -> Vec<u8> {
+    let hash = get_hash_from_uri(uri);
+
+    let res = client.cat(&hash).map_ok(|chunk| chunk.to_vec()).try_concat().await;
+    assert!(res.is_ok(), "Unable to read the IPFS artifact {} for {}", uri, element_name);
+
+    res.unwrap()
+}
+
+/// Check the validity of artifact metadata fields.
+///
+/// # Arguments
+///
+/// * `client` - a IPFS client.
+/// * `metadata` - the metadata to check.
+/// * `expected_metadata` - the metadata values coming from local Dojo metadata.
+/// * `element_name` - the name of the element linked to this metadata.
+async fn check_artifact_fields(
+    client: &HyperBackend,
+    metadata: &ArtifactMetadata,
+    expected_metadata: &ArtifactMetadata,
+    element_name: &String,
+) {
+    assert!(metadata.abi.is_some(), "'abi' field not set for {}", element_name);
+    let abi = metadata.abi.as_ref().unwrap();
+    let expected_abi = expected_metadata.abi.as_ref().unwrap();
+    check_file_field(client, abi, expected_abi, "abi".to_string(), element_name).await;
+
+    assert!(metadata.source.is_some(), "'source' field not set for {}", element_name);
+    let source = metadata.source.as_ref().unwrap();
+    let expected_source = expected_metadata.source.as_ref().unwrap();
+    check_file_field(client, source, expected_source, "source".to_string(), element_name).await;
+}
+
+/// Check the validity of a IPFS artifact metadata.
+///
+/// # Arguments
+///
+/// * `client` - a IPFS client.
+/// * `element_name` - the fully qualified name of the element linked to the artifact.
+/// * `uri` - the full metadata URI.
+/// * `expected_metadata` - the expected metadata values coming from local Dojo metadata.
+async fn check_ipfs_metadata(
+    client: &HyperBackend,
+    element_name: &String,
+    uri: &String,
+    expected_metadata: &ArtifactMetadata,
+) {
+    let resource_bytes = get_ipfs_resource_data(client, element_name, uri).await;
+    let metadata = resource_bytes_to_metadata(&resource_bytes, element_name);
+
+    check_artifact_fields(client, &metadata, expected_metadata, element_name).await;
+}
+
+/// Rebuild the full metadata URI from an array of 3 FieldElement.
+///
+/// # Arguments
+///
+/// * `element_name` - name of the element (model or contract) linked to the metadata URI.
+/// * `uri` - uri as an array of 3 FieldElement.
+///
+/// # Returns
+///
+/// A [`String`] containing the full metadata URI.
+fn get_and_check_metadata_uri(element_name: &String, uri: &Vec<FieldElement>) -> String {
+    assert!(uri.len() == 3, "bad metadata URI length for {} ({:#?})", element_name, uri);
+
+    let mut i = 0;
+    let mut full_uri = "".to_string();
+
+    while i < uri.len() && uri[i] != FieldElement::ZERO {
+        let uri_str = parse_cairo_short_string(&uri[i]);
+        assert!(
+            uri_str.is_ok(),
+            "unable to parse the part {} of the metadata URI for {}",
+            i + 1,
+            element_name
+        );
+
+        full_uri = format!("{}{}", full_uri, uri_str.unwrap());
+
+        i += 1;
+    }
+
+    assert!(!full_uri.is_empty(), "metadata URI is empty for {}", element_name);
+
+    assert!(
+        full_uri.starts_with("ipfs://"),
+        "metadata URI for {} is not an IPFS artifact",
+        element_name
+    );
+
+    full_uri
+}
+
+/// Check an artifact metadata read from the resource registry against its value
+/// in the local Dojo metadata.  
+///
+/// # Arguments
+///
+/// * `client` - a IPFS client.
+/// * `world_reader` - a world reader object.
+/// * `resource_id` - the resource ID in the resource registry.
+/// * `element_name` - the fully qualified name of the element linked to this metadata.
+/// * `dojo_metadata` - local Dojo metadata.
+async fn check_artifact_metadata<P: starknet::providers::Provider + Sync>(
+    client: &HyperBackend,
+    world_reader: &WorldContractReader<P>,
+    resource_id: FieldElement,
+    element_name: &String,
+    dojo_metadata: &DojoMetadata,
+) {
+    let resource = world_reader.metadata(&resource_id).call().await.unwrap();
+
+    let expected_artifact = dojo_metadata.artifacts.get(element_name);
+    assert!(
+        expected_artifact.is_some(),
+        "Unable to find local artifact metadata for {}",
+        element_name
+    );
+    let expected_artifact = expected_artifact.unwrap();
+
+    let full_uri = get_and_check_metadata_uri(element_name, &resource.metadata_uri);
+    check_ipfs_metadata(client, element_name, &full_uri, expected_artifact).await;
+}

--- a/crates/sozo/ops/src/tests/mod.rs
+++ b/crates/sozo/ops/src/tests/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
 pub mod call;
+pub mod migration;
 pub mod setup;
 pub mod utils;

--- a/crates/sozo/ops/src/tests/setup.rs
+++ b/crates/sozo/ops/src/tests/setup.rs
@@ -3,7 +3,9 @@ use dojo_test_utils::compiler::build_test_config;
 use dojo_test_utils::migration::prepare_migration;
 use dojo_test_utils::sequencer::TestSequencer;
 use dojo_world::contracts::world::WorldContract;
+use dojo_world::migration::strategy::MigrationStrategy;
 use dojo_world::migration::TxConfig;
+use scarb::core::{Config, Workspace};
 use scarb::ops;
 use starknet::accounts::SingleOwnerAccount;
 use starknet::core::types::{BlockId, BlockTag};
@@ -13,7 +15,46 @@ use starknet::signers::LocalWallet;
 
 use crate::migration;
 
+/// Load the spawn-and-moves project configuration.
+///
+/// # Returns
+///
+/// A [`Config`] object loaded from the spawn-and-moves Scarb.toml file.
+pub fn load_config() -> Config {
+    build_test_config("../../../examples/spawn-and-move/Scarb.toml")
+        .unwrap_or_else(|c| panic!("Error loading config: {c:?}"))
+}
+
+/// Setups the workspace for the spawn-and-moves project.
+///
+/// # Arguments
+/// * `config` - the project configuration.
+///
+/// # Returns
+///
+/// A [`Workspace`] loaded from the spawn-and-moves project.
+pub fn setup_ws(config: &Config) -> Workspace<'_> {
+    ops::read_workspace(config.manifest_path(), config)
+        .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"))
+}
+
+/// Prepare the migration for the spawn-and-moves project.
+///
+/// # Returns
+///
+/// A [`MigrationStrategy`] to execute to migrate the full spawn-and-moves project.
+pub fn setup_migration() -> Result<MigrationStrategy> {
+    let base_dir = "../../../examples/spawn-and-move";
+    let target_dir = format!("{}/target/dev", base_dir);
+
+    prepare_migration(base_dir.into(), target_dir.into())
+}
+
 /// Setups the project by migrating the full spawn-and-moves project.
+///
+/// # Arguments
+///
+/// * `sequencer` - The sequencer used for tests.
 ///
 /// # Returns
 ///
@@ -22,13 +63,10 @@ use crate::migration;
 pub async fn setup(
     sequencer: &TestSequencer,
 ) -> Result<WorldContract<SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>>> {
-    let config = build_test_config("../../../examples/spawn-and-move/Scarb.toml")?;
-    let ws = ops::read_workspace(config.manifest_path(), &config)
-        .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    let base_dir = "../../../examples/spawn-and-move";
-    let target_dir = format!("{}/target/dev", base_dir);
+    let config = load_config();
+    let ws = setup_ws(&config);
 
-    let mut migration = prepare_migration(base_dir.into(), target_dir.into())?;
+    let mut migration = setup_migration()?;
 
     let mut account = sequencer.account();
     account.set_block_id(BlockId::Tag(BlockTag::Pending));

--- a/crates/torii/graphql/src/tests/metadata_test.rs
+++ b/crates/torii/graphql/src/tests/metadata_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use dojo_world::metadata::Metadata as DojoMetadata;
+    use dojo_world::metadata::{project_to_world_metadata, ProjectMetadata};
     use sqlx::SqlitePool;
     use starknet_crypto::FieldElement;
     use torii_core::sql::Sql;
@@ -51,7 +51,7 @@ mod tests {
         let schema = build_schema(&pool).await.unwrap();
 
         let cover_img = "QWxsIHlvdXIgYmFzZSBiZWxvbmcgdG8gdXM=";
-        let dojo_metadata: DojoMetadata = toml::from_str(
+        let project_metadata: ProjectMetadata = toml::from_str(
             r#"
   [world]
   name = "example"
@@ -62,7 +62,7 @@ mod tests {
           "#,
         )
         .unwrap();
-        let world_metadata = dojo_metadata.world.unwrap();
+        let world_metadata = project_to_world_metadata(project_metadata.world);
         db.set_metadata(&RESOURCE, URI, BLOCK_TIMESTAMP);
         db.update_metadata(&RESOURCE, URI, &world_metadata, &None, &Some(cover_img.to_string()))
             .await

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -630,7 +630,7 @@ async fn validate_message(
     } else {
         return Err(Error::InvalidMessageError("Model name is missing".to_string()));
     };
-    let model_selector = get_selector_from_name(&model_name).map_err(|e| {
+    let model_selector = get_selector_from_name(model_name).map_err(|e| {
         Error::InvalidMessageError(format!("Failed to get selector from model name: {}", e))
     })?;
 


### PR DESCRIPTION
related to https://github.com/dojoengine/dojo/issues/1121.
related to DOJ-113

- compiler updated to save:
   - formatted and expanded contract source file in `target` dir,
   - ABI file (separated from the full artifact file),
- migration updated to upload ABI and source as IPFS artifacts and then store them in the `ResourceMetadata` registry. 
- tests reworked and updated.