### PR TITLE
refactor(katana-db): database schema 

### DIFF
--- a/crates/katana/storage/db/src/codecs/postcard.rs
+++ b/crates/katana/storage/db/src/codecs/postcard.rs
@@ -1,4 +1,4 @@
-use katana_primitives::block::Header;
+use katana_primitives::block::{BlockNumber, Header};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo};
 use katana_primitives::receipt::Receipt;
 use katana_primitives::trace::TxExecInfo;
@@ -39,6 +39,7 @@ impl_compress_and_decompress_for_table_values!(
     Receipt,
     FieldElement,
     ContractAddress,
+    Vec<BlockNumber>,
     BlockList,
     GenericContractInfo,
     StoredBlockBodyIndices,

--- a/crates/katana/storage/db/src/lib.rs
+++ b/crates/katana/storage/db/src/lib.rs
@@ -24,12 +24,12 @@ use version::{check_db_version, create_db_version_file, DatabaseVersionError};
 ///
 /// This will create the default tables, if necessary.
 pub fn init_db<P: AsRef<Path>>(path: P) -> anyhow::Result<DbEnv> {
-    init_db_with_schema::<tables::Tables>(path)
+    init_db_with_schema::<tables::SchemaV1>(path)
 }
 
 /// Open the database at the given `path` in read-write mode.
 pub fn open_db<P: AsRef<Path>>(path: P) -> anyhow::Result<DbEnv> {
-    open_db_with_schema::<tables::Tables>(path)
+    open_db_with_schema::<tables::SchemaV1>(path)
 }
 
 pub(crate) fn init_db_with_schema<S: Schema>(path: impl AsRef<Path>) -> anyhow::Result<DbEnv<S>> {

--- a/crates/katana/storage/db/src/lib.rs
+++ b/crates/katana/storage/db/src/lib.rs
@@ -16,6 +16,7 @@ pub mod version;
 use mdbx::{DbEnv, DbEnvKind};
 use tables::Schema;
 use utils::is_database_empty;
+pub use version::CURRENT_DB_VERSION;
 use version::{check_db_version, create_db_version_file, DatabaseVersionError};
 
 /// Initialize the database at the given path and returning a handle to the its

--- a/crates/katana/storage/db/src/mdbx/cursor.rs
+++ b/crates/katana/storage/db/src/mdbx/cursor.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
-use libmdbx::{self, TransactionKind, WriteFlags, RW};
+use libmdbx::{TransactionKind, WriteFlags, RW};
 
 use crate::codecs::{Compress, Encode};
 use crate::error::DatabaseError;

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -132,6 +132,37 @@ macro_rules! tables {
             }
        )*
     };
