### PR TITLE
CI: add workflow_dispatch for devcontainer.yml

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,6 +1,7 @@
 name: devcontainer
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - ".devcontainer/**"
@@ -40,7 +41,7 @@ jobs:
           echo "tag_name=$DOCKER_TAG" >> $GITHUB_OUTPUT
 
       - name: Set Docker tag for push event
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c 1-7)
           echo "DOCKER_TAG=$SHORT_SHA" >> $GITHUB_ENV

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -2,6 +2,11 @@ name: devcontainer
 
 on:
   workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: Descriptive name of the devcontainer for the Docker tag
+        required: true
+        type: string
   push:
     paths:
       - ".devcontainer/**"
@@ -41,10 +46,15 @@ jobs:
           echo "tag_name=$DOCKER_TAG" >> $GITHUB_OUTPUT
 
       - name: Set Docker tag for push event
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push'
         run: |
           SHORT_SHA=$(echo "${{ github.sha }}" | cut -c 1-7)
           echo "DOCKER_TAG=$SHORT_SHA" >> $GITHUB_ENV
+
+      - name: Set Docker tag for workflow_dispatch event
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "DOCKER_TAG=${{ inputs.docker_tag }}" >> $GITHUB_ENV
 
       - name: Set outputs
         id: release_info


### PR DESCRIPTION
We should have a manual trigger to avoid pushing a new docker image anytime Katana changes, as some changes may not be related to Cairo version for instance.