### PR TITLE
fix: remove typescript v2 causing flaky tests

### DIFF
--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -123,6 +123,9 @@ mod tests {
 
     use super::{create_stats_table, BuildArgs};
 
+    // TODO: uncomment when new types like `ByteArray` are fully supported,
+    // which are present in the world.
+    #[ignore]
     #[test]
     fn build_example_with_typescript_and_unity_bindings() {
         let config = build_test_config("../../examples/spawn-and-move/Scarb.toml").unwrap();

--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -15,10 +15,9 @@ pub struct BuildArgs {
     #[arg(help = "Generate Typescript bindings.")]
     pub typescript: bool,
 
-    #[arg(long)]
-    #[arg(help = "Generate Typescript bindings.")]
-    pub typescript_v2: bool,
-
+    // #[arg(long)]
+    // #[arg(help = "Generate Typescript bindings.")]
+    // pub typescript_v2: bool,
     #[arg(long)]
     #[arg(help = "Generate Unity bindings.")]
     pub unity: bool,
@@ -44,9 +43,9 @@ impl BuildArgs {
             builtin_plugins.push(BuiltinPlugins::Typescript);
         }
 
-        if self.typescript_v2 {
-            builtin_plugins.push(BuiltinPlugins::TypeScriptV2);
-        }
+        // if self.typescript_v2 {
+        //     builtin_plugins.push(BuiltinPlugins::TypeScriptV2);
+        // }
 
         if self.unity {
             builtin_plugins.push(BuiltinPlugins::Unity);
@@ -131,7 +130,6 @@ mod tests {
             bindings_output: "generated".to_string(),
             typescript: true,
             unity: true,
-            typescript_v2: false,
             stats: true,
         };
         let result = build_args.run(&config);

--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -123,9 +123,6 @@ mod tests {
 
     use super::{create_stats_table, BuildArgs};
 
-    // TODO: uncomment when new types like `ByteArray` are fully supported,
-    // which are present in the world.
-    #[ignore]
     #[test]
     fn build_example_with_typescript_and_unity_bindings() {
         let config = build_test_config("../../examples/spawn-and-move/Scarb.toml").unwrap();
@@ -134,7 +131,7 @@ mod tests {
             bindings_output: "generated".to_string(),
             typescript: true,
             unity: true,
-            typescript_v2: true,
+            typescript_v2: false,
             stats: true,
         };
         let result = build_args.run(&config);

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -12,7 +12,7 @@ use error::{BindgenResult, Error};
 
 mod plugins;
 use plugins::typescript::TypescriptPlugin;
-use plugins::typescript_v2::TypeScriptV2Plugin;
+// use plugins::typescript_v2::TypeScriptV2Plugin;
 use plugins::unity::UnityPlugin;
 use plugins::BuiltinPlugin;
 pub use plugins::BuiltinPlugins;
@@ -86,7 +86,7 @@ impl PluginManager {
             let builder: Box<dyn BuiltinPlugin> = match plugin {
                 BuiltinPlugins::Typescript => Box::new(TypescriptPlugin::new()),
                 BuiltinPlugins::Unity => Box::new(UnityPlugin::new()),
-                BuiltinPlugins::TypeScriptV2 => Box::new(TypeScriptV2Plugin::new()),
+                // BuiltinPlugins::TypeScriptV2 => Box::new(TypeScriptV2Plugin::new()),
             };
 
             let files = builder.generate_code(&data).await?;

--- a/crates/dojo-bindgen/src/plugins/mod.rs
+++ b/crates/dojo-bindgen/src/plugins/mod.rs
@@ -15,7 +15,7 @@ pub mod unity;
 pub enum BuiltinPlugins {
     Typescript,
     Unity,
-    TypeScriptV2,
+    // TypeScriptV2,
 }
 
 impl fmt::Display for BuiltinPlugins {
@@ -23,7 +23,7 @@ impl fmt::Display for BuiltinPlugins {
         match self {
             BuiltinPlugins::Typescript => write!(f, "typescript"),
             BuiltinPlugins::Unity => write!(f, "unity"),
-            BuiltinPlugins::TypeScriptV2 => write!(f, "typescript_v2"),
+            // BuiltinPlugins::TypeScriptV2 => write!(f, "typescript_v2"),
         }
     }
 }

--- a/crates/dojo-bindgen/src/plugins/typescript_v2/mod.rs
+++ b/crates/dojo-bindgen/src/plugins/typescript_v2/mod.rs
@@ -12,9 +12,9 @@ use crate::{DojoContract, DojoData, DojoModel};
 pub struct TypeScriptV2Plugin {}
 
 impl TypeScriptV2Plugin {
-    pub fn new() -> Self {
-        Self {}
-    }
+    // pub fn new() -> Self {
+    //    Self {}
+    // }
 
     // Maps cairo types to TypeScript defined types
     fn map_type(type_name: &str) -> String {


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

Test to generate bindings with unity and typescript can be flaky due to the support of `ByteArray` that is not fully updated yet.
This PR disable for now one test that will be introduced again once bindings are updated.

The reason seemed to be typescript v2 has it's not currently maintain to follow SDK updates.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [ ] I've requested a review after addressing the comments
