### PR TITLE
refactor(torii): don't use feature-only type in non-feature code

### DIFF
--- a/crates/torii/client/src/client/error.rs
+++ b/crates/torii/client/src/client/error.rs
@@ -1,5 +1,6 @@
 use dojo_world::contracts::model::ModelError;
 use starknet::core::utils::{CairoShortStringToFeltError, ParseCairoShortStringError};
+use torii_grpc::types::schema::SchemaError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -22,6 +23,8 @@ pub enum Error {
     Model(#[from] ModelError),
     #[error("Unsupported query")]
     UnsupportedQuery,
+    #[error(transparent)]
+    Schema(#[from] SchemaError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -13,7 +13,6 @@ use strum_macros::{AsRefStr, EnumIter, FromRepr};
 
 use crate::proto::{self};
 
-#[cfg(feature = "client")]
 pub mod schema;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -13,6 +13,7 @@ use strum_macros::{AsRefStr, EnumIter, FromRepr};
 
 use crate::proto::{self};
 
+#[cfg(feature = "client")]
 pub mod schema;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]

--- a/crates/torii/grpc/src/types/schema.rs
+++ b/crates/torii/grpc/src/types/schema.rs
@@ -2,10 +2,20 @@ use crypto_bigint::{Encoding, U256};
 use dojo_types::primitive::Primitive;
 use dojo_types::schema::{Enum, EnumOption, Member, Struct, Ty};
 use serde::{Deserialize, Serialize};
+use starknet::core::types::FromByteSliceError;
 use starknet_crypto::FieldElement;
 
-use crate::client::Error as ClientError;
 use crate::proto::{self};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SchemaError {
+    #[error("Missing expected data")]
+    MissingExpectedData,
+    #[error("Unsupported type")]
+    UnsupportedType,
+    #[error(transparent)]
+    SliceError(#[from] FromByteSliceError),
+}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
 pub struct Entity {
@@ -20,11 +30,10 @@ pub struct Model {
 }
 
 impl TryFrom<proto::types::Entity> for Entity {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(entity: proto::types::Entity) -> Result<Self, Self::Error> {
         Ok(Self {
-            hashed_keys: FieldElement::from_byte_slice_be(&entity.hashed_keys)
-                .map_err(ClientError::SliceError)?,
+            hashed_keys: FieldElement::from_byte_slice_be(&entity.hashed_keys)?,
             models: entity
                 .models
                 .into_iter()
@@ -35,7 +44,7 @@ impl TryFrom<proto::types::Entity> for Entity {
 }
 
 impl TryFrom<proto::types::Model> for Model {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(model: proto::types::Model) -> Result<Self, Self::Error> {
         Ok(Self {
             name: model.name,
@@ -49,7 +58,7 @@ impl TryFrom<proto::types::Model> for Model {
 }
 
 impl TryFrom<Ty> for proto::types::Ty {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(ty: Ty) -> Result<Self, Self::Error> {
         let ty_type = match ty {
             Ty::Primitive(primitive) => {
@@ -65,18 +74,18 @@ impl TryFrom<Ty> for proto::types::Ty {
 }
 
 impl TryFrom<proto::types::Member> for Member {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(member: proto::types::Member) -> Result<Self, Self::Error> {
         Ok(Member {
             name: member.name,
-            ty: member.ty.ok_or(ClientError::MissingExpectedData)?.try_into()?,
+            ty: member.ty.ok_or(SchemaError::MissingExpectedData)?.try_into()?,
             key: member.key,
         })
     }
 }
 
 impl TryFrom<Member> for proto::types::Member {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(member: Member) -> Result<Self, Self::Error> {
         Ok(proto::types::Member {
             name: member.name,
@@ -119,7 +128,7 @@ impl From<Enum> for proto::types::Enum {
 }
 
 impl TryFrom<proto::types::Struct> for Struct {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(r#struct: proto::types::Struct) -> Result<Self, Self::Error> {
         Ok(Struct {
             name: r#struct.name,
@@ -133,7 +142,7 @@ impl TryFrom<proto::types::Struct> for Struct {
 }
 
 impl TryFrom<Struct> for proto::types::Struct {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(r#struct: Struct) -> Result<Self, Self::Error> {
         Ok(proto::types::Struct {
             name: r#struct.name,
@@ -147,7 +156,7 @@ impl TryFrom<Struct> for proto::types::Struct {
 }
 
 impl TryFrom<Struct> for proto::types::Model {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(r#struct: Struct) -> Result<Self, Self::Error> {
         let r#struct: proto::types::Struct = r#struct.try_into()?;
 
@@ -167,14 +176,14 @@ impl From<proto::types::Struct> for proto::types::Model {
 // warning.
 #[allow(deprecated)]
 impl TryFrom<proto::types::Primitive> for Primitive {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(primitive: proto::types::Primitive) -> Result<Self, Self::Error> {
         let primitive_type = primitive.r#type;
         let value_type = primitive
             .value
-            .ok_or(ClientError::MissingExpectedData)?
+            .ok_or(SchemaError::MissingExpectedData)?
             .value_type
-            .ok_or(ClientError::MissingExpectedData)?;
+            .ok_or(SchemaError::MissingExpectedData)?;
 
         let primitive = match &value_type {
             proto::types::value::ValueType::BoolValue(bool) => Primitive::Bool(Some(*bool)),
@@ -185,7 +194,7 @@ impl TryFrom<proto::types::Primitive> for Primitive {
                     Some(proto::types::PrimitiveType::U32) => Primitive::U32(Some(*int as u32)),
                     Some(proto::types::PrimitiveType::U64) => Primitive::U64(Some(*int)),
                     Some(proto::types::PrimitiveType::Usize) => Primitive::USize(Some(*int as u32)),
-                    _ => return Err(ClientError::UnsupportedType),
+                    _ => return Err(SchemaError::UnsupportedType),
                 }
             }
             proto::types::value::ValueType::ByteValue(bytes) => {
@@ -196,17 +205,17 @@ impl TryFrom<proto::types::Primitive> for Primitive {
                     | Some(proto::types::PrimitiveType::ContractAddress) => {
                         Primitive::Felt252(Some(
                             FieldElement::from_byte_slice_be(bytes)
-                                .map_err(ClientError::SliceError)?,
+                                .map_err(SchemaError::SliceError)?,
                         ))
                     }
                     Some(proto::types::PrimitiveType::U256) => {
                         Primitive::U256(Some(U256::from_be_slice(bytes)))
                     }
-                    _ => return Err(ClientError::UnsupportedType),
+                    _ => return Err(SchemaError::UnsupportedType),
                 }
             }
             _ => {
-                return Err(ClientError::UnsupportedType);
+                return Err(SchemaError::UnsupportedType);
             }
         };
 
@@ -215,7 +224,7 @@ impl TryFrom<proto::types::Primitive> for Primitive {
 }
 
 impl TryFrom<Primitive> for proto::types::Primitive {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(primitive: Primitive) -> Result<Self, Self::Error> {
         use proto::types::value::ValueType;
 
@@ -252,9 +261,9 @@ impl TryFrom<Primitive> for proto::types::Primitive {
 }
 
 impl TryFrom<proto::types::Ty> for Ty {
-    type Error = ClientError;
+    type Error = SchemaError;
     fn try_from(ty: proto::types::Ty) -> Result<Self, Self::Error> {
-        match ty.ty_type.ok_or(ClientError::MissingExpectedData)? {
+        match ty.ty_type.ok_or(SchemaError::MissingExpectedData)? {
             proto::types::ty::TyType::Primitive(primitive) => {
                 Ok(Ty::Primitive(primitive.try_into()?))
             }


### PR DESCRIPTION
Create a new `SchemaError` type to be used in the schema module, and replace the usage of  `ClientError` because it is feature-gated. 

Previously running `cargo check -p torii` would result in error where the `ClientError` is not found because `torii` crate doesn't rely on the `client` feature which the error type is hidden under. 