### PR TITLE
fix(katana): expected module path in json logs

### DIFF
--- a/crates/katana/runner/src/utils.rs
+++ b/crates/katana/runner/src/utils.rs
@@ -23,7 +23,7 @@ pub fn wait_for_server_started_and_signal(path: &Path, stdout: ChildStdout, send
         let line = line.expect("failed to read line from subprocess stdout");
         writeln!(log_writer, "{}", line).expect("failed to write to log file");
 
-        if line.contains(r#""target":"katana""#) {
+        if line.contains(r#""target":"katana::cli""#) {
             sender.send(()).expect("failed to send start signal");
         }
     }


### PR DESCRIPTION
seems like this change was made in: https://github.com/dojoengine/dojo/pull/1702

https://github.com/dojoengine/dojo/pull/1702/files#diff-ffe1d3f22e2ddc3f1f496a1271db7c7b842862592ef71db7692a40be928aeefdR121

where author updated the target to be `katana::cli` instead of default which i think is crate name `katana` because of which we would never send a signal on channel and any tests running with `KatanaRunner` would timeout and would fail