### PR TITLE
refactor(katana): replace cursor-based api with by block basis for simplicity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7001,6 +7001,7 @@ dependencies = [
  "cairo-lang-starknet-classes",
  "dojo-metrics",
  "dojo-test-utils",
+ "dojo-world",
  "flate2",
  "futures",
  "hex",

--- a/crates/katana/rpc/rpc-api/src/saya.rs
+++ b/crates/katana/rpc/rpc-api/src/saya.rs
@@ -1,5 +1,7 @@
 use jsonrpsee::core::RpcResult;
 use jsonrpsee::proc_macros::rpc;
+use katana_primitives::block::BlockIdOrTag;
+use katana_rpc_types::trace::TxExecutionInfo;
 use katana_rpc_types::transaction::{TransactionsExecutionsPage, TransactionsPageCursor};
 
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "saya"))]
@@ -17,4 +19,11 @@ pub trait SayaApi {
         &self,
         cursor: TransactionsPageCursor,
     ) -> RpcResult<TransactionsExecutionsPage>;
+
+    /// Retrieves a list of transaction execution informations of a given block.
+    #[method(name = "getTransactionExecutionsByBlock")]
+    async fn transaction_executions_by_block(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> RpcResult<Vec<TxExecutionInfo>>;
 }

--- a/crates/katana/rpc/rpc-types/src/trace.rs
+++ b/crates/katana/rpc/rpc-types/src/trace.rs
@@ -1,4 +1,6 @@
-use katana_primitives::trace::CallInfo;
+use katana_primitives::trace::{CallInfo, TxExecInfo};
+use katana_primitives::transaction::TxHash;
+use serde::{Deserialize, Serialize};
 use starknet::core::types::{
     CallType, EntryPointType, ExecutionResources, OrderedEvent, OrderedMessage,
 };
@@ -71,4 +73,13 @@ impl From<CallInfo> for FunctionInvocation {
             class_hash: info.class_hash.expect("Class hash mut be set after execution"),
         })
     }
+}
+
+/// The type returned by the `saya_getTransactionExecutionsByBlock` RPC method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxExecutionInfo {
+    /// The transaction hash.
+    pub hash: TxHash,
+    /// The transaction execution trace.
+    pub trace: TxExecInfo,
 }

--- a/crates/katana/rpc/rpc/Cargo.toml
+++ b/crates/katana/rpc/rpc/Cargo.toml
@@ -40,6 +40,7 @@ assert_matches.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-lang-starknet.workspace = true
 dojo-test-utils.workspace = true
+dojo-world.workspace = true
 jsonrpsee = { workspace = true, features = [ "client" ] }
 katana-rpc-api = { workspace = true, features = [ "client" ] }
 url.workspace = true

--- a/crates/katana/rpc/rpc/src/saya.rs
+++ b/crates/katana/rpc/rpc/src/saya.rs
@@ -3,10 +3,13 @@ use std::sync::Arc;
 use jsonrpsee::core::{async_trait, RpcResult};
 use katana_core::sequencer::KatanaSequencer;
 use katana_executor::ExecutorFactory;
-use katana_primitives::block::BlockHashOrNumber;
-use katana_provider::traits::transaction::TransactionTraceProvider;
+use katana_primitives::block::{BlockHashOrNumber, BlockIdOrTag, BlockTag};
+use katana_provider::error::ProviderError;
+use katana_provider::traits::block::{BlockIdReader, BlockProvider};
+use katana_provider::traits::transaction::{TransactionTraceProvider, TransactionsProviderExt};
 use katana_rpc_api::saya::SayaApiServer;
 use katana_rpc_types::error::saya::SayaApiError;
+use katana_rpc_types::trace::TxExecutionInfo;
 use katana_rpc_types::transaction::{TransactionsExecutionsPage, TransactionsPageCursor};
 use katana_tasks::TokioTaskSpawner;
 