+
+    {   $version:ident, $($(#[$docs:meta])+ $table_name:ident: ($key:ty $(,$key_type2:ty)?) => $value:ty ),* } => {
+      	#[doc = concat!("Tables that were changed in ", stringify!($version), ".")]
+    	mod $version {
+     		use super::*;
+
+		    $(
+		        $(#[$docs])+
+		        ///
+		        #[doc = concat!("Takes [`", stringify!($key), "`] as a key and returns [`", stringify!($value), "`].")]
+		        #[derive(Debug)]
+		        pub struct $table_name;
+
+		        impl Table for $table_name {
+		            const NAME: &'static str = stringify!($table_name);
+		            type Key = $key;
+		            type Value = $value;
+		        }
+
+		        $(
+		            dupsort!($table_name, $key_type2);
+		        )?
+
+		        impl std::fmt::Display for $table_name {
+		            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		                write!(f, "{}", stringify!($table_name))
+		            }
+		        }
+		    )*
+    	 }
+    };
 }
 
 /// Macro to declare duplicate key value table.
@@ -225,6 +256,18 @@ tables! {
     /// Account storage change set
     StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry
 
+}
+
+// Declaring tables struct that exist only previous database versions
+tables! {
+    v0,
+
+    /// Contract nonce changes by block.
+    NonceChanges: (BlockNumber, ContractAddress) => ContractNonceChange,
+    /// Contract class hash changes by block.
+    ContractClassChanges: (BlockNumber, ContractAddress) => ContractClassChange,
+    /// Account storage change set
+    StorageChanges: (BlockNumber, ContractStorageKey) => ContractStorageEntry
 }
 
 #[cfg(test)]

--- a/crates/katana/storage/db/src/tables/mod.rs
+++ b/crates/katana/storage/db/src/tables/mod.rs
@@ -1,23 +1,27 @@
 pub mod v0;
+mod v1;
 
-use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
-use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
-use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
-use katana_primitives::receipt::Receipt;
-use katana_primitives::trace::TxExecInfo;
-use katana_primitives::transaction::{Tx, TxHash, TxNumber};
+pub use self::v1::*;
+use std::fmt::{Debug, Display};
+use std::str::FromStr;
 
 use crate::codecs::{Compress, Decode, Decompress, Encode};
-use crate::models::block::StoredBlockBodyIndices;
-use crate::models::contract::{ContractClassChange, ContractInfoChangeList, ContractNonceChange};
-use crate::models::list::BlockList;
-use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
 
 pub trait Key: Encode + Decode + Clone + std::fmt::Debug {}
 pub trait Value: Compress + Decompress + std::fmt::Debug {}
 
 impl<T> Key for T where T: Encode + Decode + Clone + std::fmt::Debug {}
 impl<T> Value for T where T: Compress + Decompress + std::fmt::Debug {}
+
+/// Trait for defining the database schema.
+pub trait Schema: Debug + Display + FromStr + 'static {
+    /// The number of tables in the schema.
+    fn all() -> &'static [Self];
+    /// The name of the tables.
+    fn name(&self) -> &str;
+    /// The type of the tables.
+    fn table_type(&self) -> TableType;
+}
 
 /// An asbtraction for a table.
 pub trait Table {
@@ -46,26 +50,23 @@ pub enum TableType {
     DupSort,
 }
 
-pub const NUM_TABLES: usize = 23;
-
-/// Macro to declare `libmdbx` tables.
+/// Macro to declare database tables based on the [DatabaseTables] trait.
 #[macro_export]
 macro_rules! define_tables_enum {
     { [$(($table:ident, $type:expr)),*] } => {
         #[derive(Debug, PartialEq, Copy, Clone)]
-        /// Default tables that should be present inside database.
         pub enum Tables {
             $(
                 $table,
             )*
         }
 
-        impl Tables {
-            /// Array of all tables in database
-            pub const ALL: [Tables; NUM_TABLES] = [$(Tables::$table,)*];
+        impl Schema for Tables {
+            fn all() -> &'static [Self] {
+				&[$(Tables::$table,)*]
+			}
 
-            /// The name of the given table in database
-            pub const fn name(&self) -> &str {
+            fn name(&self) -> &str {
                 match self {
                     $(Tables::$table => {
                         $table::NAME
@@ -73,8 +74,7 @@ macro_rules! define_tables_enum {
                 }
             }
 
-            /// The type of the given table in database
-            pub const fn table_type(&self) -> TableType {
+            fn table_type(&self) -> TableType {
                 match self {
                     $(Tables::$table => {
                         $type
@@ -144,230 +144,4 @@ macro_rules! dupsort {
             type SubKey = $subkey;
         }
     };
-}
-
-define_tables_enum! {[
-    (Headers, TableType::Table),
-    (BlockHashes, TableType::Table),
-    (BlockNumbers, TableType::Table),
-    (BlockBodyIndices, TableType::Table),
-    (BlockStatusses, TableType::Table),
-    (TxNumbers, TableType::Table),
-    (TxBlocks, TableType::Table),
-    (TxHashes, TableType::Table),
-    (TxTraces, TableType::Table),
-    (Transactions, TableType::Table),
-    (Receipts, TableType::Table),
-    (CompiledClassHashes, TableType::Table),
-    (CompiledClasses, TableType::Table),
-    (SierraClasses, TableType::Table),
-    (ContractInfo, TableType::Table),
-    (ContractStorage, TableType::DupSort),
-    (ClassDeclarationBlock, TableType::Table),
-    (ClassDeclarations, TableType::DupSort),
-    (ContractInfoChangeSet, TableType::Table),
-    (NonceChangeHistory, TableType::DupSort),
-    (ClassChangeHistory, TableType::DupSort),
-    (StorageChangeHistory, TableType::DupSort),
-    (StorageChangeSet, TableType::Table)
-]}
-
-tables! {
-    /// Store canonical block headers
-    Headers: (BlockNumber) => Header,
-    /// Stores block hashes according to its block number
-    BlockHashes: (BlockNumber) => BlockHash,
-    /// Stores block numbers according to its block hash
-    BlockNumbers: (BlockHash) => BlockNumber,
-    /// Stores block finality status according to its block number
-    BlockStatusses: (BlockNumber) => FinalityStatus,
-    /// Block number to its body indices which stores the tx number of
-    /// the first tx in the block and the number of txs in the block.
-    BlockBodyIndices: (BlockNumber) => StoredBlockBodyIndices,
-    /// Transaction number based on its hash
-    TxNumbers: (TxHash) => TxNumber,
-    /// Transaction hash based on its number
-    TxHashes: (TxNumber) => TxHash,
-    /// Store canonical transactions
-    Transactions: (TxNumber) => Tx,
-    /// Stores the block number of a transaction.
-    TxBlocks: (TxNumber) => BlockNumber,
-    /// Stores the transaction's traces.
-    TxTraces: (TxNumber) => TxExecInfo,
-    /// Store transaction receipts
-    Receipts: (TxNumber) => Receipt,
-    /// Store compiled classes
-    CompiledClassHashes: (ClassHash) => CompiledClassHash,
-    /// Store compiled contract classes according to its compiled class hash
-    CompiledClasses: (ClassHash) => CompiledClass,
-    /// Store Sierra classes according to its class hash
-    SierraClasses: (ClassHash) => FlattenedSierraClass,
-    /// Store contract information according to its contract address
-    ContractInfo: (ContractAddress) => GenericContractInfo,
-    /// Store contract storage
-    ContractStorage: (ContractAddress, StorageKey) => StorageEntry,
-
-
-    /// Stores the block number where the class hash was declared.
-    ClassDeclarationBlock: (ClassHash) => BlockNumber,
-    /// Stores the list of class hashes according to the block number it was declared in.
-    ClassDeclarations: (BlockNumber, ClassHash) => ClassHash,
-
-    /// Generic contract info change set.
-    ///
-    /// Stores the list of blocks where the contract info (nonce / class hash) has changed.
-    ContractInfoChangeSet: (ContractAddress) => ContractInfoChangeList,
-    /// Contract nonce changes by block.
-    NonceChangeHistory: (BlockNumber, ContractAddress) => ContractNonceChange,
-    /// Contract class hash changes by block.
-    ClassChangeHistory: (BlockNumber, ContractAddress) => ContractClassChange,
-
-    /// storage change set
-    StorageChangeSet: (ContractStorageKey) => BlockList,
-    /// Account storage change set
-    StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry
-
-}
-
-#[cfg(test)]
-mod tests {
-
-    #[test]
-    fn test_tables() {
-        use super::*;
-
-        assert_eq!(Tables::ALL.len(), NUM_TABLES);
-        assert_eq!(Tables::ALL[0].name(), Headers::NAME);
-        assert_eq!(Tables::ALL[1].name(), BlockHashes::NAME);
-        assert_eq!(Tables::ALL[2].name(), BlockNumbers::NAME);
-        assert_eq!(Tables::ALL[3].name(), BlockBodyIndices::NAME);
-        assert_eq!(Tables::ALL[4].name(), BlockStatusses::NAME);
-        assert_eq!(Tables::ALL[5].name(), TxNumbers::NAME);
-        assert_eq!(Tables::ALL[6].name(), TxBlocks::NAME);
-        assert_eq!(Tables::ALL[7].name(), TxHashes::NAME);
-        assert_eq!(Tables::ALL[8].name(), TxTraces::NAME);
-        assert_eq!(Tables::ALL[9].name(), Transactions::NAME);
-        assert_eq!(Tables::ALL[10].name(), Receipts::NAME);
-        assert_eq!(Tables::ALL[11].name(), CompiledClassHashes::NAME);
-        assert_eq!(Tables::ALL[12].name(), CompiledClasses::NAME);
-        assert_eq!(Tables::ALL[13].name(), SierraClasses::NAME);
-        assert_eq!(Tables::ALL[14].name(), ContractInfo::NAME);
-        assert_eq!(Tables::ALL[15].name(), ContractStorage::NAME);
-        assert_eq!(Tables::ALL[16].name(), ClassDeclarationBlock::NAME);
-        assert_eq!(Tables::ALL[17].name(), ClassDeclarations::NAME);
-        assert_eq!(Tables::ALL[18].name(), ContractInfoChangeSet::NAME);
-        assert_eq!(Tables::ALL[19].name(), NonceChangeHistory::NAME);
-        assert_eq!(Tables::ALL[20].name(), ClassChangeHistory::NAME);
-        assert_eq!(Tables::ALL[21].name(), StorageChangeHistory::NAME);
-        assert_eq!(Tables::ALL[22].name(), StorageChangeSet::NAME);
-
-        assert_eq!(Tables::Headers.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockHashes.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockNumbers.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockBodyIndices.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockStatusses.table_type(), TableType::Table);
-        assert_eq!(Tables::TxNumbers.table_type(), TableType::Table);
-        assert_eq!(Tables::TxBlocks.table_type(), TableType::Table);
-        assert_eq!(Tables::TxHashes.table_type(), TableType::Table);
-        assert_eq!(Tables::TxTraces.table_type(), TableType::Table);
-        assert_eq!(Tables::Transactions.table_type(), TableType::Table);
-        assert_eq!(Tables::Receipts.table_type(), TableType::Table);
-        assert_eq!(Tables::CompiledClassHashes.table_type(), TableType::Table);
-        assert_eq!(Tables::CompiledClasses.table_type(), TableType::Table);
-        assert_eq!(Tables::SierraClasses.table_type(), TableType::Table);
-        assert_eq!(Tables::ContractInfo.table_type(), TableType::Table);
-        assert_eq!(Tables::ContractStorage.table_type(), TableType::DupSort);
-        assert_eq!(Tables::ClassDeclarationBlock.table_type(), TableType::Table);
-        assert_eq!(Tables::ClassDeclarations.table_type(), TableType::DupSort);
-        assert_eq!(Tables::ContractInfoChangeSet.table_type(), TableType::Table);
-        assert_eq!(Tables::NonceChangeHistory.table_type(), TableType::DupSort);
-        assert_eq!(Tables::ClassChangeHistory.table_type(), TableType::DupSort);
-        assert_eq!(Tables::StorageChangeHistory.table_type(), TableType::DupSort);
-        assert_eq!(Tables::StorageChangeSet.table_type(), TableType::Table);
-    }
-
-    use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
-    use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
-    use katana_primitives::contract::{ContractAddress, GenericContractInfo};
-    use katana_primitives::receipt::Receipt;
-    use katana_primitives::trace::TxExecInfo;
-    use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber};
-    use starknet::macros::felt;
-
-    use crate::codecs::{Compress, Decode, Decompress, Encode};
-    use crate::models::block::StoredBlockBodyIndices;
-    use crate::models::contract::{
-        ContractClassChange, ContractInfoChangeList, ContractNonceChange,
-    };
-    use crate::models::list::BlockList;
-    use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
-
-    macro_rules! assert_key_encode_decode {
-	    { $( ($name:ty, $key:expr) ),* } => {
-			$(
-				{
-					let key: $name = $key;
-					let encoded = key.encode();
-					let decoded = <$name as Decode>::decode(encoded.as_slice()).expect("decode failed");
-					assert_eq!($key, decoded);
-				}
-			)*
-		};
-	}
-
-    macro_rules! assert_value_compress_decompress {
-		{ $( ($name:ty, $value:expr) ),* } => {
-			$(
-				{
-					let value: $name = $value;
-					let compressed = value.compress();
-					let decompressed = <$name as Decompress>::decompress(compressed.as_slice()).expect("decode failed");
-					assert_eq!($value, decompressed);
-				}
-			)*
-		};
-	}
-
-    // Test that all key/subkey types can be encoded and decoded
-    // through the Encode and Decode traits
-    #[test]
-    fn test_key_encode_decode() {
-        assert_key_encode_decode! {
-            (BlockNumber, 100),
-            (BlockHash, felt!("0x123456789")),
-            (TxHash, felt!("0x123456789")),
-            (TxNumber, 100),
-            (ClassHash, felt!("0x123456789")),
-            (ContractAddress, ContractAddress(felt!("0x123456789"))),
-            (ContractStorageKey, ContractStorageKey { contract_address : ContractAddress(felt!("0x123456789")), key : felt!("0x123456789")})
-        }
-    }
-
-    // Test that all value types can be compressed and decompressed
-    // through the Compress and Decompress traits
-    #[test]
-    fn test_value_compress_decompress() {
-        assert_value_compress_decompress! {
-            (Header, Header::default()),
-            (BlockHash, BlockHash::default()),
-            (BlockNumber, BlockNumber::default()),
-            (FinalityStatus, FinalityStatus::AcceptedOnL1),
-            (StoredBlockBodyIndices, StoredBlockBodyIndices::default()),
-            (TxNumber, 77),
-            (TxHash, felt!("0x123456789")),
-            (Tx, Tx::Invoke(InvokeTx::V1(Default::default()))),
-            (BlockNumber, 99),
-            (TxExecInfo, TxExecInfo::default()),
-            (Receipt, Receipt::Invoke(Default::default())),
-            (CompiledClassHash, felt!("211")),
-            (CompiledClass, CompiledClass::Deprecated(Default::default())),
-            (GenericContractInfo, GenericContractInfo::default()),
-            (StorageEntry, StorageEntry::default()),
-            (ContractInfoChangeList, ContractInfoChangeList::default()),
-            (ContractNonceChange, ContractNonceChange::default()),
-            (ContractClassChange, ContractClassChange::default()),
-            (BlockList, BlockList::default()),
-            (ContractStorageEntry, ContractStorageEntry::default())
-        }
-    }
 }

--- a/crates/katana/storage/db/src/tables/mod.rs
+++ b/crates/katana/storage/db/src/tables/mod.rs
@@ -14,6 +14,8 @@ impl<T> Key for T where T: Encode + Decode + Clone + std::fmt::Debug {}
 impl<T> Value for T where T: Compress + Decompress + std::fmt::Debug {}
 
 /// Trait for defining the database schema.
+///
+/// This trait is useful for us to maintain the schema for different database versions.
 pub trait Schema: Debug + Display + FromStr + 'static {
     /// Returns the list of tables in the schema.
     fn all() -> &'static [Self];

--- a/crates/katana/storage/db/src/tables/mod.rs
+++ b/crates/katana/storage/db/src/tables/mod.rs
@@ -1,3 +1,5 @@
+pub mod v0;
+
 use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
@@ -132,37 +134,6 @@ macro_rules! tables {
             }
        )*
     };
-
-    {   $version:ident, $($(#[$docs:meta])+ $table_name:ident: ($key:ty $(,$key_type2:ty)?) => $value:ty ),* } => {
-      	#[doc = concat!("Tables that were changed in ", stringify!($version), ".")]
-    	mod $version {
-     		use super::*;
-
-		    $(
-		        $(#[$docs])+
-		        ///
-		        #[doc = concat!("Takes [`", stringify!($key), "`] as a key and returns [`", stringify!($value), "`].")]
-		        #[derive(Debug)]
-		        pub struct $table_name;
-
-		        impl Table for $table_name {
-		            const NAME: &'static str = stringify!($table_name);
-		            type Key = $key;
-		            type Value = $value;
-		        }
-
-		        $(
-		            dupsort!($table_name, $key_type2);
-		        )?
-
-		        impl std::fmt::Display for $table_name {
-		            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		                write!(f, "{}", stringify!($table_name))
-		            }
-		        }
-		    )*
-    	 }
-    };
 }
 
 /// Macro to declare duplicate key value table.
@@ -256,18 +227,6 @@ tables! {
     /// Account storage change set
     StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry
 
-}
-
-// Declaring tables struct that exist only previous database versions
-tables! {
-    v0,
-
-    /// Contract nonce changes by block.
-    NonceChanges: (BlockNumber, ContractAddress) => ContractNonceChange,
-    /// Contract class hash changes by block.
-    ContractClassChanges: (BlockNumber, ContractAddress) => ContractClassChange,
-    /// Account storage change set
-    StorageChanges: (BlockNumber, ContractStorageKey) => ContractStorageEntry
 }
 
 #[cfg(test)]

--- a/crates/katana/storage/db/src/tables/mod.rs
+++ b/crates/katana/storage/db/src/tables/mod.rs
@@ -17,6 +17,8 @@ impl<T> Value for T where T: Compress + Decompress + std::fmt::Debug {}
 ///
 /// This trait is useful for us to maintain the schema for different database versions.
 pub trait Schema: Debug + Display + FromStr + 'static {
+    /// The version of the schema.
+    const VERSION: u32;
     /// Returns the list of tables in the schema.
     fn all() -> &'static [Self];
     /// The name of the tables.
@@ -55,7 +57,7 @@ pub enum TableType {
 /// Macro to declare database tables based on the [DatabaseTables] trait.
 #[macro_export]
 macro_rules! define_tables_enum {
-    { [$(($table:ident, $type:expr)),*] } => {
+    { $ver:expr, [$(($table:ident, $type:expr)),*] } => {
         #[derive(Debug, PartialEq, Copy, Clone)]
         pub enum Tables {
             $(
@@ -64,6 +66,8 @@ macro_rules! define_tables_enum {
         }
 
         impl Schema for Tables {
+        	const VERSION: u32 = $ver;
+
             fn all() -> &'static [Self] {
 				&[$(Tables::$table,)*]
 			}

--- a/crates/katana/storage/db/src/tables/mod.rs
+++ b/crates/katana/storage/db/src/tables/mod.rs
@@ -15,7 +15,7 @@ impl<T> Value for T where T: Compress + Decompress + std::fmt::Debug {}
 
 /// Trait for defining the database schema.
 pub trait Schema: Debug + Display + FromStr + 'static {
-    /// The number of tables in the schema.
+    /// Returns the list of tables in the schema.
     fn all() -> &'static [Self];
     /// The name of the tables.
     fn name(&self) -> &str;

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -5,11 +5,11 @@ use super::*;
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::error::CodecError;
 use crate::models::contract::{ContractClassChange, ContractNonceChange};
-use crate::models::storage::ContractStorageEntry;
-use crate::models::storage::ContractStorageKey;
+use crate::models::storage::{ContractStorageEntry, ContractStorageKey};
 use crate::{define_tables_enum, dupsort, tables};
 
-// TODO(kariy): can we somehow define this without repeating existing tables, and only add the older ones?
+// TODO(kariy): can we somehow define this without repeating existing tables, and only add the older
+// ones?
 define_tables_enum! {[
     (Headers, TableType::Table),
     (BlockHashes, TableType::Table),

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -2,18 +2,18 @@ use katana_primitives::block::BlockNumber;
 use katana_primitives::contract::{ContractAddress, StorageKey};
 
 use super::*;
-use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::error::CodecError;
 use crate::models::contract::{ContractClassChange, ContractNonceChange};
 use crate::models::storage::{ContractStorageEntry, ContractStorageKey};
-use crate::{define_tables_enum, dupsort, tables};
+use crate::{define_schema_enum, dupsort, tables};
 
 pub const NUM_TABLES: usize = 22;
 
 // TODO(kariy): can we somehow define this without repeating existing tables, and only add the older
 // ones?
-define_tables_enum! {
+define_schema_enum! {
     0,
+    SchemaV0,
     [(Headers, TableType::Table),
     (BlockHashes, TableType::Table),
     (BlockNumbers, TableType::Table),

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -1,7 +1,9 @@
 use katana_primitives::block::BlockNumber;
-use katana_primitives::contract::ContractAddress;
+use katana_primitives::contract::{ContractAddress, StorageKey};
 
 use super::{DupSort, Table};
+use crate::codecs::{Compress, Decode, Decompress, Encode};
+use crate::error::CodecError;
 use crate::models::contract::{ContractClassChange, ContractNonceChange};
 use crate::models::storage::ContractStorageEntry;
 use crate::models::storage::ContractStorageKey;
@@ -12,6 +14,36 @@ tables! {
     NonceChanges: (BlockNumber, ContractAddress) => ContractNonceChange,
     /// Contract class hash changes by block.
     ContractClassChanges: (BlockNumber, ContractAddress) => ContractClassChange,
+
+    /// storage change set
+    StorageChangeSet: (ContractAddress, StorageKey) => StorageEntryChangeList,
     /// Account storage change set
     StorageChanges: (BlockNumber, ContractStorageKey) => ContractStorageEntry
+}
+
+pub type BlockList = Vec<BlockNumber>;
+
+#[derive(Debug)]
+pub struct StorageEntryChangeList {
+    pub key: StorageKey,
+    pub block_list: Vec<BlockNumber>,
+}
+
+impl Compress for StorageEntryChangeList {
+    type Compressed = Vec<u8>;
+    fn compress(self) -> Self::Compressed {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&self.key.encode());
+        buf.extend_from_slice(&self.block_list.compress());
+        buf
+    }
+}
+
+impl Decompress for StorageEntryChangeList {
+    fn decompress<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+        let key = StorageKey::decode(&bytes[0..32])?;
+        let blocks = Vec::<BlockNumber>::decompress(&bytes[32..])?;
+        Ok(Self { key, block_list: blocks })
+    }
 }

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -1,13 +1,39 @@
 use katana_primitives::block::BlockNumber;
 use katana_primitives::contract::{ContractAddress, StorageKey};
 
-use super::{DupSort, Table};
+use super::*;
 use crate::codecs::{Compress, Decode, Decompress, Encode};
 use crate::error::CodecError;
 use crate::models::contract::{ContractClassChange, ContractNonceChange};
 use crate::models::storage::ContractStorageEntry;
 use crate::models::storage::ContractStorageKey;
-use crate::{dupsort, tables};
+use crate::{define_tables_enum, dupsort, tables};
+
+// TODO(kariy): can we somehow define this without repeating existing tables, and only add the older ones?
+define_tables_enum! {[
+    (Headers, TableType::Table),
+    (BlockHashes, TableType::Table),
+    (BlockNumbers, TableType::Table),
+    (BlockBodyIndices, TableType::Table),
+    (BlockStatusses, TableType::Table),
+    (TxNumbers, TableType::Table),
+    (TxBlocks, TableType::Table),
+    (TxHashes, TableType::Table),
+    (Transactions, TableType::Table),
+    (Receipts, TableType::Table),
+    (CompiledClassHashes, TableType::Table),
+    (CompiledClasses, TableType::Table),
+    (SierraClasses, TableType::Table),
+    (ContractInfo, TableType::Table),
+    (ContractStorage, TableType::DupSort),
+    (ClassDeclarationBlock, TableType::Table),
+    (ClassDeclarations, TableType::DupSort),
+    (ContractInfoChangeSet, TableType::Table),
+    (NonceChanges, TableType::DupSort),
+    (ContractClassChanges, TableType::DupSort),
+    (StorageChanges, TableType::DupSort),
+    (StorageChangeSet, TableType::DupSort)
+]}
 
 tables! {
     /// Contract nonce changes by block.

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -12,8 +12,9 @@ pub const NUM_TABLES: usize = 22;
 
 // TODO(kariy): can we somehow define this without repeating existing tables, and only add the older
 // ones?
-define_tables_enum! {[
-    (Headers, TableType::Table),
+define_tables_enum! {
+    0,
+    [(Headers, TableType::Table),
     (BlockHashes, TableType::Table),
     (BlockNumbers, TableType::Table),
     (BlockBodyIndices, TableType::Table),

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -1,0 +1,17 @@
+use katana_primitives::block::BlockNumber;
+use katana_primitives::contract::ContractAddress;
+
+use super::{DupSort, Table};
+use crate::models::contract::{ContractClassChange, ContractNonceChange};
+use crate::models::storage::ContractStorageEntry;
+use crate::models::storage::ContractStorageKey;
+use crate::{dupsort, tables};
+
+tables! {
+    /// Contract nonce changes by block.
+    NonceChanges: (BlockNumber, ContractAddress) => ContractNonceChange,
+    /// Contract class hash changes by block.
+    ContractClassChanges: (BlockNumber, ContractAddress) => ContractClassChange,
+    /// Account storage change set
+    StorageChanges: (BlockNumber, ContractStorageKey) => ContractStorageEntry
+}

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -23,12 +23,15 @@ tables! {
 
 pub type BlockList = Vec<BlockNumber>;
 
+/// This is used as a value type for the [`StorageChangeSet`] dupsort table
 #[derive(Debug)]
 pub struct StorageEntryChangeList {
     pub key: StorageKey,
     pub block_list: Vec<BlockNumber>,
 }
 
+// The `key` field is the subkey of the dupsort table, so we must use
+// the Encode and Decode traits  when de/serializing it to the database.
 impl Compress for StorageEntryChangeList {
     type Compressed = Vec<u8>;
     fn compress(self) -> Self::Compressed {

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -8,6 +8,8 @@ use crate::models::contract::{ContractClassChange, ContractNonceChange};
 use crate::models::storage::{ContractStorageEntry, ContractStorageKey};
 use crate::{define_tables_enum, dupsort, tables};
 
+pub const NUM_TABLES: usize = 22;
+
 // TODO(kariy): can we somehow define this without repeating existing tables, and only add the older
 // ones?
 define_tables_enum! {[

--- a/crates/katana/storage/db/src/tables/v1.rs
+++ b/crates/katana/storage/db/src/tables/v1.rs
@@ -7,18 +7,18 @@ use katana_primitives::receipt::Receipt;
 use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{Tx, TxHash, TxNumber};
 
+use super::{DupSort, Schema, Table, TableType};
 use crate::models::block::StoredBlockBodyIndices;
 use crate::models::contract::{ContractClassChange, ContractInfoChangeList, ContractNonceChange};
 use crate::models::list::BlockList;
 use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
-use crate::{define_tables_enum, dupsort, tables};
-
-use super::{DupSort, Schema, Table, TableType};
+use crate::{define_schema_enum, dupsort, tables};
 
 pub const NUM_TABLES: usize = 23;
 
-define_tables_enum! {
+define_schema_enum! {
     1,
+    SchemaV1,
     [(Headers, TableType::Table),
     (BlockHashes, TableType::Table),
     (BlockNumbers, TableType::Table),
@@ -108,54 +108,54 @@ mod tests {
     fn test_tables() {
         use super::*;
 
-        assert_eq!(Tables::all().len(), NUM_TABLES);
-        assert_eq!(Tables::all()[0].name(), Headers::NAME);
-        assert_eq!(Tables::all()[1].name(), BlockHashes::NAME);
-        assert_eq!(Tables::all()[2].name(), BlockNumbers::NAME);
-        assert_eq!(Tables::all()[3].name(), BlockBodyIndices::NAME);
-        assert_eq!(Tables::all()[4].name(), BlockStatusses::NAME);
-        assert_eq!(Tables::all()[5].name(), TxNumbers::NAME);
-        assert_eq!(Tables::all()[6].name(), TxBlocks::NAME);
-        assert_eq!(Tables::all()[7].name(), TxTraces::NAME);
-        assert_eq!(Tables::all()[8].name(), TxHashes::NAME);
-        assert_eq!(Tables::all()[9].name(), Transactions::NAME);
-        assert_eq!(Tables::all()[10].name(), Receipts::NAME);
-        assert_eq!(Tables::all()[11].name(), CompiledClassHashes::NAME);
-        assert_eq!(Tables::all()[12].name(), CompiledClasses::NAME);
-        assert_eq!(Tables::all()[13].name(), SierraClasses::NAME);
-        assert_eq!(Tables::all()[14].name(), ContractInfo::NAME);
-        assert_eq!(Tables::all()[15].name(), ContractStorage::NAME);
-        assert_eq!(Tables::all()[16].name(), ClassDeclarationBlock::NAME);
-        assert_eq!(Tables::all()[17].name(), ClassDeclarations::NAME);
-        assert_eq!(Tables::all()[18].name(), ContractInfoChangeSet::NAME);
-        assert_eq!(Tables::all()[19].name(), NonceChangeHistory::NAME);
-        assert_eq!(Tables::all()[20].name(), ClassChangeHistory::NAME);
-        assert_eq!(Tables::all()[21].name(), StorageChangeHistory::NAME);
-        assert_eq!(Tables::all()[22].name(), StorageChangeSet::NAME);
+        assert_eq!(SchemaV1::all().len(), NUM_TABLES);
+        assert_eq!(SchemaV1::all()[0].name(), Headers::NAME);
+        assert_eq!(SchemaV1::all()[1].name(), BlockHashes::NAME);
+        assert_eq!(SchemaV1::all()[2].name(), BlockNumbers::NAME);
+        assert_eq!(SchemaV1::all()[3].name(), BlockBodyIndices::NAME);
+        assert_eq!(SchemaV1::all()[4].name(), BlockStatusses::NAME);
+        assert_eq!(SchemaV1::all()[5].name(), TxNumbers::NAME);
+        assert_eq!(SchemaV1::all()[6].name(), TxBlocks::NAME);
+        assert_eq!(SchemaV1::all()[7].name(), TxTraces::NAME);
+        assert_eq!(SchemaV1::all()[8].name(), TxHashes::NAME);
+        assert_eq!(SchemaV1::all()[9].name(), Transactions::NAME);
+        assert_eq!(SchemaV1::all()[10].name(), Receipts::NAME);
+        assert_eq!(SchemaV1::all()[11].name(), CompiledClassHashes::NAME);
+        assert_eq!(SchemaV1::all()[12].name(), CompiledClasses::NAME);
+        assert_eq!(SchemaV1::all()[13].name(), SierraClasses::NAME);
+        assert_eq!(SchemaV1::all()[14].name(), ContractInfo::NAME);
+        assert_eq!(SchemaV1::all()[15].name(), ContractStorage::NAME);
+        assert_eq!(SchemaV1::all()[16].name(), ClassDeclarationBlock::NAME);
+        assert_eq!(SchemaV1::all()[17].name(), ClassDeclarations::NAME);
+        assert_eq!(SchemaV1::all()[18].name(), ContractInfoChangeSet::NAME);
+        assert_eq!(SchemaV1::all()[19].name(), NonceChangeHistory::NAME);
+        assert_eq!(SchemaV1::all()[20].name(), ClassChangeHistory::NAME);
+        assert_eq!(SchemaV1::all()[21].name(), StorageChangeHistory::NAME);
+        assert_eq!(SchemaV1::all()[22].name(), StorageChangeSet::NAME);
 
-        assert_eq!(Tables::Headers.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockHashes.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockNumbers.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockBodyIndices.table_type(), TableType::Table);
-        assert_eq!(Tables::BlockStatusses.table_type(), TableType::Table);
-        assert_eq!(Tables::TxNumbers.table_type(), TableType::Table);
-        assert_eq!(Tables::TxBlocks.table_type(), TableType::Table);
-        assert_eq!(Tables::TxHashes.table_type(), TableType::Table);
-        assert_eq!(Tables::TxTraces.table_type(), TableType::Table);
-        assert_eq!(Tables::Transactions.table_type(), TableType::Table);
-        assert_eq!(Tables::Receipts.table_type(), TableType::Table);
-        assert_eq!(Tables::CompiledClassHashes.table_type(), TableType::Table);
-        assert_eq!(Tables::CompiledClasses.table_type(), TableType::Table);
-        assert_eq!(Tables::SierraClasses.table_type(), TableType::Table);
-        assert_eq!(Tables::ContractInfo.table_type(), TableType::Table);
-        assert_eq!(Tables::ContractStorage.table_type(), TableType::DupSort);
-        assert_eq!(Tables::ClassDeclarationBlock.table_type(), TableType::Table);
-        assert_eq!(Tables::ClassDeclarations.table_type(), TableType::DupSort);
-        assert_eq!(Tables::ContractInfoChangeSet.table_type(), TableType::Table);
-        assert_eq!(Tables::NonceChangeHistory.table_type(), TableType::DupSort);
-        assert_eq!(Tables::ClassChangeHistory.table_type(), TableType::DupSort);
-        assert_eq!(Tables::StorageChangeHistory.table_type(), TableType::DupSort);
-        assert_eq!(Tables::StorageChangeSet.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::Headers.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::BlockHashes.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::BlockNumbers.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::BlockBodyIndices.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::BlockStatusses.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::TxNumbers.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::TxBlocks.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::TxHashes.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::TxTraces.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::Transactions.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::Receipts.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::CompiledClassHashes.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::CompiledClasses.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::SierraClasses.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::ContractInfo.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::ContractStorage.table_type(), TableType::DupSort);
+        assert_eq!(SchemaV1::ClassDeclarationBlock.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::ClassDeclarations.table_type(), TableType::DupSort);
+        assert_eq!(SchemaV1::ContractInfoChangeSet.table_type(), TableType::Table);
+        assert_eq!(SchemaV1::NonceChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(SchemaV1::ClassChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(SchemaV1::StorageChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(SchemaV1::StorageChangeSet.table_type(), TableType::Table);
     }
 
     use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};

--- a/crates/katana/storage/db/src/tables/v1.rs
+++ b/crates/katana/storage/db/src/tables/v1.rs
@@ -17,8 +17,9 @@ use super::{DupSort, Schema, Table, TableType};
 
 pub const NUM_TABLES: usize = 23;
 
-define_tables_enum! {[
-    (Headers, TableType::Table),
+define_tables_enum! {
+    1,
+    [(Headers, TableType::Table),
     (BlockHashes, TableType::Table),
     (BlockNumbers, TableType::Table),
     (BlockBodyIndices, TableType::Table),

--- a/crates/katana/storage/db/src/tables/v1.rs
+++ b/crates/katana/storage/db/src/tables/v1.rs
@@ -1,0 +1,244 @@
+use std::fmt::Debug;
+
+use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
+use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
+use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey};
+use katana_primitives::receipt::Receipt;
+use katana_primitives::trace::TxExecInfo;
+use katana_primitives::transaction::{Tx, TxHash, TxNumber};
+
+use crate::models::block::StoredBlockBodyIndices;
+use crate::models::contract::{ContractClassChange, ContractInfoChangeList, ContractNonceChange};
+use crate::models::list::BlockList;
+use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
+use crate::{define_tables_enum, dupsort, tables};
+
+use super::{DupSort, Schema, Table, TableType};
+
+pub const NUM_TABLES: usize = 23;
+
+define_tables_enum! {[
+    (Headers, TableType::Table),
+    (BlockHashes, TableType::Table),
+    (BlockNumbers, TableType::Table),
+    (BlockBodyIndices, TableType::Table),
+    (BlockStatusses, TableType::Table),
+    (TxNumbers, TableType::Table),
+    (TxBlocks, TableType::Table),
+    (TxHashes, TableType::Table),
+    (TxTraces, TableType::Table),
+    (Transactions, TableType::Table),
+    (Receipts, TableType::Table),
+    (CompiledClassHashes, TableType::Table),
+    (CompiledClasses, TableType::Table),
+    (SierraClasses, TableType::Table),
+    (ContractInfo, TableType::Table),
+    (ContractStorage, TableType::DupSort),
+    (ClassDeclarationBlock, TableType::Table),
+    (ClassDeclarations, TableType::DupSort),
+    (ContractInfoChangeSet, TableType::Table),
+    (NonceChangeHistory, TableType::DupSort),
+    (ClassChangeHistory, TableType::DupSort),
+    (StorageChangeHistory, TableType::DupSort),
+    (StorageChangeSet, TableType::Table)
+]}
+
+tables! {
+    /// Store canonical block headers
+    Headers: (BlockNumber) => Header,
+    /// Stores block hashes according to its block number
+    BlockHashes: (BlockNumber) => BlockHash,
+    /// Stores block numbers according to its block hash
+    BlockNumbers: (BlockHash) => BlockNumber,
+    /// Stores block finality status according to its block number
+    BlockStatusses: (BlockNumber) => FinalityStatus,
+    /// Block number to its body indices which stores the tx number of
+    /// the first tx in the block and the number of txs in the block.
+    BlockBodyIndices: (BlockNumber) => StoredBlockBodyIndices,
+    /// Transaction number based on its hash
+    TxNumbers: (TxHash) => TxNumber,
+    /// Transaction hash based on its number
+    TxHashes: (TxNumber) => TxHash,
+    /// Store canonical transactions
+    Transactions: (TxNumber) => Tx,
+    /// Stores the block number of a transaction.
+    TxBlocks: (TxNumber) => BlockNumber,
+    /// Stores the transaction's traces.
+    TxTraces: (TxNumber) => TxExecInfo,
+    /// Store transaction receipts
+    Receipts: (TxNumber) => Receipt,
+    /// Store compiled classes
+    CompiledClassHashes: (ClassHash) => CompiledClassHash,
+    /// Store compiled contract classes according to its compiled class hash
+    CompiledClasses: (ClassHash) => CompiledClass,
+    /// Store Sierra classes according to its class hash
+    SierraClasses: (ClassHash) => FlattenedSierraClass,
+    /// Store contract information according to its contract address
+    ContractInfo: (ContractAddress) => GenericContractInfo,
+    /// Store contract storage
+    ContractStorage: (ContractAddress, StorageKey) => StorageEntry,
+
+
+    /// Stores the block number where the class hash was declared.
+    ClassDeclarationBlock: (ClassHash) => BlockNumber,
+    /// Stores the list of class hashes according to the block number it was declared in.
+    ClassDeclarations: (BlockNumber, ClassHash) => ClassHash,
+
+    /// Generic contract info change set.
+    ///
+    /// Stores the list of blocks where the contract info (nonce / class hash) has changed.
+    ContractInfoChangeSet: (ContractAddress) => ContractInfoChangeList,
+    /// Contract nonce changes by block.
+    NonceChangeHistory: (BlockNumber, ContractAddress) => ContractNonceChange,
+    /// Contract class hash changes by block.
+    ClassChangeHistory: (BlockNumber, ContractAddress) => ContractClassChange,
+
+    /// storage change set
+    StorageChangeSet: (ContractStorageKey) => BlockList,
+    /// Account storage change set
+    StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry
+
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_tables() {
+        use super::*;
+
+        assert_eq!(Tables::all().len(), NUM_TABLES);
+        assert_eq!(Tables::all()[0].name(), Headers::NAME);
+        assert_eq!(Tables::all()[1].name(), BlockHashes::NAME);
+        assert_eq!(Tables::all()[2].name(), BlockNumbers::NAME);
+        assert_eq!(Tables::all()[3].name(), BlockBodyIndices::NAME);
+        assert_eq!(Tables::all()[4].name(), BlockStatusses::NAME);
+        assert_eq!(Tables::all()[5].name(), TxNumbers::NAME);
+        assert_eq!(Tables::all()[6].name(), TxBlocks::NAME);
+        assert_eq!(Tables::all()[7].name(), TxTraces::NAME);
+        assert_eq!(Tables::all()[8].name(), TxHashes::NAME);
+        assert_eq!(Tables::all()[9].name(), Transactions::NAME);
+        assert_eq!(Tables::all()[10].name(), Receipts::NAME);
+        assert_eq!(Tables::all()[11].name(), CompiledClassHashes::NAME);
+        assert_eq!(Tables::all()[12].name(), CompiledClasses::NAME);
+        assert_eq!(Tables::all()[13].name(), SierraClasses::NAME);
+        assert_eq!(Tables::all()[14].name(), ContractInfo::NAME);
+        assert_eq!(Tables::all()[15].name(), ContractStorage::NAME);
+        assert_eq!(Tables::all()[16].name(), ClassDeclarationBlock::NAME);
+        assert_eq!(Tables::all()[17].name(), ClassDeclarations::NAME);
+        assert_eq!(Tables::all()[18].name(), ContractInfoChangeSet::NAME);
+        assert_eq!(Tables::all()[19].name(), NonceChangeHistory::NAME);
+        assert_eq!(Tables::all()[20].name(), ClassChangeHistory::NAME);
+        assert_eq!(Tables::all()[21].name(), StorageChangeHistory::NAME);
+        assert_eq!(Tables::all()[22].name(), StorageChangeSet::NAME);
+
+        assert_eq!(Tables::Headers.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockHashes.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockNumbers.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockBodyIndices.table_type(), TableType::Table);
+        assert_eq!(Tables::BlockStatusses.table_type(), TableType::Table);
+        assert_eq!(Tables::TxNumbers.table_type(), TableType::Table);
+        assert_eq!(Tables::TxBlocks.table_type(), TableType::Table);
+        assert_eq!(Tables::TxHashes.table_type(), TableType::Table);
+        assert_eq!(Tables::TxTraces.table_type(), TableType::Table);
+        assert_eq!(Tables::Transactions.table_type(), TableType::Table);
+        assert_eq!(Tables::Receipts.table_type(), TableType::Table);
+        assert_eq!(Tables::CompiledClassHashes.table_type(), TableType::Table);
+        assert_eq!(Tables::CompiledClasses.table_type(), TableType::Table);
+        assert_eq!(Tables::SierraClasses.table_type(), TableType::Table);
+        assert_eq!(Tables::ContractInfo.table_type(), TableType::Table);
+        assert_eq!(Tables::ContractStorage.table_type(), TableType::DupSort);
+        assert_eq!(Tables::ClassDeclarationBlock.table_type(), TableType::Table);
+        assert_eq!(Tables::ClassDeclarations.table_type(), TableType::DupSort);
+        assert_eq!(Tables::ContractInfoChangeSet.table_type(), TableType::Table);
+        assert_eq!(Tables::NonceChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(Tables::ClassChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(Tables::StorageChangeHistory.table_type(), TableType::DupSort);
+        assert_eq!(Tables::StorageChangeSet.table_type(), TableType::Table);
+    }
+
+    use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
+    use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
+    use katana_primitives::contract::{ContractAddress, GenericContractInfo};
+    use katana_primitives::receipt::Receipt;
+    use katana_primitives::trace::TxExecInfo;
+    use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber};
+    use starknet::macros::felt;
+
+    use crate::codecs::{Compress, Decode, Decompress, Encode};
+    use crate::models::block::StoredBlockBodyIndices;
+    use crate::models::contract::{
+        ContractClassChange, ContractInfoChangeList, ContractNonceChange,
+    };
+    use crate::models::list::BlockList;
+    use crate::models::storage::{ContractStorageEntry, ContractStorageKey, StorageEntry};
+
+    macro_rules! assert_key_encode_decode {
+	    { $( ($name:ty, $key:expr) ),* } => {
+			$(
+				{
+					let key: $name = $key;
+					let encoded = key.encode();
+					let decoded = <$name as Decode>::decode(encoded.as_slice()).expect("decode failed");
+					assert_eq!($key, decoded);
+				}
+			)*
+		};
+	}
+
+    macro_rules! assert_value_compress_decompress {
+		{ $( ($name:ty, $value:expr) ),* } => {
+			$(
+				{
+					let value: $name = $value;
+					let compressed = value.compress();
+					let decompressed = <$name as Decompress>::decompress(compressed.as_slice()).expect("decode failed");
+					assert_eq!($value, decompressed);
+				}
+			)*
+		};
+	}
+
+    // Test that all key/subkey types can be encoded and decoded
+    // through the Encode and Decode traits
+    #[test]
+    fn test_key_encode_decode() {
+        assert_key_encode_decode! {
+            (BlockNumber, 100),
+            (BlockHash, felt!("0x123456789")),
+            (TxHash, felt!("0x123456789")),
+            (TxNumber, 100),
+            (ClassHash, felt!("0x123456789")),
+            (ContractAddress, ContractAddress(felt!("0x123456789"))),
+            (ContractStorageKey, ContractStorageKey { contract_address : ContractAddress(felt!("0x123456789")), key : felt!("0x123456789")})
+        }
+    }
+
+    // Test that all value types can be compressed and decompressed
+    // through the Compress and Decompress traits
+    #[test]
+    fn test_value_compress_decompress() {
+        assert_value_compress_decompress! {
+            (Header, Header::default()),
+            (BlockHash, BlockHash::default()),
+            (BlockNumber, BlockNumber::default()),
+            (FinalityStatus, FinalityStatus::AcceptedOnL1),
+            (StoredBlockBodyIndices, StoredBlockBodyIndices::default()),
+            (TxNumber, 77),
+            (TxHash, felt!("0x123456789")),
+            (Tx, Tx::Invoke(InvokeTx::V1(Default::default()))),
+            (BlockNumber, 99),
+            (TxExecInfo, TxExecInfo::default()),
+            (Receipt, Receipt::Invoke(Default::default())),
+            (CompiledClassHash, felt!("211")),
+            (CompiledClass, CompiledClass::Deprecated(Default::default())),
+            (GenericContractInfo, GenericContractInfo::default()),
+            (StorageEntry, StorageEntry::default()),
+            (ContractInfoChangeList, ContractInfoChangeList::default()),
+            (ContractNonceChange, ContractNonceChange::default()),
+            (ContractClassChange, ContractClassChange::default()),
+            (BlockList, BlockList::default()),
+            (ContractStorageEntry, ContractStorageEntry::default())
+        }
+    }
+}

--- a/crates/katana/storage/db/src/version.rs
+++ b/crates/katana/storage/db/src/version.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use crate::tables::{self, Schema};
 
 /// The version of the latest database schema we're using.
-pub const CURRENT_DB_VERSION: u32 = tables::Tables::VERSION;
+pub const CURRENT_DB_VERSION: u32 = tables::SchemaV1::VERSION;
 
 /// Name of the version file.
 const DB_VERSION_FILE_NAME: &str = "db.version";

--- a/crates/katana/storage/db/src/version.rs
+++ b/crates/katana/storage/db/src/version.rs
@@ -4,8 +4,10 @@ use std::io::{Read, Write};
 use std::mem;
 use std::path::{Path, PathBuf};
 
-/// Current version of the database.
-pub const CURRENT_DB_VERSION: u32 = 1;
+use crate::tables::{self, Schema};
+
+/// The version of the latest database schema we're using.
+pub const CURRENT_DB_VERSION: u32 = tables::Tables::VERSION;
 
 /// Name of the version file.
 const DB_VERSION_FILE_NAME: &str = "db.version";


### PR DESCRIPTION
- refactor database tables to be based on a 'schema'
- added `Schema` trait to define database schema; basically a collection of tables that will be created in the database
- use schema to create a notion of database 'versioning'