### PR TITLE
style(katana-db): standardize naming for historical tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6714,7 +6714,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "postcard",
  "reth-libmdbx",
- "roaring",
  "serde",
  "serde_json",
  "starknet 0.9.0",
@@ -9860,17 +9859,6 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
-]
-
-[[package]]
-name = "roaring"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
-dependencies = [
- "bytemuck",
- "byteorder",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6714,6 +6714,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "postcard",
  "reth-libmdbx",
+ "roaring",
  "serde",
  "serde_json",
  "starknet 0.9.0",
@@ -9859,6 +9860,17 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "roaring"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "serde",
 ]
 
 [[package]]

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -164,9 +164,9 @@ define_tables_enum! {[
     (ClassDeclarationBlock, TableType::Table),
     (ClassDeclarations, TableType::DupSort),
     (ContractInfoChangeSet, TableType::Table),
-    (NonceChanges, TableType::DupSort),
-    (ContractClassChanges, TableType::DupSort),
-    (StorageChanges, TableType::DupSort),
+    (NonceChangeHistory, TableType::DupSort),
+    (ClassChangeHistory, TableType::DupSort),
+    (StorageChangeHistory, TableType::DupSort),
     (StorageChangeSet, TableType::DupSort)
 ]}
 
@@ -215,16 +215,15 @@ tables! {
     ///
     /// Stores the list of blocks where the contract info (nonce / class hash) has changed.
     ContractInfoChangeSet: (ContractAddress) => ContractInfoChangeList,
-
     /// Contract nonce changes by block.
-    NonceChanges: (BlockNumber, ContractAddress) => ContractNonceChange,
+    NonceChangeHistory: (BlockNumber, ContractAddress) => ContractNonceChange,
     /// Contract class hash changes by block.
-    ContractClassChanges: (BlockNumber, ContractAddress) => ContractClassChange,
+    ClassChangeHistory: (BlockNumber, ContractAddress) => ContractClassChange,
 
     /// storage change set
     StorageChangeSet: (ContractAddress, StorageKey) => StorageEntryChangeList,
     /// Account storage change set
-    StorageChanges: (BlockNumber, ContractStorageKey) => ContractStorageEntry
+    StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry
 
 }
 
