### PR TITLE
fix(docker): build `jemalloc` with 64KB pagesize for `linux/arm64`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,9 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y gcc-aarch64-linux-gnu libssl-dev
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+          # We build jemalloc with 64KB pagesize so that it works for all linux/arm64 pagesize variants
+          # See: https://github.com/jemalloc/jemalloc/issues/467
+          echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
 
       - name: Build binaries
         run: cargo build --release --bins --target ${{ matrix.job.target }}


### PR DESCRIPTION
fixes #1913 

`jemalloc` by default builds with the host pagesize. This makes a `jemalloc` thats built from a system with 4KB page size wouldnt work correctly on a 16KB page size system. Thus making the docker image not portable across systems with different page sizes. https://github.com/jemalloc/jemalloc/issues/467#issuecomment-2054282344

So we build `jemalloc` with `JEMALLOC_SYS_WITH_LG_PAGE=16` for the maximal supported page size of 64KB on `aarch64`. `jemalloc` supports page size that is larger than the system's page size: https://github.com/jemalloc/jemalloc/pull/769