### PR TITLE
fix: incorrect assumption about migration output

### DIFF
--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -36,6 +36,7 @@ pub struct DeployOutput {
     // base class hash at time of deployment
     pub base_class_hash: FieldElement,
     pub was_upgraded: bool,
+    pub name: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -215,6 +216,7 @@ pub trait Deployable: Declarable + Sync {
             declare,
             base_class_hash,
             was_upgraded,
+            name: None,
         })
     }
 
@@ -287,6 +289,7 @@ pub trait Deployable: Declarable + Sync {
             declare,
             base_class_hash: FieldElement::default(),
             was_upgraded: false,
+            name: None,
         })
     }
 

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use anyhow::{anyhow, bail, Context, Result};
 use camino::Utf8PathBuf;
 use dojo_lang::compiler::{ABIS_DIR, BASE_DIR, DEPLOYMENTS_DIR, MANIFESTS_DIR, OVERLAYS_DIR};
-use dojo_lang::model;
 use dojo_world::contracts::abi::world::ResourceMetadata;
 use dojo_world::contracts::cairo_utils;
 use dojo_world::contracts::world::WorldContract;


### PR DESCRIPTION
Previously we assumed that there is one to one mapping between contracts in `local_manifest` and `migration_output` but thats not the case because `migration_output` just contains contracts that got upgraded/deployed.

So now we find the manifest based on its name.