@@ -46,7 +49,7 @@ impl<EF: ExecutorFactory> SayaApiServer for SayaApi<EF> {
             let mut next_cursor = cursor;
 
             let transactions_executions = provider
-                .transactions_executions_by_block(BlockHashOrNumber::Num(cursor.block_number))
+                .transaction_executions_by_block(BlockHashOrNumber::Num(cursor.block_number))
                 .map_err(SayaApiError::from)?
                 .ok_or(SayaApiError::BlockNotFound)?;
 
@@ -70,6 +73,76 @@ impl<EF: ExecutorFactory> SayaApiServer for SayaApi<EF> {
             }
 
             Ok(TransactionsExecutionsPage { transactions_executions, cursor: next_cursor })
+        })
+        .await
+    }
+
+    async fn transaction_executions_by_block(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> RpcResult<Vec<TxExecutionInfo>> {
+        self.on_io_blocking_task(move |this| {
+            let provider = this.sequencer.backend.blockchain.provider();
+
+            match block_id {
+                BlockIdOrTag::Tag(BlockTag::Pending) => {
+                    // if there is no pending block (eg on instant mining), return an empty list
+                    let Some(pending) = this.sequencer.pending_executor() else {
+                        return Ok(Vec::new());
+                    };
+
+                    // get the read lock on the pending block
+                    let lock = pending.read();
+
+                    // extract the traces from the pending block
+                    let mut traces = Vec::new();
+                    for (tx, res) in lock.transactions() {
+                        if let Some(trace) = res.trace().cloned() {
+                            traces.push(TxExecutionInfo { hash: tx.hash, trace });
+                        }
+                    }
+
+                    Ok(traces)
+                }
+
+                id => {
+                    let number = provider
+                        .convert_block_id(id)
+                        .map_err(SayaApiError::from)?
+                        .ok_or(SayaApiError::BlockNotFound)?;
+
+                    // get the transaction traces and their corresponding hashes
+
+                    let traces = provider
+                        .transaction_executions_by_block(number.into())
+                        .map_err(SayaApiError::from)?
+                        .expect("qed; must be Some if block exists");
+
+                    // get the block body indices for the requested block to determine its tx range
+                    // in the db for the tx hashes
+
+                    let block_indices = provider
+                        .block_body_indices(number.into())
+                        .map_err(SayaApiError::from)?
+                        .ok_or(ProviderError::MissingBlockBodyIndices(number))
+                        .expect("qed; must be Some if block exists");
+
+                    // TODO: maybe we should add a `_by_block` method for the tx hashes as well?
+                    let hashes = provider
+                        .transaction_hashes_in_range(block_indices.clone().into())
+                        .map_err(SayaApiError::from)?;
+
+                    // build the rpc response
+
+                    let traces = hashes
+                        .into_iter()
+                        .zip(traces)
+                        .map(|(hash, trace)| TxExecutionInfo { hash, trace })
+                        .collect::<Vec<_>>();
+
+                    Ok(traces)
+                }
+            }
         })
         .await
     }

--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -195,11 +195,18 @@ where
         TransactionTraceProvider::transaction_execution(&self.provider, hash)
     }
 
-    fn transactions_executions_by_block(
+    fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<TxExecInfo>>> {
-        TransactionTraceProvider::transactions_executions_by_block(&self.provider, block_id)
+        TransactionTraceProvider::transaction_executions_by_block(&self.provider, block_id)
+    }
+
+    fn transaction_executions_in_range(
+        &self,
+        range: Range<TxNumber>,
+    ) -> ProviderResult<Vec<TxExecInfo>> {
+        TransactionTraceProvider::transaction_executions_in_range(&self.provider, range)
     }
 }
 

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -332,7 +332,7 @@ impl TransactionTraceProvider for ForkedProvider {
         Ok(exec)
     }
 
