### PR TITLE
chore: ensure Cargo.lock is committed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.55",
+ "syn 2.0.61",
 ]
 
 [[package]]


### PR DESCRIPTION
Quick fix for the CI failing for missing commit.