### PR TITLE
Info trace outputs txn hash as hex

### DIFF
--- a/crates/katana/core/src/pool.rs
+++ b/crates/katana/core/src/pool.rs
@@ -25,7 +25,7 @@ impl TransactionPool {
         let hash = transaction.hash;
         self.transactions.write().push(transaction);
 
-        info!(target: LOG_TARGET, hash = %hash, "Transaction received.");
+        info!(target: LOG_TARGET, hash = %format!("\"{hash:#x}\""), "Transaction received.");
 
         // notify listeners of new tx added to the pool
         self.notify_listener(hash)
@@ -58,7 +58,7 @@ impl TransactionPool {
                     if e.is_full() {
                         warn!(
                             target: LOG_TARGET,
-                            hash = ?hash,
+                            hash = ?format!("\"{hash:#x}\""),
                             "Unable to send tx notification because channel is full."
                         );
                         true


### PR DESCRIPTION
Small devex improvement - convert hash to hex and add quotes so double-clicking in terminal selects only the hex

Previously:
```2024-04-09T23:48:32.464311Z  INFO txpool: Transaction received. hash=3070079164994693211170539684739988933124593645787751782488497078786805917239```

New:
```2024-04-10T00:06:45.014781Z  INFO txpool: Transaction received. hash="0x6d1edbbdb861522d06392eda659499ede0de2d72b00d79eff5513821871a3a4"```