-    fn transactions_executions_by_block(
+    fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<TxExecInfo>>> {
@@ -341,26 +341,34 @@ impl TransactionTraceProvider for ForkedProvider {
             BlockHashOrNumber::Hash(hash) => self.storage.read().block_numbers.get(&hash).cloned(),
         };
 
-        let Some(StoredBlockBodyIndices { tx_offset, tx_count }) =
+        let Some(index) =
             block_num.and_then(|num| self.storage.read().block_body_indices.get(&num).cloned())
         else {
             return Ok(None);
         };
 
-        let offset = tx_offset as usize;
-        let count = tx_count as usize;
+        let traces = self.transaction_executions_in_range(index.into())?;
+        Ok(Some(traces))
+    }
 
-        let execs = self
+    fn transaction_executions_in_range(
+        &self,
+        range: Range<TxNumber>,
+    ) -> ProviderResult<Vec<TxExecInfo>> {
+        let start = range.start as usize;
+        let total = range.end as usize - start;
+
+        let traces = self
             .storage
             .read()
             .transactions_executions
             .iter()
-            .skip(offset)
-            .take(count)
+            .skip(start)
+            .take(total)
             .cloned()
             .collect();
 
-        Ok(Some(execs))
+        Ok(traces)
     }
 }
 

--- a/crates/katana/storage/provider/src/traits/transaction.rs
+++ b/crates/katana/storage/provider/src/traits/transaction.rs
@@ -59,10 +59,16 @@ pub trait TransactionTraceProvider: Send + Sync {
     fn transaction_execution(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>>;
 
     /// Returns all the transactions executions for a given block.
-    fn transactions_executions_by_block(
+    fn transaction_executions_by_block(
         &self,
         block_id: BlockHashOrNumber,
     ) -> ProviderResult<Option<Vec<TxExecInfo>>>;
+
+    /// Retrieves the execution traces for the given range of tx numbers.
+    fn transaction_executions_in_range(
+        &self,
+        range: Range<TxNumber>,
+    ) -> ProviderResult<Vec<TxExecInfo>>;
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]

--- a/crates/katana/storage/provider/tests/block.rs
+++ b/crates/katana/storage/provider/tests/block.rs
@@ -139,7 +139,7 @@ where
 
         let actual_block_tx_count = provider.transaction_count_by_block(block_id)?;
         let actual_receipts = provider.receipts_by_block(block_id)?;
-        let actual_executions = provider.transactions_executions_by_block(block_id)?;
+        let actual_executions = provider.transaction_executions_by_block(block_id)?;
 
         let expected_block_with_tx_hashes = BlockWithTxHashes {
             header: expected_block.header.clone(),
@@ -244,7 +244,7 @@ where
 
         let actual_block_tx_count = provider.transaction_count_by_block(block_id)?;
         let actual_receipts = provider.receipts_by_block(block_id)?;
-        let actual_executions = provider.transactions_executions_by_block(block_id)?;
+        let actual_executions = provider.transaction_executions_by_block(block_id)?;
 
         let expected_block_with_tx_hashes =
             BlockWithTxHashes { header: expected_block.header.clone(), body: vec![] };


### PR DESCRIPTION
# Description

currently, the `saya_getTransactionsExecutions` API is based on a cursor to determine how the traces are being fetched. 

https://github.com/dojoengine/dojo/blob/855da3112c87faea87646db5a406ac77b4daf149/crates/saya/provider/src/rpc/mod.rs#L160-L175

one issue it currently has it that the api params does not put any constraint on whether the returned traces are guarantee to only be from a specific block. however, the implementation seems to indicate otherwise.

anyway, this pr basically want to remove the complexity of the pagination logic (which we dont even need!) and to replace it with a basic `get Xs from block Y` api instead.


so we can simplify the endpoint itself to just return the traces per block instead of based on a cursor. the cursor is only adding more complexity to the api itself.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [x] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [ ] I've requested a review after addressing the comments
