### PR TITLE
feat(katana-db): integer set using roaring bitmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6720,6 +6720,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "postcard",
  "reth-libmdbx",
+ "roaring",
  "serde",
  "serde_json",
  "starknet 0.9.0",
@@ -9865,6 +9866,17 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "roaring"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1c77081a55300e016cb86f2864415b7518741879db925b8d488a0ee0d2da6bf"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytemuck"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/katana/storage/db/Cargo.toml
+++ b/crates/katana/storage/db/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 
 cairo-vm.workspace = true
 starknet_api.workspace = true
+roaring = { version = "0.10.3", features = ["serde"] }
 
 # codecs
 [dependencies.postcard]

--- a/crates/katana/storage/db/src/codecs/postcard.rs
+++ b/crates/katana/storage/db/src/codecs/postcard.rs
@@ -10,7 +10,7 @@ use super::{Compress, Decompress};
 use crate::error::CodecError;
 use crate::models::block::StoredBlockBodyIndices;
 use crate::models::contract::ContractInfoChangeList;
-use crate::models::storage::BlockList;
+use crate::models::list::BlockList;
 
 macro_rules! impl_compress_and_decompress_for_table_values {
     ($($name:ty),*) => {

--- a/crates/katana/storage/db/src/models/contract.rs
+++ b/crates/katana/storage/db/src/models/contract.rs
@@ -2,7 +2,7 @@ use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, Nonce};
 use serde::{Deserialize, Serialize};
 
-use super::storage::BlockList;
+use super::list::BlockList;
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/katana/storage/db/src/models/contract.rs
+++ b/crates/katana/storage/db/src/models/contract.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::list::BlockList;
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct ContractInfoChangeList {
     pub class_change_list: BlockList,
     pub nonce_change_list: BlockList,

--- a/crates/katana/storage/db/src/models/list.rs
+++ b/crates/katana/storage/db/src/models/list.rs
@@ -3,18 +3,18 @@ use serde::{Deserialize, Serialize};
 
 /// Stores a list of block numbers.
 /// Mainly used for changeset tables to store the list of block numbers where a change occurred.
-pub type BlockList = IntegerList;
+pub type BlockList = IntegerSet;
 
-/// A list of integers.
+/// A set for storing integer values.
 ///
 /// The list is stored in a Roaring bitmap data structure as it uses less space compared to a normal
 /// bitmap or even a naive array with similar cardinality.
 ///
 /// See <https://www.roaringbitmap.org/>.
 #[derive(Debug, Default, Serialize, Deserialize)]
-pub struct IntegerList(RoaringTreemap);
+pub struct IntegerSet(RoaringTreemap);
 
-impl IntegerList {
+impl IntegerSet {
     pub fn new() -> Self {
         Self(RoaringTreemap::new())
     }

--- a/crates/katana/storage/db/src/models/list.rs
+++ b/crates/katana/storage/db/src/models/list.rs
@@ -19,17 +19,17 @@ impl IntegerSet {
         Self(RoaringTreemap::new())
     }
 
-    /// Insert a new number to the list.
+    /// Insert a new number to the set.
     pub fn insert(&mut self, num: u64) {
         self.0.insert(num);
     }
 
-    /// Checks if the list contains the given number.
+    /// Checks if the set contains the given number.
     pub fn contains(&self, num: u64) -> bool {
         self.0.contains(num)
     }
 
-    /// Returns the number of elements in the list that are smaller or equal to the given `value`.
+    /// Returns the number of elements in the set that are smaller or equal to the given `value`.
     pub fn rank(&self, value: u64) -> u64 {
         self.0.rank(value)
     }

--- a/crates/katana/storage/db/src/models/list.rs
+++ b/crates/katana/storage/db/src/models/list.rs
@@ -8,7 +8,7 @@ pub type BlockList = IntegerList;
 /// A list of integers.
 ///
 /// The list is stored in a Roaring bitmap data structure as it uses less space compared to a normal
-/// bitmap or even a naive array with the same cardinality.
+/// bitmap or even a naive array with similar cardinality.
 ///
 /// See <https://www.roaringbitmap.org/>.
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/crates/katana/storage/db/src/models/list.rs
+++ b/crates/katana/storage/db/src/models/list.rs
@@ -1,0 +1,41 @@
+use roaring::RoaringTreemap;
+use serde::{Deserialize, Serialize};
+
+/// Stores a list of block numbers.
+/// Mainly used for changeset tables to store the list of block numbers where a change occurred.
+pub type BlockList = IntegerList;
+
+/// A list of integers.
+///
+/// The list is stored in a Roaring bitmap data structure as it uses less space compared to a normal
+/// bitmap or even a naive array with the same cardinality.
+///
+/// See <https://www.roaringbitmap.org/>.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct IntegerList(RoaringTreemap);
+
+impl IntegerList {
+    pub fn new() -> Self {
+        Self(RoaringTreemap::new())
+    }
+
+    /// Insert a new number to the list.
+    pub fn insert(&mut self, num: u64) {
+        self.0.insert(num);
+    }
+
+    /// Checks if the list contains the given number.
+    pub fn contains(&self, num: u64) -> bool {
+        self.0.contains(num)
+    }
+
+    /// Returns the number of elements in the list that are smaller or equal to the given `value`.
+    pub fn rank(&self, value: u64) -> u64 {
+        self.0.rank(value)
+    }
+
+    /// Returns the `n`th integer in the set or `None` if `n >= len()`.
+    pub fn select(&self, n: u64) -> Option<u64> {
+        self.0.select(n)
+    }
+}

--- a/crates/katana/storage/db/src/models/list.rs
+++ b/crates/katana/storage/db/src/models/list.rs
@@ -11,7 +11,7 @@ pub type BlockList = IntegerSet;
 /// bitmap or even a naive array with similar cardinality.
 ///
 /// See <https://www.roaringbitmap.org/>.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct IntegerSet(RoaringTreemap);
 
 impl IntegerSet {

--- a/crates/katana/storage/db/src/models/list.rs
+++ b/crates/katana/storage/db/src/models/list.rs
@@ -39,3 +39,9 @@ impl IntegerSet {
         self.0.select(n)
     }
 }
+
+impl<const N: usize> From<[u64; N]> for IntegerSet {
+    fn from(arr: [u64; N]) -> Self {
+        Self(RoaringTreemap::from_iter(arr))
+    }
+}

--- a/crates/katana/storage/db/src/models/mod.rs
+++ b/crates/katana/storage/db/src/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod block;
 pub mod class;
 pub mod contract;
+pub mod list;
 pub mod storage;

--- a/crates/katana/storage/db/src/models/storage.rs
+++ b/crates/katana/storage/db/src/models/storage.rs
@@ -1,6 +1,4 @@
-use katana_primitives::block::BlockNumber;
 use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
-use serde::{Deserialize, Serialize};
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::error::CodecError;
@@ -35,9 +33,6 @@ impl Decompress for StorageEntry {
         Ok(Self { key, value })
     }
 }
-
-#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
-pub struct BlockList(pub Vec<BlockNumber>);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ContractStorageKey {

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -8,7 +8,8 @@ use katana_primitives::transaction::{Tx, TxHash, TxNumber};
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::models::block::StoredBlockBodyIndices;
 use crate::models::contract::{ContractClassChange, ContractInfoChangeList, ContractNonceChange};
-use crate::models::storage::{BlockList, ContractStorageEntry, ContractStorageKey, StorageEntry};
+use crate::models::list::BlockList;
+use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 
 pub trait Key: Encode + Decode + Clone + std::fmt::Debug {}
 pub trait Value: Compress + Decompress + std::fmt::Debug {}

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -294,9 +294,8 @@ mod tests {
     use crate::models::contract::{
         ContractClassChange, ContractInfoChangeList, ContractNonceChange,
     };
-    use crate::models::storage::{
-        BlockList, ContractStorageEntry, ContractStorageKey, StorageEntry,
-    };
+    use crate::models::list::BlockList;
+    use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 
     macro_rules! assert_key_encode_decode {
 	    { $( ($name:ty, $key:expr) ),* } => {

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -10,9 +10,8 @@ use katana_db::models::block::StoredBlockBodyIndices;
 use katana_db::models::contract::{
     ContractClassChange, ContractInfoChangeList, ContractNonceChange,
 };
-use katana_db::models::storage::{
-    BlockList, ContractStorageEntry, ContractStorageKey, StorageEntry,
-};
+use katana_db::models::list::BlockList;
+use katana_db::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 use katana_db::tables::{self, DupSort, Table};
 use katana_db::utils::KeyValue;
 use katana_primitives::block::{
@@ -633,13 +632,12 @@ impl BlockWriter for DbProvider {
 
                         let updated_list = match list {
                             Some(mut list) => {
-                                list.0.push(block_number);
-                                list.0.sort();
+                                list.insert(block_number);
                                 list
                             }
                             // create a new block list if it doesn't yet exist, and insert the block
                             // number
-                            None => BlockList(vec![block_number]),
+                            None => BlockList::from([block_number]),
                         };
 
                         db_tx.put::<tables::StorageChangeSet>(changeset_key, updated_list)?;
@@ -671,12 +669,11 @@ impl BlockWriter for DbProvider {
                 let new_change_set = if let Some(mut change_set) =
                     db_tx.get::<tables::ContractInfoChangeSet>(addr)?
                 {
-                    change_set.class_change_list.0.push(block_number);
-                    change_set.class_change_list.0.sort();
+                    change_set.class_change_list.insert(block_number);
                     change_set
                 } else {
                     ContractInfoChangeList {
-                        class_change_list: BlockList(vec![block_number]),
+                        class_change_list: BlockList::from([block_number]),
                         ..Default::default()
                     }
                 };
@@ -698,12 +695,11 @@ impl BlockWriter for DbProvider {
                 let new_change_set = if let Some(mut change_set) =
                     db_tx.get::<tables::ContractInfoChangeSet>(addr)?
                 {
-                    change_set.nonce_change_list.0.push(block_number);
-                    change_set.nonce_change_list.0.sort();
+                    change_set.nonce_change_list.insert(block_number);
                     change_set
                 } else {
                     ContractInfoChangeList {
-                        nonce_change_list: BlockList(vec![block_number]),
+                        nonce_change_list: BlockList::from([block_number]),
                         ..Default::default()
                     }
                 };


### PR DESCRIPTION
Related #1762 

Introduces an `IntegerSet` struct for storing a list of block numbers. 

We use [Roaring bitmap](https://www.roaringbitmap.org/) data structure as they provide better compression compared to a naive `Vec` when storing the same amount of elements.

----

Storing `1_000_000` u64s:
- roaring bitmap = `131.22KB`
- vec = `8MB`