### PR TITLE
feat(sozo): print-env subcommand

### DIFF
--- a/bin/sozo/src/commands/account.rs
+++ b/bin/sozo/src/commands/account.rs
@@ -84,7 +84,7 @@ pub enum AccountCommand {
 
 impl AccountArgs {
     pub fn run(self, config: &Config) -> Result<()> {
-        trace!(command = ?self.command, "Executing command.");
+        trace!(args = ?self);
         let env_metadata = utils::load_metadata_from_config(config)?;
 
         config.tokio_handle().block_on(async {

--- a/bin/sozo/src/commands/auth.rs
+++ b/bin/sozo/src/commands/auth.rs
@@ -58,7 +58,7 @@ pub enum AuthCommand {
 
 impl AuthArgs {
     pub fn run(self, config: &Config) -> Result<()> {
-        trace!(command=?self.command, "Executing Auth command.", );
+        trace!(args = ?self);
 
         let env_metadata = utils::load_metadata_from_config(config)?;
         trace!(metadata=?env_metadata, "Loaded environment.");

--- a/bin/sozo/src/commands/call.rs
+++ b/bin/sozo/src/commands/call.rs
@@ -36,7 +36,7 @@ pub struct CallArgs {
 
 impl CallArgs {
     pub fn run(self, config: &Config) -> Result<()> {
-        trace!(contract=?self.contract, entrypoint=self.entrypoint, calldata=?self.calldata, block_id=self.block_id, "Executing Call command.");
+        trace!(args = ?self);
 
         let env_metadata = utils::load_metadata_from_config(config)?;
         trace!(?env_metadata, "Loaded metadata from config.");

--- a/bin/sozo/src/commands/execute.rs
+++ b/bin/sozo/src/commands/execute.rs
@@ -42,6 +42,7 @@ pub struct ExecuteArgs {
 
 impl ExecuteArgs {
     pub fn run(self, config: &Config) -> Result<()> {
+        trace!(args = ?self);
         let env_metadata = utils::load_metadata_from_config(config)?;
 
         config.tokio_handle().block_on(async {

--- a/bin/sozo/src/commands/init.rs
+++ b/bin/sozo/src/commands/init.rs
@@ -19,6 +19,7 @@ pub struct InitArgs {
 
 impl InitArgs {
     pub fn run(self, config: &Config) -> Result<()> {
+        trace!(args = ?self);
         let target_dir = match self.path {
             Some(path) => {
                 if path.is_absolute() {
@@ -31,7 +32,7 @@ impl InitArgs {
             }
             None => current_dir().unwrap(),
         };
-        trace!(?target_dir, "Executing Init command.");
+        trace!(?target_dir);
 
         if target_dir.exists() {
             ensure!(

--- a/bin/sozo/src/commands/keystore.rs
+++ b/bin/sozo/src/commands/keystore.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 use scarb::core::Config;
 use sozo_ops::keystore;
+use tracing::trace;
 
 #[derive(Debug, Args)]
 pub struct KeystoreArgs {
@@ -67,6 +68,7 @@ pub enum KeystoreCommand {
 
 impl KeystoreArgs {
     pub fn run(self, _config: &Config) -> Result<()> {
+        trace!(args = ?self);
         match self.command {
             KeystoreCommand::New { password, force, file } => keystore::new(password, force, file),
             KeystoreCommand::FromKey { force, private_key, password, file } => {

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -54,7 +54,7 @@ pub enum MigrateCommand {
 
 impl MigrateArgs {
     pub fn run(self, config: &Config) -> Result<()> {
-        trace!(command=?self.command, "Executing Migrate command.");
+        trace!(args = ?self);
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
 
         let env_metadata = if config.manifest_path().exists() {

--- a/bin/sozo/src/commands/mod.rs
+++ b/bin/sozo/src/commands/mod.rs
@@ -1,5 +1,7 @@
+use core::fmt;
+
 use anyhow::Result;
-use clap::{command, Subcommand};
+use clap::Subcommand;
 use scarb::core::Config;
 
 pub(crate) mod account;
@@ -36,6 +38,7 @@ use model::ModelArgs;
 use print_env::PrintEnvArgs;
 use register::RegisterArgs;
 use test::TestArgs;
+use tracing::info_span;
 
 #[derive(Debug, Subcommand)]
 pub enum Commands {
@@ -74,7 +77,34 @@ pub enum Commands {
     PrintEnv(PrintEnvArgs),
 }
 
+impl fmt::Display for Commands {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Commands::Account(_) => write!(f, "Account"),
+            Commands::Keystore(_) => write!(f, "Keystore"),
+            Commands::Build(_) => write!(f, "Build"),
+            Commands::Init(_) => write!(f, "Init"),
+            Commands::Clean(_) => write!(f, "Clean"),
+            Commands::Migrate(_) => write!(f, "Migrate"),
+            Commands::Dev(_) => write!(f, "Dev"),
+            Commands::Test(_) => write!(f, "Test"),
+            Commands::Execute(_) => write!(f, "Execute"),
+            Commands::Call(_) => write!(f, "Call"),
+            Commands::Model(_) => write!(f, "Model"),
+            Commands::Register(_) => write!(f, "Register"),
+            Commands::Events(_) => write!(f, "Events"),
+            Commands::Auth(_) => write!(f, "Auth"),
+            Commands::Completions(_) => write!(f, "Completions"),
+            Commands::PrintEnv(_) => write!(f, "PrintEnv"),
+        }
+    }
+}
+
 pub fn run(command: Commands, config: &Config) -> Result<()> {
+    let name = command.to_string();
+    let span = info_span!("Subcommand", name);
+    let _span = span.enter();
+
     match command {
         Commands::Account(args) => args.run(config),
         Commands::Keystore(args) => args.run(config),

--- a/bin/sozo/src/commands/mod.rs
+++ b/bin/sozo/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod keystore;
 pub(crate) mod migrate;
 pub(crate) mod model;
 pub(crate) mod options;
+pub(crate) mod print_env;
 pub(crate) mod register;
 pub(crate) mod test;
 
@@ -32,6 +33,7 @@ use init::InitArgs;
 use keystore::KeystoreArgs;
 use migrate::MigrateArgs;
 use model::ModelArgs;
+use print_env::PrintEnvArgs;
 use register::RegisterArgs;
 use test::TestArgs;
 
@@ -68,6 +70,8 @@ pub enum Commands {
     Auth(AuthArgs),
     #[command(about = "Generate shell completion file for specified shell")]
     Completions(CompletionsArgs),
+    #[command(about = "Print information about current")]
+    PrintEnv(PrintEnvArgs),
 }
 
 pub fn run(command: Commands, config: &Config) -> Result<()> {
@@ -86,6 +90,7 @@ pub fn run(command: Commands, config: &Config) -> Result<()> {
         Commands::Model(args) => args.run(config),
         Commands::Register(args) => args.run(config),
         Commands::Events(args) => args.run(config),
+        Commands::PrintEnv(args) => args.run(config),
         Commands::Completions(args) => args.run(),
     }
 }

--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 use scarb::core::Config;
 use sozo_ops::model;
 use starknet::core::types::FieldElement;
+use tracing::trace;
 
 use super::options::starknet::StarknetOptions;
 use super::options::world::WorldOptions;
@@ -76,6 +77,7 @@ pub enum ModelCommand {
 
 impl ModelArgs {
     pub fn run(self, config: &Config) -> Result<()> {
+        trace!(args = ?self);
         let env_metadata = utils::load_metadata_from_config(config)?;
 
         config.tokio_handle().block_on(async {

--- a/bin/sozo/src/commands/options/account.rs
+++ b/bin/sozo/src/commands/options/account.rs
@@ -65,7 +65,7 @@ impl AccountOptions {
         Ok(account)
     }
 
-    fn account_address(&self, env_metadata: Option<&Environment>) -> Result<FieldElement> {
+    pub fn account_address(&self, env_metadata: Option<&Environment>) -> Result<FieldElement> {
         if let Some(address) = self.account_address {
             trace!(?address, "Account address found.");
             Ok(address)

--- a/bin/sozo/src/commands/options/signer.rs
+++ b/bin/sozo/src/commands/options/signer.rs
@@ -71,7 +71,7 @@ impl SignerOptions {
 
     pub fn private_key(&self, env_metadata: Option<&Environment>) -> Option<String> {
         if let Some(s) = &self.private_key {
-            return Some(s.to_owned());
+            Some(s.to_owned())
         } else {
             env_metadata.and_then(|env| env.private_key().map(|s| s.to_string()))
         }
@@ -79,7 +79,7 @@ impl SignerOptions {
 
     pub fn keystore_path(&self, env_metadata: Option<&Environment>) -> Option<String> {
         if let Some(s) = &self.keystore_path {
-            return Some(s.to_owned());
+            Some(s.to_owned())
         } else {
             env_metadata.and_then(|env| env.keystore_path().map(|s| s.to_string()))
         }
@@ -87,7 +87,7 @@ impl SignerOptions {
 
     pub fn keystore_password(&self, env_metadata: Option<&Environment>) -> Option<String> {
         if let Some(s) = &self.keystore_password {
-            return Some(s.to_owned());
+            Some(s.to_owned())
         } else {
             env_metadata.and_then(|env| env.keystore_password().map(|s| s.to_string()))
         }

--- a/bin/sozo/src/commands/print_env.rs
+++ b/bin/sozo/src/commands/print_env.rs
@@ -43,8 +43,8 @@ impl PrintEnvArgs {
             ui.print(format!("Account address: {account_address:#064x}"));
         }
 
-        if let Some(_) = account.signer.private_key(env_metadata.as_ref()) {
-            ui.print(format!("Private key is set. It will take precedence over keystore"))
+        if account.signer.private_key(env_metadata.as_ref()).is_some() {
+            ui.print("Private key is set. It will take precedence over keystore".to_string())
         } else if let Some(keystore_path) = account.signer.keystore_path(env_metadata.as_ref()) {
             ui.print(format!("Keystore Path: {keystore_path}"));
         }

--- a/bin/sozo/src/commands/print_env.rs
+++ b/bin/sozo/src/commands/print_env.rs
@@ -22,7 +22,7 @@ pub struct PrintEnvArgs {
 
 impl PrintEnvArgs {
     pub fn run(self, config: &Config) -> Result<()> {
-        trace!("Executing PrintEnv command.");
+        trace!(args = ?self);
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
         let ui = ws.config().ui();
 

--- a/bin/sozo/src/commands/register.rs
+++ b/bin/sozo/src/commands/register.rs
@@ -45,7 +45,7 @@ pub enum RegisterCommand {
 
 impl RegisterArgs {
     pub fn run(self, config: &Config) -> Result<()> {
-        trace!(command=?self.command, "Executing Register command.");
+        trace!(args = ?self);
         let env_metadata = utils::load_metadata_from_config(config)?;
 
         let (starknet, world, account, transaction, models) = match self.command {


### PR DESCRIPTION
adds `print-env` subcommand which prints given list of arguments (or no arguments) what values will sozo use for things like `account_address`, `world_address`, etc...