### PR TITLE
fix(katana-core): dont use optional dep in non-feature specific code

### DIFF
--- a/crates/katana/core/tests/sequencer.rs
+++ b/crates/katana/core/tests/sequencer.rs
@@ -1,4 +1,3 @@
-use ethers::types::U256;
 use katana_core::backend::config::{Environment, StarknetConfig};
 use katana_core::sequencer::{KatanaSequencer, SequencerConfig};
 use katana_executor::implementation::noop::NoopExecutorFactory;
@@ -7,6 +6,7 @@ use katana_primitives::genesis::constant::DEFAULT_PREFUNDED_ACCOUNT_BALANCE;
 use katana_primitives::genesis::Genesis;
 use katana_provider::traits::block::{BlockNumberProvider, BlockProvider};
 use katana_provider::traits::env::BlockEnvProvider;
+use primitive_types::U256;
 
 fn create_test_sequencer_config() -> (SequencerConfig, StarknetConfig) {
     let accounts = DevAllocationsGenerator::new(2)


### PR DESCRIPTION
- **feat(sozo): add seed to manifest (#1674)**
- **fix(sozo): don't upload to ipfs if in offline mode (#1678)**
- **Torii fix queries with keys regex (#1609)**
- **[sozo] Detect and manage manifests and artifacts discrepancies  (#1672)**
- **Prepare release: v0.6.0-alpha.7 (#1680)**
- **Add explorer flag to open World Explorer in browser (#1581)**
- **refactor(torii): retrieve events and store only relevant txns (#1631)**
- **Split sozo ops into its own crate (#1546)**
- **feat: add eventmessage for emitting models & start refactoring emit macro (#1656)**
- **fix: ensure sozo clean only affect base (#1685)**
- **sozo: add dry-run mode (#1686)**
- **feat(torii): Expose block timestamp (#1676)**
- **[sozo] generate JSON manifest (#1694)**
- **Prepare release: v0.6.0-alpha.8 (#1699)**
- **`katana-executor` rewrite + `starknet_in_rust` intergration + `saya` namespace (#1697)**
- **fix: add script to teardown tests and updated cargo lock (#1707)**
- **Update devcontainer image hash: 5340720 (#1706)**
- **Sozo CLI --version displaying more info  (#1710)**
- **fix: ensure world contract is used by ref and add tests for auth grant (#1715)**
- **Prepare release: v0.6.0-alpha.9 (#1716)**
- **refactor(katana-rpc-types): include api error data when converting to rpc error (#1717)**
- **[sozo][auth]: revoke logic added (#1712)**
- **Sozo call command (#1704)**
- **Bump rust to `1.76.0` (#1720)**
- **Update devcontainer image hash: 8d66222 (#1727)**
- ** Re-export `reth-metrics-derive` crate from `dojo-metrics` (#1719)**
- **fix missing dep when testing `core` crate individually**
