### PR TITLE
test(katana-db): ensure key/value types implement their respective traits

### DIFF
--- a/crates/katana/storage/db/src/models/block.rs
+++ b/crates/katana/storage/db/src/models/block.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use katana_primitives::transaction::TxNumber;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct StoredBlockBodyIndices {
     /// The offset in database of the first transaction in the block.
     ///

--- a/crates/katana/storage/db/src/models/contract.rs
+++ b/crates/katana/storage/db/src/models/contract.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 use super::storage::BlockList;
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ContractInfoChangeList {
     pub class_change_list: BlockList,
     pub nonce_change_list: BlockList,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ContractClassChange {
     pub contract_address: ContractAddress,
     /// The updated class hash of `contract_address`.
@@ -37,7 +37,7 @@ impl Decompress for ContractClassChange {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ContractNonceChange {
     pub contract_address: ContractAddress,
     /// The updated nonce value of `contract_address`.

--- a/crates/katana/storage/db/src/models/storage.rs
+++ b/crates/katana/storage/db/src/models/storage.rs
@@ -36,7 +36,7 @@ impl Decompress for StorageEntry {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BlockList(pub Vec<BlockNumber>);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -280,23 +280,22 @@ mod tests {
         assert_eq!(Tables::StorageChangeSet.table_type(), TableType::Table);
     }
 
-    use crate::{
-        codecs::{Compress, Decode, Decompress, Encode},
-        models::{
-            block::StoredBlockBodyIndices,
-            contract::{ContractClassChange, ContractInfoChangeList, ContractNonceChange},
-            storage::{BlockList, ContractStorageEntry, ContractStorageKey, StorageEntry},
-        },
-    };
-    use katana_primitives::{
-        block::{BlockHash, BlockNumber, FinalityStatus, Header},
-        class::{ClassHash, CompiledClass, CompiledClassHash},
-        contract::{ContractAddress, GenericContractInfo},
-        receipt::Receipt,
-        trace::TxExecInfo,
-        transaction::{InvokeTx, Tx, TxHash, TxNumber},
-    };
+    use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
+    use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
+    use katana_primitives::contract::{ContractAddress, GenericContractInfo};
+    use katana_primitives::receipt::Receipt;
+    use katana_primitives::trace::TxExecInfo;
+    use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber};
     use starknet::macros::felt;
+
+    use crate::codecs::{Compress, Decode, Decompress, Encode};
+    use crate::models::block::StoredBlockBodyIndices;
+    use crate::models::contract::{
+        ContractClassChange, ContractInfoChangeList, ContractNonceChange,
+    };
+    use crate::models::storage::{
+        BlockList, ContractStorageEntry, ContractStorageKey, StorageEntry,
+    };
 
     macro_rules! assert_key_encode_decode {
 	    { $( ($name:ty, $key:expr) ),* } => {


### PR DESCRIPTION
Add simple unit tests for making sure that the types that are used as the key/value types of the tables, implements the `Encode`/`Decode` (key) or `Compress`/`Decompress` (value) code respectively.