### PR TITLE
fix(katana): include full fee info in primitive receipts

### DIFF
--- a/crates/katana/core/src/backend/storage.rs
+++ b/crates/katana/core/src/backend/storage.rs
@@ -138,6 +138,7 @@ mod tests {
     use katana_primitives::block::{
         Block, FinalityStatus, GasPrices, Header, SealedBlockWithStatus,
     };
+    use katana_primitives::fee::TxFeeInfo;
     use katana_primitives::genesis::constant::{
         DEFAULT_FEE_TOKEN_ADDRESS, DEFAULT_LEGACY_ERC20_CONTRACT_CASM,
         DEFAULT_LEGACY_ERC20_CONTRACT_CLASS_HASH, DEFAULT_LEGACY_UDC_CASM,
@@ -156,6 +157,7 @@ mod tests {
     };
     use katana_provider::traits::state::StateFactoryProvider;
     use katana_provider::traits::transaction::{TransactionProvider, TransactionTraceProvider};
+    use starknet::core::types::PriceUnit;
     use starknet::macros::felt;
 
     use super::Blockchain;
@@ -254,7 +256,18 @@ mod tests {
                 .insert_block_with_states_and_receipts(
                     dummy_block.clone(),
                     StateUpdatesWithDeclaredClasses::default(),
-                    vec![Receipt::Invoke(InvokeTxReceipt::default())],
+                    vec![Receipt::Invoke(InvokeTxReceipt {
+                        revert_error: None,
+                        events: Vec::new(),
+                        messages_sent: Vec::new(),
+                        execution_resources: Default::default(),
+                        fee: TxFeeInfo {
+                            gas_price: 0,
+                            overall_fee: 0,
+                            gas_consumed: 0,
+                            unit: PriceUnit::Wei,
+                        },
+                    })],
                     vec![TxExecInfo::default()],
                 )
                 .unwrap();

--- a/crates/katana/executor/src/abstraction/mod.rs
+++ b/crates/katana/executor/src/abstraction/mod.rs
@@ -5,7 +5,6 @@ pub use error::*;
 pub use executor::*;
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
 use katana_primitives::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
-use katana_primitives::fee::TxFeeInfo;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
 use katana_primitives::trace::TxExecInfo;
@@ -105,13 +104,13 @@ pub struct EntryPointCall {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub enum ExecutionResult {
-    Success { receipt: Receipt, trace: TxExecInfo, fee: TxFeeInfo },
+    Success { receipt: Receipt, trace: TxExecInfo },
     Failed { error: ExecutionError },
 }
 
 impl ExecutionResult {
-    pub fn new_success(receipt: Receipt, trace: TxExecInfo, fee: TxFeeInfo) -> Self {
-        ExecutionResult::Success { receipt, trace, fee }
+    pub fn new_success(receipt: Receipt, trace: TxExecInfo) -> Self {
+        ExecutionResult::Success { receipt, trace }
     }
 
     pub fn new_failed(error: impl Into<ExecutionError>) -> Self {
@@ -136,13 +135,6 @@ impl ExecutionResult {
     pub fn trace(&self) -> Option<&TxExecInfo> {
         match self {
             ExecutionResult::Success { trace, .. } => Some(trace),
-            _ => None,
-        }
-    }
-
-    pub fn fee(&self) -> Option<&TxFeeInfo> {
-        match self {
-            ExecutionResult::Success { fee, .. } => Some(fee),
             _ => None,
         }
     }

--- a/crates/katana/executor/src/implementation/sir/mod.rs
+++ b/crates/katana/executor/src/implementation/sir/mod.rs
@@ -21,7 +21,7 @@ use crate::abstraction::{
     BlockExecutor, ExecutionOutput, ExecutorExt, ExecutorFactory, ExecutorResult, SimulationFlag,
     StateProviderDb,
 };
-use crate::utils::receipt_from_exec_info;
+use crate::utils::build_receipt;
 use crate::{EntryPointCall, ExecutionError, ExecutionResult, ExecutionStats, ResultAndStates};
 
 pub(crate) const LOG_TARGET: &str = "katana::executor::sir";
@@ -155,19 +155,19 @@ impl<'a> BlockExecutor<'a> for StarknetVMProcessor<'a> {
                 Ok((info, fee)) => {
                     // get the trace and receipt from the execution info
                     let trace = utils::to_exec_info(&info);
-                    let receipt = receipt_from_exec_info(&tx, &trace);
+                    let receipt = build_receipt(&tx, fee, &trace);
 
                     crate::utils::log_resources(&trace.actual_resources);
                     crate::utils::log_events(receipt.events());
 
-                    self.stats.l1_gas_used += fee.gas_consumed;
+                    self.stats.l1_gas_used += receipt.fee().gas_consumed;
                     self.stats.cairo_steps_used += receipt.resources_used().steps as u128;
 
                     if let Some(reason) = receipt.revert_reason() {
                         info!(target: LOG_TARGET, reason = %reason, "Transaction reverted.");
                     }
 
-                    ExecutionResult::new_success(receipt, trace, fee)
+                    ExecutionResult::new_success(receipt, trace)
                 }
                 Err(e) => {
                     info!(target: LOG_TARGET, error = %e, "Executing transaction.");
@@ -235,8 +235,8 @@ impl<'a> ExecutorExt for StarknetVMProcessor<'a> {
                 Ok((info, fee)) => {
                     // get the trace and receipt from the execution info
                     let trace = utils::to_exec_info(&info);
-                    let receipt = receipt_from_exec_info(&tx, &trace);
-                    ExecutionResult::new_success(receipt, trace, fee)
+                    let receipt = build_receipt(&tx, fee, &trace);
+                    ExecutionResult::new_success(receipt, trace)
                 }
                 Err(e) => ExecutionResult::new_failed(e),
             };

--- a/crates/katana/executor/src/utils.rs
+++ b/crates/katana/executor/src/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use convert_case::{Case, Casing};
+use katana_primitives::fee::TxFeeInfo;
 use katana_primitives::receipt::{
     DeclareTxReceipt, DeployAccountTxReceipt, Event, InvokeTxReceipt, L1HandlerTxReceipt,
     MessageToL1, Receipt, TxExecutionResources,
@@ -47,8 +48,7 @@ pub fn log_events(events: &[Event]) {
     }
 }
 
-pub fn receipt_from_exec_info(tx: &Tx, info: &TxExecInfo) -> Receipt {
-    let actual_fee = info.actual_fee;
+pub fn build_receipt(tx: &Tx, fee: TxFeeInfo, info: &TxExecInfo) -> Receipt {
     let events = events_from_exec_info(info);
     let revert_error = info.revert_error.clone();
     let messages_sent = l2_to_l1_messages_from_exec_info(info);
@@ -57,7 +57,7 @@ pub fn receipt_from_exec_info(tx: &Tx, info: &TxExecInfo) -> Receipt {
     match tx {
         Tx::Invoke(_) => Receipt::Invoke(InvokeTxReceipt {
             events,
-            actual_fee,
+            fee,
             revert_error,
             messages_sent,
             execution_resources: actual_resources,
@@ -65,7 +65,7 @@ pub fn receipt_from_exec_info(tx: &Tx, info: &TxExecInfo) -> Receipt {
 
         Tx::Declare(_) => Receipt::Declare(DeclareTxReceipt {
             events,
-            actual_fee,
+            fee,
             revert_error,
             messages_sent,
             execution_resources: actual_resources,
@@ -73,7 +73,7 @@ pub fn receipt_from_exec_info(tx: &Tx, info: &TxExecInfo) -> Receipt {
 
         Tx::L1Handler(tx) => Receipt::L1Handler(L1HandlerTxReceipt {
             events,
-            actual_fee,
+            fee,
             revert_error,
             messages_sent,
             message_hash: tx.message_hash,
@@ -82,7 +82,7 @@ pub fn receipt_from_exec_info(tx: &Tx, info: &TxExecInfo) -> Receipt {
 
         Tx::DeployAccount(tx) => Receipt::DeployAccount(DeployAccountTxReceipt {
             events,
-            actual_fee,
+            fee,
             revert_error,
             messages_sent,
             execution_resources: actual_resources,

--- a/crates/katana/executor/tests/executor.rs
+++ b/crates/katana/executor/tests/executor.rs
@@ -268,7 +268,7 @@ fn test_executor_with_valid_blocks_impl<EF: ExecutorFactory>(
     let actual_txs: Vec<TxWithHash> = transactions
         .iter()
         .map(|(tx, res)| {
-            if let Some(fee) = res.fee() {
+            if let Some(fee) = res.receipt().map(|r| r.fee()) {
                 actual_total_gas += fee.gas_consumed;
             }
             if let Some(rec) = res.receipt() {

--- a/crates/katana/primitives/src/fee.rs
+++ b/crates/katana/primitives/src/fee.rs
@@ -1,7 +1,8 @@
 use starknet::core::types::PriceUnit;
 
 /// Information regarding the fee and gas usages of a transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TxFeeInfo {
     /// The total amount of L1 gas consumed by the transaction.
     pub gas_consumed: u128,

--- a/crates/katana/primitives/src/receipt.rs
+++ b/crates/katana/primitives/src/receipt.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::B256;
 
 use crate::contract::ContractAddress;
+use crate::fee::TxFeeInfo;
 use crate::FieldElement;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -27,11 +28,11 @@ pub struct MessageToL1 {
 }
 
 /// Receipt for a `Invoke` transaction.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InvokeTxReceipt {
-    /// Actual fee paid for the transaction.
-    pub actual_fee: u128,
+    /// Information about the transaction fee.
+    pub fee: TxFeeInfo,
     /// Events emitted by contracts.
     pub events: Vec<Event>,
     /// Messages sent to L1.
@@ -46,8 +47,8 @@ pub struct InvokeTxReceipt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeclareTxReceipt {
-    /// Actual fee paid for the transaction.
-    pub actual_fee: u128,
+    /// Information about the transaction fee.
+    pub fee: TxFeeInfo,
     /// Events emitted by contracts.
     pub events: Vec<Event>,
     /// Messages sent to L1.
@@ -62,8 +63,8 @@ pub struct DeclareTxReceipt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct L1HandlerTxReceipt {
-    /// Actual fee paid for the transaction.
-    pub actual_fee: u128,
+    /// Information about the transaction fee.
+    pub fee: TxFeeInfo,
     /// Events emitted by contracts.
     pub events: Vec<Event>,
     /// The hash of the L1 message
@@ -80,8 +81,8 @@ pub struct L1HandlerTxReceipt {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeployAccountTxReceipt {
-    /// Actual fee paid for the transaction.
-    pub actual_fee: u128,
+    /// Information about the transaction fee.
+    pub fee: TxFeeInfo,
     /// Events emitted by contracts.
     pub events: Vec<Event>,
     /// Messages sent to L1.
@@ -149,6 +150,15 @@ impl Receipt {
             Receipt::Declare(rct) => &rct.execution_resources,
             Receipt::L1Handler(rct) => &rct.execution_resources,
             Receipt::DeployAccount(rct) => &rct.execution_resources,
+        }
+    }
+
+    pub fn fee(&self) -> &TxFeeInfo {
+        match self {
+            Receipt::Invoke(rct) => &rct.fee,
+            Receipt::Declare(rct) => &rct.fee,
+            Receipt::L1Handler(rct) => &rct.fee,
+            Receipt::DeployAccount(rct) => &rct.fee,
         }
     }
 }

--- a/crates/katana/rpc/rpc-types/src/receipt.rs
+++ b/crates/katana/rpc/rpc-types/src/receipt.rs
@@ -1,4 +1,5 @@
 use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus};
+use katana_primitives::fee::TxFeeInfo;
 use katana_primitives::receipt::{MessageToL1, Receipt, TxExecutionResources};
 use katana_primitives::transaction::TxHash;
 use serde::{Deserialize, Serialize};
@@ -7,7 +8,7 @@ use starknet::core::types::{
     Hash256, InvokeTransactionReceipt, L1HandlerTransactionReceipt,
     PendingDeclareTransactionReceipt, PendingDeployAccountTransactionReceipt,
     PendingInvokeTransactionReceipt, PendingL1HandlerTransactionReceipt, PendingTransactionReceipt,
-    PriceUnit, TransactionFinalityStatus, TransactionReceipt,
+    TransactionFinalityStatus, TransactionReceipt,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,7 +41,7 @@ impl TxReceipt {
                     messages_sent,
                     finality_status,
                     transaction_hash,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     execution_result: if let Some(reason) = rct.revert_error {
                         ExecutionResult::Reverted { reason }
@@ -62,7 +63,7 @@ impl TxReceipt {
                     messages_sent,
                     finality_status,
                     transaction_hash,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     execution_result: if let Some(reason) = rct.revert_error {
                         ExecutionResult::Reverted { reason }
@@ -84,7 +85,7 @@ impl TxReceipt {
                     messages_sent,
                     finality_status,
                     transaction_hash,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     message_hash: Hash256::from_bytes(*rct.message_hash),
                     execution_result: if let Some(reason) = rct.revert_error {
@@ -107,7 +108,7 @@ impl TxReceipt {
                     messages_sent,
                     finality_status,
                     transaction_hash,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     contract_address: rct.contract_address.into(),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     execution_result: if let Some(reason) = rct.revert_error {
@@ -139,7 +140,7 @@ impl PendingTxReceipt {
                     transaction_hash,
                     events,
                     messages_sent,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     execution_result: if let Some(reason) = rct.revert_error {
                         ExecutionResult::Reverted { reason }
@@ -158,7 +159,7 @@ impl PendingTxReceipt {
                     events,
                     transaction_hash,
                     messages_sent,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     execution_result: if let Some(reason) = rct.revert_error {
                         ExecutionResult::Reverted { reason }
@@ -177,7 +178,7 @@ impl PendingTxReceipt {
                     transaction_hash,
                     events,
                     messages_sent,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     message_hash: Hash256::from_bytes(rct.message_hash.0),
                     execution_result: if let Some(reason) = rct.revert_error {
@@ -197,7 +198,7 @@ impl PendingTxReceipt {
                     transaction_hash,
                     events,
                     messages_sent,
-                    actual_fee: FeePayment { amount: rct.actual_fee.into(), unit: PriceUnit::Wei },
+                    actual_fee: to_rpc_fee(rct.fee),
                     contract_address: rct.contract_address.into(),
                     execution_resources: ExecutionResources::from(rct.execution_resources).0,
                     execution_result: if let Some(reason) = rct.revert_error {
@@ -267,4 +268,8 @@ impl From<TxExecutionResources> for ExecutionResources {
             segment_arena_builtin: value.segment_arena_builtin,
         })
     }
+}
+
+fn to_rpc_fee(fee: TxFeeInfo) -> FeePayment {
+    FeePayment { amount: fee.overall_fee.into(), unit: fee.unit }
 }

--- a/crates/katana/rpc/rpc/src/starknet.rs
+++ b/crates/katana/rpc/rpc/src/starknet.rs
@@ -818,7 +818,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
             let mut simulated = Vec::with_capacity(results.len());
             for (i, ResultAndStates { result, .. }) in results.into_iter().enumerate() {
                 match result {
-                    ExecutionResult::Success { trace, fee, receipt } => {
+                    ExecutionResult::Success { trace, receipt } => {
                         let fee_transfer_invocation =
                             trace.fee_transfer_call_info.map(|f| FunctionInvocation::from(f).0);
                         let validate_invocation =
@@ -875,6 +875,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                             }
                         };
 
+                        let fee = receipt.fee();
                         simulated.push(SimulatedTransaction {
                             transaction_trace,
                             fee_estimation: FeeEstimate {

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -287,9 +287,11 @@ mod tests {
     use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
     use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
-    use katana_primitives::receipt::Receipt;
+    use katana_primitives::fee::TxFeeInfo;
+    use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
     use katana_primitives::trace::TxExecInfo;
     use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxNumber};
+    use starknet::core::types::PriceUnit;
     use starknet::macros::felt;
 
     use crate::codecs::{Compress, Decode, Decompress, Encode};
@@ -356,7 +358,6 @@ mod tests {
             (Tx, Tx::Invoke(InvokeTx::V1(Default::default()))),
             (BlockNumber, 99),
             (TxExecInfo, TxExecInfo::default()),
-            (Receipt, Receipt::Invoke(Default::default())),
             (CompiledClassHash, felt!("211")),
             (CompiledClass, CompiledClass::Deprecated(Default::default())),
             (GenericContractInfo, GenericContractInfo::default()),
@@ -365,7 +366,14 @@ mod tests {
             (ContractNonceChange, ContractNonceChange::default()),
             (ContractClassChange, ContractClassChange::default()),
             (BlockList, BlockList::default()),
-            (ContractStorageEntry, ContractStorageEntry::default())
+            (ContractStorageEntry, ContractStorageEntry::default()),
+            (Receipt, Receipt::Invoke(InvokeTxReceipt {
+                        revert_error: None,
+                        events: Vec::new(),
+                        messages_sent: Vec::new(),
+                        execution_resources: Default::default(),
+                        fee: TxFeeInfo { gas_consumed: 0, gas_price: 0, overall_fee: 0, unit: PriceUnit::Wei },
+                    }))
         }
     }
 }

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -756,10 +756,12 @@ mod tests {
         Block, BlockHashOrNumber, FinalityStatus, Header, SealedBlockWithStatus,
     };
     use katana_primitives::contract::ContractAddress;
-    use katana_primitives::receipt::Receipt;
+    use katana_primitives::fee::TxFeeInfo;
+    use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
     use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
     use katana_primitives::trace::TxExecInfo;
     use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxWithHash};
+    use starknet::core::types::PriceUnit;
     use starknet::macros::felt;
 
     use super::DbProvider;
@@ -843,7 +845,18 @@ mod tests {
             &provider,
             block.clone(),
             state_updates,
-            vec![Receipt::Invoke(Default::default())],
+            vec![Receipt::Invoke(InvokeTxReceipt {
+                revert_error: None,
+                events: Vec::new(),
+                messages_sent: Vec::new(),
+                execution_resources: Default::default(),
+                fee: TxFeeInfo {
+                    gas_consumed: 0,
+                    gas_price: 0,
+                    overall_fee: 0,
+                    unit: PriceUnit::Wei,
+                },
+            })],
             vec![TxExecInfo::default()],
         )
         .expect("failed to insert block");
@@ -921,7 +934,18 @@ mod tests {
             &provider,
             block.clone(),
             state_updates1,
-            vec![Receipt::Invoke(Default::default())],
+            vec![Receipt::Invoke(InvokeTxReceipt {
+                revert_error: None,
+                events: Vec::new(),
+                messages_sent: Vec::new(),
+                execution_resources: Default::default(),
+                fee: TxFeeInfo {
+                    gas_consumed: 0,
+                    gas_price: 0,
+                    overall_fee: 0,
+                    unit: PriceUnit::Wei,
+                },
+            })],
             vec![TxExecInfo::default()],
         )
         .expect("failed to insert block");
@@ -931,7 +955,18 @@ mod tests {
             &provider,
             block,
             state_updates2,
-            vec![Receipt::Invoke(Default::default())],
+            vec![Receipt::Invoke(InvokeTxReceipt {
+                revert_error: None,
+                events: Vec::new(),
+                messages_sent: Vec::new(),
+                execution_resources: Default::default(),
+                fee: TxFeeInfo {
+                    gas_consumed: 0,
+                    gas_price: 0,
+                    overall_fee: 0,
+                    unit: PriceUnit::Wei,
+                },
+            })],
             vec![TxExecInfo::default()],
         )
         .expect("failed to insert block");

--- a/crates/katana/storage/provider/tests/utils.rs
+++ b/crates/katana/storage/provider/tests/utils.rs
@@ -1,8 +1,10 @@
 use katana_primitives::block::{Block, BlockHash, FinalityStatus, Header, SealedBlockWithStatus};
+use katana_primitives::fee::TxFeeInfo;
 use katana_primitives::receipt::{InvokeTxReceipt, Receipt};
 use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{InvokeTx, Tx, TxHash, TxWithHash};
 use katana_primitives::FieldElement;
+use starknet::core::types::PriceUnit;
 
 pub fn generate_dummy_txs_and_receipts(
     count: usize,
@@ -18,7 +20,13 @@ pub fn generate_dummy_txs_and_receipts(
             transaction: Tx::Invoke(InvokeTx::V1(Default::default())),
         });
 
-        receipts.push(Receipt::Invoke(InvokeTxReceipt::default()));
+        receipts.push(Receipt::Invoke(InvokeTxReceipt {
+            revert_error: None,
+            events: Vec::new(),
+            messages_sent: Vec::new(),
+            execution_resources: Default::default(),
+            fee: TxFeeInfo { gas_consumed: 0, gas_price: 0, overall_fee: 0, unit: PriceUnit::Wei },
+        }));
         executions.push(TxExecInfo::default());
     }
 


### PR DESCRIPTION
Include transaction fee information in the receipt types. 

this also replace the hardcoding of the price unit in the rpc receipt types which doesn't reflect the actual unit that is being used by the transaction.