### PR TITLE
fix(katana-provider): temporarily invalidate cache if nonce or class hash is default value

### DIFF
--- a/crates/katana/storage/provider/src/providers/fork/backend.rs
+++ b/crates/katana/storage/provider/src/providers/fork/backend.rs
@@ -353,7 +353,22 @@ impl ContractInfoProvider for SharedStateProvider {
 
 impl StateProvider for SharedStateProvider {
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
-        if let nonce @ Some(_) = self.contract(address)?.map(|i| i.nonce) {
+        // TEMP:
+        //
+        // The nonce and class hash are stored in the same struct, so if we call either `nonce` or
+        // `class_hash_of_contract` first, the other would be filled with the default value.
+        // Currently, the data types that we're using doesn't allow us to distinguish between
+        // 'not fetched' vs the actual value.
+        //
+        // Right now, if the nonce value is 0, we couldn't distinguish whether that is the actual
+        // value or just the default value. So this filter is a pessimistic approach to always
+        // invalidate 0 nonce value in the cache.
+        //
+        // Similar story with `class_hash_of_contract`
+        //
+        if let nonce @ Some(_) =
+            self.contract(address)?.map(|i| i.nonce).filter(|n| n != &Nonce::ZERO)
+        {
             return Ok(nonce);
         }
 
@@ -413,7 +428,10 @@ impl StateProvider for SharedStateProvider {
         &self,
         address: ContractAddress,
     ) -> ProviderResult<Option<ClassHash>> {
-        if let hash @ Some(_) = self.contract(address)?.map(|i| i.class_hash) {
+        // See comment at `nonce` for the explanation of this filter.
+        if let hash @ Some(_) =
+            self.contract(address)?.map(|i| i.class_hash).filter(|h| h != &ClassHash::ZERO)
+        {
             return Ok(hash);
         }
 

--- a/crates/katana/storage/provider/src/providers/fork/backend.rs
+++ b/crates/katana/storage/provider/src/providers/fork/backend.rs
@@ -364,6 +364,9 @@ impl StateProvider for SharedStateProvider {
         // value or just the default value. So this filter is a pessimistic approach to always
         // invalidate 0 nonce value in the cache.
         //
+        // Meaning, if the nonce is 0, we always fetch the nonce from the forked provider, even if
+        // we already fetched it before.
+        //
         // Similar story with `class_hash_of_contract`
         //
         if let nonce @ Some(_) =

--- a/crates/katana/storage/provider/src/providers/fork/state.rs
+++ b/crates/katana/storage/provider/src/providers/fork/state.rs
@@ -38,14 +38,22 @@ impl StateProvider for ForkedStateDb {
         &self,
         address: ContractAddress,
     ) -> ProviderResult<Option<ClassHash>> {
-        if let hash @ Some(_) = self.contract_state.read().get(&address).map(|i| i.class_hash) {
+        if let hash @ Some(_) = self
+            .contract_state
+            .read()
+            .get(&address)
+            .map(|i| i.class_hash)
+            .filter(|h| h != &ClassHash::ZERO)
+        {
             return Ok(hash);
         }
         StateProvider::class_hash_of_contract(&self.db, address)
     }
 
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
-        if let nonce @ Some(_) = self.contract_state.read().get(&address).map(|i| i.nonce) {
+        if let nonce @ Some(_) =
+            self.contract_state.read().get(&address).map(|i| i.nonce).filter(|n| n != &Nonce::ZERO)
+        {
             return Ok(nonce);
         }
         StateProvider::nonce(&self.db, address)
@@ -148,7 +156,13 @@ impl ContractInfoProvider for ForkedSnapshot {
 
 impl StateProvider for ForkedSnapshot {
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
-        if let nonce @ Some(_) = self.inner.contract_state.get(&address).map(|info| info.nonce) {
+        if let nonce @ Some(_) = self
+            .inner
+            .contract_state
+            .get(&address)
+            .map(|info| info.nonce)
+            .filter(|n| n != &Nonce::ZERO)
+        {
             return Ok(nonce);
         }
         StateProvider::nonce(&self.inner.db, address)
@@ -171,8 +185,12 @@ impl StateProvider for ForkedSnapshot {
         &self,
         address: ContractAddress,
     ) -> ProviderResult<Option<ClassHash>> {
-        if let class_hash @ Some(_) =
-            self.inner.contract_state.get(&address).map(|info| info.class_hash)
+        if let class_hash @ Some(_) = self
+            .inner
+            .contract_state
+            .get(&address)
+            .map(|info| info.class_hash)
+            .filter(|h| h != &ClassHash::ZERO)
         {
             return Ok(class_hash);
         }


### PR DESCRIPTION
invalidate the local nonce or class hash value for forked provider if they are `0`.

The reason why we do this is because the nonce and class hash are stored within the same struct (ie `GenericContractInfo`), and to give some context, forked provider works like this:

1. find value in local storage
2. if value exist, return. but if not,
3. fetch from remote network, and store in local storage

these steps are done for each of the methods within the `StateProvider` trait. So when the `StateProvider::nonce()` is called, it will find in local, if not found then fallback to remote network. Once it receives the value from the remote network, it will store locally in the `GenericContractInfo` struct. AND BECAUSE this struct is used to store both the nonce AND the class hash, so when we create it for the first time (either thru `StateProvider::nonce()` or `StateProvider::class_hash_of_contract()`), the other field would be set to its default value. 

The issue happens when you're calling `StateProvider::class_hash_of_contract()` after `StateProvider::nonce()` (or vice versa), the class hash returned will be `ZERO`. Because it sees that the corresponding `GenericContractInfo` exist and extract the class hash from there.

---

NOTE:

this would mainly be a temporary fix until we're able to use a better data types to represent 'not yet fetched' and 'default value'.