### PR TITLE
fix(katana): wrong `from_address` value taken from the transaction trace

### DIFF
--- a/crates/katana/executor/src/implementation/blockifier/output.rs
+++ b/crates/katana/executor/src/implementation/blockifier/output.rs
@@ -92,7 +92,7 @@ fn l2_to_l1_messages_from_exec_info(info: &TxExecInfo) -> Vec<MessageToL1> {
         let mut messages = vec![];
 
         messages.extend(info.l2_to_l1_messages.iter().map(|m| MessageToL1 {
-            from_address: info.contract_address,
+            from_address: m.from_address,
             payload: m.payload.clone(),
             to_address: m.to_address,
         }));

--- a/crates/katana/executor/src/implementation/blockifier/output.rs
+++ b/crates/katana/executor/src/implementation/blockifier/output.rs
@@ -57,17 +57,8 @@ fn events_from_exec_info(info: &TxExecInfo) -> Vec<Event> {
     fn get_events_recursively(call_info: &CallInfo) -> Vec<Event> {
         let mut events: Vec<Event> = vec![];
 
-        // By default, `from_address` must correspond to the contract address that
-        // is sending the message. In the case of library calls, `code_address` is `None`,
-        // we then use the `caller_address` instead (which can also be an account).
-        let from_address = if let Some(code_address) = call_info.code_address {
-            code_address
-        } else {
-            call_info.caller_address
-        };
-
         events.extend(call_info.events.iter().map(|e| Event {
-            from_address,
+            from_address: call_info.contract_address,
             data: e.data.clone(),
             keys: e.keys.clone(),
         }));
@@ -100,17 +91,8 @@ fn l2_to_l1_messages_from_exec_info(info: &TxExecInfo) -> Vec<MessageToL1> {
     fn get_messages_recursively(info: &CallInfo) -> Vec<MessageToL1> {
         let mut messages = vec![];
 
-        // By default, `from_address` must correspond to the contract address that
-        // is sending the message. In the case of library calls, `code_address` is `None`,
-        // we then use the `caller_address` instead (which can also be an account).
-        let from_address = if let Some(code_address) = info.code_address {
-            code_address
-        } else {
-            info.caller_address
-        };
-
         messages.extend(info.l2_to_l1_messages.iter().map(|m| MessageToL1 {
-            from_address,
+            from_address: info.contract_address,
             payload: m.payload.clone(),
             to_address: m.to_address,
         }));

--- a/crates/katana/executor/src/implementation/blockifier/utils.rs
+++ b/crates/katana/executor/src/implementation/blockifier/utils.rs
@@ -526,12 +526,6 @@ pub fn to_exec_info(exec_info: TransactionExecutionInfo) -> TxExecInfo {
 }
 
 fn to_call_info(call_info: CallInfo) -> katana_primitives::trace::CallInfo {
-    let message_to_l1_from_address = if let Some(a) = call_info.call.code_address {
-        to_address(a)
-    } else {
-        to_address(call_info.call.caller_address)
-    };
-
     katana_primitives::trace::CallInfo {
         contract_address: to_address(call_info.call.storage_address),
         caller_address: to_address(call_info.call.caller_address),
@@ -573,14 +567,11 @@ fn to_call_info(call_info: CallInfo) -> katana_primitives::trace::CallInfo {
             .execution
             .l2_to_l1_messages
             .iter()
-            .map(|m| {
-                let to_address = starknet_api_ethaddr_to_felt(m.message.to_address);
-                katana_primitives::message::OrderedL2ToL1Message {
-                    order: m.order as u64,
-                    from_address: message_to_l1_from_address,
-                    to_address,
-                    payload: m.message.payload.0.iter().map(|f| (*f).into()).collect(),
-                }
+            .map(|m| katana_primitives::message::OrderedL2ToL1Message {
+                order: m.order as u64,
+                from_address: to_address(call_info.call.storage_address),
+                to_address: starknet_api_ethaddr_to_felt(m.message.to_address),
+                payload: m.message.payload.0.iter().map(|f| (*f).into()).collect(),
             })
             .collect(),
         storage_read_values: call_info.storage_read_values.into_iter().map(|f| f.into()).collect(),

--- a/crates/katana/executor/src/implementation/sir/output.rs
+++ b/crates/katana/executor/src/implementation/sir/output.rs
@@ -57,17 +57,8 @@ fn events_from_exec_info(info: &TxExecInfo) -> Vec<Event> {
     fn get_events_recursively(call_info: &CallInfo) -> Vec<Event> {
         let mut events: Vec<Event> = vec![];
 
-        // By default, `from_address` must correspond to the contract address that
-        // is sending the message. In the case of library calls, `code_address` is `None`,
-        // we then use the `caller_address` instead (which can also be an account).
-        let from_address = if let Some(code_address) = call_info.code_address {
-            code_address
-        } else {
-            call_info.caller_address
-        };
-
         events.extend(call_info.events.iter().map(|e| Event {
-            from_address,
+            from_address: call_info.contract_address,
             data: e.data.clone(),
             keys: e.keys.clone(),
         }));
@@ -100,17 +91,8 @@ fn l2_to_l1_messages_from_exec_info(info: &TxExecInfo) -> Vec<MessageToL1> {
     fn get_messages_recursively(info: &CallInfo) -> Vec<MessageToL1> {
         let mut messages = vec![];
 
-        // By default, `from_address` must correspond to the contract address that
-        // is sending the message. In the case of library calls, `code_address` is `None`,
-        // we then use the `caller_address` instead (which can also be an account).
-        let from_address = if let Some(code_address) = info.code_address {
-            code_address
-        } else {
-            info.caller_address
-        };
-
         messages.extend(info.l2_to_l1_messages.iter().map(|m| MessageToL1 {
-            from_address,
+            from_address: m.from_address,
             to_address: m.to_address,
             payload: m.payload.clone(),
         }));

--- a/crates/katana/executor/src/implementation/sir/utils.rs
+++ b/crates/katana/executor/src/implementation/sir/utils.rs
@@ -560,12 +560,6 @@ pub fn to_exec_info(exec_info: &TransactionExecutionInfo) -> TxExecInfo {
 }
 
 fn from_sir_call_info(call_info: CallInfo) -> katana_primitives::trace::CallInfo {
-    let message_to_l1_from_address = if let Some(ref a) = call_info.code_address {
-        to_address(a)
-    } else {
-        to_address(&call_info.caller_address)
-    };
-
     katana_primitives::trace::CallInfo {
         contract_address: to_address(&call_info.contract_address),
         caller_address: to_address(&call_info.caller_address),
@@ -616,7 +610,7 @@ fn from_sir_call_info(call_info: CallInfo) -> katana_primitives::trace::CallInfo
             .iter()
             .map(|m| katana_primitives::message::OrderedL2ToL1Message {
                 order: m.order as u64,
-                from_address: message_to_l1_from_address,
+                from_address: to_address(&call_info.contract_address),
                 to_address: *to_address(&m.to_address),
                 payload: m.payload.iter().map(to_felt).collect(),
             })

--- a/crates/katana/primitives/src/trace.rs
+++ b/crates/katana/primitives/src/trace.rs
@@ -32,10 +32,13 @@ pub struct ExecutionResources {
     pub builtin_instance_counter: HashMap<String, u64>,
 }
 
+/// The call type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CallType {
+    /// Normal contract call.
     Call,
+    /// Library call.
     Delegate,
 }
 
@@ -55,6 +58,10 @@ pub struct CallInfo {
     /// The call type.
     pub call_type: CallType,
     /// The contract address.
+    ///
+    /// The contract address of the current call execution context. This would be the address of
+    /// the contract whose code is currently being executed, or in the case of library call, the
+    /// address of the contract where the library call is being initiated from.
     pub contract_address: ContractAddress,
     /// The address where the code is being executed.
     /// Optional, since there is no address to the code implementation in a delegate call.


### PR DESCRIPTION
fix event/messages using wrong `from_address` value. 

we use the contract address (or storage address on blockifier types) for the current call execution context as the `from_address`. `caller_address` will be zero if the call is a top level call (ie the first call in the transaction)

ref #1279 