### PR TITLE
refactor(katana): make genesis and gas price cli args conflicting

### DIFF
--- a/bin/katana/src/args.rs
+++ b/bin/katana/src/args.rs
@@ -181,10 +181,12 @@ pub struct EnvironmentOptions {
     pub invoke_max_steps: Option<u32>,
 
     #[arg(long = "eth-gas-price")]
+    #[arg(conflicts_with = "genesis")]
     #[arg(help = "The L1 ETH gas price.")]
     pub l1_eth_gas_price: Option<u128>,
 
     #[arg(long = "strk-gas-price")]
+    #[arg(conflicts_with = "genesis")]
     #[arg(help = "The L1 STRK gas price.")]
     pub l1_strk_gas_price: Option<u128>,
 }


### PR DESCRIPTION
ref #1744 

to limit and simplify how gas prices can be set in katana.

currently there are two ways to do this:
1. using the `--*-gas-price` cli arg
2. set in the genesis config

this change only allow the gas price to be set using one way or the other and not through a combination of both (eg pass a genesis config but set gas prices in cli) which makes it counterintuitive imo