### PR TITLE
fix(sozo/katana): remove max_bytecode_size limitation

### DIFF
--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -27,13 +27,6 @@ pub mod world;
 
 pub type DeclareOutput = DeclareTransactionResult;
 
-// TODO: this was taken from the current network limit
-// https://docs.starknet.io/documentation/tools/limits_and_triggers/.
-// This constant is also used into `katana-primitives`, which common crate
-// should expose this value to have it configurable.
-// Or should we just accept any size here?
-pub const MAX_BYTECODE_SIZE: usize = 81_290;
-
 #[derive(Clone, Debug)]
 pub struct DeployOutput {
     pub transaction_hash: FieldElement,
@@ -390,7 +383,7 @@ fn get_compiled_class_hash(artifact_path: &PathBuf) -> Result<FieldElement> {
     let file = File::open(artifact_path)?;
     let casm_contract_class: ContractClass = serde_json::from_reader(file)?;
     let casm_contract =
-        CasmContractClass::from_contract_class(casm_contract_class, true, MAX_BYTECODE_SIZE)?;
+        CasmContractClass::from_contract_class(casm_contract_class, true, usize::MAX)?;
     let res = serde_json::to_string_pretty(&casm_contract)?;
     let compiled_class: CompiledClass = serde_json::from_str(&res)?;
     Ok(compiled_class.class_hash()?)

--- a/crates/katana/primitives/src/conversion/rpc.rs
+++ b/crates/katana/primitives/src/conversion/rpc.rs
@@ -27,7 +27,6 @@ use crate::class::{
     ClassHash, CompiledClassHash, DeprecatedCompiledClass, FlattenedSierraClass,
     SierraCompiledClass, SierraProgram,
 };
-use crate::utils::class::MAX_BYTECODE_SIZE;
 use crate::FieldElement;
 
 /// Converts the legacy inner compiled class type [DeprecatedCompiledClass] into its RPC equivalent
@@ -149,7 +148,7 @@ pub fn flattened_sierra_to_compiled_class(
     let entry_points_by_type = class.entry_points_by_type.clone();
     let sierra = SierraProgram { program, entry_points_by_type };
 
-    let casm = CasmContractClass::from_contract_class(class, true, MAX_BYTECODE_SIZE)?;
+    let casm = CasmContractClass::from_contract_class(class, true, usize::MAX)?;
     let compiled_hash = FieldElement::from_bytes_be(&casm.compiled_class_hash().to_be_bytes())?;
 
     let class = crate::class::CompiledClass::Class(SierraCompiledClass { casm, sierra });
@@ -161,7 +160,7 @@ pub fn compiled_class_hash_from_flattened_sierra_class(
     contract_class: &FlattenedSierraClass,
 ) -> Result<FieldElement> {
     let contract_class = rpc_to_cairo_contract_class(contract_class)?;
-    let casm = CasmContractClass::from_contract_class(contract_class, true, MAX_BYTECODE_SIZE)?;
+    let casm = CasmContractClass::from_contract_class(contract_class, true, usize::MAX)?;
     let compiled_class: CompiledClass = serde_json::from_str(&serde_json::to_string(&casm)?)?;
     Ok(compiled_class.class_hash()?)
 }

--- a/crates/katana/primitives/src/utils/class.rs
+++ b/crates/katana/primitives/src/utils/class.rs
@@ -12,7 +12,7 @@ use crate::class::{
 // We may want to make this configurable.
 // We also need this value into `dojo-world`.. which is not ideal as we don't want
 // primitives to depend on `dojo-world` or vice-versa.
-pub const MAX_BYTECODE_SIZE: usize = 81_290;
+// pub const MAX_BYTECODE_SIZE: usize = 81_290;
 
 pub fn parse_compiled_class(artifact: Value) -> Result<CompiledClass> {
     if let Ok(class) = parse_compiled_class_v1(artifact.clone()) {
@@ -29,7 +29,7 @@ pub fn parse_compiled_class_v1(class: Value) -> Result<SierraCompiledClass> {
     let entry_points_by_type = class.entry_points_by_type.clone();
     let sierra = SierraProgram { program, entry_points_by_type };
 
-    let casm = CasmContractClass::from_contract_class(class, true, MAX_BYTECODE_SIZE)?;
+    let casm = CasmContractClass::from_contract_class(class, true, usize::MAX)?;
 
     Ok(SierraCompiledClass { casm, sierra })
 }

--- a/crates/katana/rpc/rpc/tests/common/mod.rs
+++ b/crates/katana/rpc/rpc/tests/common/mod.rs
@@ -5,7 +5,6 @@ use anyhow::{anyhow, Result};
 use cairo_lang_starknet_classes::casm_contract_class::CasmContractClass;
 use cairo_lang_starknet_classes::contract_class::ContractClass;
 use katana_primitives::conversion::rpc::CompiledClass;
-use katana_primitives::utils::class::MAX_BYTECODE_SIZE;
 use starknet::accounts::Call;
 use starknet::core::types::contract::SierraClass;
 use starknet::core::types::{FieldElement, FlattenedSierraClass};
@@ -31,7 +30,7 @@ fn get_compiled_class_hash(artifact_path: &PathBuf) -> Result<FieldElement> {
     let file = File::open(artifact_path)?;
     let casm_contract_class: ContractClass = serde_json::from_reader(file)?;
     let casm_contract =
-        CasmContractClass::from_contract_class(casm_contract_class, true, MAX_BYTECODE_SIZE)
+        CasmContractClass::from_contract_class(casm_contract_class, true, usize::MAX)
             .map_err(|e| anyhow!("CasmContractClass from ContractClass error: {e}"))?;
     let res = serde_json::to_string_pretty(&casm_contract)?;
     let compiled_class: CompiledClass = serde_json::from_str(&res)?;

--- a/crates/sozo/ops/src/migration/migrate.rs
+++ b/crates/sozo/ops/src/migration/migrate.rs
@@ -648,8 +648,8 @@ pub fn handle_artifact_error(ui: &Ui, artifact_path: &Path, error: anyhow::Error
     ui.verbose(format!("{path}: {error:?}"));
 
     anyhow!(
-        "Discrepancy detected in {name}.\nUse `sozo clean` to clean your project or `sozo clean \
-         --artifacts` to clean artifacts only.\nThen, rebuild your project with `sozo build`."
+        "Discrepancy detected in {name}.\nUse `sozo clean` to clean your project.\n
+        Then, rebuild your project with `sozo build`."
     )
 }
 


### PR DESCRIPTION
fix: #1950

for sozo it doesn't make sense to have this limitation since it depends on the network contract is being deployed to.
