### PR TITLE
sozo: add dry-run mode

### DIFF
--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -119,7 +119,8 @@ impl MigrateArgs {
             )
             .await?;
 
-            migration::migrate(&ws, world_address, chain_id, &account, self.name).await
+            migration::migrate(&ws, world_address, chain_id, &account, self.name, self.dry_run)
+                .await
         })
     }
 }

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -699,7 +699,7 @@ pub fn print_strategy(ui: &Ui, strategy: &MigrationStrategy) {
 
     if let Some(world) = &strategy.world {
         ui.print_header("# World");
-        ui.print_sub(format!("declare (classhash: {:#x})\n", world.diff.local));
+        ui.print_sub(format!("declare (class hash: {:#x})\n", world.diff.local));
     }
 
     if !&strategy.models.is_empty() {

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -734,11 +734,8 @@ where
     format!("deploy {}", contract.diff.name)
 }
 
-pub async fn print_strategy<P>(
-    ui: &Ui,
-    provider: &P,
-    strategy: &MigrationStrategy,
-) where
+pub async fn print_strategy<P>(ui: &Ui, provider: &P, strategy: &MigrationStrategy)
+where
     P: Provider + Sync + Send + 'static,
 {
     ui.print("\n📋 Migration Strategy\n");

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -694,7 +694,7 @@ pub fn print_strategy(ui: &Ui, strategy: &MigrationStrategy) {
 
     if let Some(base) = &strategy.base {
         ui.print_header("# Base Contract");
-        ui.print_sub(format!("declare (classhash: {:#x})\n", base.diff.local));
+        ui.print_sub(format!("declare (class hash: {:#x})\n", base.diff.local));
     }
 
     if let Some(world) = &strategy.world {

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -705,7 +705,7 @@ pub fn print_strategy(ui: &Ui, strategy: &MigrationStrategy) {
     if !&strategy.models.is_empty() {
         ui.print_header(format!("# Models ({})", &strategy.models.len()));
         for m in &strategy.models {
-            ui.print_sub(format!("register {} (classhash: {:#x})", m.diff.name, m.diff.local));
+            ui.print_sub(format!("register {} (class hash: {:#x})", m.diff.name, m.diff.local));
         }
         ui.print(" ");
     }

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -713,7 +713,7 @@ pub fn print_strategy(ui: &Ui, strategy: &MigrationStrategy) {
     if !&strategy.contracts.is_empty() {
         ui.print_header(format!("# Contracts ({})", &strategy.contracts.len()));
         for c in &strategy.contracts {
-            ui.print_sub(format!("deploy {} (classhash: {:#x})", c.diff.name, c.diff.local));
+            ui.print_sub(format!("deploy {} (class hash: {:#x})", c.diff.name, c.diff.local));
         }
         ui.print(" ");
     }


### PR DESCRIPTION
Related to https://github.com/dojoengine/dojo/issues/1468.
closes DOJ-129

In dry-run mode, display the computed migration strategy instead of executing it.