### PR TITLE
feat: use the manifest for dojo bindgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ output.txt
 crates/benches/bench_results.txt
 **/generated
 .vscode
+bindings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3267,6 +3267,7 @@ dependencies = [
  "camino",
  "chrono",
  "convert_case 0.6.0",
+ "dojo-world",
  "serde",
  "serde_json",
  "starknet 0.9.0",

--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -39,7 +39,8 @@ impl BuildArgs {
         // Custom plugins are always empty for now.
         let bindgen = PluginManager {
             output_path: self.bindings_output.into(),
-            artifacts_path: compile_info.target_dir,
+            manifest_path: compile_info.manifest_path,
+            root_package_name: compile_info.root_package_name,
             plugins: vec![],
             builtin_plugins,
         };

--- a/crates/dojo-bindgen/Cargo.toml
+++ b/crates/dojo-bindgen/Cargo.toml
@@ -20,4 +20,5 @@ chrono.workspace = true
 # https://github.com/dojoengine/dojo/actions/runs/7736050751/job/21092743552?pr=1501#step:6:249
 # dojo-test-utils = { path = "../dojo-test-utils", features = [ "build-examples" ] }
 
+dojo-world = { path = "../dojo-world", features = [ "manifest" ] }
 cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.2.2" }

--- a/crates/dojo-bindgen/src/error.rs
+++ b/crates/dojo-bindgen/src/error.rs
@@ -1,4 +1,5 @@
 use cainome::parser::Error as CainomeError;
+use dojo_world::manifest::AbstractManifestError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -11,6 +12,8 @@ pub enum Error {
     Cainome(#[from] CainomeError),
     #[error("Format error: {0}")]
     Format(String),
+    #[error(transparent)]
+    Manifest(#[from] AbstractManifestError),
 }
 
 pub type BindgenResult<T, E = Error> = Result<T, E>;

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -6,7 +6,7 @@ use cainome::parser::tokens::Token;
 use cainome::parser::{AbiParser, TokenizedAbi};
 use camino::Utf8PathBuf;
 use convert_case::{Case, Casing};
-
+use dojo_world::manifest::BaseManifest;
 pub mod error;
 use error::{BindgenResult, Error};
 
@@ -29,8 +29,8 @@ pub struct DojoModel {
 
 #[derive(Debug, PartialEq)]
 pub struct DojoContract {
-    /// Contract's name.
-    pub contract_file_name: String,
+    /// Contract's fully qualified name.
+    pub qualified_path: String,
     /// Full ABI of the contract in case the plugin wants to make extra checks,
     /// or generated other functions than the systems.
     pub tokens: TokenizedAbi,
@@ -38,8 +38,16 @@ pub struct DojoContract {
     pub systems: Vec<Token>,
 }
 
+#[derive(Debug, PartialEq)]
+pub struct DojoWorld {
+    /// The world's name from the Scarb manifest.
+    pub name: String,
+}
+
 #[derive(Debug)]
 pub struct DojoData {
+    /// World data.
+    pub world: DojoWorld,
     /// All contracts found in the project.
     pub contracts: HashMap<String, DojoContract>,
     /// All the models contracts found in the project.
@@ -49,10 +57,12 @@ pub struct DojoData {
 // TODO: include the manifest to have more metadata when new manifest is available.
 #[derive(Debug)]
 pub struct PluginManager {
+    /// Root package name.
+    pub root_package_name: String,
     /// Path of generated files.
     pub output_path: PathBuf,
     /// Path of contracts artifacts.
-    pub artifacts_path: Utf8PathBuf,
+    pub manifest_path: Utf8PathBuf,
     /// A list of builtin plugins to invoke.
     pub builtin_plugins: Vec<BuiltinPlugins>,
     /// A list of custom plugins to invoke.
@@ -66,7 +76,7 @@ impl PluginManager {
             return Ok(());
         }
 
-        let data = gather_dojo_data(&self.artifacts_path)?;
+        let data = gather_dojo_data(&self.manifest_path, &self.root_package_name)?;
 
         for plugin in &self.builtin_plugins {
             // Get the plugin builder from the plugin enum.
@@ -94,95 +104,88 @@ impl PluginManager {
 ///
 /// # Arguments
 ///
-/// * `artifacts_path` - Artifacts path where contracts were generated.
-fn gather_dojo_data(artifacts_path: &Utf8PathBuf) -> BindgenResult<DojoData> {
+/// * `manifest_path` - Artifacts path where contracts were generated.
+fn gather_dojo_data(
+    manifest_path: &Utf8PathBuf,
+    root_package_name: &str,
+) -> BindgenResult<DojoData> {
+    let root_dir: Utf8PathBuf = manifest_path.parent().unwrap().into();
+    let base_manifest_dir: Utf8PathBuf = root_dir.join("manifests").join("base");
+    let base_manifest = BaseManifest::load_from_path(&base_manifest_dir)?;
+
     let mut models = HashMap::new();
     let mut contracts = HashMap::new();
 
-    for entry in fs::read_dir(artifacts_path)? {
-        let entry = entry?;
-        let path = entry.path();
+    for contract_manifest in &base_manifest.contracts {
+        // Base manifest always use path for ABI.
+        let abi = contract_manifest
+            .inner
+            .abi
+            .as_ref()
+            .expect("Valid ABI for contract")
+            .load_abi_string(&root_dir)?;
 
-        if path.is_file() {
-            if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
-                let file_content = fs::read_to_string(&path)?;
+        let tokens = AbiParser::tokens_from_abi_string(&abi, &HashMap::new())?;
 
-                // Models and Contracts must have a valid ABI.
-                if let Ok(tokens) =
-                    AbiParser::tokens_from_abi_string(&file_content, &HashMap::new())
-                {
-                    // Contract.
-                    if is_systems_contract(file_name, &file_content) {
-                        // Identify the systems -> for now only take the functions from the
-                        // interfaces.
-                        let mut systems = vec![];
-                        let interface_blacklist = [
-                            "dojo::world::IWorldProvider",
-                            "dojo::components::upgradeable::IUpgradeable",
-                        ];
+        // Identify the systems -> for now only take the functions from the
+        // interfaces.
+        // TODO: we may expose internal ones, no?
+        let mut systems = vec![];
+        let interface_blacklist =
+            ["dojo::world::IWorldProvider", "dojo::components::upgradeable::IUpgradeable"];
 
-                        for (interface, funcs) in &tokens.interfaces {
-                            if !interface_blacklist.contains(&interface.as_str()) {
-                                systems.extend(funcs.clone());
-                            }
-                        }
-
-                        contracts.insert(
-                            file_name.to_string(),
-                            DojoContract {
-                                contract_file_name: file_name.to_string(),
-                                tokens: tokens.clone(),
-                                systems,
-                            },
-                        );
-                    }
-
-                    // Model.
-                    if is_model_contract(&tokens) {
-                        if let Some(model_name) = model_name_from_artifact_filename(file_name) {
-                            let model_pascal_case =
-                                model_name.from_case(Case::Snake).to_case(Case::Pascal);
-
-                            let model = DojoModel {
-                                name: model_pascal_case.clone(),
-                                qualified_path: file_name
-                                    .replace(&model_name, &model_pascal_case)
-                                    .trim_end_matches(".json")
-                                    .to_string(),
-                                tokens: filter_model_tokens(&tokens),
-                            };
-
-                            models.insert(model_pascal_case, model);
-                        } else {
-                            return Err(Error::Format(format!(
-                                "Could not extract model name from file name `{file_name}`"
-                            )));
-                        }
-                    }
-                }
+        for (interface, funcs) in &tokens.interfaces {
+            if !interface_blacklist.contains(&interface.as_str()) {
+                systems.extend(funcs.clone());
             }
+        }
+
+        let contract_name = contract_manifest.name.to_string();
+
+        contracts.insert(
+            contract_name.clone(),
+            DojoContract { qualified_path: contract_name, tokens, systems },
+        );
+    }
+
+    for model_manifest in &base_manifest.models {
+        // Base manifest always use path for ABI.
+        let abi = model_manifest
+            .inner
+            .abi
+            .as_ref()
+            .expect("Valid ABI for contract")
+            .load_abi_string(&root_dir)?;
+
+        let tokens = AbiParser::tokens_from_abi_string(&abi, &HashMap::new())?;
+
+        let name = model_manifest.name.to_string();
+
+        if let Some(model_name) = model_name_from_fully_qualified_path(&name) {
+            let model_pascal_case = model_name.from_case(Case::Snake).to_case(Case::Pascal);
+
+            let model = DojoModel {
+                name: model_pascal_case.clone(),
+                qualified_path: name
+                    .replace(&model_name, &model_pascal_case)
+                    .trim_end_matches(".json")
+                    .to_string(),
+                tokens: filter_model_tokens(&tokens),
+            };
+
+            models.insert(model_pascal_case, model);
+        } else {
+            return Err(Error::Format(format!(
+                "Could not extract model name from file name `{name}`"
+            )));
         }
     }
 
-    Ok(DojoData { models, contracts })
-}
+    // TODO: do we want the world's name from the metadata, or it's the
+    // project name that we are looking for?
+    let world = DojoWorld { name: root_package_name.to_string() };
 
-/// Identifies if the given contract contains systems.
-///
-/// For now the identification is very naive and don't use the manifest
-/// as the manifest format will change soon.
-/// TODO: use the new manifest files once available.
-///
-/// # Arguments
-///
-/// * `file_name` - Name of the contract file.
-/// * `file_content` - Content of the contract artifact.
-fn is_systems_contract(file_name: &str, file_content: &str) -> bool {
-    if file_name.starts_with("dojo::") || file_name == "manifest.json" {
-        return false;
-    }
-
-    file_content.contains("IWorldDispatcher")
+    Ok(DojoData { world, models, contracts })
 }
 
 /// Filters the model ABI to keep relevant types
@@ -222,138 +225,54 @@ fn filter_model_tokens(tokens: &TokenizedAbi) -> TokenizedAbi {
     TokenizedAbi { structs, enums, ..Default::default() }
 }
 
-/// Extracts a model name from the artifact file name.
+/// Extracts a model name from the fully qualified path of the model.
 ///
 /// # Example
 ///
-/// The file name "dojo_examples::models::position.json" should return "position".
+/// The fully qualified name "dojo_examples::models::position" should return "position".
 ///
 /// # Arguments
 ///
-/// * `file_name` - Artifact file name.
-fn model_name_from_artifact_filename(file_name: &str) -> Option<String> {
+/// * `file_name` - Fully qualified model name.
+fn model_name_from_fully_qualified_path(file_name: &str) -> Option<String> {
     let parts: Vec<&str> = file_name.split("::").collect();
 
-    if let Some(last_part) = parts.last() {
-        // TODO: for now, we always reconstruct with PascalCase.
-        // Once manifest data are available, use the exact name instead.
-        // We may have errors here is the struct is named like myStruct and not MyStruct.
-        // Plugin dev should consider case insensitive comparison.
-        last_part.split_once(".json").map(|m_ext| m_ext.0.to_string())
-    } else {
-        None
-    }
+    // TODO: we may want to have inside the manifest the name of the model struct.
+    parts.last().map(|last_part| last_part.to_string())
 }
 
-/// Identifies if the given contract contains a model.
-///
-/// The identification is based on the methods name. This must
-/// be adjusted if the model attribute expansion change in the future.
-/// <https://github.com/dojoengine/dojo/blob/36e5853877d011a5bb4b3bd77b9de676fb454b0c/crates/dojo-lang/src/model.rs#L81>
-///
-/// # Arguments
-///
-/// * `file_name` - Name of the contract file.
-/// * `file_content` - Content of the contract artifact.
-fn is_model_contract(tokens: &TokenizedAbi) -> bool {
-    let expected_funcs = ["name", "layout", "packed_size", "unpacked_size", "schema"];
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let mut funcs_counts = 0;
-
-    for functions in tokens.interfaces.values() {
-        for f in functions {
-            if expected_funcs.contains(&f.to_function().expect("Function expected").name.as_str()) {
-                funcs_counts += 1;
-            }
-        }
+    #[test]
+    fn model_name_from_fully_qualified_path_ok() {
+        let file_name = "dojo_examples::models::position";
+        assert_eq!(model_name_from_fully_qualified_path(file_name), Some("position".to_string()));
     }
 
-    funcs_counts == expected_funcs.len()
+    #[test]
+    fn gather_data_ok() {
+        let data = gather_dojo_data(
+            &Utf8PathBuf::from("src/test_data/spawn-and-move/Scarb.toml"),
+            "dojo_example",
+        )
+        .unwrap();
+
+        assert_eq!(data.models.len(), 3);
+
+        assert_eq!(data.world.name, "dojo_example");
+
+        let pos = data.models.get("Position").unwrap();
+        assert_eq!(pos.name, "Position");
+        assert_eq!(pos.qualified_path, "dojo_examples::models::Position");
+
+        let moves = data.models.get("Moves").unwrap();
+        assert_eq!(moves.name, "Moves");
+        assert_eq!(moves.qualified_path, "dojo_examples::models::Moves");
+
+        let moved = data.models.get("Moved").unwrap();
+        assert_eq!(moved.name, "Moved");
+        assert_eq!(moved.qualified_path, "dojo_examples::actions::actions::Moved");
+    }
 }
-
-// Uncomment tests once windows issue is solved.
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-
-//     #[test]
-//     fn is_system_contract_ok() {
-//         let file_name = "dojo_examples::actions::actions.json";
-//         let file_content = include_str!(
-//             "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
-//         );
-
-//         assert!(is_systems_contract(file_name, file_content));
-//     }
-
-//     #[test]
-//     fn is_system_contract_ignore_dojo_files() {
-//         let file_name = "dojo::world::world.json";
-//         let file_content = "";
-//         assert!(!is_systems_contract(file_name, file_content));
-
-//         let file_name = "manifest.json";
-//         assert!(!is_systems_contract(file_name, file_content));
-//     }
-
-//     #[test]
-//     fn test_is_system_contract_ignore_models() {
-//         let file_name = "dojo_examples::models::position.json";
-//         let file_content = include_str!(
-//             "test_data/spawn-and-move/target/dev/dojo_examples::models::position.json"
-//         );
-//         assert!(!is_systems_contract(file_name, file_content));
-//     }
-
-//     #[test]
-//     fn model_name_from_artifact_filename_ok() {
-//         let file_name = "dojo_examples::models::position.json";
-//         assert_eq!(model_name_from_artifact_filename(file_name), Some("position".to_string()));
-//     }
-
-//     #[test]
-//     fn is_model_contract_ok() {
-//         let file_content =
-//
-// include_str!("test_data/spawn-and-move/target/dev/dojo_examples::models::moves.json");
-//         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
-
-//         assert!(is_model_contract(&tokens));
-//     }
-
-//     #[test]
-//     fn is_model_contract_ignore_systems() {
-//         let file_content = include_str!(
-//             "test_data/spawn-and-move/target/dev/dojo_examples::actions::actions.json"
-//         );
-//         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
-
-//         assert!(!is_model_contract(&tokens));
-//     }
-
-//     #[test]
-//     fn is_model_contract_ignore_dojo_files() {
-//         let file_content =
-//             include_str!("test_data/spawn-and-move/target/dev/dojo::world::world.json");
-//         let tokens = AbiParser::tokens_from_abi_string(file_content, &HashMap::new()).unwrap();
-
-//         assert!(!is_model_contract(&tokens));
-//     }
-
-//     #[test]
-//     fn gather_data_ok() {
-//         let data =
-// gather_dojo_data(&Utf8PathBuf::from("src/test_data/spawn-and-move/target/dev"))
-// .unwrap();
-
-//         assert_eq!(data.models.len(), 2);
-
-//         let pos = data.models.get("Position").unwrap();
-//         assert_eq!(pos.name, "Position");
-//         assert_eq!(pos.qualified_path, "dojo_examples::models::Position");
-
-//         let moves = data.models.get("Moves").unwrap();
-//         assert_eq!(moves.name, "Moves");
-//         assert_eq!(moves.qualified_path, "dojo_examples::models::Moves");
-//     }
-// }

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -54,14 +54,13 @@ pub struct DojoData {
     pub models: HashMap<String, DojoModel>,
 }
 
-// TODO: include the manifest to have more metadata when new manifest is available.
 #[derive(Debug)]
 pub struct PluginManager {
     /// Root package name.
     pub root_package_name: String,
     /// Path of generated files.
     pub output_path: PathBuf,
-    /// Path of contracts artifacts.
+    /// Path of Dojo manifest.
     pub manifest_path: Utf8PathBuf,
     /// A list of builtin plugins to invoke.
     pub builtin_plugins: Vec<BuiltinPlugins>,
@@ -98,13 +97,11 @@ impl PluginManager {
     }
 }
 
-/// Gathers dojo data from artifacts.
-/// TODO: this should be modified later to use the new manifest structure.
-///       it's currently done from the artifacts to decouple from the manifest.
+/// Gathers dojo data from the manifests files.
 ///
 /// # Arguments
 ///
-/// * `manifest_path` - Artifacts path where contracts were generated.
+/// * `manifest_path` - Dojo manifest path.
 fn gather_dojo_data(
     manifest_path: &Utf8PathBuf,
     root_package_name: &str,
@@ -129,7 +126,6 @@ fn gather_dojo_data(
 
         // Identify the systems -> for now only take the functions from the
         // interfaces.
-        // TODO: we may expose internal ones, no?
         let mut systems = vec![];
         let interface_blacklist =
             ["dojo::world::IWorldProvider", "dojo::components::upgradeable::IUpgradeable"];
@@ -181,8 +177,6 @@ fn gather_dojo_data(
         }
     }
 
-    // TODO: do we want the world's name from the metadata, or it's the
-    // project name that we are looking for?
     let world = DojoWorld { name: root_package_name.to_string() };
 
     Ok(DojoData { world, models, contracts })
@@ -237,7 +231,8 @@ fn filter_model_tokens(tokens: &TokenizedAbi) -> TokenizedAbi {
 fn model_name_from_fully_qualified_path(file_name: &str) -> Option<String> {
     let parts: Vec<&str> = file_name.split("::").collect();
 
-    // TODO: we may want to have inside the manifest the name of the model struct.
+    // TODO: we may want to have inside the manifest the name of the model struct
+    // instead of extracting it from the file's name.
     parts.last().map(|last_part| last_part.to_string())
 }
 

--- a/crates/dojo-bindgen/src/plugins/typescript/mod.rs
+++ b/crates/dojo-bindgen/src/plugins/typescript/mod.rs
@@ -376,10 +376,10 @@ export function defineContractComponents(world: World) {
         }};
     }}
 ",
-                contract.contract_file_name,
+                contract.qualified_path,
                 // capitalize contract name
-                TypescriptPlugin::formatted_contract_name(&contract.contract_file_name),
-                TypescriptPlugin::formatted_contract_name(&contract.contract_file_name),
+                TypescriptPlugin::formatted_contract_name(&contract.qualified_path),
+                TypescriptPlugin::formatted_contract_name(&contract.qualified_path),
                 systems,
                 contract
                     .systems
@@ -401,8 +401,8 @@ export function defineContractComponents(world: World) {
             .map(|c| {
                 format!(
                     "{}: {}()",
-                    TypescriptPlugin::formatted_contract_name(&c.contract_file_name),
-                    TypescriptPlugin::formatted_contract_name(&c.contract_file_name)
+                    TypescriptPlugin::formatted_contract_name(&c.qualified_path),
+                    TypescriptPlugin::formatted_contract_name(&c.qualified_path)
                 )
             })
             .collect::<Vec<String>>()

--- a/crates/dojo-bindgen/src/plugins/unity/mod.rs
+++ b/crates/dojo-bindgen/src/plugins/unity/mod.rs
@@ -300,9 +300,9 @@ public class {} : MonoBehaviour {{
     {}
 }}
         ",
-            contract.contract_file_name,
+            contract.qualified_path,
             // capitalize contract name
-            UnityPlugin::formatted_contract_name(&contract.contract_file_name),
+            UnityPlugin::formatted_contract_name(&contract.qualified_path),
             systems
         );
 

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -309,13 +309,13 @@ fn update_manifest(
         )?;
     }
 
-    for (_, (manifest, _)) in models.iter_mut() {
+    for (_, (manifest, abi)) in models.iter_mut() {
         write_manifest_and_abi(
             &relative_manifests_dir.join(MODELS_DIR),
             &relative_abis_dir.join(MODELS_DIR),
             &manifest_dir,
             manifest,
-            &None,
+            abi,
         )?;
     }
 

--- a/crates/dojo-lang/src/scarb_internal/mod.rs
+++ b/crates/dojo-lang/src/scarb_internal/mod.rs
@@ -23,7 +23,9 @@ use tracing::trace;
 use crate::plugin::dojo_plugin_suite;
 
 pub struct CompileInfo {
+    pub manifest_path: Utf8PathBuf,
     pub target_dir: Utf8PathBuf,
+    pub root_package_name: String,
 }
 
 pub fn crates_config_for_compilation_unit(unit: &CompilationUnit) -> AllCratesConfig {
@@ -79,10 +81,12 @@ pub fn compile_workspace(config: &Config, opts: CompileOpts) -> Result<CompileIn
         }
     }
 
+    let manifest_path = ws.manifest_path().into();
     let target_dir = ws.target_dir().path_existent().unwrap();
     let target_dir = target_dir.join(ws.config().profile().as_str());
+    let root_package_name = ws.root_package().expect("No root package name").id.name.to_string();
 
-    Ok(CompileInfo { target_dir })
+    Ok(CompileInfo { manifest_path, target_dir, root_package_name })
 }
 
 fn build_project_config(unit: &CompilationUnit) -> Result<ProjectConfig> {

--- a/crates/dojo-world/src/manifest.rs
+++ b/crates/dojo-world/src/manifest.rs
@@ -55,6 +55,10 @@ pub enum AbstractManifestError {
     TOML(#[from] toml::de::Error),
     #[error(transparent)]
     IO(#[from] io::Error),
+    #[error("Abi couldn't be loaded from path: {0}")]
+    AbiError(String),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
 }
 
 /// Represents a model member.
@@ -141,10 +145,23 @@ impl PartialEq for AbiFormat {
 }
 
 impl AbiFormat {
+    /// Returns the path to the ABI file, or None if embedded.
     pub fn to_path(&self) -> Option<&Utf8PathBuf> {
         match self {
             AbiFormat::Path(p) => Some(p),
             AbiFormat::Embed(_) => None,
+        }
+    }
+
+    /// Loads an ABI from the path or embedded entries.
+    ///
+    /// # Arguments
+    ///
+    /// * `root_dir` - The root directory of the ABI file.
+    pub fn load_abi_string(&self, root_dir: &Utf8PathBuf) -> Result<String, AbstractManifestError> {
+        match self {
+            AbiFormat::Path(abi_path) => Ok(fs::read_to_string(root_dir.join(abi_path))?),
+            AbiFormat::Embed(abi) => Ok(serde_json::to_string(&abi)?),
         }
     }
 }

--- a/examples/spawn-and-move/abis/base/models/moved.json
+++ b/examples/spawn-and-move/abis/base/models/moved.json
@@ -1,0 +1,239 @@
+[
+  {
+    "type": "impl",
+    "name": "DojoModelImpl",
+    "interface_name": "dojo::model::IDojoModel"
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::integer::u8>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::integer::u8>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::felt252>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::felt252>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Struct",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Enum",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::database::introspect::Ty",
+    "variants": [
+      {
+        "name": "Primitive",
+        "type": "core::felt252"
+      },
+      {
+        "name": "Struct",
+        "type": "dojo::database::introspect::Struct"
+      },
+      {
+        "name": "Enum",
+        "type": "dojo::database::introspect::Enum"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+      },
+      {
+        "name": "Array",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::model::IDojoModel",
+    "items": [
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "unpacked_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u32"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "packed_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u32"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "layout",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::array::Span::<core::integer::u8>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "schema",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::database::introspect::Ty"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "movedImpl",
+    "interface_name": "dojo_examples::actions::actions::Imoved"
+  },
+  {
+    "type": "enum",
+    "name": "dojo_examples::models::Direction",
+    "variants": [
+      {
+        "name": "None",
+        "type": "()"
+      },
+      {
+        "name": "Left",
+        "type": "()"
+      },
+      {
+        "name": "Right",
+        "type": "()"
+      },
+      {
+        "name": "Up",
+        "type": "()"
+      },
+      {
+        "name": "Down",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo_examples::actions::actions::Moved",
+    "members": [
+      {
+        "name": "player",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "direction",
+        "type": "dojo_examples::models::Direction"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo_examples::actions::actions::Imoved",
+    "items": [
+      {
+        "type": "function",
+        "name": "ensure_abi",
+        "inputs": [
+          {
+            "name": "model",
+            "type": "dojo_examples::actions::actions::Moved"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "dojo_examples::actions::actions::moved::Event",
+    "kind": "enum",
+    "variants": []
+  }
+]

--- a/examples/spawn-and-move/abis/base/models/moves.json
+++ b/examples/spawn-and-move/abis/base/models/moves.json
@@ -1,0 +1,243 @@
+[
+  {
+    "type": "impl",
+    "name": "DojoModelImpl",
+    "interface_name": "dojo::model::IDojoModel"
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::integer::u8>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::integer::u8>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::felt252>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::felt252>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Struct",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Enum",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::database::introspect::Ty",
+    "variants": [
+      {
+        "name": "Primitive",
+        "type": "core::felt252"
+      },
+      {
+        "name": "Struct",
+        "type": "dojo::database::introspect::Struct"
+      },
+      {
+        "name": "Enum",
+        "type": "dojo::database::introspect::Enum"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+      },
+      {
+        "name": "Array",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::model::IDojoModel",
+    "items": [
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "unpacked_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u32"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "packed_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u32"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "layout",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::array::Span::<core::integer::u8>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "schema",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::database::introspect::Ty"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "movesImpl",
+    "interface_name": "dojo_examples::models::Imoves"
+  },
+  {
+    "type": "enum",
+    "name": "dojo_examples::models::Direction",
+    "variants": [
+      {
+        "name": "None",
+        "type": "()"
+      },
+      {
+        "name": "Left",
+        "type": "()"
+      },
+      {
+        "name": "Right",
+        "type": "()"
+      },
+      {
+        "name": "Up",
+        "type": "()"
+      },
+      {
+        "name": "Down",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo_examples::models::Moves",
+    "members": [
+      {
+        "name": "player",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "remaining",
+        "type": "core::integer::u8"
+      },
+      {
+        "name": "last_direction",
+        "type": "dojo_examples::models::Direction"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo_examples::models::Imoves",
+    "items": [
+      {
+        "type": "function",
+        "name": "ensure_abi",
+        "inputs": [
+          {
+            "name": "model",
+            "type": "dojo_examples::models::Moves"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "dojo_examples::models::moves::Event",
+    "kind": "enum",
+    "variants": []
+  }
+]

--- a/examples/spawn-and-move/abis/base/models/position.json
+++ b/examples/spawn-and-move/abis/base/models/position.json
@@ -1,0 +1,227 @@
+[
+  {
+    "type": "impl",
+    "name": "DojoModelImpl",
+    "interface_name": "dojo::model::IDojoModel"
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::integer::u8>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::integer::u8>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::felt252>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::felt252>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::array::Span::<core::felt252>>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::array::Span::<core::felt252>>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Struct",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<(core::felt252, core::array::Span::<core::felt252>)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Enum",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<(core::felt252, core::array::Span::<core::felt252>)>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::database::introspect::Ty",
+    "variants": [
+      {
+        "name": "Primitive",
+        "type": "core::felt252"
+      },
+      {
+        "name": "Struct",
+        "type": "dojo::database::introspect::Struct"
+      },
+      {
+        "name": "Enum",
+        "type": "dojo::database::introspect::Enum"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<core::array::Span::<core::felt252>>"
+      },
+      {
+        "name": "Array",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::model::IDojoModel",
+    "items": [
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "unpacked_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u32"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "packed_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u32"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "layout",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::array::Span::<core::integer::u8>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "schema",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::database::introspect::Ty"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "positionImpl",
+    "interface_name": "dojo_examples::models::Iposition"
+  },
+  {
+    "type": "struct",
+    "name": "dojo_examples::models::Vec2",
+    "members": [
+      {
+        "name": "x",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "y",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo_examples::models::Position",
+    "members": [
+      {
+        "name": "player",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "vec",
+        "type": "dojo_examples::models::Vec2"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo_examples::models::Iposition",
+    "items": [
+      {
+        "type": "function",
+        "name": "ensure_abi",
+        "inputs": [
+          {
+            "name": "model",
+            "type": "dojo_examples::models::Position"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "dojo_examples::models::position::Event",
+    "kind": "enum",
+    "variants": []
+  }
+]

--- a/examples/spawn-and-move/manifests/base/models/moved.toml
+++ b/examples/spawn-and-move/manifests/base/models/moved.toml
@@ -1,5 +1,6 @@
 kind = "DojoModel"
 class_hash = "0x52659850f9939482810d9f6b468b91dc99e0b7fa42c2016cf12833ec06ce911"
+abi = "abis/base/models/moved.json"
 name = "dojo_examples::actions::actions::moved"
 
 [[members]]

--- a/examples/spawn-and-move/manifests/base/models/moves.toml
+++ b/examples/spawn-and-move/manifests/base/models/moves.toml
@@ -1,5 +1,6 @@
 kind = "DojoModel"
 class_hash = "0x511fbd833938f5c4b743eea1e67605a125d7ff60e8a09e8dc227ad2fb59ca54"
+abi = "abis/base/models/moves.json"
 name = "dojo_examples::models::moves"
 
 [[members]]

--- a/examples/spawn-and-move/manifests/base/models/position.toml
+++ b/examples/spawn-and-move/manifests/base/models/position.toml
@@ -1,5 +1,6 @@
 kind = "DojoModel"
 class_hash = "0xb33ae053213ccb2a57967ffc4411901f3efab24781ca867adcd0b90f2fece5"
+abi = "abis/base/models/position.json"
 name = "dojo_examples::models::position"
 
 [[members]]


### PR DESCRIPTION
This PR uses the new manifest system to feed the binding generation plugins.

@RareSecond I've a question, what the world name is for you? Because I've seen that we don't output it into the manifest.
Is it the package id (`dojo_example`) which is usually at the top of the `Scarb.toml`. Or do we want the metadata from dojo?
```toml
[tool.dojo.world]
description = "example world"
name = "example"
```