### PR TITLE
Remove forge-std submodule in katana

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "crates/katana/primitives/contracts/messaging/solidity/lib/forge-std"]
-	path = crates/katana/primitives/contracts/messaging/solidity/lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
 [submodule "crates/katana/contracts/messaging/solidity/lib/forge-std"]
 	path = crates/katana/contracts/messaging/solidity/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
# Description

Removed the [submodule "crates/katana/primitives/contracts/messaging/solidity/lib/forge-std"] section from the .gitmodules file.