### PR TITLE
fix: handle invalid version validation for installation script

### DIFF
--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -139,7 +139,7 @@ main() {
     # Check if the version mentioned by user exists in the Dojo repository.
     if ! curl --output /dev/null --silent --head --fail "$BIN_ARCHIVE_URL"; then
       say "Version ${DOJOUP_VERSION} does not exist at ${RELEASE_URL%/}"
-      say "Please mention a valid version."
+      say "Please specify a valid version, or omit -v to install the latest stable version automatically."
       err "Aborting installation."
     fi
 

--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -138,7 +138,7 @@ main() {
 
     # Check if the version mentioned by user exists in the Dojo repository.
     if ! curl --output /dev/null --silent --head --fail "$BIN_ARCHIVE_URL"; then
-      say "Version ${DOJOUP_VERSION} does not exist at ${RELEASE_URL%/}"
+      say "Version ${DOJOUP_VERSION} does not match any release listed at https://github.com/dojoengine/dojo/releases."
       say "Please specify a valid version, or omit -v to install the latest stable version automatically."
       err "Aborting installation."
     fi

--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -73,6 +73,9 @@ main() {
 
   DOJOUP_REPO=${DOJOUP_REPO-dojoengine/dojo}
 
+  # Store user specified version seperately
+  DOJOUP_USER_VERSION=${DOJOUP_VERSION}
+
   # Install by downloading binaries
   if [[ "$DOJOUP_REPO" == "dojoengine/dojo" && -z "$DOJOUP_BRANCH" && -z "$DOJOUP_COMMIT" ]]; then
     DOJOUP_VERSION=${DOJOUP_VERSION-stable}
@@ -142,8 +145,12 @@ main() {
 
     echo $BIN_ARCHIVE_URL
 
-    # Download and extract the binaries archive
+    # display message only if version is not mentioned by user
+    if [ ! -n "$DOJOUP_USER_VERSION" ]; then
     say "downloading latest dojo"
+    fi
+
+    # Download and extract the binaries archive
     if [ "$PLATFORM" = "win32" ]; then
       tmp="$(mktemp -d 2>/dev/null || echo ".")/dojo.zip"
       ensure download "$BIN_ARCHIVE_URL" "$tmp"

--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -133,6 +133,13 @@ main() {
     RELEASE_URL="https://github.com/${DOJOUP_REPO}/releases/download/${DOJOUP_TAG}/"
     BIN_ARCHIVE_URL="${RELEASE_URL}dojo_${DOJOUP_VERSION}_${PLATFORM}_${ARCHITECTURE}.$EXT"
 
+    # Check if the version mentioned by user exists in the Dojo repository.
+    if ! curl --output /dev/null --silent --head --fail "$BIN_ARCHIVE_URL"; then
+      say "Version ${DOJOUP_VERSION} does not exist at ${RELEASE_URL%/}"
+      say "Please mention a valid version."
+      err "Aborting installation."
+    fi
+
     echo $BIN_ARCHIVE_URL
 
     # Download and extract the binaries archive

--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -73,7 +73,7 @@ main() {
 
   DOJOUP_REPO=${DOJOUP_REPO-dojoengine/dojo}
 
-  # Store user specified version seperately
+  # Store user specified version seperately.
   DOJOUP_USER_VERSION=${DOJOUP_VERSION}
 
   # Install by downloading binaries

--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -145,7 +145,7 @@ main() {
 
     echo $BIN_ARCHIVE_URL
 
-    # display message only if version is not mentioned by user
+    # Display message only if version is not mentioned by user.
     if [ ! -n "$DOJOUP_USER_VERSION" ]; then
       say "downloading latest dojo"
     fi

--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -147,7 +147,7 @@ main() {
 
     # display message only if version is not mentioned by user
     if [ ! -n "$DOJOUP_USER_VERSION" ]; then
-    say "downloading latest dojo"
+      say "downloading latest dojo"
     fi
 
     # Download and extract the binaries archive


### PR DESCRIPTION
fix: https://github.com/dojoengine/dojo/issues/1831

- dojoup script will fail with proper error handling when invalid version is mentioned by the user while installation.
- currently `downloading latest dojo` was being displayed in spite of the user downloading a mentioned version. Fixed that by displaying the message only when a version is not provided by the user in the command