### PR TITLE
refactor(katana-db): convert `StorageChangeSet` into a normal table

### DIFF
--- a/crates/katana/storage/db/src/codecs/postcard.rs
+++ b/crates/katana/storage/db/src/codecs/postcard.rs
@@ -1,4 +1,4 @@
-use katana_primitives::block::{BlockNumber, Header};
+use katana_primitives::block::Header;
 use katana_primitives::contract::{ContractAddress, GenericContractInfo};
 use katana_primitives::receipt::Receipt;
 use katana_primitives::trace::TxExecInfo;
@@ -10,6 +10,7 @@ use super::{Compress, Decompress};
 use crate::error::CodecError;
 use crate::models::block::StoredBlockBodyIndices;
 use crate::models::contract::ContractInfoChangeList;
+use crate::models::storage::BlockList;
 
 macro_rules! impl_compress_and_decompress_for_table_values {
     ($($name:ty),*) => {
@@ -38,7 +39,7 @@ impl_compress_and_decompress_for_table_values!(
     Receipt,
     FieldElement,
     ContractAddress,
-    Vec<BlockNumber>,
+    BlockList,
     GenericContractInfo,
     StoredBlockBodyIndices,
     ContractInfoChangeList

--- a/crates/katana/storage/db/src/models/contract.rs
+++ b/crates/katana/storage/db/src/models/contract.rs
@@ -1,11 +1,10 @@
-use katana_primitives::block::BlockNumber;
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, Nonce};
 use serde::{Deserialize, Serialize};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 
-pub type BlockList = Vec<BlockNumber>;
+use super::storage::BlockList;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ContractInfoChangeList {

--- a/crates/katana/storage/db/src/models/contract.rs
+++ b/crates/katana/storage/db/src/models/contract.rs
@@ -2,9 +2,8 @@ use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, Nonce};
 use serde::{Deserialize, Serialize};
 
-use crate::codecs::{Compress, Decode, Decompress, Encode};
-
 use super::storage::BlockList;
+use crate::codecs::{Compress, Decode, Decompress, Encode};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ContractInfoChangeList {

--- a/crates/katana/storage/db/src/models/storage.rs
+++ b/crates/katana/storage/db/src/models/storage.rs
@@ -1,5 +1,6 @@
 use katana_primitives::block::BlockNumber;
 use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
+use serde::{Deserialize, Serialize};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::error::CodecError;
@@ -35,30 +36,8 @@ impl Decompress for StorageEntry {
     }
 }
 
-#[derive(Debug)]
-pub struct StorageEntryChangeList {
-    pub key: StorageKey,
-    pub block_list: Vec<BlockNumber>,
-}
-
-impl Compress for StorageEntryChangeList {
-    type Compressed = Vec<u8>;
-    fn compress(self) -> Self::Compressed {
-        let mut buf = Vec::new();
-        buf.extend_from_slice(&self.key.encode());
-        buf.extend_from_slice(&self.block_list.compress());
-        buf
-    }
-}
-
-impl Decompress for StorageEntryChangeList {
-    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
-        let bytes = bytes.as_ref();
-        let key = StorageKey::decode(&bytes[0..32])?;
-        let blocks = Vec::<BlockNumber>::decompress(&bytes[32..])?;
-        Ok(Self { key, block_list: blocks })
-    }
-}
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct BlockList(pub Vec<BlockNumber>);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ContractStorageKey {

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -254,5 +254,28 @@ mod tests {
         assert_eq!(Tables::ALL[19].name(), ClassChangeHistory::NAME);
         assert_eq!(Tables::ALL[20].name(), StorageChangeHistory::NAME);
         assert_eq!(Tables::ALL[21].name(), StorageChangeSet::NAME);
+
+        assert_eq!(Tables::Headers.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockHashes.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockNumbers.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockBodyIndices.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockStatusses.table_type(), TableType::Table);
+        assert_eq!(Tables::TxNumbers.table_type(), TableType::Table);
+        assert_eq!(Tables::TxBlocks.table_type(), TableType::Table);
+        assert_eq!(Tables::TxHashes.table_type(), TableType::Table);
+        assert_eq!(Tables::Transactions.table_type(), TableType::Table);
+        assert_eq!(Tables::Receipts.table_type(), TableType::Table);
+        assert_eq!(Tables::CompiledClassHashes.table_type(), TableType::Table);
+        assert_eq!(Tables::CompiledClasses.table_type(), TableType::Table);
+        assert_eq!(Tables::SierraClasses.table_type(), TableType::Table);
+        assert_eq!(Tables::ContractInfo.table_type(), TableType::Table);
+        assert_eq!(Tables::ContractStorage.table_type(), TableType::DupSort);
+        assert_eq!(Tables::ClassDeclarationBlock.table_type(), TableType::Table);
+        assert_eq!(Tables::ClassDeclarations.table_type(), TableType::DupSort);
+        assert_eq!(Tables::ContractInfoChangeSet.table_type(), TableType::Table);
+        assert_eq!(Tables::NonceChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(Tables::ClassChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(Tables::StorageChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(Tables::StorageChangeSet.table_type(), TableType::Table);
     }
 }

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -8,9 +8,7 @@ use katana_primitives::transaction::{Tx, TxHash, TxNumber};
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::models::block::StoredBlockBodyIndices;
 use crate::models::contract::{ContractClassChange, ContractInfoChangeList, ContractNonceChange};
-use crate::models::storage::{
-    ContractStorageEntry, ContractStorageKey, StorageEntry, StorageEntryChangeList,
-};
+use crate::models::storage::{BlockList, ContractStorageEntry, ContractStorageKey, StorageEntry};
 
 pub trait Key: Encode + Decode + Clone + std::fmt::Debug {}
 pub trait Value: Compress + Decompress + std::fmt::Debug {}
@@ -221,7 +219,7 @@ tables! {
     ClassChangeHistory: (BlockNumber, ContractAddress) => ContractClassChange,
 
     /// storage change set
-    StorageChangeSet: (ContractAddress, StorageKey) => StorageEntryChangeList,
+    StorageChangeSet: (ContractStorageKey) => BlockList,
     /// Account storage change set
     StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry
 

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -165,7 +165,7 @@ define_tables_enum! {[
     (NonceChangeHistory, TableType::DupSort),
     (ClassChangeHistory, TableType::DupSort),
     (StorageChangeHistory, TableType::DupSort),
-    (StorageChangeSet, TableType::DupSort)
+    (StorageChangeSet, TableType::Table)
 ]}
 
 tables! {

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -637,7 +637,8 @@ impl BlockWriter for DbProvider {
                                 list.0.sort();
                                 list
                             }
-                            // create a new block list if it doesn't yet exist, and insert the block number
+                            // create a new block list if it doesn't yet exist, and insert the block
+                            // number
                             None => BlockList(vec![block_number]),
                         };
 

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -11,7 +11,7 @@ use katana_db::models::contract::{
     ContractClassChange, ContractInfoChangeList, ContractNonceChange,
 };
 use katana_db::models::storage::{
-    ContractStorageEntry, ContractStorageKey, StorageEntry, StorageEntryChangeList,
+    BlockList, ContractStorageEntry, ContractStorageKey, StorageEntry,
 };
 use katana_db::tables::{self, DupSort, Table};
 use katana_db::utils::KeyValue;
@@ -626,28 +626,22 @@ impl BlockWriter for DbProvider {
                             _ => {}
                         }
 
-                        let mut change_set_cursor = db_tx.cursor::<tables::StorageChangeSet>()?;
-                        let new_block_list =
-                            match change_set_cursor.seek_by_key_subkey(addr, entry.key)? {
-                                Some(StorageEntryChangeList { mut block_list, key })
-                                    if key == entry.key =>
-                                {
-                                    change_set_cursor.delete_current()?;
+                        // update block list in the change set
+                        let changeset_key =
+                            ContractStorageKey { contract_address: addr, key: entry.key };
+                        let list = db_tx.get::<tables::StorageChangeSet>(changeset_key.clone())?;
 
-                                    block_list.push(block_number);
-                                    block_list.sort();
-                                    block_list
-                                }
+                        let updated_list = match list {
+                            Some(mut list) => {
+                                list.0.push(block_number);
+                                list.0.sort();
+                                list
+                            }
+                            // create a new block list if it doesn't yet exist, and insert the block number
+                            None => BlockList(vec![block_number]),
+                        };
 
-                                _ => {
-                                    vec![block_number]
-                                }
-                            };
-
-                        change_set_cursor.upsert(
-                            addr,
-                            StorageEntryChangeList { key: entry.key, block_list: new_block_list },
-                        )?;
+                        db_tx.put::<tables::StorageChangeSet>(changeset_key, updated_list)?;
                         storage_cursor.upsert(addr, entry)?;
 
                         let storage_change_sharded_key =
@@ -676,12 +670,12 @@ impl BlockWriter for DbProvider {
                 let new_change_set = if let Some(mut change_set) =
                     db_tx.get::<tables::ContractInfoChangeSet>(addr)?
                 {
-                    change_set.class_change_list.push(block_number);
-                    change_set.class_change_list.sort();
+                    change_set.class_change_list.0.push(block_number);
+                    change_set.class_change_list.0.sort();
                     change_set
                 } else {
                     ContractInfoChangeList {
-                        class_change_list: vec![block_number],
+                        class_change_list: BlockList(vec![block_number]),
                         ..Default::default()
                     }
                 };
@@ -703,12 +697,12 @@ impl BlockWriter for DbProvider {
                 let new_change_set = if let Some(mut change_set) =
                     db_tx.get::<tables::ContractInfoChangeSet>(addr)?
                 {
-                    change_set.nonce_change_list.push(block_number);
-                    change_set.nonce_change_list.sort();
+                    change_set.nonce_change_list.0.push(block_number);
+                    change_set.nonce_change_list.0.sort();
                     change_set
                 } else {
                     ContractInfoChangeList {
-                        nonce_change_list: vec![block_number],
+                        nonce_change_list: BlockList(vec![block_number]),
                         ..Default::default()
                     }
                 };

--- a/crates/katana/storage/provider/src/providers/db/state.rs
+++ b/crates/katana/storage/provider/src/providers/db/state.rs
@@ -183,11 +183,7 @@ impl HistoricalStateProvider {
         // then that means there is no change happening before the pinned block number.
         let pos = {
             if let Some(pos) = block_list.0.last().and_then(|num| {
-                if block_number >= *num {
-                    Some(block_list.0.len() - 1)
-                } else {
-                    None
-                }
+                if block_number >= *num { Some(block_list.0.len() - 1) } else { None }
             }) {
                 Some(pos)
             } else {

--- a/crates/katana/storage/provider/src/providers/db/state.rs
+++ b/crates/katana/storage/provider/src/providers/db/state.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use katana_db::mdbx::{self};
 use katana_db::models::contract::ContractInfoChangeList;
-use katana_db::models::storage::{ContractStorageKey, StorageEntry};
+use katana_db::models::storage::{BlockList, ContractStorageKey, StorageEntry};
 use katana_db::tables;
 use katana_primitives::block::BlockNumber;
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
@@ -173,21 +173,25 @@ impl HistoricalStateProvider {
     // if I don't document it. But im lazy.
     fn recent_block_change_relative_to_pinned_block_num(
         block_number: BlockNumber,
-        block_list: &[BlockNumber],
+        block_list: &BlockList,
     ) -> Option<BlockNumber> {
-        if block_list.first().is_some_and(|num| block_number < *num) {
+        if block_list.0.first().is_some_and(|num| block_number < *num) {
             return None;
         }
 
         // if the pinned block number is smaller than the first block number in the list,
         // then that means there is no change happening before the pinned block number.
         let pos = {
-            if let Some(pos) = block_list.last().and_then(|num| {
-                if block_number >= *num { Some(block_list.len() - 1) } else { None }
+            if let Some(pos) = block_list.0.last().and_then(|num| {
+                if block_number >= *num {
+                    Some(block_list.0.len() - 1)
+                } else {
+                    None
+                }
             }) {
                 Some(pos)
             } else {
-                block_list.iter().enumerate().find_map(|(i, num)| match block_number.cmp(num) {
+                block_list.0.iter().enumerate().find_map(|(i, num)| match block_number.cmp(num) {
                     Ordering::Equal => Some(i),
                     Ordering::Greater => None,
                     Ordering::Less => {
@@ -201,7 +205,7 @@ impl HistoricalStateProvider {
             }
         }?;
 
-        block_list.get(pos).copied()
+        block_list.0.get(pos).copied()
     }
 }
 
@@ -300,18 +304,14 @@ impl StateProvider for HistoricalStateProvider {
         address: ContractAddress,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
-        let mut cursor = self.tx.cursor::<tables::StorageChangeSet>()?;
+        let key = ContractStorageKey { contract_address: address, key: storage_key };
+        let block_list = self.tx.get::<tables::StorageChangeSet>(key.clone())?;
 
-        if let Some(num) = cursor.seek_by_key_subkey(address, storage_key)?.and_then(|entry| {
-            Self::recent_block_change_relative_to_pinned_block_num(
-                self.block_number,
-                &entry.block_list,
-            )
+        if let Some(num) = block_list.and_then(|list| {
+            Self::recent_block_change_relative_to_pinned_block_num(self.block_number, &list)
         }) {
             let mut cursor = self.tx.cursor::<tables::StorageChangeHistory>()?;
-            let sharded_key = ContractStorageKey { contract_address: address, key: storage_key };
-
-            let entry = cursor.seek_by_key_subkey(num, sharded_key)?.ok_or(
+            let entry = cursor.seek_by_key_subkey(num, key)?.ok_or(
                 ProviderError::MissingStorageChangeEntry {
                     block: num,
                     storage_key,
@@ -330,9 +330,9 @@ impl StateProvider for HistoricalStateProvider {
 
 #[cfg(test)]
 mod tests {
-    use super::HistoricalStateProvider;
+    use katana_db::models::storage::BlockList;
 
-    const BLOCK_LIST: [u64; 5] = [1, 2, 5, 6, 10];
+    use super::HistoricalStateProvider;
 
     #[rstest::rstest]
     #[case(0, None)]
@@ -349,7 +349,7 @@ mod tests {
         assert_eq!(
             HistoricalStateProvider::recent_block_change_relative_to_pinned_block_num(
                 block_num,
-                &BLOCK_LIST,
+                &BlockList(vec![1, 2, 5, 6, 10]),
             ),
             expected_block_num
         );


### PR DESCRIPTION
Resolves #1762 

Convert `StorageChangeSet` into a normal table instead of  dupsort.

This change is so to allow the block list of the `StorageChangeSet` to grow without being bounded by the value size of a `DUPSORT` table. 

The max size for a DUPSORT table value is equal to the max size of the table key. So, when the list cardinality increases too much, the resulting subkey size will become larger than the max size. This will result in a `MDBX_BAD_VALSIZE` error.

