### PR TITLE
chore(katana): ignore forked backend thread spawn test

### DIFF
--- a/crates/katana/storage/provider/src/providers/fork/backend.rs
+++ b/crates/katana/storage/provider/src/providers/fork/backend.rs
@@ -734,7 +734,10 @@ mod tests {
         );
     }
 
+    // TODO: unignore this once we have separate the spawning of the backend thread from the backend
+    // creation
     #[test]
+    #[ignore]
     fn fetch_from_fork_will_err_if_backend_thread_not_running() {
         let backend = create_forked_backend(LOCAL_RPC_URL, 1);
         let provider = SharedStateProvider(Arc::new(CacheStateDb::new(backend)));


### PR DESCRIPTION
# Description

ignore test that checks if the backend thread is spawned or not, for now, as we have made sure that the thread will always be spawned when creating a new `Backend`:

https://github.com/dojoengine/dojo/blob/628542f3084778c1216768d3eb05172adc43e79b/crates/katana/storage/provider/src/providers/fork/backend.rs#L140-L157

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
