### PR TITLE
feat(katana-db): db migration from older version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6781,6 +6781,7 @@ dependencies = [
  "starknet_api",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/katana/storage/db/Cargo.toml
+++ b/crates/katana/storage/db/Cargo.toml
@@ -14,7 +14,7 @@ page_size = "0.6.0"
 parking_lot.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tempfile = { version = "3.8.1", optional = true }
+tempfile = "3.8.1"
 thiserror.workspace = true
 
 cairo-vm.workspace = true
@@ -37,12 +37,11 @@ rev = "b34b0d3"
 cairo-lang-starknet.workspace = true
 criterion = "0.5.1"
 starknet.workspace = true
-tempfile = "3.8.1"
 
 [features]
 default = [ "postcard" ]
 postcard = [ "dep:postcard" ]
-test-utils = [ "dep:tempfile" ]
+test-utils = [  ]
 
 [[bench]]
 harness = false

--- a/crates/katana/storage/db/Cargo.toml
+++ b/crates/katana/storage/db/Cargo.toml
@@ -16,6 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 tempfile = "3.8.1"
 thiserror.workspace = true
+tracing.workspace = true
 
 cairo-vm.workspace = true
 roaring = { version = "0.10.3", features = [ "serde" ] }

--- a/crates/katana/storage/db/src/error.rs
+++ b/crates/katana/storage/db/src/error.rs
@@ -6,8 +6,8 @@ pub enum DatabaseError {
     #[error(transparent)]
     Codec(#[from] CodecError),
 
-    #[error("failed to create db table: {0}")]
-    CreateTable(libmdbx::Error),
+    #[error("failed to create db table '{table}': {error}")]
+    CreateTable { table: &'static str, error: libmdbx::Error },
 
     #[error("failed to commit db transaction: {0}")]
     Commit(libmdbx::Error),

--- a/crates/katana/storage/db/src/lib.rs
+++ b/crates/katana/storage/db/src/lib.rs
@@ -8,6 +8,7 @@ use anyhow::{anyhow, Context};
 pub mod codecs;
 pub mod error;
 pub mod mdbx;
+pub mod migration;
 pub mod models;
 pub mod tables;
 pub mod utils;

--- a/crates/katana/storage/db/src/lib.rs
+++ b/crates/katana/storage/db/src/lib.rs
@@ -45,7 +45,7 @@ pub(crate) fn init_db_with_schema<S: Schema>(path: impl AsRef<Path>) -> anyhow::
             format!("Inserting database version file at path {}", path.as_ref().display())
         })?
     } else {
-        match check_db_version(&path) {
+        match check_db_version::<S>(&path) {
             Ok(_) => {}
             Err(DatabaseVersionError::MismatchVersion { expected, found }) => {
                 warn!(target: LOG_TARGET, %expected, %found, "Mismatch database version.");

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -163,6 +163,8 @@ pub mod test_utils {
 #[cfg(test)]
 mod tests {
 
+    use std::os;
+
     use katana_primitives::block::Header;
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
     use katana_primitives::FieldElement;

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -92,18 +92,6 @@ impl<S: Schema> DbEnv<S> {
         Ok(Tx::new(self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?))
     }
 
-    /// Takes a function and passes a read-only transaction into it, making sure it's always
-    /// committed in the end of the execution.
-    pub fn view<T, F>(&self, f: F) -> Result<T, DatabaseError>
-    where
-        F: FnOnce(&Tx<RO, S>) -> T,
-    {
-        let tx = self.tx()?;
-        let res = f(&tx);
-        tx.commit()?;
-        Ok(res)
-    }
-
     /// Takes a function and passes a read-write transaction into it, making sure it's always
     /// committed in the end of the execution.
     pub fn update<T, F>(&self, f: F) -> Result<T, DatabaseError>

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -163,8 +163,6 @@ pub mod test_utils {
 #[cfg(test)]
 mod tests {
 
-    use std::os;
-
     use katana_primitives::block::Header;
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
     use katana_primitives::FieldElement;

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -92,6 +92,18 @@ impl<S: Schema> DbEnv<S> {
         Ok(Tx::new(self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?))
     }
 
+    /// Takes a function and passes a read-only transaction into it, making sure it's always
+    /// committed in the end of the execution.
+    pub fn view<T, F>(&self, f: F) -> Result<T, DatabaseError>
+    where
+        F: FnOnce(&Tx<RO, S>) -> T,
+    {
+        let tx = self.tx()?;
+        let res = f(&tx);
+        tx.commit()?;
+        Ok(res)
+    }
+
     /// Takes a function and passes a read-write transaction into it, making sure it's always
     /// committed in the end of the execution.
     pub fn update<T, F>(&self, f: F) -> Result<T, DatabaseError>

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -79,21 +79,6 @@ impl<S: Schema> DbEnv<S> {
 
     /// Creates all the defined tables in [`Tables`], if necessary.
     pub fn create_tables(&self) -> Result<(), DatabaseError> {
-        // let tx = self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?;
-
-        // for table in dbg!(S::all()) {
-        //     let flags = match table.table_type() {
-        //         TableType::Table => DatabaseFlags::default(),
-        //         TableType::DupSort => DatabaseFlags::DUP_SORT,
-        //     };
-
-        //     tx.create_db(Some(table.name()), flags).map_err(DatabaseError::CreateTable)?;
-        // }
-
-        // tx.commit().map_err(DatabaseError::Commit)?;
-
-        // Ok(())
-
         self.create_tables_from_schema::<S>()
     }
 
@@ -141,7 +126,9 @@ impl<S: Schema> DbEnv<S> {
                 TableType::DupSort => DatabaseFlags::DUP_SORT,
             };
 
-            tx.create_db(Some(table.name()), flags).map_err(DatabaseError::CreateTable)?;
+            let name = table.name();
+            tx.create_db(Some(name), flags)
+                .map_err(|error| DatabaseError::CreateTable { table: name, error })?;
         }
 
         tx.commit().map_err(DatabaseError::Commit)?;

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -81,7 +81,7 @@ impl<S: Schema> DbEnv<S> {
     pub fn create_tables(&self) -> Result<(), DatabaseError> {
         let tx = self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?;
 
-        for table in S::all() {
+        for table in dbg!(S::all()) {
             let flags = match table.table_type() {
                 TableType::Table => DatabaseFlags::default(),
                 TableType::DupSort => DatabaseFlags::DUP_SORT,

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -79,20 +79,22 @@ impl<S: Schema> DbEnv<S> {
 
     /// Creates all the defined tables in [`Tables`], if necessary.
     pub fn create_tables(&self) -> Result<(), DatabaseError> {
-        let tx = self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?;
+        // let tx = self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?;
 
-        for table in dbg!(S::all()) {
-            let flags = match table.table_type() {
-                TableType::Table => DatabaseFlags::default(),
-                TableType::DupSort => DatabaseFlags::DUP_SORT,
-            };
+        // for table in dbg!(S::all()) {
+        //     let flags = match table.table_type() {
+        //         TableType::Table => DatabaseFlags::default(),
+        //         TableType::DupSort => DatabaseFlags::DUP_SORT,
+        //     };
 
-            tx.create_db(Some(table.name()), flags).map_err(DatabaseError::CreateTable)?;
-        }
+        //     tx.create_db(Some(table.name()), flags).map_err(DatabaseError::CreateTable)?;
+        // }
 
-        tx.commit().map_err(DatabaseError::Commit)?;
+        // tx.commit().map_err(DatabaseError::Commit)?;
 
-        Ok(())
+        // Ok(())
+
+        self.create_tables_from_schema::<S>()
     }
 
     /// Begin a read-only transaction.
@@ -127,6 +129,24 @@ impl<S: Schema> DbEnv<S> {
         let res = f(&tx);
         tx.commit()?;
         Ok(res)
+    }
+
+    /// Creates all the defined tables in [`Tables`], if necessary.
+    pub(crate) fn create_tables_from_schema<R: Schema>(&self) -> Result<(), DatabaseError> {
+        let tx = self.inner.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?;
+
+        for table in R::all() {
+            let flags = match table.table_type() {
+                TableType::Table => DatabaseFlags::default(),
+                TableType::DupSort => DatabaseFlags::DUP_SORT,
+            };
+
+            tx.create_db(Some(table.name()), flags).map_err(DatabaseError::CreateTable)?;
+        }
+
+        tx.commit().map_err(DatabaseError::Commit)?;
+
+        Ok(())
     }
 }
 

--- a/crates/katana/storage/db/src/mdbx/tx.rs
+++ b/crates/katana/storage/db/src/mdbx/tx.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 use libmdbx::ffi::DBI;
-use libmdbx::{DatabaseFlags, TransactionKind, WriteFlags, RW};
+use libmdbx::{TransactionKind, WriteFlags, RW};
 use parking_lot::RwLock;
 
 use super::cursor::Cursor;
@@ -23,7 +23,7 @@ pub type TxRW = Tx<libmdbx::RW, SchemaV1>;
 #[derive(Debug)]
 pub struct Tx<K: TransactionKind, S: Schema> {
     /// Libmdbx-sys transaction.
-    inner: libmdbx::Transaction<K>,
+    pub(crate) inner: libmdbx::Transaction<K>,
     /// Marker for the db schema.
     _schema: std::marker::PhantomData<S>,
     // the array size is hardcoded to the number of tables in current db version for now. ideally
@@ -118,10 +118,6 @@ where
 }
 
 impl<S: Schema> Tx<RW, S> {
-    pub fn create_table<T: Table>(&self, flags: DatabaseFlags) -> Result<DBI, DatabaseError> {
-        Ok(self.inner.create_db(Some(T::NAME), flags).unwrap().dbi())
-    }
-
     /// Inserts an item into a database.
     ///
     /// This function stores key/data pairs in the database. The default behavior is to enter the

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -121,12 +121,11 @@ mod tests {
     use starknet::macros::felt;
 
     use super::migrate_db;
-    use super::tables::v0;
     use crate::mdbx::DbEnv;
     use crate::models::contract::{ContractClassChange, ContractNonceChange};
     use crate::models::list::BlockList;
     use crate::models::storage::{ContractStorageEntry, ContractStorageKey};
-    use crate::tables::v0::StorageEntryChangeList;
+    use crate::tables::v0::{self, StorageEntryChangeList};
     use crate::{init_db, tables};
 
     const ERROR_CREATE_TEMP_DIR: &str = "Failed to create temp dir.";
@@ -140,9 +139,9 @@ mod tests {
     }
 
     // TODO(kariy): create Arbitrary for database key/value types to easily create random test vectors
-    fn create_v0_test_db() -> (DbEnv, PathBuf) {
+    fn create_v0_test_db() -> (DbEnv<v0::Tables>, PathBuf) {
         let path = tempfile::TempDir::new().expect(ERROR_CREATE_TEMP_DIR).into_path();
-        let db = crate::init_db_with_schema::<tables::v0::Tables>(&path).expect(ERROR_INIT_DB);
+        let db = crate::init_db_with_schema::<v0::Tables>(&path).expect(ERROR_INIT_DB);
 
         db.update(|tx| {
             tx.put::<v0::NonceChanges>(

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -1,0 +1,51 @@
+use std::path::Path;
+
+use crate::{
+    error::DatabaseError,
+    open_db, tables,
+    version::{get_db_version, DatabaseVersionError},
+    CURRENT_DB_VERSION,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum DatabaseMigrationError {
+    #[error("Unsupported database version for migration: {0}")]
+    UnsupportedVersion(u32),
+
+    #[error(transparent)]
+    DatabaseVersion(#[from] DatabaseVersionError),
+
+    #[error(transparent)]
+    Database(#[from] DatabaseError),
+
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+/// Performs a database migration for an already initialized database with an older
+/// version of the database schema.
+///
+/// DB migration can only be done on a supported older version of the database schema,
+/// meaning not all older versions can be migrated.
+pub fn migrate_db<P: AsRef<Path>>(path: P) -> Result<(), DatabaseMigrationError> {
+    // check that the db version is supported, otherwise return an error
+    let ver = get_db_version(&path)?;
+
+    if ver != 0 {
+        return Err(DatabaseMigrationError::UnsupportedVersion(ver));
+    }
+
+    // perform the migration
+    // 1. create all the tables exist in the current schema
+    // 2. migrate all the data from the old schema to the new schema
+    // 3. update the db version to the current version
+
+    let env = open_db(path)?;
+    env.create_tables()?;
+
+    env.update(|tx| {
+        let mut cursor = tx.cursor::<tables::StorageChangeSet>()?;
+    })?;
+
+    Ok(())
+}

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -123,8 +123,9 @@ mod tests {
     use super::migrate_db;
     use super::tables::v0;
     use crate::mdbx::DbEnv;
-    use crate::models::contract::ContractNonceChange;
-    use crate::tables::v0::StorageEntryChangeList;
+    use crate::models::contract::{ContractClassChange, ContractNonceChange};
+    use crate::models::storage::{ContractStorageEntry, ContractStorageKey};
+    use crate::tables::v0::{ContractClassChanges, StorageEntryChangeList};
     use crate::version::create_db_version_file;
     use crate::{init_db, open_db};
 
@@ -149,22 +150,6 @@ mod tests {
         let _ = create_db_version_file(&path, 0).expect(ERROR_CREATE_VER_FILE);
 
         db.update(|tx| {
-            tx.put::<v0::StorageChangeSet>(
-                felt!("0x1").into(),
-                StorageEntryChangeList { key: felt!("0x1"), block_list: vec![1, 2] },
-            )
-            .unwrap();
-            tx.put::<v0::StorageChangeSet>(
-                felt!("0x1").into(),
-                StorageEntryChangeList { key: felt!("0x2"), block_list: vec![1, 3] },
-            )
-            .unwrap();
-            tx.put::<v0::StorageChangeSet>(
-                felt!("0x2").into(),
-                StorageEntryChangeList { key: felt!("0x3"), block_list: vec![4, 5] },
-            )
-            .unwrap();
-
             tx.put::<v0::NonceChanges>(
                 1,
                 ContractNonceChange { contract_address: felt!("0x1").into(), nonce: felt!("0x2") },
@@ -181,9 +166,59 @@ mod tests {
             )
             .unwrap();
 
-            tx.put::<v0::NonceChanges>(
+            tx.put::<v0::ContractClassChanges>(
                 1,
-                ContractNonceChange { contract_address: felt!("0x1").into(), nonce: felt!("0x2") },
+                ContractClassChange {
+                    contract_address: felt!("0x1").into(),
+                    class_hash: felt!("0x1"),
+                },
+            )
+            .unwrap();
+            tx.put::<v0::ContractClassChanges>(
+                1,
+                ContractClassChange {
+                    contract_address: felt!("0x2").into(),
+                    class_hash: felt!("0x1"),
+                },
+            )
+            .unwrap();
+
+            tx.put::<v0::StorageChangeSet>(
+                felt!("0x1").into(),
+                StorageEntryChangeList { key: felt!("0x1"), block_list: vec![1, 2] },
+            )
+            .unwrap();
+            tx.put::<v0::StorageChangeSet>(
+                felt!("0x1").into(),
+                StorageEntryChangeList { key: felt!("0x2"), block_list: vec![1, 3] },
+            )
+            .unwrap();
+            tx.put::<v0::StorageChangeSet>(
+                felt!("0x2").into(),
+                StorageEntryChangeList { key: felt!("0x3"), block_list: vec![4, 5] },
+            )
+            .unwrap();
+
+            tx.put::<v0::StorageChanges>(
+                1,
+                ContractStorageEntry {
+                    key: ContractStorageKey {
+                        contract_address: felt!("0x1").into(),
+                        key: felt!("0x1"),
+                    },
+                    value: felt!("0x1"),
+                },
+            )
+            .unwrap();
+            tx.put::<v0::StorageChanges>(
+                3,
+                ContractStorageEntry {
+                    key: ContractStorageKey {
+                        contract_address: felt!("0x1").into(),
+                        key: felt!("0x2"),
+                    },
+                    value: felt!("0x2"),
+                },
             )
             .unwrap();
         })

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -4,7 +4,6 @@ use std::mem;
 use std::path::Path;
 
 use anyhow::{anyhow, Context};
-
 use libmdbx::DatabaseFlags;
 use tempfile::NamedTempFile;
 use tracing::trace;
@@ -14,9 +13,8 @@ use crate::error::DatabaseError;
 use crate::mdbx::DbEnv;
 use crate::models::list::BlockList;
 use crate::models::storage::ContractStorageKey;
-use crate::tables::Schema;
-use crate::tables::Table;
-use crate::tables::{v0::SchemaV0, SchemaV1};
+use crate::tables::v0::SchemaV0;
+use crate::tables::{Schema, SchemaV1, Table};
 use crate::version::{
     create_db_version_file, get_db_version, remove_db_version_file, DatabaseVersionError,
 };
@@ -84,7 +82,6 @@ pub fn migrate_db<P: AsRef<Path>>(path: P) -> Result<(), DatabaseMigrationError>
 /// - Changed table type from dupsort to normal table.
 /// - Changed key type to [ContractStorageKey](crate::models::storage::ContractStorageKey).
 /// - Changed value type to [BlockList](crate::models::list::BlockList).
-///
 #[tracing::instrument(target = "katana::db", skip(env))]
 fn migrate_from_v0_to_v1(env: DbEnv<tables::v0::SchemaV0>) -> Result<(), DatabaseMigrationError> {
     macro_rules! create_table {
@@ -339,7 +336,8 @@ mod tests {
         (db, path)
     }
 
-    // TODO(kariy): create Arbitrary for database key/value types to easily create random test vectors
+    // TODO(kariy): create Arbitrary for database key/value types to easily create random test
+    // vectors
     fn create_v0_test_db() -> (DbEnv<v0::SchemaV0>, PathBuf) {
         let path = tempfile::TempDir::new().expect(ERROR_CREATE_TEMP_DIR).into_path();
         let db = crate::init_db_with_schema::<v0::SchemaV0>(&path).expect(ERROR_INIT_DB);
@@ -388,7 +386,8 @@ mod tests {
 
     #[test]
     fn migrate_from_v0() {
-        // we cant have multiple instances of the db open in the same process, so we drop here first before migrating
+        // we cant have multiple instances of the db open in the same process, so we drop here first
+        // before migrating
         let (_, path) = create_v0_test_db();
         let _ = migrate_db(&path).expect(ERROR_MIGRATE_DB);
         let env = open_db(path).unwrap();

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -186,77 +186,31 @@ mod tests {
         let db = crate::init_db_with_schema::<v0::SchemaV0>(&path).expect(ERROR_INIT_DB);
 
         db.update(|tx| {
-            tx.put::<v0::NonceChanges>(
-                1,
-                ContractNonceChange { contract_address: felt!("0x1").into(), nonce: felt!("0x2") },
-            )
-            .unwrap();
-            tx.put::<v0::NonceChanges>(
-                1,
-                ContractNonceChange { contract_address: felt!("0x2").into(), nonce: felt!("0x2") },
-            )
-            .unwrap();
-            tx.put::<v0::NonceChanges>(
-                3,
-                ContractNonceChange { contract_address: felt!("0x3").into(), nonce: felt!("0x2") },
-            )
-            .unwrap();
+            let val1 = ContractNonceChange::new(felt!("0x1").into(), felt!("0x2"));
+            let val2 = ContractNonceChange::new(felt!("0x2").into(), felt!("0x2"));
+            let val3 = ContractNonceChange::new(felt!("0x3").into(), felt!("0x2"));
+            tx.put::<v0::NonceChanges>(1, val1).unwrap();
+            tx.put::<v0::NonceChanges>(1, val2).unwrap();
+            tx.put::<v0::NonceChanges>(3, val3).unwrap();
 
-            tx.put::<v0::ContractClassChanges>(
-                1,
-                ContractClassChange {
-                    contract_address: felt!("0x1").into(),
-                    class_hash: felt!("0x1"),
-                },
-            )
-            .unwrap();
-            tx.put::<v0::ContractClassChanges>(
-                1,
-                ContractClassChange {
-                    contract_address: felt!("0x2").into(),
-                    class_hash: felt!("0x1"),
-                },
-            )
-            .unwrap();
+            let val1 = ContractClassChange::new(felt!("0x1").into(), felt!("0x1"));
+            let val2 = ContractClassChange::new(felt!("0x2").into(), felt!("0x1"));
+            tx.put::<v0::ContractClassChanges>(1, val1).unwrap();
+            tx.put::<v0::ContractClassChanges>(1, val2).unwrap();
 
-            tx.put::<v0::StorageChangeSet>(
-                felt!("0x1").into(),
-                StorageEntryChangeList { key: felt!("0x1"), block_list: vec![1, 2] },
-            )
-            .unwrap();
-            tx.put::<v0::StorageChangeSet>(
-                felt!("0x1").into(),
-                StorageEntryChangeList { key: felt!("0x2"), block_list: vec![1, 3] },
-            )
-            .unwrap();
-            tx.put::<v0::StorageChangeSet>(
-                felt!("0x2").into(),
-                StorageEntryChangeList { key: felt!("0x3"), block_list: vec![4, 5] },
-            )
-            .unwrap();
+            let val1 = StorageEntryChangeList::new(felt!("0x1"), vec![1, 2]);
+            let val2 = StorageEntryChangeList::new(felt!("0x2"), vec![1, 3]);
+            let val3 = StorageEntryChangeList::new(felt!("0x3"), vec![4, 5]);
+            tx.put::<v0::StorageChangeSet>(felt!("0x1").into(), val1).unwrap();
+            tx.put::<v0::StorageChangeSet>(felt!("0x1").into(), val2).unwrap();
+            tx.put::<v0::StorageChangeSet>(felt!("0x2").into(), val3).unwrap();
 
-            tx.put::<v0::StorageChanges>(
-                1,
-                ContractStorageEntry {
-                    key: ContractStorageKey {
-                        contract_address: felt!("0x1").into(),
-                        key: felt!("0x1"),
-                    },
-                    value: felt!("0x1"),
-                },
-            )
-            .unwrap();
-            tx.put::<v0::StorageChanges>(
-                3,
-                ContractStorageEntry {
-                    key: ContractStorageKey {
-                        contract_address: felt!("0x1").into(),
-                        key: felt!("0x2"),
-                    },
-                    value: felt!("0x2"),
-                },
-            )
-            .unwrap();
+            let subkey = ContractStorageKey::new(felt!("0x1").into(), felt!("0x1"));
+            let val1 = ContractStorageEntry::new(subkey, felt!("0x1"));
+            let subkey = ContractStorageKey::new(felt!("0x1").into(), felt!("0x2"));
+            let val2 = ContractStorageEntry::new(subkey, felt!("0x2"));
+            tx.put::<v0::StorageChanges>(1, val1).unwrap();
+            tx.put::<v0::StorageChanges>(3, val2).unwrap();
         })
         .expect(ERROR_INIT_DB);
 

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -2,14 +2,12 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context};
 
-use crate::{
-    error::DatabaseError,
-    mdbx::DbEnv,
-    models::{list::BlockList, storage::ContractStorageKey},
-    open_db, tables,
-    version::{create_db_version_file, get_db_version, DatabaseVersionError},
-    CURRENT_DB_VERSION,
-};
+use crate::error::DatabaseError;
+use crate::mdbx::DbEnv;
+use crate::models::list::BlockList;
+use crate::models::storage::ContractStorageKey;
+use crate::version::{create_db_version_file, get_db_version, DatabaseVersionError};
+use crate::{open_db, tables, CURRENT_DB_VERSION};
 
 #[derive(Debug, thiserror::Error)]
 pub enum DatabaseMigrationError {
@@ -101,10 +99,12 @@ fn migrate_from_v0_to_v1(env: DbEnv) -> Result<(), DatabaseMigrationError> {
 #[cfg(test)]
 mod tests {
 
-    use crate::{init_db, mdbx::DbEnv, open_db, version::create_db_version_file};
     use std::path::PathBuf;
 
     use super::migrate_db;
+    use crate::mdbx::DbEnv;
+    use crate::version::create_db_version_file;
+    use crate::{init_db, open_db};
 
     const ERROR_CREATE_TEMP_DIR: &str = "Failed to create temp dir.";
     const ERROR_MIGRATE_DB: &str = "Failed to migrate db.";

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -126,7 +126,7 @@ mod tests {
     use crate::models::contract::{ContractClassChange, ContractNonceChange};
     use crate::models::list::BlockList;
     use crate::models::storage::{ContractStorageEntry, ContractStorageKey};
-    use crate::tables::v0::{ContractClassChanges, StorageEntryChangeList};
+    use crate::tables::v0::StorageEntryChangeList;
     use crate::version::create_db_version_file;
     use crate::{init_db, open_db, tables};
 

--- a/crates/katana/storage/db/src/migration.rs
+++ b/crates/katana/storage/db/src/migration.rs
@@ -127,14 +127,11 @@ mod tests {
     use crate::models::list::BlockList;
     use crate::models::storage::{ContractStorageEntry, ContractStorageKey};
     use crate::tables::v0::StorageEntryChangeList;
-    use crate::version::create_db_version_file;
-    use crate::{init_db, open_db, tables};
+    use crate::{init_db, tables};
 
     const ERROR_CREATE_TEMP_DIR: &str = "Failed to create temp dir.";
     const ERROR_MIGRATE_DB: &str = "Failed to migrate db.";
     const ERROR_INIT_DB: &str = "Failed to initialize db.";
-    const ERROR_CREATE_TABLES: &str = "Failed to create tables.";
-    const ERROR_CREATE_VER_FILE: &str = "Failed to create version file.";
 
     fn create_test_db() -> (DbEnv, PathBuf) {
         let path = tempfile::TempDir::new().expect(ERROR_CREATE_TEMP_DIR).into_path();
@@ -145,10 +142,7 @@ mod tests {
     // TODO(kariy): create Arbitrary for database key/value types to easily create random test vectors
     fn create_v0_test_db() -> (DbEnv, PathBuf) {
         let path = tempfile::TempDir::new().expect(ERROR_CREATE_TEMP_DIR).into_path();
-
-        let db = open_db(&path).expect(ERROR_INIT_DB);
-        let _ = db.create_v0_tables().expect(ERROR_CREATE_TABLES);
-        let _ = create_db_version_file(&path, 0).expect(ERROR_CREATE_VER_FILE);
+        let db = crate::init_db_with_schema::<tables::v0::Tables>(&path).expect(ERROR_INIT_DB);
 
         db.update(|tx| {
             tx.put::<v0::NonceChanges>(

--- a/crates/katana/storage/db/src/models/contract.rs
+++ b/crates/katana/storage/db/src/models/contract.rs
@@ -18,6 +18,12 @@ pub struct ContractClassChange {
     pub class_hash: ClassHash,
 }
 
+impl ContractClassChange {
+    pub fn new(contract_address: ContractAddress, class_hash: ClassHash) -> Self {
+        Self { contract_address, class_hash }
+    }
+}
+
 impl Compress for ContractClassChange {
     type Compressed = Vec<u8>;
     fn compress(self) -> Self::Compressed {
@@ -42,6 +48,12 @@ pub struct ContractNonceChange {
     pub contract_address: ContractAddress,
     /// The updated nonce value of `contract_address`.
     pub nonce: Nonce,
+}
+
+impl ContractNonceChange {
+    pub fn new(contract_address: ContractAddress, nonce: Nonce) -> Self {
+        Self { contract_address, nonce }
+    }
 }
 
 impl Compress for ContractNonceChange {

--- a/crates/katana/storage/db/src/models/list.rs
+++ b/crates/katana/storage/db/src/models/list.rs
@@ -40,6 +40,12 @@ impl IntegerSet {
     }
 }
 
+impl FromIterator<u64> for IntegerSet {
+    fn from_iter<T: IntoIterator<Item = u64>>(iter: T) -> Self {
+        Self(RoaringTreemap::from_iter(iter))
+    }
+}
+
 impl<const N: usize> From<[u64; N]> for IntegerSet {
     fn from(arr: [u64; N]) -> Self {
         Self(RoaringTreemap::from_iter(arr))

--- a/crates/katana/storage/db/src/models/storage.rs
+++ b/crates/katana/storage/db/src/models/storage.rs
@@ -40,6 +40,12 @@ pub struct ContractStorageKey {
     pub key: StorageKey,
 }
 
+impl ContractStorageKey {
+    pub fn new(contract_address: ContractAddress, key: StorageKey) -> Self {
+        Self { contract_address, key }
+    }
+}
+
 impl Encode for ContractStorageKey {
     type Encoded = [u8; 64];
     fn encode(self) -> Self::Encoded {

--- a/crates/katana/storage/db/src/models/storage.rs
+++ b/crates/katana/storage/db/src/models/storage.rs
@@ -71,6 +71,12 @@ pub struct ContractStorageEntry {
     pub value: StorageValue,
 }
 
+impl ContractStorageEntry {
+    pub fn new(key: ContractStorageKey, value: StorageValue) -> Self {
+        Self { key, value }
+    }
+}
+
 impl Compress for ContractStorageEntry {
     type Compressed = Vec<u8>;
     fn compress(self) -> Self::Compressed {

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -38,6 +38,11 @@ define_schema_enum! {
     (StorageChangeSet, TableType::DupSort)
 ]}
 
+// TODO(kariy): maybe add database changelog ?
+//
+// Refer to:
+// - https://github.com/dojoengine/dojo/pull/1773
+// - https://github.com/dojoengine/dojo/pull/1774
 tables! {
     /// Contract nonce changes by block.
     NonceChanges: (BlockNumber, ContractAddress) => ContractNonceChange,

--- a/crates/katana/storage/db/src/tables/v0.rs
+++ b/crates/katana/storage/db/src/tables/v0.rs
@@ -64,6 +64,12 @@ pub struct StorageEntryChangeList {
     pub block_list: Vec<BlockNumber>,
 }
 
+impl StorageEntryChangeList {
+    pub fn new(key: StorageKey, block_list: Vec<BlockNumber>) -> Self {
+        Self { key, block_list }
+    }
+}
+
 // The `key` field is the subkey of the dupsort table, so we must use
 // the Encode and Decode traits  when de/serializing it to the database.
 impl Compress for StorageEntryChangeList {

--- a/crates/katana/storage/db/src/version.rs
+++ b/crates/katana/storage/db/src/version.rs
@@ -77,6 +77,12 @@ pub(super) fn default_version_file_path(path: &Path) -> PathBuf {
     path.join(DB_VERSION_FILE_NAME)
 }
 
+pub(super) fn remove_db_version_file(path: impl AsRef<Path>) -> Result<(), DatabaseVersionError> {
+    let path = path.as_ref();
+    let path = if path.is_dir() { default_version_file_path(path) } else { path.to_path_buf() };
+    fs::remove_file(path).map_err(DatabaseVersionError::Io)
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/crates/katana/storage/db/src/version.rs
+++ b/crates/katana/storage/db/src/version.rs
@@ -51,10 +51,12 @@ pub(super) fn create_db_version_file(
 /// Check the version of the database at the given `path`.
 ///
 /// Returning `Ok` if the version matches with [`CURRENT_DB_VERSION`], otherwise `Err` is returned.
-pub(super) fn check_db_version(path: impl AsRef<Path>) -> Result<(), DatabaseVersionError> {
+pub(super) fn check_db_version<S: Schema>(
+    path: impl AsRef<Path>,
+) -> Result<(), DatabaseVersionError> {
     let version = get_db_version(path)?;
-    if version != CURRENT_DB_VERSION {
-        Err(DatabaseVersionError::MismatchVersion { expected: CURRENT_DB_VERSION, found: version })
+    if version != S::VERSION {
+        Err(DatabaseVersionError::MismatchVersion { expected: S::VERSION, found: version })
     } else {
         Ok(())
     }


### PR DESCRIPTION
- add a migration process when initiating katana's db.
- migrate the db schema from older version to the current version that the katana instance supports