### PR TITLE
Torii external-url arg to support https

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -93,7 +93,7 @@ struct Args {
 
     /// The external url of the server, used for configuring the GraphQL Playground in a hosted
     /// environment
-    #[arg(long)]
+    #[arg(long, value_parser = parse_url)]
     external_url: Option<Url>,
 
     /// Enable Prometheus metrics.

--- a/crates/torii/graphql/src/server.rs
+++ b/crates/torii/graphql/src/server.rs
@@ -49,7 +49,17 @@ fn graphql_filter(
     );
 
     let subscription_endpoint = if let Some(external_url) = external_url {
-        format!("{external_url}/graphql/ws").replace("http", "ws")
+        let mut websocket_url = external_url.clone();
+        websocket_url.set_path("/graphql/ws");
+
+        let websocket_scheme = match websocket_url.scheme() {
+            "http" => "ws",
+            "https" => "wss",
+            _ => panic!("Invalid URL scheme"), // URL validated on input so this never hits
+        };
+
+        let _ = websocket_url.set_scheme(websocket_scheme);
+        websocket_url.to_string()
     } else {
         "/graphql/ws".to_string()
     };


### PR DESCRIPTION
Torii's external-url arg to support https scheme, this will help fix the broken subscription queries in the gql playground for Slot hosted Toriis

Current subscription error slot torii:
```
{
  "error": "Could not connect to websocket endpoint wss://api.cartridge.gg/graphql/ws. Please check if the endpoint url is correct."
}
```