### PR TITLE
fix: ensure account defaults to block pending

### DIFF
--- a/bin/sozo/src/commands/options/account.rs
+++ b/bin/sozo/src/commands/options/account.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Context, Result};
 use clap::Args;
 use dojo_world::metadata::Environment;
 use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};
-use starknet::core::types::FieldElement;
+use starknet::core::types::{BlockId, BlockTag, FieldElement};
 use starknet::providers::Provider;
 use starknet::signers::LocalWallet;
 
@@ -50,7 +50,14 @@ impl AccountOptions {
 
         let encoding = if self.legacy { ExecutionEncoding::Legacy } else { ExecutionEncoding::New };
 
-        Ok(SingleOwnerAccount::new(provider, signer, account_address, chain_id, encoding))
+        let mut account =
+            SingleOwnerAccount::new(provider, signer, account_address, chain_id, encoding);
+
+        // The default is `Latest` in starknet-rs, which does not reflect
+        // the nonce changes in the pending block.
+        account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        Ok(account)
     }
 
     fn account_address(&self, env_metadata: Option<&Environment>) -> Result<FieldElement> {

--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -15,7 +15,7 @@ use katana_rpc::{spawn, NodeHandle};
 use katana_rpc_api::ApiKind;
 use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::chain_id;
-use starknet::core::types::FieldElement;
+use starknet::core::types::{BlockId, BlockTag, FieldElement};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet::signers::{LocalWallet, SigningKey};
@@ -92,13 +92,17 @@ impl TestSequencer {
     }
 
     pub fn account(&self) -> SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet> {
-        SingleOwnerAccount::new(
+        let mut account = SingleOwnerAccount::new(
             JsonRpcClient::new(HttpTransport::new(self.url.clone())),
             LocalWallet::from_signing_key(SigningKey::from_secret_scalar(self.account.private_key)),
             self.account.account_address,
             chain_id::TESTNET,
             ExecutionEncoding::New,
-        )
+        );
+
+        account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        account
     }
 
     pub fn provider(&self) -> JsonRpcClient<HttpTransport> {
@@ -115,13 +119,17 @@ impl TestSequencer {
         let private_key = account.1.private_key().unwrap();
         let address: FieldElement = (*(account.0)).into();
 
-        SingleOwnerAccount::new(
+        let mut account = SingleOwnerAccount::new(
             JsonRpcClient::new(HttpTransport::new(self.url.clone())),
             LocalWallet::from_signing_key(SigningKey::from_secret_scalar(private_key)),
             address,
             chain_id::TESTNET,
             ExecutionEncoding::New,
-        )
+        );
+
+        account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        account
     }
 
     pub fn raw_account(&self) -> &TestAccount {

--- a/crates/katana/executor/tests/fixtures/transaction.rs
+++ b/crates/katana/executor/tests/fixtures/transaction.rs
@@ -7,7 +7,7 @@ use katana_primitives::genesis::Genesis;
 use katana_primitives::transaction::ExecutableTxWithHash;
 use katana_primitives::FieldElement;
 use starknet::accounts::{Account, Call, ExecutionEncoding, SingleOwnerAccount};
-use starknet::core::types::BroadcastedInvokeTransaction;
+use starknet::core::types::{BlockId, BlockTag, BroadcastedInvokeTransaction};
 use starknet::macros::{felt, selector};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Url};
@@ -28,13 +28,15 @@ pub fn invoke_executable_tx(
     let provider = JsonRpcClient::new(HttpTransport::new(Url::try_from(url).unwrap()));
     let signer = LocalWallet::from_signing_key(SigningKey::from_secret_scalar(private_key));
 
-    let account = SingleOwnerAccount::new(
+    let mut account = SingleOwnerAccount::new(
         provider,
         signer,
         address.into(),
         chain_id.into(),
         ExecutionEncoding::New,
     );
+
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let calls = vec![Call {
         to: DEFAULT_FEE_TOKEN_ADDRESS.into(),

--- a/crates/katana/runner/src/prefunded.rs
+++ b/crates/katana/runner/src/prefunded.rs
@@ -3,6 +3,7 @@ use katana_primitives::chain::ChainId;
 use katana_primitives::contract::ContractAddress;
 use katana_primitives::genesis::allocation::DevGenesisAccount;
 use starknet::accounts::{ExecutionEncoding, SingleOwnerAccount};
+use starknet::core::types::{BlockId, BlockTag};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet::signers::{LocalWallet, SigningKey};
@@ -36,12 +37,16 @@ impl KatanaRunner {
         debug_assert_eq!(Environment::default().chain_id, ChainId::parse("KATANA").unwrap());
         let provider = self.owned_provider();
 
-        SingleOwnerAccount::new(
+        let mut account = SingleOwnerAccount::new(
             provider,
             signer,
             account.0.into(),
             chain_id.into(),
             ExecutionEncoding::New,
-        )
+        );
+
+        account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+        account
     }
 }


### PR DESCRIPTION
Katana is often used for instant mining, but some weird issues appear when using a block time. Ensuring we're using by default the pending block is usually the expected behavior to reflect account nonces instantly.