### PR TITLE
feat(torii): add flag for indexing everything

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -109,6 +109,10 @@ struct Args {
     /// Chunk size of the events page when indexing using events
     #[arg(long, default_value = "1000")]
     events_chunk_size: u64,
+
+    /// Index all blocks and transactions 
+    #[arg(long, default_value = "false")]
+    all: bool,
 }
 
 #[tokio::main]
@@ -179,6 +183,7 @@ async fn main() -> anyhow::Result<()> {
         EngineConfig {
             start_block: args.start_block,
             events_chunk_size: args.events_chunk_size,
+            index_all: args.all,
             ..Default::default()
         },
         shutdown_tx.clone(),

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -36,11 +36,12 @@ pub struct EngineConfig {
     pub block_time: Duration,
     pub start_block: u64,
     pub events_chunk_size: u64,
+    pub index_all: bool,
 }
 
 impl Default for EngineConfig {
     fn default() -> Self {
-        Self { block_time: Duration::from_secs(1), start_block: 0, events_chunk_size: 1000 }
+        Self { block_time: Duration::from_secs(1), start_block: 0, events_chunk_size: 1000, index_all: false }
     }
 }
 


### PR DESCRIPTION
DOJ-350

blocked by #1798
once it is merged, we should modify the logic to use the all arg to know if we should index all blcoks and transactions that dont necessarily contain world events