### PR TITLE
feat: add metadata section to the world contract manifest

### DIFF
--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -216,7 +216,7 @@ impl DevArgs {
         let mut previous_manifest: Option<DeploymentManifest> = Option::None;
         let result = build(&mut context);
 
-        let Some((mut world_address, account, _)) = context
+        let Some((mut world_address, account, _, _)) = context
             .ws
             .config()
             .tokio_handle()

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -142,7 +142,8 @@ impl MigrateArgs {
                     )
                     .await?;
 
-                    migration::migrate(&ws, world_address, chain_id, rpc_url, &account, name, true).await
+                    migration::migrate(&ws, world_address, chain_id, rpc_url, &account, name, true)
+                        .await
                 })
             }
             MigrateCommand::Apply { mut name, world, starknet, account } => {
@@ -163,7 +164,8 @@ impl MigrateArgs {
                     )
                     .await?;
 
-                    migration::migrate(&ws, world_address, chain_id, rpc_url,&account, name, false).await
+                    migration::migrate(&ws, world_address, chain_id, rpc_url, &account, name, false)
+                        .await
                 })
             }
         }

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -158,8 +158,17 @@ impl MigrateArgs {
                     )
                     .await?;
 
-                    migration::migrate(&ws, world_address, chain_id, rpc_url, &account, name, true, None)
-                        .await
+                    migration::migrate(
+                        &ws,
+                        world_address,
+                        chain_id,
+                        rpc_url,
+                        &account,
+                        name,
+                        true,
+                        None,
+                    )
+                    .await
                 })
             }
             MigrateCommand::Apply { mut name, world, starknet, account, transaction } => {

--- a/bin/sozo/src/commands/options/starknet.rs
+++ b/bin/sozo/src/commands/options/starknet.rs
@@ -24,8 +24,10 @@ impl StarknetOptions {
         Ok(JsonRpcClient::new(HttpTransport::new(self.url(env_metadata)?)))
     }
 
-    // we dont check the env var because that would be handled by `clap`
-    fn url(&self, env_metadata: Option<&Environment>) -> Result<Url> {
+    // We dont check the env var because that would be handled by `clap`.
+    // This function is made public because [`JsonRpcClient`] does not expose
+    // the raw rpc url.
+    pub fn url(&self, env_metadata: Option<&Environment>) -> Result<Url> {
         if let Some(url) = self.rpc_url.as_ref() {
             Ok(url.clone())
         } else if let Some(url) = env_metadata.and_then(|env| env.rpc_url()) {

--- a/crates/dojo-world/src/manifest/mod.rs
+++ b/crates/dojo-world/src/manifest/mod.rs
@@ -29,9 +29,9 @@ mod test;
 mod types;
 
 pub use types::{
-    AbiFormat, BaseManifest, Class, ComputedValueEntrypoint, Contract, DeploymentManifest,
+    AbiFormat, BaseManifest, Class, ComputedValueEntrypoint, WorldContract, DeploymentManifest,
     DojoContract, DojoModel, Manifest, ManifestMethods, Member, OverlayClass, OverlayContract,
-    OverlayDojoContract, OverlayDojoModel, OverlayManifest,
+    OverlayDojoContract, OverlayDojoModel, OverlayManifest, WorldMetadata,
 };
 
 pub const WORLD_CONTRACT_NAME: &str = "dojo::world::world";
@@ -65,10 +65,10 @@ pub enum AbstractManifestError {
     Json(#[from] serde_json::Error),
 }
 
-impl From<Manifest<Class>> for Manifest<Contract> {
+impl From<Manifest<Class>> for Manifest<WorldContract> {
     fn from(value: Manifest<Class>) -> Self {
         Manifest::new(
-            Contract {
+            WorldContract {
                 class_hash: value.inner.class_hash,
                 abi: value.inner.abi,
                 original_class_hash: value.inner.original_class_hash,
@@ -254,7 +254,7 @@ impl DeploymentManifest {
             models,
             contracts,
             world: Manifest::new(
-                Contract {
+                WorldContract {
                     address: Some(world_address),
                     class_hash: world_class_hash,
                     ..Default::default()
@@ -607,7 +607,7 @@ impl ManifestMethods for DojoModel {
     }
 }
 
-impl ManifestMethods for Contract {
+impl ManifestMethods for WorldContract {
     type OverlayType = OverlayContract;
 
     fn abi(&self) -> Option<&AbiFormat> {

--- a/crates/dojo-world/src/manifest/mod.rs
+++ b/crates/dojo-world/src/manifest/mod.rs
@@ -29,9 +29,9 @@ mod test;
 mod types;
 
 pub use types::{
-    AbiFormat, BaseManifest, Class, ComputedValueEntrypoint, WorldContract, DeploymentManifest,
-    DojoContract, DojoModel, Manifest, ManifestMethods, Member, OverlayClass, OverlayContract,
-    OverlayDojoContract, OverlayDojoModel, OverlayManifest, WorldMetadata,
+    AbiFormat, BaseManifest, Class, ComputedValueEntrypoint, DeploymentManifest, DojoContract,
+    DojoModel, Manifest, ManifestMethods, Member, OverlayClass, OverlayContract,
+    OverlayDojoContract, OverlayDojoModel, OverlayManifest, WorldContract, WorldMetadata,
 };
 
 pub const WORLD_CONTRACT_NAME: &str = "dojo::world::world";

--- a/crates/dojo-world/src/manifest/types.rs
+++ b/crates/dojo-world/src/manifest/types.rs
@@ -30,7 +30,7 @@ pub struct BaseManifest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct DeploymentManifest {
-    pub world: Manifest<Contract>,
+    pub world: Manifest<WorldContract>,
     pub base: Manifest<Class>,
     pub contracts: Vec<Manifest<DojoContract>>,
     pub models: Vec<Manifest<DojoModel>>,
@@ -117,7 +117,7 @@ pub struct DojoModel {
 #[derive(Clone, Default, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(tag = "kind")]
-pub struct Contract {
+pub struct WorldContract {
     #[serde_as(as = "UfeHex")]
     pub class_hash: FieldElement,
     #[serde_as(as = "UfeHex")]
@@ -128,8 +128,8 @@ pub struct Contract {
     #[serde_as(as = "Option<UfeHex>")]
     pub transaction_hash: Option<FieldElement>,
     pub block_number: Option<u64>,
-    // used by World contract
     pub seed: Option<String>,
+    pub metadata: Option<WorldMetadata>,
 }
 
 #[serde_as]
@@ -285,4 +285,12 @@ impl PartialEq for AbiFormat {
             _ => false,
         }
     }
+}
+
+#[serde_as]
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct WorldMetadata {
+    pub profile_name: String,
+    pub rpc_url: String,
 }

--- a/crates/sozo/ops/src/migration/migration_test.rs
+++ b/crates/sozo/ops/src/migration/migration_test.rs
@@ -117,7 +117,6 @@ fn migrate_world_without_seed_will_fail() {
     assert!(res.is_err_and(|e| e.to_string().contains("Missing seed for World deployment.")))
 }
 
-#[ignore]
 #[tokio::test]
 async fn migration_from_remote() {
     let config = build_test_config("../../../examples/spawn-and-move/Scarb.toml").unwrap();
@@ -139,10 +138,13 @@ async fn migration_from_remote() {
         ExecutionEncoding::New,
     );
 
+    let profile_name = ws.current_profile().unwrap().to_string();
+
     let manifest = BaseManifest::load_from_path(
-        &Utf8Path::new(base).to_path_buf().join(MANIFESTS_DIR).join(BASE_DIR),
+        &Utf8Path::new(base).to_path_buf().join(MANIFESTS_DIR).join(&profile_name).join(BASE_DIR),
     )
     .unwrap();
+
     let world = WorldDiff::compute(manifest, None);
 
     let mut migration = prepare_for_migration(
@@ -156,9 +158,10 @@ async fn migration_from_remote() {
     execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
 
     let local_manifest = BaseManifest::load_from_path(
-        &Utf8Path::new(base).to_path_buf().join(MANIFESTS_DIR).join(BASE_DIR),
+        &Utf8Path::new(base).to_path_buf().join(MANIFESTS_DIR).join(&profile_name).join(BASE_DIR),
     )
     .unwrap();
+
     let remote_manifest = DeploymentManifest::load_from_remote(
         JsonRpcClient::new(HttpTransport::new(sequencer.url())),
         migration.world_address().unwrap(),

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -7,8 +7,9 @@ use dojo_world::contracts::abi::world::ResourceMetadata;
 use dojo_world::contracts::cairo_utils;
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::manifest::{
-    AbiFormat, AbstractManifestError, BaseManifest, WorldContract as ManifestWorldContract, DeploymentManifest, DojoContract,
-    DojoModel, Manifest, ManifestMethods, OverlayManifest, WorldMetadata,
+    AbiFormat, AbstractManifestError, BaseManifest, DeploymentManifest, DojoContract, DojoModel,
+    Manifest, ManifestMethods, OverlayManifest, WorldContract as ManifestWorldContract,
+    WorldMetadata,
 };
 use dojo_world::metadata::dojo_metadata_from_workspace;
 use dojo_world::migration::contract::ContractMigration;
@@ -261,7 +262,8 @@ async fn update_manifest_abis(
         manifest.inner.set_abi(Some(AbiFormat::Path(deployed_relative_path)));
     }
 
-    inner_helper::<ManifestWorldContract>(profile_dir, profile_name, &mut local_manifest.world).await;
+    inner_helper::<ManifestWorldContract>(profile_dir, profile_name, &mut local_manifest.world)
+        .await;
 
     for contract in local_manifest.contracts.iter_mut() {
         inner_helper::<DojoContract>(profile_dir, profile_name, contract).await;

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -7,8 +7,8 @@ use dojo_world::contracts::abi::world::ResourceMetadata;
 use dojo_world::contracts::cairo_utils;
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::manifest::{
-    AbiFormat, AbstractManifestError, BaseManifest, Contract, DeploymentManifest, DojoContract,
-    DojoModel, Manifest, ManifestMethods, OverlayManifest,
+    AbiFormat, AbstractManifestError, BaseManifest, WorldContract as ManifestWorldContract, DeploymentManifest, DojoContract,
+    DojoModel, Manifest, ManifestMethods, OverlayManifest, WorldMetadata,
 };
 use dojo_world::metadata::dojo_metadata_from_workspace;
 use dojo_world::migration::contract::ContractMigration;
@@ -57,6 +57,7 @@ pub async fn migrate<P, S>(
     ws: &Workspace<'_>,
     world_address: Option<FieldElement>,
     chain_id: String,
+    rpc_url: String,
     account: &SingleOwnerAccount<P, S>,
     name: Option<String>,
     dry_run: bool,
@@ -104,38 +105,20 @@ where
     let mut strategy = prepare_migration(&target_dir, diff, name.clone(), world_address, &ui)?;
     let world_address = strategy.world_address().expect("world address must exist");
 
-    if dry_run {
+    let migration_output = if dry_run {
         print_strategy(&ui, account.provider(), &strategy).await;
-
-        update_manifests_and_abis(
-            ws,
-            local_manifest,
-            &profile_dir,
-            &profile_name,
-            MigrationOutput { world_address, ..Default::default() },
-            name.as_ref(),
-        )
-        .await?;
+        MigrationOutput { world_address, ..Default::default() }
     } else {
         // Migrate according to the diff.
         match apply_diff(ws, account, None, &mut strategy).await {
-            Ok(migration_output) => {
-                update_manifests_and_abis(
-                    ws,
-                    local_manifest,
-                    &profile_dir,
-                    &profile_name,
-                    migration_output,
-                    name.as_ref(),
-                )
-                .await?;
-            }
+            Ok(migration_output) => migration_output,
             Err(e) => {
                 update_manifests_and_abis(
                     ws,
                     local_manifest,
                     &profile_dir,
                     &profile_name,
+                    &rpc_url,
                     MigrationOutput { world_address, ..Default::default() },
                     name.as_ref(),
                 )
@@ -145,6 +128,17 @@ where
         }
     };
 
+    update_manifests_and_abis(
+        ws,
+        local_manifest,
+        &profile_dir,
+        &profile_name,
+        &rpc_url,
+        migration_output,
+        name.as_ref(),
+    )
+    .await?;
+
     Ok(())
 }
 
@@ -153,6 +147,7 @@ async fn update_manifests_and_abis(
     local_manifest: BaseManifest,
     profile_dir: &Utf8PathBuf,
     profile_name: &str,
+    rpc_url: &str,
     migration_output: MigrationOutput,
     salt: Option<&String>,
 ) -> Result<()> {
@@ -163,6 +158,11 @@ async fn update_manifests_and_abis(
     let deployed_path_json = profile_dir.join("manifest").with_extension("json");
 
     let mut local_manifest: DeploymentManifest = local_manifest.into();
+
+    local_manifest.world.inner.metadata = Some(WorldMetadata {
+        profile_name: profile_name.to_string(),
+        rpc_url: rpc_url.to_string(),
+    });
 
     if deployed_path.exists() {
         let previous_manifest = DeploymentManifest::load_from_path(&deployed_path)?;
@@ -261,7 +261,7 @@ async fn update_manifest_abis(
         manifest.inner.set_abi(Some(AbiFormat::Path(deployed_relative_path)));
     }
 
-    inner_helper::<Contract>(profile_dir, profile_name, &mut local_manifest.world).await;
+    inner_helper::<ManifestWorldContract>(profile_dir, profile_name, &mut local_manifest.world).await;
 
     for contract in local_manifest.contracts.iter_mut() {
         inner_helper::<DojoContract>(profile_dir, profile_name, contract).await;

--- a/examples/spawn-and-move/manifests/dev/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/manifest.json
@@ -1,6 +1,6 @@
 {
   "world": {
-    "kind": "Contract",
+    "kind": "WorldContract",
     "class_hash": "0x799bc4e9da10bfb3dd88e6f223c9cfbf7745435cd14f5d69675ea448e578cd",
     "original_class_hash": "0x799bc4e9da10bfb3dd88e6f223c9cfbf7745435cd14f5d69675ea448e578cd",
     "abi": [
@@ -664,6 +664,10 @@
     "transaction_hash": "0x6afefdcc49b3563a4f3657900ba71e9f9356861b15b942a73f2018f046a1048",
     "block_number": 3,
     "seed": "dojo_examples",
+    "metadata": {
+      "profile_name": "dev",
+      "rpc_url": "http://localhost:5050/"
+    },
     "name": "dojo::world::world"
   },
   "base": {

--- a/examples/spawn-and-move/manifests/dev/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/manifest.toml
@@ -1,5 +1,5 @@
 [world]
-kind = "Contract"
+kind = "WorldContract"
 class_hash = "0x799bc4e9da10bfb3dd88e6f223c9cfbf7745435cd14f5d69675ea448e578cd"
 original_class_hash = "0x799bc4e9da10bfb3dd88e6f223c9cfbf7745435cd14f5d69675ea448e578cd"
 abi = "abis/deployments/dojo_world_world.json"
@@ -8,6 +8,10 @@ transaction_hash = "0x6afefdcc49b3563a4f3657900ba71e9f9356861b15b942a73f2018f046
 block_number = 3
 seed = "dojo_examples"
 name = "dojo::world::world"
+
+[world.metadata]
+profile_name = "dev"
+rpc_url = "http://localhost:5050/"
 
 [base]
 kind = "Class"


### PR DESCRIPTION
Binding generation could be done by almost only the manifest as input.
As a request, here is a modification that adds some metadata to the manifest to obtain more context on what was done during deployment.

Doing so, the client can behaves differently based on the profile used + the RPC URL already embedded.