### PR TITLE
fix(katana-rpc): use tx rpc type instead of primitive for torii api

### DIFF
--- a/crates/katana/rpc/rpc-types/src/transaction.rs
+++ b/crates/katana/rpc/rpc-types/src/transaction.rs
@@ -238,7 +238,7 @@ pub enum BroadcastedTx {
     DeployAccount(BroadcastedDeployAccountTx),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Deref)]
 #[serde(transparent)]
 pub struct Tx(pub starknet::core::types::Transaction);
 
@@ -516,7 +516,7 @@ impl Default for TransactionsPageCursor {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionsPage {
-    pub transactions: Vec<(TxWithHash, MaybePendingTxReceipt)>,
+    pub transactions: Vec<(Tx, MaybePendingTxReceipt)>,
     pub cursor: TransactionsPageCursor,
 }
 

--- a/crates/katana/rpc/rpc/src/torii.rs
+++ b/crates/katana/rpc/rpc/src/torii.rs
@@ -10,7 +10,7 @@ use katana_provider::traits::transaction::TransactionProvider;
 use katana_rpc_api::torii::ToriiApiServer;
 use katana_rpc_types::error::torii::ToriiApiError;
 use katana_rpc_types::receipt::{MaybePendingTxReceipt, PendingTxReceipt};
-use katana_rpc_types::transaction::{TransactionsPage, TransactionsPageCursor};
+use katana_rpc_types::transaction::{TransactionsPage, TransactionsPageCursor, Tx};
 use katana_rpc_types_builder::ReceiptBuilder;
 use katana_tasks::TokioTaskSpawner;
 
@@ -83,7 +83,7 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
                                     .build()
                                     .expect("Receipt should exist for tx")
                                     .expect("Receipt should exist for tx");
-                                (tx, MaybePendingTxReceipt::Receipt(receipt))
+                                (Tx::from(tx), MaybePendingTxReceipt::Receipt(receipt))
                             })
                             .collect::<Vec<_>>();
 
@@ -113,7 +113,7 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
                             .filter_map(|(tx, res)| {
                                 res.receipt().map(|rct| {
                                     (
-                                        tx.clone(),
+                                        Tx::from(tx.clone()),
                                         MaybePendingTxReceipt::Pending(PendingTxReceipt::new(
                                             tx.hash,
                                             rct.clone(),
@@ -151,7 +151,7 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
                             .filter_map(|(tx, res)| {
                                 res.receipt().map(|rct| {
                                     (
-                                        tx.clone(),
+                                        Tx::from(tx.clone()),
                                         MaybePendingTxReceipt::Pending(PendingTxReceipt::new(
                                             tx.hash,
                                             rct.clone(),
@@ -200,7 +200,7 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
                         .into_iter()
                         .map(|tx_outcome| {
                             (
-                                tx_outcome.tx.clone(),
+                                Tx::from(tx_outcome.tx.clone()),
                                 MaybePendingTxReceipt::Pending(PendingTxReceipt::new(
                                     tx_outcome.tx.hash,
                                     tx_outcome.receipt,

--- a/crates/katana/rpc/rpc/tests/torii.rs
+++ b/crates/katana/rpc/rpc/tests/torii.rs
@@ -100,9 +100,9 @@ async fn test_get_transactions() {
         .unwrap();
 
     assert!(response.transactions.len() == 1);
-    assert!(response.transactions[0].0.hash == deploy_txn_future.transaction_hash);
     assert!(response.cursor.block_number == 3);
     assert!(response.cursor.transaction_index == 1);
+    assert!(response.transactions[0].0.transaction_hash() == &deploy_txn_future.transaction_hash);
 
     // Create block 3.
     let _: () = client.generate_block().await.unwrap();
@@ -214,9 +214,9 @@ async fn test_get_transactions_with_instant_mining() {
         .unwrap();
 
     assert!(response.transactions.len() == 1);
-    assert!(response.transactions[0].0.hash == deploy_txn_future.transaction_hash);
     assert!(response.cursor.block_number == 3);
     assert!(response.cursor.transaction_index == 1);
+    assert!(response.transactions[0].0.transaction_hash() == &deploy_txn_future.transaction_hash);
 
     sequencer.stop().expect("failed to stop sequencer");
 }


### PR DESCRIPTION
RPC apis should use rpc types by convention so that it can be parsed using other client libraries.. 