### PR TITLE
fix: ensure scarb compilation even when root package is missing

### DIFF
--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -40,7 +40,9 @@ impl BuildArgs {
         let bindgen = PluginManager {
             output_path: self.bindings_output.into(),
             manifest_path: compile_info.manifest_path,
-            root_package_name: compile_info.root_package_name,
+            root_package_name: compile_info
+                .root_package_name
+                .unwrap_or("NO_ROOT_PACKAGE".to_string()),
             plugins: vec![],
             builtin_plugins,
         };

--- a/crates/dojo-lang/src/scarb_internal/mod.rs
+++ b/crates/dojo-lang/src/scarb_internal/mod.rs
@@ -27,7 +27,7 @@ pub(crate) const LOG_TARGET: &str = "dojo_lang::scarb_internal";
 pub struct CompileInfo {
     pub manifest_path: Utf8PathBuf,
     pub target_dir: Utf8PathBuf,
-    pub root_package_name: String,
+    pub root_package_name: Option<String>,
 }
 
 pub fn crates_config_for_compilation_unit(unit: &CompilationUnit) -> AllCratesConfig {
@@ -86,7 +86,14 @@ pub fn compile_workspace(config: &Config, opts: CompileOpts) -> Result<CompileIn
     let manifest_path = ws.manifest_path().into();
     let target_dir = ws.target_dir().path_existent().unwrap();
     let target_dir = target_dir.join(ws.config().profile().as_str());
-    let root_package_name = ws.root_package().expect("No root package name").id.name.to_string();
+
+    // The root package may be non existent in a scarb project/workspace.
+    // Please refer here:
+    let root_package_name = if let Some(package) = ws.root_package() {
+        Some(package.id.name.to_string())
+    } else {
+        None
+    };
 
     Ok(CompileInfo { manifest_path, target_dir, root_package_name })
 }


### PR DESCRIPTION
Scarb can be compiled without having a root package. To ensure compatibility for bindgen and library compilation, bindgen uses now a default NO_ROOT_PACKAGE in case it can't be found.

Closes #1758
Closes DOJ-320