### PR TITLE
feat(katana-db): add new db methods 

### DIFF
--- a/crates/katana/storage/db/src/error.rs
+++ b/crates/katana/storage/db/src/error.rs
@@ -38,6 +38,9 @@ pub enum DatabaseError {
 
     #[error("failed to clear db: {0}")]
     Clear(libmdbx::Error),
+
+    #[error("failed to drop '{table}' table: {error}")]
+    DropTable { table: &'static str, error: libmdbx::Error },
 }
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -105,6 +105,18 @@ impl<S: Schema> DbEnv<S> {
         Ok(Tx::new(self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?))
     }
 
+    /// Takes a function and passes a read-only transaction into it, making sure it's always
+    /// committed in the end of the execution.
+    pub fn view<T, F>(&self, f: F) -> Result<T, DatabaseError>
+    where
+        F: FnOnce(&Tx<RO>) -> T,
+    {
+        let tx = self.tx()?;
+        let res = f(&tx);
+        tx.commit()?;
+        Ok(res)
+    }
+
     /// Takes a function and passes a read-write transaction into it, making sure it's always
     /// committed in the end of the execution.
     pub fn update<T, F>(&self, f: F) -> Result<T, DatabaseError>

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -109,7 +109,7 @@ impl<S: Schema> DbEnv<S> {
     /// committed in the end of the execution.
     pub fn view<T, F>(&self, f: F) -> Result<T, DatabaseError>
     where
-        F: FnOnce(&Tx<RO>) -> T,
+        F: FnOnce(&Tx<RO, S>) -> T,
     {
         let tx = self.tx()?;
         let res = f(&tx);

--- a/crates/katana/storage/db/src/mdbx/tx.rs
+++ b/crates/katana/storage/db/src/mdbx/tx.rs
@@ -57,7 +57,8 @@ where
         // the index is guaranteed to be in bounds by the schema only on current schema
         // version because we hardcode the size exactly for the number of tables in current db
         // schema. see `tables::v1::NUM_TABLES`.
-        let table = S::index::<T>().expect(&format!("table {} not found in schema", T::NAME));
+        let table =
+            S::index::<T>().unwrap_or_else(|| panic!("table {} not found in schema", T::NAME));
 
         let mut handles = self.db_handles.write();
         let dbi_handle = handles.get_mut(table).expect("should exist");

--- a/crates/katana/storage/db/src/mdbx/tx.rs
+++ b/crates/katana/storage/db/src/mdbx/tx.rs
@@ -162,10 +162,9 @@ impl<S: Schema> Tx<RW, S> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        mdbx::{test_utils::create_test_db, DbEnvKind},
-        tables::{Headers, Table},
-    };
+    use crate::mdbx::test_utils::create_test_db;
+    use crate::mdbx::DbEnvKind;
+    use crate::tables::{Headers, Table};
 
     const ERROR_DROP_TABLE: &str = "Not able to drop table.";
     const ERROR_INIT_TX: &str = "Failed to create a MDBX transaction.";


### PR DESCRIPTION
add some new methods to the database:
- `view`: basically similar to `update` but for read-only tx
- `drop_table`: for dropping a table from the database