### PR TITLE
fix: add script to teardown tests and updated cargo lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10427,7 +10427,7 @@ dependencies = [
 
 [[package]]
 name = "saya-provider"
-version = "0.6.0-alpha.7"
+version = "0.6.0-alpha.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/torii/types-test/manifests/base/contracts/records.toml
+++ b/crates/torii/types-test/manifests/base/contracts/records.toml
@@ -1,5 +1,5 @@
 kind = "DojoContract"
-class_hash = "0x5f0a221b80b5667c20574d62953f99eb6ddf7d351f531a9f0c56f96adb0d48b"
+class_hash = "0xf6347423d9f59912d0b441646d448f5d4d30869e634061670e090266a41d0d"
 abi = "abis/base/contracts/records.json"
 reads = []
 writes = []

--- a/scripts/teardown_test_artifacts.sh
+++ b/scripts/teardown_test_artifacts.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# When tests are run, the `build.rs` of `dojo-test-utils` is re-building the
+# cairo artifacts ONLY if they don't exist.
+# This script gives an easy way to remove those artifacts.
+
+rm -rf examples/spawn-and-move/target
+rm -rf crates/torii/types-test/target


### PR DESCRIPTION
1. directory wasn't clean, which causes fail on the benchmark CI.
2. ensure the test projects can be reset for accurate testing. 