@@ -253,9 +252,9 @@ mod tests {
         assert_eq!(Tables::ALL[15].name(), ClassDeclarationBlock::NAME);
         assert_eq!(Tables::ALL[16].name(), ClassDeclarations::NAME);
         assert_eq!(Tables::ALL[17].name(), ContractInfoChangeSet::NAME);
-        assert_eq!(Tables::ALL[18].name(), NonceChanges::NAME);
-        assert_eq!(Tables::ALL[19].name(), ContractClassChanges::NAME);
-        assert_eq!(Tables::ALL[20].name(), StorageChanges::NAME);
+        assert_eq!(Tables::ALL[18].name(), NonceChangeHistory::NAME);
+        assert_eq!(Tables::ALL[19].name(), ClassChangeHistory::NAME);
+        assert_eq!(Tables::ALL[20].name(), StorageChangeHistory::NAME);
         assert_eq!(Tables::ALL[21].name(), StorageChangeSet::NAME);
     }
 }

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -288,7 +288,7 @@ impl StateUpdateProvider for DbProvider {
 
         if let Some(block_num) = block_num {
             let nonce_updates = dup_entries::<
-                tables::NonceChanges,
+                tables::NonceChangeHistory,
                 HashMap<ContractAddress, Nonce>,
                 _,
             >(&db_tx, block_num, |entry| {
@@ -297,7 +297,7 @@ impl StateUpdateProvider for DbProvider {
             })?;
 
             let contract_updates = dup_entries::<
-                tables::ContractClassChanges,
+                tables::ClassChangeHistory,
                 HashMap<ContractAddress, ClassHash>,
                 _,
             >(&db_tx, block_num, |entry| {
@@ -321,7 +321,7 @@ impl StateUpdateProvider for DbProvider {
 
             let storage_updates = {
                 let entries = dup_entries::<
-                    tables::StorageChanges,
+                    tables::StorageChangeHistory,
                     Vec<(ContractAddress, (StorageKey, StorageValue))>,
                     _,
                 >(&db_tx, block_num, |entry| {
@@ -653,7 +653,7 @@ impl BlockWriter for DbProvider {
                         let storage_change_sharded_key =
                             ContractStorageKey { contract_address: addr, key: entry.key };
 
-                        db_tx.put::<tables::StorageChanges>(
+                        db_tx.put::<tables::StorageChangeHistory>(
                             block_number,
                             ContractStorageEntry {
                                 key: storage_change_sharded_key,
@@ -689,7 +689,7 @@ impl BlockWriter for DbProvider {
                 db_tx.put::<tables::ContractInfo>(addr, value)?;
 
                 let class_change_key = ContractClassChange { contract_address: addr, class_hash };
-                db_tx.put::<tables::ContractClassChanges>(block_number, class_change_key)?;
+                db_tx.put::<tables::ClassChangeHistory>(block_number, class_change_key)?;
                 db_tx.put::<tables::ContractInfoChangeSet>(addr, new_change_set)?;
             }
 
@@ -716,7 +716,7 @@ impl BlockWriter for DbProvider {
                 db_tx.put::<tables::ContractInfo>(addr, value)?;
 
                 let nonce_change_key = ContractNonceChange { contract_address: addr, nonce };
-                db_tx.put::<tables::NonceChanges>(block_number, nonce_change_key)?;
+                db_tx.put::<tables::NonceChangeHistory>(block_number, nonce_change_key)?;
                 db_tx.put::<tables::ContractInfoChangeSet>(addr, new_change_set)?;
             }
 

--- a/crates/katana/storage/provider/src/providers/db/state.rs
+++ b/crates/katana/storage/provider/src/providers/db/state.rs
@@ -250,7 +250,7 @@ impl StateProvider for HistoricalStateProvider {
                 &entry.nonce_change_list,
             )
         }) {
-            let mut cursor = self.tx.cursor::<tables::NonceChanges>()?;
+            let mut cursor = self.tx.cursor::<tables::NonceChangeHistory>()?;
             let entry = cursor.seek_by_key_subkey(num, address)?.ok_or(
                 ProviderError::MissingContractNonceChangeEntry {
                     block: num,
@@ -279,7 +279,7 @@ impl StateProvider for HistoricalStateProvider {
                 &entry.class_change_list,
             )
         }) {
-            let mut cursor = self.tx.cursor::<tables::ContractClassChanges>()?;
+            let mut cursor = self.tx.cursor::<tables::ClassChangeHistory>()?;
             let entry = cursor.seek_by_key_subkey(num, address)?.ok_or(
                 ProviderError::MissingContractClassChangeEntry {
                     block: num,
@@ -308,7 +308,7 @@ impl StateProvider for HistoricalStateProvider {
                 &entry.block_list,
             )
         }) {
-            let mut cursor = self.tx.cursor::<tables::StorageChanges>()?;
+            let mut cursor = self.tx.cursor::<tables::StorageChangeHistory>()?;
             let sharded_key = ContractStorageKey { contract_address: address, key: storage_key };
 
             let entry = cursor.seek_by_key_subkey(num, sharded_key)?.ok_or(


### PR DESCRIPTION
Standardize the naming convention of historical-data related tables.

- `*ChangeHistory` 

tables that store data changes based on the block number it occured.

- `*ChangeSet` 

tables that maintain a **set** of block numbers used for indexing the respective `*ChangeHistory` table. The elements in the set corresponds to the _primary key_ of `*ChangeHistory` table where an entry exist with a _subkey_ that is equal to _primary key_ corresponds to the aforementioned **set**.