### PR TITLE
Remove `sozo` as a dependency of `katana-runner` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7086,7 +7086,6 @@ dependencies = [
  "runner-macro",
  "serde",
  "serde_json",
- "sozo",
  "starknet",
  "tokio",
  "url",

--- a/crates/katana/runner/Cargo.toml
+++ b/crates/katana/runner/Cargo.toml
@@ -16,7 +16,6 @@ lazy_static.workspace = true
 runner-macro = { path = "./runner-macro" }
 serde.workspace = true
 serde_json.workspace = true
-sozo = { path = "../../../bin/sozo" }
 starknet.workspace = true
 tokio.workspace = true
 url.workspace = true


### PR DESCRIPTION
# Description

its not being used, and there's not reason to use this as a dependency unless maybe for testing. but its not being used for testing anyway.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
