### PR TITLE
fix: use `fee_estimate_multiplier` on more places

### DIFF
--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -13,6 +13,7 @@ use dojo_lang::scarb_internal::build_scarb_root_database;
 use dojo_world::manifest::{BaseManifest, DeploymentManifest};
 use dojo_world::metadata::dojo_metadata_from_workspace;
 use dojo_world::migration::world::WorldDiff;
+use dojo_world::migration::TxnConfig;
 use notify_debouncer_mini::notify::RecursiveMode;
 use notify_debouncer_mini::{new_debouncer, DebouncedEvent, DebouncedEventKind};
 use scarb::compiler::CompilationUnit;
@@ -146,7 +147,7 @@ where
     let ui = ws.config().ui();
     let mut strategy = prepare_migration(&target_dir, diff, name, world_address, &ui)?;
 
-    match migration::apply_diff(ws, account, None, &mut strategy).await {
+    match migration::apply_diff(ws, account, TxnConfig::default(), &mut strategy).await {
         Ok(migration_output) => {
             config.ui().print(format!(
                 "🎉 World at address {} updated!",

--- a/bin/sozo/src/commands/execute.rs
+++ b/bin/sozo/src/commands/execute.rs
@@ -54,7 +54,8 @@ impl ExecuteArgs {
             .unwrap();
             let tx_config = self.transaction.into();
 
-            execute::execute(self.contract, self.entrypoint, self.calldata, &world, tx_config).await
+            execute::execute(self.contract, self.entrypoint, self.calldata, &world, &tx_config)
+                .await
         })
     }
 }

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::{Args, Subcommand};
 use dojo_lang::compiler::MANIFESTS_DIR;
 use dojo_world::metadata::{dojo_metadata_from_workspace, Environment};
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 use katana_rpc_api::starknet::RPC_SPEC_VERSION;
 use scarb::core::{Config, Workspace};
 use sozo_ops::migration;
@@ -172,7 +172,7 @@ impl MigrateArgs {
                 })
             }
             MigrateCommand::Apply { mut name, world, starknet, account, transaction } => {
-                let txn_config: Option<TxConfig> = Some(transaction.into());
+                let txn_config: Option<TxnConfig> = Some(transaction.into());
 
                 if name.is_none() {
                     if let Some(root_package) = ws.root_package() {

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -166,13 +166,13 @@ impl MigrateArgs {
                         &account,
                         name,
                         true,
-                        None,
+                        TxnConfig::default(),
                     )
                     .await
                 })
             }
             MigrateCommand::Apply { mut name, world, starknet, account, transaction } => {
-                let txn_config: Option<TxnConfig> = Some(transaction.into());
+                let txn_config: TxnConfig = transaction.into();
 
                 if name.is_none() {
                     if let Some(root_package) = ws.root_package() {

--- a/bin/sozo/src/commands/options/transaction.rs
+++ b/bin/sozo/src/commands/options/transaction.rs
@@ -1,5 +1,5 @@
 use clap::Args;
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 
 #[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Transaction options")]
@@ -29,7 +29,7 @@ pub struct TransactionOptions {
     pub receipt: bool,
 }
 
-impl From<TransactionOptions> for TxConfig {
+impl From<TransactionOptions> for TxnConfig {
     fn from(value: TransactionOptions) -> Self {
         Self {
             fee_estimate_multiplier: value.fee_estimate_multiplier,

--- a/bin/sozo/tests/register_test.rs
+++ b/bin/sozo/tests/register_test.rs
@@ -5,6 +5,7 @@ use dojo_test_utils::migration::prepare_migration;
 use dojo_test_utils::sequencer::{
     get_default_test_starknet_config, SequencerConfig, TestSequencer,
 };
+use dojo_world::migration::TxnConfig;
 use scarb::ops;
 use sozo_ops::migration::execute_strategy;
 use starknet::accounts::Account;
@@ -27,7 +28,7 @@ async fn reregister_models() {
     let mut account = sequencer.account();
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
-    execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+    execute_strategy(&ws, &mut migration, &account, TxnConfig::default()).await.unwrap();
     let world_address = &format!("0x{:x}", &migration.world_address().unwrap());
     let account_address = &format!("0x{:x}", account.address());
     let private_key = &format!("0x{:x}", sequencer.raw_account().private_key);

--- a/crates/dojo-world/src/contracts/world_test.rs
+++ b/crates/dojo-world/src/contracts/world_test.rs
@@ -12,7 +12,7 @@ use super::{WorldContract, WorldContractReader};
 use crate::manifest::BaseManifest;
 use crate::migration::strategy::prepare_for_migration;
 use crate::migration::world::WorldDiff;
-use crate::migration::{Declarable, Deployable};
+use crate::migration::{Declarable, Deployable, TxnConfig};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_world_contract_reader() {
@@ -54,7 +54,7 @@ pub async fn deploy_world(
     .unwrap();
 
     let base_class_hash =
-        strategy.base.unwrap().declare(&account, Default::default()).await.unwrap().class_hash;
+        strategy.base.unwrap().declare(&account, &TxnConfig::default()).await.unwrap().class_hash;
 
     // wait for the tx to be mined
     tokio::time::sleep(Duration::from_millis(250)).await;
@@ -66,7 +66,7 @@ pub async fn deploy_world(
             manifest.clone().world.inner.class_hash,
             vec![base_class_hash],
             &account,
-            Default::default(),
+            &TxnConfig::default(),
         )
         .await
         .unwrap()
@@ -74,7 +74,7 @@ pub async fn deploy_world(
 
     let mut declare_output = vec![];
     for model in strategy.models {
-        let res = model.declare(&account, Default::default()).await.unwrap();
+        let res = model.declare(&account, &TxnConfig::default()).await.unwrap();
         declare_output.push(res);
     }
 
@@ -94,14 +94,14 @@ pub async fn deploy_world(
     tokio::time::sleep(Duration::from_millis(250)).await;
 
     for contract in strategy.contracts {
-        let declare_res = contract.declare(&account, Default::default()).await.unwrap();
+        let declare_res = contract.declare(&account, &TxnConfig::default()).await.unwrap();
         contract
             .deploy_dojo_contract(
                 world_address,
                 declare_res.class_hash,
                 base_class_hash,
                 &account,
-                Default::default(),
+                &TxnConfig::default(),
             )
             .await
             .unwrap();

--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -91,7 +91,7 @@ pub trait StateDiff {
 
 /// The transaction configuration to use when sending a transaction.
 #[derive(Debug, Copy, Clone, Default)]
-pub struct TxConfig {
+pub struct TxnConfig {
     /// The multiplier for how much the actual transaction max fee should be relative to the
     /// estimated fee. If `None` is provided, the multiplier is set to `1.1`.
     pub fee_estimate_multiplier: Option<f64>,
@@ -105,7 +105,7 @@ pub trait Declarable {
     async fn declare<P, S>(
         &self,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxConfig,
+        txn_config: TxnConfig,
     ) -> Result<DeclareOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -126,7 +126,7 @@ pub trait Declarable {
 
         let mut txn = account.declare(Arc::new(flattened_class), casm_class_hash);
 
-        if let TxConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
+        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
             txn = txn.fee_estimate_multiplier(multiplier);
         }
 
@@ -152,7 +152,7 @@ pub trait Deployable: Declarable + Sync {
         class_hash: FieldElement,
         base_class_hash: FieldElement,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxConfig,
+        txn_config: TxnConfig,
     ) -> Result<DeployOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -199,7 +199,7 @@ pub trait Deployable: Declarable + Sync {
 
         let mut txn = account.execute(vec![call]);
 
-        if let TxConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
+        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
             txn = txn.fee_estimate_multiplier(multiplier);
         }
 
@@ -225,7 +225,7 @@ pub trait Deployable: Declarable + Sync {
         class_hash: FieldElement,
         constructor_calldata: Vec<FieldElement>,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxConfig,
+        txn_config: TxnConfig,
     ) -> Result<DeployOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -272,7 +272,7 @@ pub trait Deployable: Declarable + Sync {
             to: felt!("0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"),
         }]);
 
-        if let TxConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
+        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
             txn = txn.fee_estimate_multiplier(multiplier);
         }
 
@@ -305,7 +305,7 @@ pub trait Upgradable: Deployable + Declarable + Sync {
         original_class_hash: FieldElement,
         original_base_class_hash: FieldElement,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxConfig,
+        txn_config: TxnConfig,
     ) -> Result<UpgradeOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -341,7 +341,7 @@ pub trait Upgradable: Deployable + Declarable + Sync {
             to: contract_address,
         }]);
 
-        if let TxConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
+        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
             txn = txn.fee_estimate_multiplier(multiplier);
         }
 

--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -18,7 +18,7 @@ use starknet::providers::{Provider, ProviderError};
 use starknet::signers::Signer;
 use thiserror::Error;
 
-use crate::utils::{TransactionWaiter, TransactionWaitingError};
+use crate::utils::{TransactionExt, TransactionWaiter, TransactionWaitingError};
 
 pub mod class;
 pub mod contract;
@@ -106,7 +106,7 @@ pub trait Declarable {
     async fn declare<P, S>(
         &self,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxnConfig,
+        txn_config: &TxnConfig,
     ) -> Result<DeclareOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -125,14 +125,11 @@ pub trait Declarable {
             Err(e) => return Err(MigrationError::Provider(e)),
         }
 
-        let mut txn = account.declare(Arc::new(flattened_class), casm_class_hash);
-
-        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
-            txn = txn.fee_estimate_multiplier(multiplier);
-        }
-
-        let DeclareTransactionResult { transaction_hash, class_hash } =
-            txn.send().await.map_err(MigrationError::Migrator)?;
+        let DeclareTransactionResult { transaction_hash, class_hash } = account
+            .declare(Arc::new(flattened_class), casm_class_hash)
+            .send_with_cfg(&txn_config)
+            .await
+            .map_err(MigrationError::Migrator)?;
 
         TransactionWaiter::new(transaction_hash, account.provider())
             .await
@@ -153,7 +150,7 @@ pub trait Deployable: Declarable + Sync {
         class_hash: FieldElement,
         base_class_hash: FieldElement,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxnConfig,
+        txn_config: &TxnConfig,
     ) -> Result<DeployOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -198,14 +195,11 @@ pub trait Deployable: Declarable + Sync {
             Err(e) => return Err(MigrationError::Provider(e)),
         };
 
-        let mut txn = account.execute(vec![call]);
-
-        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
-            txn = txn.fee_estimate_multiplier(multiplier);
-        }
-
-        let InvokeTransactionResult { transaction_hash } =
-            txn.send().await.map_err(MigrationError::Migrator)?;
+        let InvokeTransactionResult { transaction_hash } = account
+            .execute(vec![call])
+            .send_with_cfg(&txn_config)
+            .await
+            .map_err(MigrationError::Migrator)?;
 
         let receipt = TransactionWaiter::new(transaction_hash, account.provider()).await?;
         let block_number = get_block_number_from_receipt(receipt);
@@ -226,7 +220,7 @@ pub trait Deployable: Declarable + Sync {
         class_hash: FieldElement,
         constructor_calldata: Vec<FieldElement>,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxnConfig,
+        txn_config: &TxnConfig,
     ) -> Result<DeployOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -266,19 +260,15 @@ pub trait Deployable: Declarable + Sync {
             Err(e) => return Err(MigrationError::Provider(e)),
         }
 
-        let mut txn = account.execute(vec![Call {
+        let txn = account.execute(vec![Call {
             calldata,
             // devnet UDC address
             selector: selector!("deployContract"),
             to: felt!("0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"),
         }]);
 
-        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
-            txn = txn.fee_estimate_multiplier(multiplier);
-        }
-
         let InvokeTransactionResult { transaction_hash } =
-            txn.send().await.map_err(MigrationError::Migrator)?;
+            txn.send_with_cfg(&txn_config).await.map_err(MigrationError::Migrator)?;
 
         let receipt = TransactionWaiter::new(transaction_hash, account.provider()).await?;
         let block_number = get_block_number_from_receipt(receipt);
@@ -306,7 +296,7 @@ pub trait Upgradable: Deployable + Declarable + Sync {
         original_class_hash: FieldElement,
         original_base_class_hash: FieldElement,
         account: &SingleOwnerAccount<P, S>,
-        txn_config: TxnConfig,
+        txn_config: &TxnConfig,
     ) -> Result<UpgradeOutput, MigrationError<<SingleOwnerAccount<P, S> as Account>::SignError>>
     where
         P: Provider + Sync + Send,
@@ -336,18 +326,12 @@ pub trait Upgradable: Deployable + Declarable + Sync {
         }
 
         let calldata = vec![class_hash];
-        let mut txn = account.execute(vec![Call {
-            calldata,
-            selector: selector!("upgrade"),
-            to: contract_address,
-        }]);
 
-        if let TxnConfig { fee_estimate_multiplier: Some(multiplier), .. } = txn_config {
-            txn = txn.fee_estimate_multiplier(multiplier);
-        }
-
-        let InvokeTransactionResult { transaction_hash } =
-            txn.send().await.map_err(MigrationError::Migrator)?;
+        let InvokeTransactionResult { transaction_hash } = account
+            .execute(vec![Call { calldata, selector: selector!("upgrade"), to: contract_address }])
+            .send_with_cfg(&txn_config)
+            .await
+            .map_err(MigrationError::Migrator)?;
 
         let receipt = TransactionWaiter::new(transaction_hash, account.provider()).await?;
         let block_number = get_block_number_from_receipt(receipt);

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -332,6 +332,8 @@ pub fn block_number_from_receipt(receipt: &TransactionReceipt) -> u64 {
     }
 }
 
+/// Extension trait which should be implemented for any type of transactions for which we need to
+/// set configuration options from `TxnConfig` before actually sending them.
 #[allow(async_fn_in_trait)]
 pub trait TransactionExt<T>
 where
@@ -339,6 +341,8 @@ where
 {
     type R;
 
+    /// Sets `fee_estimate_multiplier` from `TxnConfig` if its present before calling `send` method
+    /// on the respective type.
     async fn send_with_cfg(
         self,
         txn_config: &TxnConfig,

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -332,8 +332,8 @@ pub fn block_number_from_receipt(receipt: &TransactionReceipt) -> u64 {
     }
 }
 
-/// Extension trait which should be implemented for any type of transactions for which we need to
-/// set configuration options from `TxnConfig` before actually sending them.
+/// Helper trait to abstract away setting `TxnConfig` configurations before sending a transaction
+/// Implemented by types from `starknet-accounts` like `Execution`, `Declaration`, etc...
 #[allow(async_fn_in_trait)]
 pub trait TransactionExt<T>
 where

--- a/crates/sozo/ops/src/auth.rs
+++ b/crates/sozo/ops/src/auth.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use dojo_world::contracts::model::ModelError;
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::contracts::{cairo_utils, WorldContractReader};
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, BlockTag};
 use starknet::core::utils::parse_cairo_short_string;
@@ -89,7 +89,7 @@ impl FromStr for OwnerResource {
 pub async fn grant_writer<A>(
     world: &WorldContract<A>,
     models_contracts: Vec<ModelContract>,
-    txn_config: TxConfig,
+    txn_config: TxnConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -120,7 +120,7 @@ where
     if !calls.is_empty() {
         let mut txn = world.account.execute(calls);
 
-        if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+        if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
             txn = txn.fee_estimate_multiplier(est_fee_mul);
         }
 
@@ -141,7 +141,7 @@ where
 pub async fn grant_owner<A>(
     world: &WorldContract<A>,
     owners_resources: Vec<OwnerResource>,
-    txn_config: TxConfig,
+    txn_config: TxnConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -161,7 +161,7 @@ where
 
     let mut txn = world.account.execute(calls);
 
-    if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+    if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
         txn = txn.fee_estimate_multiplier(est_fee_mul);
     }
 
@@ -181,7 +181,7 @@ where
 pub async fn revoke_writer<A>(
     world: &WorldContract<A>,
     models_contracts: Vec<ModelContract>,
-    txn_config: TxConfig,
+    txn_config: TxnConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -212,7 +212,7 @@ where
     if !calls.is_empty() {
         let mut txn = world.account.execute(calls);
 
-        if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+        if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
             txn = txn.fee_estimate_multiplier(est_fee_mul);
         }
 
@@ -233,7 +233,7 @@ where
 pub async fn revoke_owner<A>(
     world: &WorldContract<A>,
     owners_resources: Vec<OwnerResource>,
-    txn_config: TxConfig,
+    txn_config: TxnConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -253,7 +253,7 @@ where
 
     let mut txn = world.account.execute(calls);
 
-    if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+    if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
         txn = txn.fee_estimate_multiplier(est_fee_mul);
     }
 

--- a/crates/sozo/ops/src/auth.rs
+++ b/crates/sozo/ops/src/auth.rs
@@ -89,7 +89,7 @@ impl FromStr for OwnerResource {
 pub async fn grant_writer<A>(
     world: &WorldContract<A>,
     models_contracts: Vec<ModelContract>,
-    transaction: TxConfig,
+    txn_config: TxConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -118,18 +118,19 @@ where
     }
 
     if !calls.is_empty() {
-        let res = world
-            .account
-            .execute(calls)
-            .send()
-            .await
-            .with_context(|| "Failed to send transaction")?;
+        let mut txn = world.account.execute(calls);
+
+        if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+            txn = txn.fee_estimate_multiplier(est_fee_mul);
+        }
+
+        let res = txn.send().await.with_context(|| "Failed to send transaction")?;
 
         utils::handle_transaction_result(
             &world.account.provider(),
             res,
-            transaction.wait,
-            transaction.receipt,
+            txn_config.wait,
+            txn_config.receipt,
         )
         .await?;
     }
@@ -140,7 +141,7 @@ where
 pub async fn grant_owner<A>(
     world: &WorldContract<A>,
     owners_resources: Vec<OwnerResource>,
-    transaction: TxConfig,
+    txn_config: TxConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -158,14 +159,19 @@ where
         calls.push(world.grant_owner_getcall(&or.owner.into(), &resource));
     }
 
-    let res =
-        world.account.execute(calls).send().await.with_context(|| "Failed to send transaction")?;
+    let mut txn = world.account.execute(calls);
+
+    if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+        txn = txn.fee_estimate_multiplier(est_fee_mul);
+    }
+
+    let res = txn.send().await.with_context(|| "Failed to send transaction")?;
 
     utils::handle_transaction_result(
         &world.account.provider(),
         res,
-        transaction.wait,
-        transaction.receipt,
+        txn_config.wait,
+        txn_config.receipt,
     )
     .await?;
 
@@ -175,7 +181,7 @@ where
 pub async fn revoke_writer<A>(
     world: &WorldContract<A>,
     models_contracts: Vec<ModelContract>,
-    transaction: TxConfig,
+    txn_config: TxConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -204,18 +210,19 @@ where
     }
 
     if !calls.is_empty() {
-        let res = world
-            .account
-            .execute(calls)
-            .send()
-            .await
-            .with_context(|| "Failed to send transaction")?;
+        let mut txn = world.account.execute(calls);
+
+        if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+            txn = txn.fee_estimate_multiplier(est_fee_mul);
+        }
+
+        let res = txn.send().await.with_context(|| "Failed to send transaction")?;
 
         utils::handle_transaction_result(
             &world.account.provider(),
             res,
-            transaction.wait,
-            transaction.receipt,
+            txn_config.wait,
+            txn_config.receipt,
         )
         .await?;
     }
@@ -226,7 +233,7 @@ where
 pub async fn revoke_owner<A>(
     world: &WorldContract<A>,
     owners_resources: Vec<OwnerResource>,
-    transaction: TxConfig,
+    txn_config: TxConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -244,14 +251,19 @@ where
         calls.push(world.revoke_owner_getcall(&or.owner.into(), &resource));
     }
 
-    let res =
-        world.account.execute(calls).send().await.with_context(|| "Failed to send transaction")?;
+    let mut txn = world.account.execute(calls);
+
+    if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+        txn = txn.fee_estimate_multiplier(est_fee_mul);
+    }
+
+    let res = txn.send().await.with_context(|| "Failed to send transaction")?;
 
     utils::handle_transaction_result(
         &world.account.provider(),
         res,
-        transaction.wait,
-        transaction.receipt,
+        txn_config.wait,
+        txn_config.receipt,
     )
     .await?;
 

--- a/crates/sozo/ops/src/auth.rs
+++ b/crates/sozo/ops/src/auth.rs
@@ -5,6 +5,7 @@ use dojo_world::contracts::model::ModelError;
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::contracts::{cairo_utils, WorldContractReader};
 use dojo_world::migration::TxnConfig;
+use dojo_world::utils::TransactionExt;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, BlockTag};
 use starknet::core::utils::parse_cairo_short_string;
@@ -118,13 +119,12 @@ where
     }
 
     if !calls.is_empty() {
-        let mut txn = world.account.execute(calls);
-
-        if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
-            txn = txn.fee_estimate_multiplier(est_fee_mul);
-        }
-
-        let res = txn.send().await.with_context(|| "Failed to send transaction")?;
+        let res = world
+            .account
+            .execute(calls)
+            .send_with_cfg(&txn_config)
+            .await
+            .with_context(|| "Failed to send transaction")?;
 
         utils::handle_transaction_result(
             &world.account.provider(),
@@ -159,13 +159,12 @@ where
         calls.push(world.grant_owner_getcall(&or.owner.into(), &resource));
     }
 
-    let mut txn = world.account.execute(calls);
-
-    if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
-        txn = txn.fee_estimate_multiplier(est_fee_mul);
-    }
-
-    let res = txn.send().await.with_context(|| "Failed to send transaction")?;
+    let res = world
+        .account
+        .execute(calls)
+        .send_with_cfg(&txn_config)
+        .await
+        .with_context(|| "Failed to send transaction")?;
 
     utils::handle_transaction_result(
         &world.account.provider(),
@@ -210,13 +209,12 @@ where
     }
 
     if !calls.is_empty() {
-        let mut txn = world.account.execute(calls);
-
-        if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
-            txn = txn.fee_estimate_multiplier(est_fee_mul);
-        }
-
-        let res = txn.send().await.with_context(|| "Failed to send transaction")?;
+        let res = world
+            .account
+            .execute(calls)
+            .send_with_cfg(&txn_config)
+            .await
+            .with_context(|| "Failed to send transaction")?;
 
         utils::handle_transaction_result(
             &world.account.provider(),
@@ -251,13 +249,12 @@ where
         calls.push(world.revoke_owner_getcall(&or.owner.into(), &resource));
     }
 
-    let mut txn = world.account.execute(calls);
-
-    if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
-        txn = txn.fee_estimate_multiplier(est_fee_mul);
-    }
-
-    let res = txn.send().await.with_context(|| "Failed to send transaction")?;
+    let res = world
+        .account
+        .execute(calls)
+        .send_with_cfg(&txn_config)
+        .await
+        .with_context(|| "Failed to send transaction")?;
 
     utils::handle_transaction_result(
         &world.account.provider(),

--- a/crates/sozo/ops/src/execute.rs
+++ b/crates/sozo/ops/src/execute.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use dojo_world::contracts::world::WorldContract;
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 use starknet::accounts::{Call, ConnectedAccount};
 use starknet::core::types::FieldElement;
 use starknet::core::utils::get_selector_from_name;
@@ -12,7 +12,7 @@ pub async fn execute<A>(
     entrypoint: String,
     calldata: Vec<FieldElement>,
     world: &WorldContract<A>,
-    transaction: TxConfig,
+    transaction: TxnConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,

--- a/crates/sozo/ops/src/execute.rs
+++ b/crates/sozo/ops/src/execute.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::migration::TxnConfig;
+use dojo_world::utils::TransactionExt;
 use starknet::accounts::{Call, ConnectedAccount};
 use starknet::core::types::FieldElement;
 use starknet::core::utils::get_selector_from_name;
@@ -12,7 +13,7 @@ pub async fn execute<A>(
     entrypoint: String,
     calldata: Vec<FieldElement>,
     world: &WorldContract<A>,
-    transaction: TxnConfig,
+    txn_config: &TxnConfig,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -25,15 +26,15 @@ where
             to: contract_address,
             selector: get_selector_from_name(&entrypoint)?,
         }])
-        .send()
+        .send_with_cfg(txn_config)
         .await
         .with_context(|| "Failed to send transaction")?;
 
     utils::handle_transaction_result(
         &world.account.provider(),
         res,
-        transaction.wait,
-        transaction.receipt,
+        txn_config.wait,
+        txn_config.receipt,
     )
     .await
 }

--- a/crates/sozo/ops/src/migration/migration_test.rs
+++ b/crates/sozo/ops/src/migration/migration_test.rs
@@ -8,7 +8,7 @@ use dojo_test_utils::sequencer::{
 use dojo_world::manifest::{BaseManifest, DeploymentManifest};
 use dojo_world::migration::strategy::prepare_for_migration;
 use dojo_world::migration::world::WorldDiff;
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 use scarb::ops;
 use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::chain_id;
@@ -94,7 +94,7 @@ async fn migrate_with_small_fee_multiplier_will_fail() {
         &ws,
         &mut migration,
         &account,
-        Some(TxConfig { fee_estimate_multiplier: Some(0.2f64), wait: false, receipt: false }),
+        Some(TxnConfig { fee_estimate_multiplier: Some(0.2f64), wait: false, receipt: false }),
     )
     .await
     .is_err());

--- a/crates/sozo/ops/src/migration/migration_test.rs
+++ b/crates/sozo/ops/src/migration/migration_test.rs
@@ -90,16 +90,14 @@ async fn migrate_with_small_fee_multiplier_will_fail() {
         ExecutionEncoding::New,
     );
 
-    assert!(
-        execute_strategy(
-            &ws,
-            &mut migration,
-            &account,
-            Some(TxConfig { fee_estimate_multiplier: Some(0.2f64), wait: false, receipt: false }),
-        )
-        .await
-        .is_err()
-    );
+    assert!(execute_strategy(
+        &ws,
+        &mut migration,
+        &account,
+        Some(TxConfig { fee_estimate_multiplier: Some(0.2f64), wait: false, receipt: false }),
+    )
+    .await
+    .is_err());
     sequencer.stop().unwrap();
 }
 

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -19,7 +19,7 @@ use dojo_world::migration::{
     Declarable, DeployOutput, Deployable, MigrationError, RegisterOutput, StateDiff, TxnConfig,
     Upgradable, UpgradeOutput,
 };
-use dojo_world::utils::TransactionWaiter;
+use dojo_world::utils::{TransactionExt, TransactionWaiter};
 use futures::future;
 use scarb::core::Workspace;
 use scarb_ui::Ui;
@@ -68,7 +68,7 @@ pub async fn migrate<P, S>(
     account: &SingleOwnerAccount<P, S>,
     name: Option<String>,
     dry_run: bool,
-    txn_config: Option<TxnConfig>,
+    txn_config: TxnConfig,
 ) -> Result<()>
 where
     P: Provider + Sync + Send + 'static,
@@ -308,7 +308,7 @@ async fn update_manifest_abis(
 pub async fn apply_diff<P, S>(
     ws: &Workspace<'_>,
     account: &SingleOwnerAccount<P, S>,
-    txn_config: Option<TxnConfig>,
+    txn_config: TxnConfig,
     strategy: &mut MigrationStrategy,
 ) -> Result<MigrationOutput>
 where
@@ -445,7 +445,7 @@ pub async fn execute_strategy<P, S>(
     ws: &Workspace<'_>,
     strategy: &mut MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
-    txn_config: Option<TxnConfig>,
+    txn_config: TxnConfig,
 ) -> Result<MigrationOutput>
 where
     P: Provider + Sync + Send + 'static,
@@ -459,7 +459,7 @@ where
         Some(base) => {
             ui.print_header("# Base Contract");
 
-            match base.declare(migrator, txn_config.unwrap_or_default()).await {
+            match base.declare(migrator, &txn_config).await {
                 Ok(res) => {
                     ui.print_sub(format!("Class Hash: {:#x}", res.class_hash));
                 }
@@ -538,7 +538,7 @@ where
 
     // Once Torii supports indexing arrays, we should declare and register the
     // ResourceMetadata model.
-    match register_models(strategy, migrator, &ui, txn_config).await {
+    match register_models(strategy, migrator, &ui, &txn_config).await {
         Ok(output) => {
             migration_output.models = output.registered_model_names;
         }
@@ -548,7 +548,7 @@ where
         }
     };
 
-    match deploy_dojo_contracts(strategy, migrator, &ui, txn_config).await {
+    match deploy_dojo_contracts(strategy, migrator, &ui, &txn_config).await {
         Ok(output) => {
             migration_output.contracts = output;
         }
@@ -578,19 +578,14 @@ async fn deploy_contract<P, S>(
     constructor_calldata: Vec<FieldElement>,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: &Option<TxnConfig>,
+    txn_config: &TxnConfig,
 ) -> Result<ContractDeploymentOutput>
 where
     P: Provider + Sync + Send + 'static,
     S: Signer + Sync + Send + 'static,
 {
     match contract
-        .deploy(
-            contract.diff.local_class_hash,
-            constructor_calldata,
-            migrator,
-            txn_config.unwrap_or_default(),
-        )
+        .deploy(contract.diff.local_class_hash, constructor_calldata, migrator, txn_config)
         .await
     {
         Ok(mut val) => {
@@ -626,7 +621,7 @@ async fn upgrade_contract<P, S>(
     original_base_class_hash: FieldElement,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: &Option<TxnConfig>,
+    txn_config: &TxnConfig,
 ) -> Result<ContractUpgradeOutput>
 where
     P: Provider + Sync + Send + 'static,
@@ -638,7 +633,7 @@ where
             original_class_hash,
             original_base_class_hash,
             migrator,
-            (*txn_config).unwrap_or_default(),
+            txn_config,
         )
         .await
     {
@@ -668,7 +663,7 @@ async fn register_models<P, S>(
     strategy: &MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: Option<TxnConfig>,
+    txn_config: &TxnConfig,
 ) -> Result<RegisterOutput>
 where
     P: Provider + Sync + Send + 'static,
@@ -692,7 +687,7 @@ where
     for c in models.iter() {
         ui.print(italic_message(&c.diff.name).to_string());
 
-        let res = c.declare(migrator, txn_config.unwrap_or_default()).await;
+        let res = c.declare(migrator, txn_config).await;
         match res {
             Ok(output) => {
                 ui.print_hidden_sub(format!("Declare transaction: {:#x}", output.transaction_hash));
@@ -728,16 +723,11 @@ where
         })
         .collect::<Vec<_>>();
 
-    let mut txn = world.account.execute(calls);
-
-    if let Some(TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. }) = txn_config {
-        txn = txn.fee_estimate_multiplier(est_fee_mul);
-    }
-
-    let InvokeTransactionResult { transaction_hash } = txn.send().await.map_err(|e| {
-        ui.verbose(format!("{e:?}"));
-        anyhow!("Failed to register models to World: {e}")
-    })?;
+    let InvokeTransactionResult { transaction_hash } =
+        world.account.execute(calls).send_with_cfg(&txn_config).await.map_err(|e| {
+            ui.verbose(format!("{e:?}"));
+            anyhow!("Failed to register models to World: {e}")
+        })?;
 
     TransactionWaiter::new(transaction_hash, migrator.provider()).await?;
 
@@ -750,7 +740,7 @@ async fn deploy_dojo_contracts<P, S>(
     strategy: &mut MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: Option<TxnConfig>,
+    txn_config: &TxnConfig,
 ) -> Result<Vec<Option<ContractMigrationOutput>>>
 where
     P: Provider + Sync + Send + 'static,
@@ -778,7 +768,7 @@ where
                 contract.diff.local_class_hash,
                 contract.diff.base_class_hash,
                 migrator,
-                txn_config.unwrap_or_default(),
+                txn_config,
             )
             .await
         {
@@ -975,7 +965,7 @@ pub async fn upload_metadata<P, S>(
     ws: &Workspace<'_>,
     migrator: &SingleOwnerAccount<P, S>,
     migration_output: MigrationOutput,
-    txn_config: Option<TxnConfig>,
+    txn_config: TxnConfig,
 ) -> Result<()>
 where
     P: Provider + Sync + Send + 'static,
@@ -1049,15 +1039,11 @@ where
 
     let calls = resources.iter().map(|r| world.set_metadata_getcall(r)).collect::<Vec<_>>();
 
-    let mut txn = migrator.execute(calls);
-    if let Some(TxnConfig { fee_estimate_multiplier: Some(fee_est_mul), .. }) = txn_config {
-        txn = txn.fee_estimate_multiplier(fee_est_mul);
-    }
-
-    let InvokeTransactionResult { transaction_hash } = txn.send().await.map_err(|e| {
-        ui.verbose(format!("{e:?}"));
-        anyhow!("Failed to register metadata into the resource registry: {e}")
-    })?;
+    let InvokeTransactionResult { transaction_hash } =
+        migrator.execute(calls).send_with_cfg(&txn_config).await.map_err(|e| {
+            ui.verbose(format!("{e:?}"));
+            anyhow!("Failed to register metadata into the resource registry: {e}")
+        })?;
 
     TransactionWaiter::new(transaction_hash, migrator.provider()).await?;
 

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -16,7 +16,7 @@ use dojo_world::migration::contract::ContractMigration;
 use dojo_world::migration::strategy::{generate_salt, prepare_for_migration, MigrationStrategy};
 use dojo_world::migration::world::WorldDiff;
 use dojo_world::migration::{
-    Declarable, DeployOutput, Deployable, MigrationError, RegisterOutput, StateDiff, TxConfig,
+    Declarable, DeployOutput, Deployable, MigrationError, RegisterOutput, StateDiff, TxnConfig,
     Upgradable, UpgradeOutput,
 };
 use dojo_world::utils::TransactionWaiter;
@@ -62,7 +62,7 @@ pub async fn migrate<P, S>(
     account: &SingleOwnerAccount<P, S>,
     name: Option<String>,
     dry_run: bool,
-    txn_config: Option<TxConfig>,
+    txn_config: Option<TxnConfig>,
 ) -> Result<()>
 where
     P: Provider + Sync + Send + 'static,
@@ -280,7 +280,7 @@ async fn update_manifest_abis(
 pub async fn apply_diff<P, S>(
     ws: &Workspace<'_>,
     account: &SingleOwnerAccount<P, S>,
-    txn_config: Option<TxConfig>,
+    txn_config: Option<TxnConfig>,
     strategy: &mut MigrationStrategy,
 ) -> Result<MigrationOutput>
 where
@@ -416,7 +416,7 @@ pub async fn execute_strategy<P, S>(
     ws: &Workspace<'_>,
     strategy: &mut MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
-    txn_config: Option<TxConfig>,
+    txn_config: Option<TxnConfig>,
 ) -> Result<MigrationOutput>
 where
     P: Provider + Sync + Send + 'static,
@@ -545,7 +545,7 @@ async fn upload_metadata<P, S>(
     world: &ContractMigration,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: &Option<TxConfig>,
+    txn_config: &Option<TxnConfig>,
 ) -> Result<(), anyhow::Error>
 where
     P: Provider + Sync + Send + 'static,
@@ -568,7 +568,7 @@ where
                 let world_contract = WorldContract::new(world.contract_address, migrator);
                 let mut txn = world_contract.set_metadata(&world_metadata);
 
-                if let Some(TxConfig { fee_estimate_multiplier: Some(fee_est_mul), .. }) =
+                if let Some(TxnConfig { fee_estimate_multiplier: Some(fee_est_mul), .. }) =
                     txn_config
                 {
                     txn = txn.fee_estimate_multiplier(*fee_est_mul);
@@ -608,7 +608,7 @@ async fn deploy_contract<P, S>(
     constructor_calldata: Vec<FieldElement>,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: &Option<TxConfig>,
+    txn_config: &Option<TxnConfig>,
 ) -> Result<ContractDeploymentOutput>
 where
     P: Provider + Sync + Send + 'static,
@@ -656,7 +656,7 @@ async fn upgrade_contract<P, S>(
     original_base_class_hash: FieldElement,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: &Option<TxConfig>,
+    txn_config: &Option<TxnConfig>,
 ) -> Result<ContractUpgradeOutput>
 where
     P: Provider + Sync + Send + 'static,
@@ -698,7 +698,7 @@ async fn register_models<P, S>(
     strategy: &MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: Option<TxConfig>,
+    txn_config: Option<TxnConfig>,
 ) -> Result<Option<RegisterOutput>>
 where
     P: Provider + Sync + Send + 'static,
@@ -752,7 +752,7 @@ where
 
     let mut txn = world.account.execute(calls);
 
-    if let Some(TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. }) = txn_config {
+    if let Some(TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. }) = txn_config {
         txn = txn.fee_estimate_multiplier(est_fee_mul);
     }
 
@@ -772,7 +772,7 @@ async fn deploy_dojo_contracts<P, S>(
     strategy: &mut MigrationStrategy,
     migrator: &SingleOwnerAccount<P, S>,
     ui: &Ui,
-    txn_config: Option<TxConfig>,
+    txn_config: Option<TxnConfig>,
 ) -> Result<Vec<Option<DeployOutput>>>
 where
     P: Provider + Sync + Send + 'static,

--- a/crates/sozo/ops/src/register.rs
+++ b/crates/sozo/ops/src/register.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::{WorldContract, WorldContractReader};
 use dojo_world::manifest::DeploymentManifest;
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 use scarb::core::Config;
 use starknet::accounts::ConnectedAccount;
 use starknet::providers::Provider;
@@ -15,7 +15,7 @@ use crate::utils::handle_transaction_result;
 pub async fn model_register<A, P>(
     models: Vec<FieldElement>,
     world: &WorldContract<A>,
-    txn_config: TxConfig,
+    txn_config: TxnConfig,
     world_reader: WorldContractReader<P>,
     world_address: FieldElement,
     config: &Config,
@@ -65,7 +65,7 @@ where
 
     let mut txn = world.account.execute(calls);
 
-    if let TxConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
+    if let TxnConfig { fee_estimate_multiplier: Some(est_fee_mul), .. } = txn_config {
         txn = txn.fee_estimate_multiplier(est_fee_mul);
     }
 

--- a/crates/sozo/ops/src/tests/auth.rs
+++ b/crates/sozo/ops/src/tests/auth.rs
@@ -206,7 +206,7 @@ async fn execute_spawn<A: ConnectedAccount + Sync + Send + 'static>(
         system_spawn,
         vec![],
         world,
-        TxnConfig { wait: true, ..Default::default() },
+        &TxnConfig { wait: true, ..Default::default() },
     )
     .await
     .is_ok()

--- a/crates/sozo/ops/src/tests/auth.rs
+++ b/crates/sozo/ops/src/tests/auth.rs
@@ -2,7 +2,7 @@ use dojo_test_utils::sequencer::{
     get_default_test_starknet_config, SequencerConfig, TestSequencer,
 };
 use dojo_world::contracts::world::WorldContract;
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 use starknet::accounts::{Account, ConnectedAccount};
 use starknet::core::utils::cairo_short_string_to_felt;
 
@@ -43,7 +43,7 @@ async fn auth_grant_writer_ok() {
     auth::grant_writer(
         &world,
         vec![moves_mc, position_mc],
-        TxConfig { wait: true, ..Default::default() },
+        TxnConfig { wait: true, ..Default::default() },
     )
     .await
     .unwrap();
@@ -83,7 +83,7 @@ async fn auth_revoke_writer_ok() {
     auth::grant_writer(
         &world,
         vec![moves_mc.clone(), position_mc.clone()],
-        TxConfig { wait: true, ..Default::default() },
+        TxnConfig { wait: true, ..Default::default() },
     )
     .await
     .unwrap();
@@ -95,7 +95,7 @@ async fn auth_revoke_writer_ok() {
     auth::revoke_writer(
         &world,
         vec![moves_mc, position_mc],
-        TxConfig { wait: true, ..Default::default() },
+        TxnConfig { wait: true, ..Default::default() },
     )
     .await
     .unwrap();
@@ -132,9 +132,13 @@ async fn auth_grant_owner_ok() {
         owner: account_2_addr,
     };
 
-    auth::grant_owner(&world, vec![moves, position], TxConfig { wait: true, ..Default::default() })
-        .await
-        .unwrap();
+    auth::grant_owner(
+        &world,
+        vec![moves, position],
+        TxnConfig { wait: true, ..Default::default() },
+    )
+    .await
+    .unwrap();
 
     assert!(execute_spawn(&world_2).await);
 }
@@ -170,7 +174,7 @@ async fn auth_revoke_owner_ok() {
     auth::grant_owner(
         &world,
         vec![moves.clone(), position.clone()],
-        TxConfig { wait: true, ..Default::default() },
+        TxnConfig { wait: true, ..Default::default() },
     )
     .await
     .unwrap();
@@ -179,7 +183,7 @@ async fn auth_revoke_owner_ok() {
     auth::revoke_owner(
         &world,
         vec![moves, position],
-        TxConfig { wait: true, ..Default::default() },
+        TxnConfig { wait: true, ..Default::default() },
     )
     .await
     .unwrap();
@@ -202,7 +206,7 @@ async fn execute_spawn<A: ConnectedAccount + Sync + Send + 'static>(
         system_spawn,
         vec![],
         world,
-        TxConfig { wait: true, ..Default::default() },
+        TxnConfig { wait: true, ..Default::default() },
     )
     .await
     .is_ok()

--- a/crates/sozo/ops/src/tests/migration.rs
+++ b/crates/sozo/ops/src/tests/migration.rs
@@ -92,14 +92,16 @@ async fn migrate_with_small_fee_multiplier_will_fail() {
         ExecutionEncoding::New,
     );
 
-    assert!(execute_strategy(
-        &ws,
-        &mut migration,
-        &account,
-        TxnConfig { fee_estimate_multiplier: Some(0.2f64), wait: false, receipt: false },
-    )
-    .await
-    .is_err());
+    assert!(
+        execute_strategy(
+            &ws,
+            &mut migration,
+            &account,
+            TxnConfig { fee_estimate_multiplier: Some(0.2f64), wait: false, receipt: false },
+        )
+        .await
+        .is_err()
+    );
     sequencer.stop().unwrap();
 }
 

--- a/crates/sozo/ops/src/tests/setup.rs
+++ b/crates/sozo/ops/src/tests/setup.rs
@@ -75,7 +75,7 @@ pub async fn setup(
         &ws,
         &mut migration,
         &account,
-        Some(TxnConfig { wait: true, ..Default::default() }),
+        TxnConfig { wait: true, ..Default::default() },
     )
     .await?;
     let world = WorldContract::new(output.world_address, account);

--- a/crates/sozo/ops/src/tests/setup.rs
+++ b/crates/sozo/ops/src/tests/setup.rs
@@ -3,7 +3,7 @@ use dojo_test_utils::compiler::build_test_config;
 use dojo_test_utils::migration::prepare_migration;
 use dojo_test_utils::sequencer::TestSequencer;
 use dojo_world::contracts::world::WorldContract;
-use dojo_world::migration::TxConfig;
+use dojo_world::migration::TxnConfig;
 use scarb::ops;
 use starknet::accounts::SingleOwnerAccount;
 use starknet::core::types::{BlockId, BlockTag};
@@ -37,7 +37,7 @@ pub async fn setup(
         &ws,
         &mut migration,
         &account,
-        Some(TxConfig { wait: true, ..Default::default() }),
+        Some(TxnConfig { wait: true, ..Default::default() }),
     )
     .await?;
     let world = WorldContract::new(output.world_address, account);

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -6,6 +6,7 @@ use dojo_test_utils::sequencer::{
     get_default_test_starknet_config, SequencerConfig, TestSequencer,
 };
 use dojo_world::contracts::world::WorldContractReader;
+use dojo_world::migration::TxnConfig;
 use dojo_world::utils::TransactionWaiter;
 use scarb::ops;
 use sozo_ops::migration::execute_strategy;
@@ -70,7 +71,7 @@ async fn test_load_from_remote() {
     let config = build_test_config("../../../examples/spawn-and-move/Scarb.toml").unwrap();
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+    execute_strategy(&ws, &mut migration, &account, TxnConfig::default()).await.unwrap();
 
     // spawn
     let tx = account

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -11,6 +11,7 @@ use dojo_types::primitive::Primitive;
 use dojo_types::schema::{Enum, EnumOption, Member, Struct, Ty};
 use dojo_world::contracts::WorldContractReader;
 use dojo_world::manifest::DeploymentManifest;
+use dojo_world::migration::TxnConfig;
 use dojo_world::utils::TransactionWaiter;
 use scarb::ops;
 use serde::Deserialize;
@@ -292,7 +293,7 @@ pub async fn spinup_types_test() -> Result<SqlitePool> {
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
 
-    execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+    execute_strategy(&ws, &mut migration, &account, TxnConfig::default()).await.unwrap();
 
     let manifest =
         DeploymentManifest::load_from_remote(&provider, migration.world_address().unwrap())

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -7,6 +7,7 @@ use dojo_test_utils::sequencer::{
     get_default_test_starknet_config, SequencerConfig, TestSequencer,
 };
 use dojo_world::contracts::WorldContractReader;
+use dojo_world::migration::TxnConfig;
 use dojo_world::utils::TransactionWaiter;
 use scarb::ops;
 use sozo_ops::migration::execute_strategy;
@@ -47,7 +48,7 @@ async fn test_entities_queries() {
     let config = build_test_config("../../../examples/spawn-and-move/Scarb.toml").unwrap();
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    execute_strategy(&ws, &mut migration, &account, None).await.unwrap();
+    execute_strategy(&ws, &mut migration, &account, TxnConfig::default()).await.unwrap();
 
     // spawn
     let tx = account


### PR DESCRIPTION
fix: #1811 

- ensure we use `fee_estimate_multiplier` in all places we send transaction
- abstract this logic into `TransactionExt::send_with_cfg` method