### PR TITLE
fix(katana): place import inside its feature scope

### DIFF
--- a/crates/katana/storage/provider/src/error.rs
+++ b/crates/katana/storage/provider/src/error.rs
@@ -4,8 +4,6 @@ use katana_primitives::class::ClassHash;
 use katana_primitives::contract::{ContractAddress, StorageKey};
 use katana_primitives::transaction::TxNumber;
 
-use crate::providers::fork::backend::ForkedBackendError;
-
 /// Possible errors returned by the storage provider.
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
@@ -108,7 +106,7 @@ pub enum ProviderError {
     /// [ForkedProvider](crate::providers::fork::ForkedProvider).
     #[cfg(feature = "fork")]
     #[error(transparent)]
-    ForkedBackend(#[from] ForkedBackendError),
+    ForkedBackend(#[from] crate::providers::fork::backend::ForkedBackendError),
 
     /// Any error that is not covered by the other variants.
     #[error("soemthing went wrong: {0}")]


### PR DESCRIPTION
make sure `katana-provider` crate is compilable without the default features. currently running `cargo check --no-default-features` on the crate will return error:

```
  |
7 | use crate::providers::fork::backend::ForkedBackendError;
  |                       ^^^^ could not find `fork` in `providers`
  |
```

this change will fix it.