### PR TITLE
Storage layout improvements + sozo model commands

### DIFF
--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -41,6 +41,18 @@ pub enum ModelCommand {
         starknet: StarknetOptions,
     },
 
+    #[command(about = "Retrieve the layout used to store model records in the world storage.")]
+    Layout {
+        #[arg(help = "The name of the model")]
+        name: String,
+
+        #[command(flatten)]
+        world: WorldOptions,
+
+        #[command(flatten)]
+        starknet: StarknetOptions,
+    },
+
     #[command(about = "Retrieve the schema for a model")]
     Schema {
         #[arg(help = "The name of the model")]
@@ -91,6 +103,11 @@ impl ModelArgs {
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
                     model::model_contract_address(name, world_address, provider).await
+                }
+                ModelCommand::Layout { name, starknet, world } => {
+                    let world_address = world.address(env_metadata.as_ref()).unwrap();
+                    let provider = starknet.provider(env_metadata.as_ref()).unwrap();
+                    model::model_layout(name, world_address, provider).await
                 }
                 ModelCommand::Schema { name, to_json, starknet, world } => {
                     let world_address = world.address(env_metadata.as_ref()).unwrap();

--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -41,7 +41,25 @@ pub enum ModelCommand {
         starknet: StarknetOptions,
     },
 
-    #[command(about = "Retrieve the layout used to store model records in the world storage.")]
+    #[command(about = "The Dojo storage system uses the poseidon_hash function to compute \
+                       hashes, called 'hash' in the following documentation.
+        
+        How storage locations are computed ?
+
+        model key               = hash(model_keys)
+
+        fixed layout key        = parent_key
+        struct layout field key = hash(parent_key, field_selector)
+        tuple layout item key   = hash(parent_key, item_index)
+        enum layout 
+                    variant key = parent_key
+                    data key    = hash(parent_key, variant_index)
+        array layout
+                    length key  = parent_key
+                    item key    = hash(parent_key, item_index)
+        byte array layout       = parent_key
+
+        final storage location  = hash('dojo_storage', model_selector, record_key)")]
     Layout {
         #[arg(help = "The name of the model")]
         name: String,

--- a/crates/dojo-core/src/base_test.cairo
+++ b/crates/dojo-core/src/base_test.cairo
@@ -145,7 +145,7 @@ mod invalid_model {
     impl InvalidModelSelector of super::IMetadataOnly<ContractState> {
         fn selector(self: @ContractState) -> felt252 {
             // Pre-computed address of a contract deployed through the world.
-            0x455fe9471cb954574b16581868043841391545b9225af00bf545f9acf923295
+            0x24be6107cad9928e8b80e1404af473b1641f146114af53bef99152a382c53c0
         }
 
         fn name(self: @ContractState) -> ByteArray {

--- a/crates/dojo-core/src/database/introspect.cairo
+++ b/crates/dojo-core/src/database/introspect.cairo
@@ -16,7 +16,7 @@ enum Layout {
     ByteArray,
     // there is one layout per variant.
     // the `selector` field identifies the variant
-    // the `layout` field defines the full variant layout (variant value + optional variant data)
+    // the `layout` defines the variant data (could be empty for variant without data).
     Enum: Span<FieldLayout>,
 }
 
@@ -203,18 +203,10 @@ impl Introspect_option<T, +Introspect<T>> of Introspect<Option<T>> {
     fn layout() -> Layout {
         Layout::Enum(
             array![
-                FieldLayout {
-                    // Some
-                    selector: 0,
-                    layout: Layout::Tuple(
-                        array![Layout::Fixed(array![8].span()), Introspect::<T>::layout()].span()
-                    )
-                },
-                FieldLayout {
-                    // None
-                    selector: 1,
-                    layout: Layout::Tuple(array![Layout::Fixed(array![8].span())].span())
-                },
+                FieldLayout { // Some
+                selector: 0, layout: Introspect::<T>::layout() },
+                FieldLayout { // None
+                selector: 1, layout: Layout::Fixed(array![].span()) },
             ]
                 .span()
         )

--- a/crates/dojo-core/src/database/introspect_test.cairo
+++ b/crates/dojo-core/src/database/introspect_test.cairo
@@ -42,8 +42,23 @@ enum EnumNoData {
     Three
 }
 
+
 #[derive(Drop, Introspect)]
-enum EnumWithData {
+enum EnumWithSameData {
+    One: u256,
+    Two: u256,
+    Three: u256
+}
+
+#[derive(Drop, Introspect)]
+enum EnumWithSameTupleData {
+    One: (u256, u32),
+    Two: (u256, u32),
+    Three: (u256, u32)
+}
+
+#[derive(Drop, Introspect)]
+enum EnumWithVariousData {
     One: u32,
     Two: (u8, u16),
     Three: Array<u128>,
@@ -82,10 +97,8 @@ fn _enum(values: Array<Option<Layout>>) -> Layout {
 
         let v = *values.at(i);
         match v {
-            Option::Some(v) => {
-                items.append(field(i.into(), tuple(array![fixed(array![8]), v])));
-            },
-            Option::None => { items.append(field(i.into(), fixed(array![8]))) }
+            Option::Some(v) => { items.append(field(i.into(), v)); },
+            Option::None => { items.append(field(i.into(), fixed(array![]))) }
         }
 
         i += 1;
@@ -144,8 +157,25 @@ fn test_size_with_nested_array_in_tuple() {
 #[test]
 fn test_size_of_enum_without_variant_data() {
     let size = Introspect::<EnumNoData>::size();
-    assert!(size.is_none());
+    assert!(size.is_some());
+    assert!(size.unwrap() == 1);
 }
+
+#[test]
+fn test_size_of_enum_with_same_variant_data() {
+    let size = Introspect::<EnumWithSameData>::size();
+    assert!(size.is_some());
+    assert!(size.unwrap() == 3);
+}
+
+#[test]
+fn test_size_of_enum_with_same_tuple_variant_data() {
+    let size = Introspect::<EnumWithSameTupleData>::size();
+    assert!(size.is_some());
+    println!("size: {:?}", size);
+//    assert!(size.unwrap() == 3);
+}
+
 
 #[test]
 fn test_size_of_struct_with_option() {
@@ -155,44 +185,33 @@ fn test_size_of_struct_with_option() {
 
 #[test]
 fn test_size_of_enum_with_variant_data() {
-    let size = Introspect::<EnumWithData>::size();
+    let size = Introspect::<EnumWithVariousData>::size();
     assert!(size.is_none());
 }
 
 #[test]
 fn test_layout_of_enum_without_variant_data() {
     let layout = Introspect::<EnumNoData>::layout();
-    let expected = Layout::Enum(
-        array![
-            // One
-            field(0, tuple(array![fixed(array![8])])),
-            // Two
-            field(1, tuple(array![fixed(array![8])])),
-            // Three
-            field(2, tuple(array![fixed(array![8])])),
-        ]
-            .span()
-    );
+    let expected = _enum(array![ // One
+    Option::None, // Two
+    Option::None, // Three
+    Option::None,]);
 
     assert!(layout == expected);
 }
 
 #[test]
 fn test_layout_of_enum_with_variant_data() {
-    let layout = Introspect::<EnumWithData>::layout();
-    let expected = Layout::Enum(
+    let layout = Introspect::<EnumWithVariousData>::layout();
+    let expected = _enum(
         array![
             // One
-            field(0, tuple(array![fixed(array![8]), fixed(array![32]),])),
+            Option::Some(fixed(array![32])),
             // Two
-            field(
-                1,
-                tuple(array![fixed(array![8]), tuple(array![fixed(array![8]), fixed(array![16]),])])
-            ),
+            Option::Some(tuple(array![fixed(array![8]), fixed(array![16])])),
             // Three
-            field(2, tuple(array![fixed(array![8]), arr(fixed(array![128])),])),
+            Option::Some(arr(fixed(array![128]))),
         ]
-            .span()
     );
 
     assert!(layout == expected);

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -984,9 +984,17 @@ mod world {
             let variant = *values.at(offset);
             assert(variant.into() < 256_u256, 'invalid variant value');
 
+            // and write it
+            database::set(model, key, values, offset, array![251].span());
+            offset += 1;
+
             // find the corresponding layout and then write the full variant
+            let variant_data_key = Self::_field_key(key, variant);
+
             match Self::_find_variant_layout(variant, variant_layouts) {
-                Option::Some(layout) => Self::_write_layout(model, key, values, ref offset, layout),
+                Option::Some(layout) => Self::_write_layout(
+                    model, variant_data_key, values, ref offset, layout
+                ),
                 Option::None => panic!("Unable to find the variant layout")
             };
         }
@@ -1087,16 +1095,21 @@ mod world {
         }
 
         fn _delete_enum_layout(model: felt252, key: felt252, variant_layouts: Span<FieldLayout>) {
-            // read the variant value first which is the first stored felt252
+            // read the variant value
             let res = database::get(model, key, array![251].span());
             assert(res.len() == 1, 'internal database error');
 
             let variant = *res.at(0);
             assert(variant.into() < 256_u256, 'invalid variant value');
 
+            // reset the variant value
+            database::delete(model, key, array![251].span());
+
             // find the corresponding layout and the delete the full variant
+            let variant_data_key = Self::_field_key(key, variant);
+
             match Self::_find_variant_layout(variant, variant_layouts) {
-                Option::Some(layout) => Self::_delete_layout(model, key, layout),
+                Option::Some(layout) => Self::_delete_layout(model, variant_data_key, layout),
                 Option::None => panic!("Unable to find the variant layout")
             };
         }
@@ -1260,18 +1273,22 @@ mod world {
             ref read_data: Array<felt252>,
             variant_layouts: Span<FieldLayout>
         ) {
-            // read the variant value first, which is the first element of the tuple
-            // (because an enum is stored as a tuple).
-            let variant_key = Self::_field_key(key, 0);
-            let res = database::get(model, variant_key, array![8].span());
+            // read the variant value first
+            let res = database::get(model, key, array![8].span());
             assert(res.len() == 1, 'internal database error');
 
             let variant = *res.at(0);
             assert(variant.into() < 256_u256, 'invalid variant value');
 
-            // find the corresponding layout and the read the full variant
+            read_data.append(variant);
+
+            // find the corresponding layout and the read the variant data
+            let variant_data_key = Self::_field_key(key, variant);
+
             match Self::_find_variant_layout(variant, variant_layouts) {
-                Option::Some(layout) => Self::_read_layout(model, key, ref read_data, layout),
+                Option::Some(layout) => Self::_read_layout(
+                    model, variant_data_key, ref read_data, layout
+                ),
                 Option::None => panic!("Unable to find the variant layout")
             };
         }

--- a/crates/dojo-lang/src/introspect/layout.rs
+++ b/crates/dojo-lang/src/introspect/layout.rs
@@ -56,7 +56,9 @@ pub fn build_variant_layouts(
             let selector = format!("{i}");
 
             let variant_layout = match v.type_clause(db) {
-                OptionTypeClause::Empty(_) => "".to_string(),
+                OptionTypeClause::Empty(_) => {
+                    "dojo::database::introspect::Layout::Fixed(array![].span())".to_string()
+                }
                 OptionTypeClause::TypeClause(type_clause) => {
                     get_layout_from_type_clause(db, diagnostics, &type_clause)
                 }
@@ -65,12 +67,7 @@ pub fn build_variant_layouts(
             format!(
                 "dojo::database::introspect::FieldLayout {{
                     selector: {selector},
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            {variant_layout}
-                        ].span()
-                    )
+                    layout: {variant_layout}
                 }}"
             )
         })

--- a/crates/dojo-lang/src/introspect/size.rs
+++ b/crates/dojo-lang/src/introspect/size.rs
@@ -32,29 +32,47 @@ pub fn compute_struct_layout_size(db: &dyn SyntaxGroup, struct_ast: &ItemStruct)
     build_size_function_body(&mut sizes, cumulated_sizes, is_dynamic_size)
 }
 
-pub fn compute_enum_layout_size(
+pub fn compute_enum_variant_sizes(
     db: &dyn SyntaxGroup,
     enum_ast: &ItemEnum,
-    identical_variants: bool,
-) -> String {
-    if identical_variants {
-        match enum_ast.variants(db).elements(db).first() {
-            Some(first_variant) => {
-                let (mut sizes, cumulated_sizes, is_dynamic_size) =
-                    match first_variant.type_clause(db) {
-                        OptionTypeClause::Empty(_) => (vec![], 0, false),
-                        OptionTypeClause::TypeClause(type_clause) => {
-                            get_field_size_from_type_clause(db, &type_clause)
-                        }
-                    };
-
-                // add 8 bits to store the variant identifier
-                sizes.insert(0, "8".to_string());
-
-                build_size_function_body(&mut sizes, cumulated_sizes, is_dynamic_size)
+) -> Vec<(Vec<String>, u32, bool)> {
+    enum_ast
+        .variants(db)
+        .elements(db)
+        .iter()
+        .map(|v| match v.type_clause(db) {
+            OptionTypeClause::Empty(_) => (vec![], 0, false),
+            OptionTypeClause::TypeClause(type_clause) => {
+                get_field_size_from_type_clause(db, &type_clause)
             }
-            None => "Option::None".to_string(),
-        }
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn is_enum_packable(variant_sizes: &[(Vec<String>, u32, bool)]) -> bool {
+    if variant_sizes.is_empty() {
+        return true;
+    }
+    let v0_fixed_size = variant_sizes[0].1;
+    variant_sizes.iter().all(|vs| vs.0.is_empty() && vs.1 == v0_fixed_size && !vs.2)
+}
+
+pub fn compute_enum_layout_size(variant_sizes: &[(Vec<String>, u32, bool)]) -> String {
+    if variant_sizes.is_empty() {
+        return "Option::None".to_string();
+    }
+
+    let v0 = variant_sizes[0].clone();
+    let identical_variants =
+        variant_sizes.iter().all(|vs| vs.0 == v0.0 && vs.1 == v0.1 && vs.2 == v0.2);
+
+    if identical_variants {
+        let (mut sizes, mut cumulated_sizes, is_dynamic_size) = v0;
+
+        // add one felt252 to store the variant identifier
+        cumulated_sizes += 1;
+
+        build_size_function_body(&mut sizes, cumulated_sizes, is_dynamic_size)
     } else {
         "Option::None".to_string()
     }

--- a/crates/dojo-lang/src/introspect/utils.rs
+++ b/crates/dojo-lang/src/introspect/utils.rs
@@ -1,9 +1,5 @@
 use std::collections::HashMap;
 
-use cairo_lang_syntax::node::ast::ItemEnum;
-use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::TypedSyntaxNode;
-
 #[derive(Clone, Default)]
 pub struct TypeIntrospection(pub usize, pub Vec<usize>);
 
@@ -94,16 +90,6 @@ pub fn get_tuple_item_types(ty: &str) -> Vec<String> {
     items
 }
 
-pub fn are_enum_variants_identical(db: &dyn SyntaxGroup, enum_ast: &ItemEnum) -> bool {
-    let variants = enum_ast
-        .variants(db)
-        .elements(db)
-        .iter()
-        .map(|v| v.as_syntax_node().get_text(db))
-        .collect::<Vec<_>>();
-    variants.iter().all(|item| item == &variants[0])
-}
-
 #[test]
 pub fn test_get_tuple_item_types() {
     pub fn assert_array(got: Vec<String>, expected: Vec<String>) {
@@ -142,7 +128,7 @@ pub fn test_get_tuple_item_types() {
 
     for (value, expected) in test_cases {
         assert_array(
-            get_tuple_item_types(&value.to_string()),
+            get_tuple_item_types(value),
             expected.iter().map(|x| x.to_string()).collect::<Vec<_>>(),
         )
     }

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo_world_world.toml
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo_world_world.toml
@@ -1,5 +1,5 @@
 kind = "Class"
-class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
-original_class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
+class_hash = "0x16ab69142807e2cb54546de8735004eb4d50b6713f6bc2ecc9d8710c230cb1a"
+original_class_hash = "0x16ab69142807e2cb54546de8735004eb4d50b6713f6bc2ecc9d8710c230cb1a"
 abi = "manifests/dev/abis/base/dojo_world_world.json"
 name = "dojo::world::world"

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -43,6 +43,8 @@ pub const DOJO_EVENT_ATTR: &str = "dojo::event";
 pub const DOJO_INTROSPECT_ATTR: &str = "Introspect";
 pub const DOJO_PACKED_ATTR: &str = "IntrospectPacked";
 
+pub const DOJO_MODEL_MANDATORY_DERIVE_ATTRS: [&str; 3] = ["Drop", "Copy", "Serde"];
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Model {
     pub name: String,

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -43,8 +43,6 @@ pub const DOJO_EVENT_ATTR: &str = "dojo::event";
 pub const DOJO_INTROSPECT_ATTR: &str = "Introspect";
 pub const DOJO_PACKED_ATTR: &str = "IntrospectPacked";
 
-pub const DOJO_MODEL_MANDATORY_DERIVE_ATTRS: [&str; 3] = ["Drop", "Copy", "Serde"];
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct Model {
     pub name: String,

--- a/crates/dojo-lang/src/plugin_test_data/introspect
+++ b/crates/dojo-lang/src/plugin_test_data/introspect
@@ -14,8 +14,8 @@ struct Vec2 {
 
 #[derive(Serde, Copy, Drop, Introspect)]
 enum PlainEnum {
-    Left: (),
-    Right: (),
+    Left,
+    Right,
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
@@ -262,8 +262,8 @@ struct Vec2 {
 
 #[derive(Serde, Copy, Drop, Introspect)]
 enum PlainEnum {
-    Left: (),
-    Right: (),
+    Left,
+    Right,
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
@@ -583,7 +583,7 @@ impl PlainEnumDrop of core::traits::Drop::<PlainEnum>;
 impl PlainEnumIntrospect<> of dojo::database::introspect::Introspect<PlainEnum<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(1)
     }
 
     #[inline(always)]
@@ -592,29 +592,11 @@ impl PlainEnumIntrospect<> of dojo::database::introspect::Introspect<PlainEnum<>
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
-            array![
-            
-            ].span()
-        )
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Layout::Fixed(array![].span())
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
-            array![
-            
-            ].span()
-        )
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Layout::Fixed(array![].span())
                 }
             ].span()
         )
@@ -627,16 +609,8 @@ dojo::database::introspect::FieldLayout {
                 name: 'PlainEnum',
                 attrs: array![].span(),
                 children: array![
-                ('Left', dojo::database::introspect::Ty::Tuple(
-            array![
-            
-            ].span()
-        )),
-('Right', dojo::database::introspect::Ty::Tuple(
-            array![
-            
-            ].span()
-        ))
+                ('Left', dojo::database::introspect::Ty::Tuple(array![].span())),
+('Right', dojo::database::introspect::Ty::Tuple(array![].span()))
 
                 ].span()
             }
@@ -667,7 +641,7 @@ impl EnumWithPrimitiveDrop of core::traits::Drop::<EnumWithPrimitive>;
 impl EnumWithPrimitiveIntrospect<> of dojo::database::introspect::Introspect<EnumWithPrimitive<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(2)
     }
 
     #[inline(always)]
@@ -676,21 +650,11 @@ impl EnumWithPrimitiveIntrospect<> of dojo::database::introspect::Introspect<Enu
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<u32>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<u32>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 }
             ].span()
         )
@@ -735,7 +699,16 @@ impl EnumWithStructDrop of core::traits::Drop::<EnumWithStruct>;
 impl EnumWithStructIntrospect<> of dojo::database::introspect::Introspect<EnumWithStruct<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+Option::Some(1)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -744,21 +717,11 @@ impl EnumWithStructIntrospect<> of dojo::database::introspect::Introspect<EnumWi
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 }
             ].span()
         )
@@ -812,21 +775,11 @@ impl EnumWithSimpleArrayIntrospect<> of dojo::database::introspect::Introspect<E
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Array<u32>>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Array<u32>>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Array<u32>>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Array<u32>>::layout()
                 }
             ].span()
         )
@@ -888,21 +841,11 @@ impl EnumWithByteArrayIntrospect<> of dojo::database::introspect::Introspect<Enu
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<ByteArray>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<ByteArray>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<ByteArray>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<ByteArray>::layout()
                 }
             ].span()
         )
@@ -947,7 +890,7 @@ impl EnumWithSimpleTupleDrop of core::traits::Drop::<EnumWithSimpleTuple>;
 impl EnumWithSimpleTupleIntrospect<> of dojo::database::introspect::Introspect<EnumWithSimpleTuple<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(4)
     }
 
     #[inline(always)]
@@ -957,30 +900,20 @@ impl EnumWithSimpleTupleIntrospect<> of dojo::database::introspect::Introspect<E
             dojo::database::introspect::FieldLayout {
                     selector: 0,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<u256>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<u256>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -1035,7 +968,16 @@ impl EnumWithComplexTupleDrop of core::traits::Drop::<EnumWithComplexTuple>;
 impl EnumWithComplexTupleIntrospect<> of dojo::database::introspect::Introspect<EnumWithComplexTuple<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+Option::Some(2)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -1045,30 +987,20 @@ impl EnumWithComplexTupleIntrospect<> of dojo::database::introspect::Introspect<
             dojo::database::introspect::FieldLayout {
                     selector: 0,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<Vec2>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<Vec2>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -1123,7 +1055,7 @@ impl EnumTupleOnePrimitiveDrop of core::traits::Drop::<EnumTupleOnePrimitive>;
 impl EnumTupleOnePrimitiveIntrospect<> of dojo::database::introspect::Introspect<EnumTupleOnePrimitive<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(2)
     }
 
     #[inline(always)]
@@ -1133,28 +1065,18 @@ impl EnumTupleOnePrimitiveIntrospect<> of dojo::database::introspect::Introspect
             dojo::database::introspect::FieldLayout {
                     selector: 0,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u16>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u16>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -1207,7 +1129,16 @@ impl EnumCustomDrop of core::traits::Drop::<EnumCustom>;
 impl EnumCustomIntrospect<> of dojo::database::introspect::Introspect<EnumCustom<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+Option::Some(1)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -1216,21 +1147,11 @@ impl EnumCustomIntrospect<> of dojo::database::introspect::Introspect<EnumCustom
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 }
             ].span()
         )
@@ -1275,7 +1196,17 @@ impl EnumTupleMixDrop of core::traits::Drop::<EnumTupleMix>;
 impl EnumTupleMixIntrospect<> of dojo::database::introspect::Introspect<EnumTupleMix<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+dojo::database::introspect::Introspect::<EnumCustom>::size(),
+Option::Some(2)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -1285,32 +1216,22 @@ impl EnumTupleMixIntrospect<> of dojo::database::introspect::Introspect<EnumTupl
             dojo::database::introspect::FieldLayout {
                     selector: 0,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<Vec2>::layout(),
 dojo::database::introspect::Introspect::<u64>::layout(),
 dojo::database::introspect::Introspect::<EnumCustom>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<Vec2>::layout(),
 dojo::database::introspect::Introspect::<u64>::layout(),
 dojo::database::introspect::Introspect::<EnumCustom>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -1378,35 +1299,20 @@ impl EnumWithDifferentVariantDataIntrospect<> of dojo::database::introspect::Int
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Layout::Fixed(array![].span())
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<u32>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 2,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<Vec2>::layout(),
 dojo::database::introspect::Introspect::<u64>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -2347,8 +2253,8 @@ impl EnumWithBadOptionIntrospect<> of dojo::database::introspect::Introspect<Enu
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        8,
-dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size()
+                        dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size(),
+Option::Some(1)
                     ];
 
                     if dojo::database::utils::any_none(@sizes) {
@@ -2364,12 +2270,7 @@ dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size()
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Option<(u8, u16)>>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Option<(u8, u16)>>::layout()
                 }
             ].span()
         )
@@ -2841,12 +2742,16 @@ dojo::database::introspect::Member {
 impl EnumPacked1Introspect<> of dojo::database::introspect::Introspect<EnumPacked1<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(1)
     }
 
     #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
-        ERROR
+        dojo::database::introspect::Layout::Fixed(
+                array![
+                8,
+                ].span()
+            )
     }
 
     #[inline(always)]
@@ -2869,12 +2774,16 @@ impl EnumPacked1Introspect<> of dojo::database::introspect::Introspect<EnumPacke
 impl EnumPacked2Introspect<> of dojo::database::introspect::Introspect<EnumPacked2<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(2)
     }
 
     #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
-        ERROR
+        dojo::database::introspect::Layout::Fixed(
+                array![
+                8,8
+                ].span()
+            )
     }
 
     #[inline(always)]
@@ -2897,12 +2806,16 @@ impl EnumPacked2Introspect<> of dojo::database::introspect::Introspect<EnumPacke
 impl EnumPacked3Introspect<> of dojo::database::introspect::Introspect<EnumPacked3<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(3)
     }
 
     #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
-        ERROR
+        dojo::database::introspect::Layout::Fixed(
+                array![
+                8,128,128
+                ].span()
+            )
     }
 
     #[inline(always)]
@@ -2994,22 +2907,7 @@ error: For now, field with custom type cannot be packed
     y: StructPacked1
      ^*************^
 
-error: To be packed, all variants must have exactly the same layout.
- --> test_src/lib.cairo:223:6
-enum EnumPacked1 {
-     ^*********^
-
-error: To be packed, all variants must have exactly the same layout.
- --> test_src/lib.cairo:230:6
-enum EnumPacked2 {
-     ^*********^
-
-error: To be packed, all variants must have exactly the same layout.
- --> test_src/lib.cairo:237:6
-enum EnumPacked3 {
-     ^*********^
-
-error: To be packed, all variants must have exactly the same layout.
+error: To be packed, all variants must have fixed layout of same size.
  --> test_src/lib.cairo:243:6
 enum EnumNotPackable1 {
      ^**************^

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -324,73 +324,105 @@ error: Unsupported attribute.
 
 error: Anything other than functions is not supported in a dojo::interface
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:80:5
 =======
  --> test_src/lib.cairo:87:5
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:88:5
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
     const ONE: u8;
     ^************^
 
 error: Functions of dojo::interface cannot have `ref self` parameter.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:82:5
 =======
  --> test_src/lib.cairo:89:5
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:90:5
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
     fn do_ref_self(ref self: TContractState);
     ^***************************************^
 
 error: Functions of dojo::contract cannot have 'ref self' parameter.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:130:9
 =======
  --> test_src/lib.cairo:137:9
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:138:9
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
         fn do_with_ref_self(ref self: ContractState) -> felt252 {
         ^*******************************************************^
 
 error: Only one parameter of type IWorldDispatcher is allowed.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:134:9
 =======
  --> test_src/lib.cairo:141:9
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:142:9
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
         fn do_with_several_world_dispatchers(
         ^***********************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:140:42
 =======
  --> test_src/lib.cairo:147:42
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:148:42
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
         fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
                                          ^*****************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:145:35
 =======
  --> test_src/lib.cairo:152:35
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:153:35
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
             self: @ContractState, another_world: IWorldDispatcher
                                   ^*****************************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:150:47
 =======
  --> test_src/lib.cairo:157:47
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:158:47
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
         fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
                                               ^*********************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:155:46
 =======
  --> test_src/lib.cairo:162:46
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:163:46
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
             self: @ContractState, vec: Vec2, world: IWorldDispatcher
                                              ^*********************^
 
@@ -421,37 +453,53 @@ error: Unsupported attribute.
 
 error: Unsupported attribute.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:84:5
 =======
  --> test_src/lib.cairo:91:5
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:92:5
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
     #[my_attr]
     ^********^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
@@ -667,217 +715,313 @@ error: Unsupported attribute.
 
 error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:95:5
 =======
  --> test_src/lib.cairo:102:5
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:103:5
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:128:5
 =======
  --> test_src/lib.cairo:135:5
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:136:5
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:169:5
 =======
  --> test_src/lib.cairo:176:5
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:177:5
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
 >>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
 #[dojo::contract]
 ^***************^
 

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -203,1115 +203,6 @@ mod MyNominalContract {
 }
 
 //! > generated_cairo_code
-#[starknet::contract]
-mod spawn {
-    use dojo::world;
-    use dojo::world::IWorldDispatcher;
-    use dojo::world::IWorldDispatcherTrait;
-
-    #[storage]
-    struct Storage {
-        world_dispatcher: IWorldDispatcher,
-    }
-
-    #[abi(embed_v0)]
-    fn name(self: @ContractState) -> felt252 {
-        'spawn'
-    }
-
-    #[abi(embed_v0)]
-    impl Upgradeable of dojo::upgradable::IUpgradeable<ContractState> {
-        fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
-            let caller = starknet::get_caller_address();
-            assert(
-                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
-            );
-            dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
-        }
-    }
-
-    use traits::Into;
-    use dojo::world::Context;
-
-    #[abi(embed_v0)]
-    fn execute(self: @ContractState, ctx: Context, name: felt252) {
-        return ();
-    }
-}
-
-
-#[starknet::contract]
-mod proxy {
-    use dojo::world;
-    use dojo::world::IWorldDispatcher;
-    use dojo::world::IWorldDispatcherTrait;
-
-    #[storage]
-    struct Storage {
-        world_dispatcher: IWorldDispatcher,
-    }
-
-    #[abi(embed_v0)]
-    fn name(self: @ContractState) -> felt252 {
-        'proxy'
-    }
-
-    #[abi(embed_v0)]
-    impl Upgradeable of dojo::upgradable::IUpgradeable<ContractState> {
-        fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
-            let caller = starknet::get_caller_address();
-            assert(
-                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
-            );
-            dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
-        }
-    }
-
-
-    #[abi(embed_v0)]
-    fn execute(self: @ContractState, value: felt252) -> felt252 {
-        value
-    }
-}
-
-
-#[starknet::contract]
-mod ctxnamed {
-    use dojo::world;
-    use dojo::world::IWorldDispatcher;
-    use dojo::world::IWorldDispatcherTrait;
-
-    #[storage]
-    struct Storage {
-        world_dispatcher: IWorldDispatcher,
-    }
-
-    #[abi(embed_v0)]
-    fn name(self: @ContractState) -> felt252 {
-        'ctxnamed'
-    }
-
-    #[abi(embed_v0)]
-    impl Upgradeable of dojo::upgradable::IUpgradeable<ContractState> {
-        fn upgrade(ref self: ContractState, new_class_hash: starknet::ClassHash) {
-            let caller = starknet::get_caller_address();
-            assert(
-                self.world_dispatcher.read().contract_address == caller, 'only World can upgrade'
-            );
-            dojo::upgradable::UpgradeableTrait::upgrade(new_class_hash);
-        }
-    }
-
-    use traits::Into;
-    use dojo::world::Context;
-
-    #[abi(embed_v0)]
-    fn execute(self: @ContractState, ctx2: Context, name: felt252) {
-        return ();
-    }
-}
-
-//! > expected_diagnostics
-error: Unsupported attribute.
- --> test_src/lib.cairo:42:1
-#[starknet::component]
-^********************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:48:1
-#[starknet::component]
-^********************^
-
-error: Anything other than functions is not supported in a dojo::interface
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:80:5
-=======
- --> test_src/lib.cairo:87:5
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:88:5
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:91:5
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:80:5
->>>>>>> 4b0402e4 (fix dojo-lang system)
-    const ONE: u8;
-    ^************^
-
-error: Functions of dojo::interface cannot have `ref self` parameter.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:82:5
-=======
- --> test_src/lib.cairo:89:5
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:90:5
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:93:5
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:82:5
->>>>>>> 4b0402e4 (fix dojo-lang system)
-    fn do_ref_self(ref self: TContractState);
-    ^***************************************^
-
-error: Functions of dojo::contract cannot have 'ref self' parameter.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:130:9
-=======
- --> test_src/lib.cairo:137:9
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:138:9
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:141:9
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:130:9
->>>>>>> 4b0402e4 (fix dojo-lang system)
-        fn do_with_ref_self(ref self: ContractState) -> felt252 {
-        ^*******************************************************^
-
-error: Only one parameter of type IWorldDispatcher is allowed.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:134:9
-=======
- --> test_src/lib.cairo:141:9
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:142:9
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:145:9
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:134:9
->>>>>>> 4b0402e4 (fix dojo-lang system)
-        fn do_with_several_world_dispatchers(
-        ^***********************************^
-
-error: The IWorldDispatcher parameter must be named 'world'.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:140:42
-=======
- --> test_src/lib.cairo:147:42
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:148:42
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:151:42
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:140:42
->>>>>>> 4b0402e4 (fix dojo-lang system)
-        fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
-                                         ^*****************************^
-
-error: The IWorldDispatcher parameter must be named 'world'.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:145:35
-=======
- --> test_src/lib.cairo:152:35
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:153:35
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:156:35
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:145:35
->>>>>>> 4b0402e4 (fix dojo-lang system)
-            self: @ContractState, another_world: IWorldDispatcher
-                                  ^*****************************^
-
-error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:150:47
-=======
- --> test_src/lib.cairo:157:47
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:158:47
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:161:47
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:150:47
->>>>>>> 4b0402e4 (fix dojo-lang system)
-        fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
-                                              ^*********************^
-
-error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:155:46
-=======
- --> test_src/lib.cairo:162:46
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:163:46
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:166:46
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:155:46
->>>>>>> 4b0402e4 (fix dojo-lang system)
-            self: @ContractState, vec: Vec2, world: IWorldDispatcher
-                                             ^*********************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:84:5
-=======
- --> test_src/lib.cairo:91:5
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:92:5
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:95:5
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:84:5
->>>>>>> 4b0402e4 (fix dojo-lang system)
-    #[my_attr]
-    ^********^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:44:5
-    #[storage]
-    ^********^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:50:5
-    #[storage]
-    ^********^
-
-error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:1:1
-#[dojo::contract]
-^***************^
-
-error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:11:1
-#[dojo::contract]
-^***************^
-
-error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:18:1
-#[dojo::contract]
-^***************^
-
-error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:28:1
-#[dojo::contract]
-^***************^
-
-error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo:56:5
-    component!(path: testcomponent1, storage: testcomponent1_storage, event: testcomponent1_event);
-    ^*********************************************************************************************^
-
-error: Unknown inline item macro: 'component'.
- --> test_src/lib.cairo:57:5
-    component!(path: testcomponent2, storage: testcomponent2_storage, event: testcomponent2_event);
-    ^*********************************************************************************************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
- --> test_src/lib.cairo:54:1
-#[dojo::contract]
-^***************^
-
-error: Unknown inline item macro: 'component'.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:95:5
-=======
- --> test_src/lib.cairo:102:5
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:103:5
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:106:5
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:95:5
->>>>>>> 4b0402e4 (fix dojo-lang system)
-    #[abi(embed_v0)]
-    ^**************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:93:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unknown inline item macro: 'component'.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:128:5
-=======
- --> test_src/lib.cairo:135:5
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:136:5
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:139:5
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:128:5
->>>>>>> 4b0402e4 (fix dojo-lang system)
-    #[abi(embed_v0)]
-    ^**************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:126:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unknown inline item macro: 'component'.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:169:5
-=======
- --> test_src/lib.cairo:176:5
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:177:5
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:180:5
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:169:5
->>>>>>> 4b0402e4 (fix dojo-lang system)
-    #[abi(embed_v0)]
-    ^**************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-=======
- --> test_src/lib.cairo:162:1
->>>>>>> 4b0402e4 (fix dojo-lang system)
-#[dojo::contract]
-^***************^
 
 //! > expanded_cairo_code
 
@@ -1810,3 +701,429 @@ impl ActionDrop of core::traits::Drop::<Action>;
 impl EventDrop of core::traits::Drop::<Event>;
             
                 }
+
+//! > expected_diagnostics
+error: Unsupported attribute.
+ --> test_src/lib.cairo:42:1
+#[starknet::component]
+^********************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:48:1
+#[starknet::component]
+^********************^
+
+error: Anything other than functions is not supported in a dojo::interface
+ --> test_src/lib.cairo:80:5
+    const ONE: u8;
+    ^************^
+
+error: Functions of dojo::interface cannot have `ref self` parameter.
+ --> test_src/lib.cairo:82:5
+    fn do_ref_self(ref self: TContractState);
+    ^***************************************^
+
+error: Functions of dojo::contract cannot have 'ref self' parameter.
+ --> test_src/lib.cairo:130:9
+        fn do_with_ref_self(ref self: ContractState) -> felt252 {
+        ^*******************************************************^
+
+error: Only one parameter of type IWorldDispatcher is allowed.
+ --> test_src/lib.cairo:134:9
+        fn do_with_several_world_dispatchers(
+        ^***********************************^
+
+error: The IWorldDispatcher parameter must be named 'world'.
+ --> test_src/lib.cairo:140:42
+        fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
+                                         ^*****************************^
+
+error: The IWorldDispatcher parameter must be named 'world'.
+ --> test_src/lib.cairo:145:35
+            self: @ContractState, another_world: IWorldDispatcher
+                                  ^*****************************^
+
+error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+ --> test_src/lib.cairo:150:47
+        fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
+                                              ^*********************^
+
+error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+ --> test_src/lib.cairo:155:46
+            self: @ContractState, vec: Vec2, world: IWorldDispatcher
+                                             ^*********************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:84:5
+    #[my_attr]
+    ^********^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:44:5
+    #[storage]
+    ^********^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:50:5
+    #[storage]
+    ^********^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:1:1
+#[dojo::contract]
+^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:11:1
+#[dojo::contract]
+^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:18:1
+#[dojo::contract]
+^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:28:1
+#[dojo::contract]
+^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:56:5
+    component!(path: testcomponent1, storage: testcomponent1_storage, event: testcomponent1_event);
+    ^*********************************************************************************************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:57:5
+    component!(path: testcomponent2, storage: testcomponent2_storage, event: testcomponent2_event);
+    ^*********************************************************************************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:54:1
+#[dojo::contract]
+^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:95:5
+    #[abi(embed_v0)]
+    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:93:1
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:128:5
+    #[abi(embed_v0)]
+    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:126:1
+#[dojo::contract]
+^***************^
+
+error: Unknown inline item macro: 'component'.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:169:5
+    #[abi(embed_v0)]
+    ^**************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+ --> test_src/lib.cairo:162:1
+#[dojo::contract]
+^***************^

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -83,7 +83,7 @@ trait IEmptyTrait;
 
 #[dojo::interface]
 trait IFaultyTrait {
-   const ONE: u8;
+    const ONE: u8;
 
     fn do_ref_self(ref self: TContractState);
 
@@ -326,6 +326,7 @@ error: Anything other than functions is not supported in a dojo::interface
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:80:5
 =======
  --> test_src/lib.cairo:87:5
@@ -336,10 +337,14 @@ error: Anything other than functions is not supported in a dojo::interface
 =======
  --> test_src/lib.cairo:91:5
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:80:5
+>>>>>>> 4b0402e4 (fix dojo-lang system)
     const ONE: u8;
     ^************^
 
 error: Functions of dojo::interface cannot have `ref self` parameter.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -353,10 +358,14 @@ error: Functions of dojo::interface cannot have `ref self` parameter.
 =======
  --> test_src/lib.cairo:93:5
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:82:5
+>>>>>>> 4b0402e4 (fix dojo-lang system)
     fn do_ref_self(ref self: TContractState);
     ^***************************************^
 
 error: Functions of dojo::contract cannot have 'ref self' parameter.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -370,10 +379,14 @@ error: Functions of dojo::contract cannot have 'ref self' parameter.
 =======
  --> test_src/lib.cairo:141:9
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:130:9
+>>>>>>> 4b0402e4 (fix dojo-lang system)
         fn do_with_ref_self(ref self: ContractState) -> felt252 {
         ^*******************************************************^
 
 error: Only one parameter of type IWorldDispatcher is allowed.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -387,10 +400,14 @@ error: Only one parameter of type IWorldDispatcher is allowed.
 =======
  --> test_src/lib.cairo:145:9
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:134:9
+>>>>>>> 4b0402e4 (fix dojo-lang system)
         fn do_with_several_world_dispatchers(
         ^***********************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -404,10 +421,14 @@ error: The IWorldDispatcher parameter must be named 'world'.
 =======
  --> test_src/lib.cairo:151:42
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:140:42
+>>>>>>> 4b0402e4 (fix dojo-lang system)
         fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
                                          ^*****************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -421,10 +442,14 @@ error: The IWorldDispatcher parameter must be named 'world'.
 =======
  --> test_src/lib.cairo:156:35
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:145:35
+>>>>>>> 4b0402e4 (fix dojo-lang system)
             self: @ContractState, another_world: IWorldDispatcher
                                   ^*****************************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -438,10 +463,14 @@ error: The IWorldDispatcher parameter must be the first parameter of the functio
 =======
  --> test_src/lib.cairo:161:47
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:150:47
+>>>>>>> 4b0402e4 (fix dojo-lang system)
         fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
                                               ^*********************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -455,6 +484,9 @@ error: The IWorldDispatcher parameter must be the first parameter of the functio
 =======
  --> test_src/lib.cairo:166:46
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:155:46
+>>>>>>> 4b0402e4 (fix dojo-lang system)
             self: @ContractState, vec: Vec2, world: IWorldDispatcher
                                              ^*********************^
 
@@ -487,6 +519,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:84:5
 =======
  --> test_src/lib.cairo:91:5
@@ -497,10 +530,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:95:5
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:84:5
+>>>>>>> 4b0402e4 (fix dojo-lang system)
     #[my_attr]
     ^********^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -514,10 +551,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:104:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -531,10 +572,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:137:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -548,6 +593,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:173:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
@@ -765,22 +813,6 @@ error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:104:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
@@ -792,10 +824,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:104:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -809,10 +845,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:104:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -826,10 +866,35 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:104:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -843,6 +908,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:106:5
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:95:5
+>>>>>>> 4b0402e4 (fix dojo-lang system)
     #[abi(embed_v0)]
     ^**************^
 
@@ -850,6 +918,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
@@ -860,6 +929,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:104:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
@@ -867,6 +939,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
@@ -877,6 +950,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:104:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
@@ -884,6 +960,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
@@ -894,6 +971,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:104:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:93:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
@@ -901,22 +981,6 @@ error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:137:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
@@ -928,10 +992,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:137:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -945,10 +1013,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:137:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -962,10 +1034,35 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:137:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -979,6 +1076,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:139:5
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:128:5
+>>>>>>> 4b0402e4 (fix dojo-lang system)
     #[abi(embed_v0)]
     ^**************^
 
@@ -986,6 +1086,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
@@ -996,6 +1097,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:137:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
@@ -1003,6 +1107,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
@@ -1013,6 +1118,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:137:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
@@ -1020,6 +1128,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
@@ -1030,6 +1139,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:137:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:126:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
@@ -1037,22 +1149,6 @@ error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-=======
- --> test_src/lib.cairo:173:1
->>>>>>> a0bbad02 (update dojo-lang tests)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
-<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
@@ -1064,10 +1160,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:173:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -1081,10 +1181,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:173:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -1098,10 +1202,35 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:173:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
@@ -1115,6 +1244,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:180:5
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:169:5
+>>>>>>> 4b0402e4 (fix dojo-lang system)
     #[abi(embed_v0)]
     ^**************^
 
@@ -1122,6 +1254,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
@@ -1132,6 +1265,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:173:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
@@ -1139,6 +1275,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
@@ -1149,6 +1286,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:173:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 
@@ -1156,6 +1296,7 @@ error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
@@ -1166,6 +1307,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:173:1
 >>>>>>> a0bbad02 (update dojo-lang tests)
+=======
+ --> test_src/lib.cairo:162:1
+>>>>>>> 4b0402e4 (fix dojo-lang system)
 #[dojo::contract]
 ^***************^
 

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -323,42 +323,74 @@ error: Unsupported attribute.
 ^********************^
 
 error: Anything other than functions is not supported in a dojo::interface
+<<<<<<< HEAD
  --> test_src/lib.cairo:80:5
+=======
+ --> test_src/lib.cairo:87:5
+>>>>>>> b1b16586 (fix fmt+clippy)
     const ONE: u8;
     ^************^
 
 error: Functions of dojo::interface cannot have `ref self` parameter.
+<<<<<<< HEAD
  --> test_src/lib.cairo:82:5
+=======
+ --> test_src/lib.cairo:89:5
+>>>>>>> b1b16586 (fix fmt+clippy)
     fn do_ref_self(ref self: TContractState);
     ^***************************************^
 
 error: Functions of dojo::contract cannot have 'ref self' parameter.
+<<<<<<< HEAD
  --> test_src/lib.cairo:130:9
+=======
+ --> test_src/lib.cairo:137:9
+>>>>>>> b1b16586 (fix fmt+clippy)
         fn do_with_ref_self(ref self: ContractState) -> felt252 {
         ^*******************************************************^
 
 error: Only one parameter of type IWorldDispatcher is allowed.
+<<<<<<< HEAD
  --> test_src/lib.cairo:134:9
+=======
+ --> test_src/lib.cairo:141:9
+>>>>>>> b1b16586 (fix fmt+clippy)
         fn do_with_several_world_dispatchers(
         ^***********************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
+<<<<<<< HEAD
  --> test_src/lib.cairo:140:42
+=======
+ --> test_src/lib.cairo:147:42
+>>>>>>> b1b16586 (fix fmt+clippy)
         fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
                                          ^*****************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
+<<<<<<< HEAD
  --> test_src/lib.cairo:145:35
+=======
+ --> test_src/lib.cairo:152:35
+>>>>>>> b1b16586 (fix fmt+clippy)
             self: @ContractState, another_world: IWorldDispatcher
                                   ^*****************************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+<<<<<<< HEAD
  --> test_src/lib.cairo:150:47
+=======
+ --> test_src/lib.cairo:157:47
+>>>>>>> b1b16586 (fix fmt+clippy)
         fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
                                               ^*********************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+<<<<<<< HEAD
  --> test_src/lib.cairo:155:46
+=======
+ --> test_src/lib.cairo:162:46
+>>>>>>> b1b16586 (fix fmt+clippy)
             self: @ContractState, vec: Vec2, world: IWorldDispatcher
                                              ^*********************^
 
@@ -388,22 +420,38 @@ error: Unsupported attribute.
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:84:5
+=======
+ --> test_src/lib.cairo:91:5
+>>>>>>> b1b16586 (fix fmt+clippy)
     #[my_attr]
     ^********^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
@@ -618,122 +666,218 @@ error: Unsupported attribute.
 ^***************^
 
 error: Unknown inline item macro: 'component'.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:95:5
+=======
+ --> test_src/lib.cairo:102:5
+>>>>>>> b1b16586 (fix fmt+clippy)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unknown inline item macro: 'component'.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:128:5
+=======
+ --> test_src/lib.cairo:135:5
+>>>>>>> b1b16586 (fix fmt+clippy)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unknown inline item macro: 'component'.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:169:5
+=======
+ --> test_src/lib.cairo:176:5
+>>>>>>> b1b16586 (fix fmt+clippy)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
 #[dojo::contract]
 ^***************^
 

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -83,7 +83,7 @@ trait IEmptyTrait;
 
 #[dojo::interface]
 trait IFaultyTrait {
-    const ONE: u8;
+   const ONE: u8;
 
     fn do_ref_self(ref self: TContractState);
 
@@ -325,6 +325,7 @@ error: Unsupported attribute.
 error: Anything other than functions is not supported in a dojo::interface
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:80:5
 =======
  --> test_src/lib.cairo:87:5
@@ -332,10 +333,14 @@ error: Anything other than functions is not supported in a dojo::interface
 =======
  --> test_src/lib.cairo:88:5
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:91:5
+>>>>>>> a0bbad02 (update dojo-lang tests)
     const ONE: u8;
     ^************^
 
 error: Functions of dojo::interface cannot have `ref self` parameter.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:82:5
@@ -345,10 +350,14 @@ error: Functions of dojo::interface cannot have `ref self` parameter.
 =======
  --> test_src/lib.cairo:90:5
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:93:5
+>>>>>>> a0bbad02 (update dojo-lang tests)
     fn do_ref_self(ref self: TContractState);
     ^***************************************^
 
 error: Functions of dojo::contract cannot have 'ref self' parameter.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:130:9
@@ -358,10 +367,14 @@ error: Functions of dojo::contract cannot have 'ref self' parameter.
 =======
  --> test_src/lib.cairo:138:9
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:141:9
+>>>>>>> a0bbad02 (update dojo-lang tests)
         fn do_with_ref_self(ref self: ContractState) -> felt252 {
         ^*******************************************************^
 
 error: Only one parameter of type IWorldDispatcher is allowed.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:134:9
@@ -371,10 +384,14 @@ error: Only one parameter of type IWorldDispatcher is allowed.
 =======
  --> test_src/lib.cairo:142:9
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:145:9
+>>>>>>> a0bbad02 (update dojo-lang tests)
         fn do_with_several_world_dispatchers(
         ^***********************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:140:42
@@ -384,10 +401,14 @@ error: The IWorldDispatcher parameter must be named 'world'.
 =======
  --> test_src/lib.cairo:148:42
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:151:42
+>>>>>>> a0bbad02 (update dojo-lang tests)
         fn do_with_world_not_named_world(another_world: IWorldDispatcher) -> felt252 {
                                          ^*****************************^
 
 error: The IWorldDispatcher parameter must be named 'world'.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:145:35
@@ -397,10 +418,14 @@ error: The IWorldDispatcher parameter must be named 'world'.
 =======
  --> test_src/lib.cairo:153:35
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:156:35
+>>>>>>> a0bbad02 (update dojo-lang tests)
             self: @ContractState, another_world: IWorldDispatcher
                                   ^*****************************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:150:47
@@ -410,10 +435,14 @@ error: The IWorldDispatcher parameter must be the first parameter of the functio
 =======
  --> test_src/lib.cairo:158:47
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:161:47
+>>>>>>> a0bbad02 (update dojo-lang tests)
         fn do_with_world_not_first(vec: Vec2, world: IWorldDispatcher) -> felt252 {
                                               ^*********************^
 
 error: The IWorldDispatcher parameter must be the first parameter of the function (self excluded).
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:155:46
@@ -423,6 +452,9 @@ error: The IWorldDispatcher parameter must be the first parameter of the functio
 =======
  --> test_src/lib.cairo:163:46
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:166:46
+>>>>>>> a0bbad02 (update dojo-lang tests)
             self: @ContractState, vec: Vec2, world: IWorldDispatcher
                                              ^*********************^
 
@@ -454,6 +486,7 @@ error: Unsupported attribute.
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:84:5
 =======
  --> test_src/lib.cairo:91:5
@@ -461,10 +494,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:92:5
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:95:5
+>>>>>>> a0bbad02 (update dojo-lang tests)
     #[my_attr]
     ^********^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
@@ -474,10 +511,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:101:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
@@ -487,10 +528,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:134:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
@@ -500,6 +545,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:170:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
@@ -716,18 +764,6 @@ error: Unsupported attribute.
 error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
 <<<<<<< HEAD
- --> test_src/lib.cairo:93:1
-=======
- --> test_src/lib.cairo:100:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:101:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-#[dojo::contract(allow_ref_self)]
-^*******************************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
@@ -736,10 +772,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:101:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
@@ -749,10 +789,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:101:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:93:1
@@ -762,10 +806,31 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:101:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:93:1
+=======
+ --> test_src/lib.cairo:100:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:101:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
+#[dojo::contract(allow_ref_self)]
+^*******************************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:95:5
@@ -775,12 +840,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:103:5
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:106:5
+>>>>>>> a0bbad02 (update dojo-lang tests)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
@@ -788,12 +857,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:101:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
@@ -801,12 +874,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:101:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:93:1
 =======
  --> test_src/lib.cairo:100:1
@@ -814,24 +891,15 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:101:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:104:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract(allow_ref_self)]
 ^*******************************^
 
 error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
 <<<<<<< HEAD
- --> test_src/lib.cairo:126:1
-=======
- --> test_src/lib.cairo:133:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:134:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
@@ -840,10 +908,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:134:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
@@ -853,10 +925,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:134:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:126:1
@@ -866,10 +942,31 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:134:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:126:1
+=======
+ --> test_src/lib.cairo:133:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:134:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:128:5
@@ -879,12 +976,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:136:5
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:139:5
+>>>>>>> a0bbad02 (update dojo-lang tests)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
@@ -892,12 +993,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:134:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
@@ -905,12 +1010,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:134:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:126:1
 =======
  --> test_src/lib.cairo:133:1
@@ -918,24 +1027,15 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:134:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:137:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unknown inline item macro: 'component'.
 <<<<<<< HEAD
 <<<<<<< HEAD
- --> test_src/lib.cairo:162:1
-=======
- --> test_src/lib.cairo:169:1
->>>>>>> b1b16586 (fix fmt+clippy)
-=======
- --> test_src/lib.cairo:170:1
->>>>>>> b7940e47 (fix warning about trait path in Impl)
-#[dojo::contract]
-^***************^
-
-error: Unsupported attribute.
-<<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
@@ -944,10 +1044,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:170:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
@@ -957,10 +1061,14 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:170:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:162:1
@@ -970,10 +1078,31 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:170:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+ --> test_src/lib.cairo:162:1
+=======
+ --> test_src/lib.cairo:169:1
+>>>>>>> b1b16586 (fix fmt+clippy)
+=======
+ --> test_src/lib.cairo:170:1
+>>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
+#[dojo::contract]
+^***************^
+
+error: Unsupported attribute.
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
  --> test_src/lib.cairo:169:5
@@ -983,12 +1112,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:177:5
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:180:5
+>>>>>>> a0bbad02 (update dojo-lang tests)
     #[abi(embed_v0)]
     ^**************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
@@ -996,12 +1129,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:170:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
@@ -1009,12 +1146,16 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:170:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 
 error: Unsupported attribute.
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
  --> test_src/lib.cairo:162:1
 =======
  --> test_src/lib.cairo:169:1
@@ -1022,6 +1163,9 @@ error: Unsupported attribute.
 =======
  --> test_src/lib.cairo:170:1
 >>>>>>> b7940e47 (fix warning about trait path in Impl)
+=======
+ --> test_src/lib.cairo:173:1
+>>>>>>> a0bbad02 (update dojo-lang tests)
 #[dojo::contract]
 ^***************^
 

--- a/crates/dojo-types/src/schema.rs
+++ b/crates/dojo-types/src/schema.rs
@@ -245,12 +245,64 @@ impl<'a> Iterator for TyIter<'a> {
     }
 }
 
+// parse the Ty tree from its root and extract Ty to print.
+// (basically, structs and enums)
+fn get_printable_ty_list(root_ty: &Ty, ty_list: &mut Vec<Ty>) {
+    match root_ty {
+        Ty::Primitive(_) => {}
+        Ty::ByteArray(_) => {}
+        Ty::Struct(s) => {
+            if !ty_list.contains(root_ty) {
+                ty_list.push(root_ty.clone());
+            }
+
+            for member in &s.children {
+                if !ty_list.contains(&member.ty) {
+                    get_printable_ty_list(&member.ty, ty_list);
+                }
+            }
+        }
+        Ty::Enum(e) => {
+            if !ty_list.contains(root_ty) {
+                ty_list.push(root_ty.clone());
+            }
+
+            for child in &e.options {
+                if !ty_list.contains(&child.ty) {
+                    get_printable_ty_list(&child.ty, ty_list);
+                }
+            }
+        }
+        Ty::Tuple(tuple) => {
+            for item_ty in tuple {
+                if !ty_list.contains(&item_ty) {
+                    get_printable_ty_list(item_ty, ty_list);
+                }
+            }
+        }
+        Ty::Array(items_ty) => {
+            if !ty_list.contains(&items_ty[0]) {
+                get_printable_ty_list(&items_ty[0], ty_list)
+            }
+        }
+    };
+}
+
+// print the full Ty tree
+pub fn deep_print_ty(root: Ty) {
+    let mut ty_list = vec![];
+    get_printable_ty_list(&root, &mut ty_list);
+
+    for ty in ty_list {
+        println!("{}\n\n", ty);
+    }
+}
+
 impl std::fmt::Display for Ty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = self
             .iter()
             .filter_map(|ty| match ty {
-                Ty::Primitive(_) => None,
                 Ty::Struct(s) => {
                     let mut struct_str = format!("struct {} {{\n", s.name);
                     for member in &s.children {
@@ -267,11 +319,7 @@ impl std::fmt::Display for Ty {
                     enum_str.push('}');
                     Some(enum_str)
                 }
-                Ty::Tuple(tuple) => {
-                    Some(format!("tuple({})", tuple.iter().map(|ty| ty.name()).join(", ")))
-                }
-                Ty::Array(items_ty) => Some(format!("Array<{}>", items_ty[0].name())),
-                Ty::ByteArray(_) => Some("ByteArray".to_string()),
+                _ => None,
             })
             .collect::<Vec<_>>()
             .join("\n\n");

--- a/crates/dojo-types/src/schema.rs
+++ b/crates/dojo-types/src/schema.rs
@@ -275,7 +275,7 @@ fn get_printable_ty_list(root_ty: &Ty, ty_list: &mut Vec<Ty>) {
         }
         Ty::Tuple(tuple) => {
             for item_ty in tuple {
-                if !ty_list.contains(&item_ty) {
+                if !ty_list.contains(item_ty) {
                     get_printable_ty_list(item_ty, ty_list);
                 }
             }

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use dojo_types::schema::deep_print_ty;
 use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{BlockId, BlockTag, FieldElement};
@@ -35,6 +36,23 @@ pub async fn model_contract_address(
     Ok(())
 }
 
+pub async fn model_layout(
+    name: String,
+    world_address: FieldElement,
+    provider: JsonRpcClient<HttpTransport>,
+) -> Result<()> {
+    let mut world_reader = WorldContractReader::new(world_address, &provider);
+    world_reader.set_block(BlockId::Tag(BlockTag::Pending));
+
+    let model = world_reader.model_reader(&name).await?;
+    let layout = model.layout().await?;
+    let schema = model.schema().await?;
+
+    deep_print_layout(&layout, &schema);
+
+    Ok(())
+}
+
 pub async fn model_schema(
     name: String,
     world_address: FieldElement,
@@ -50,7 +68,7 @@ pub async fn model_schema(
     if to_json {
         println!("{}", serde_json::to_string_pretty(&schema)?)
     } else {
-        println!("{schema}");
+        deep_print_ty(schema);
     }
 
     Ok(())
@@ -72,3 +90,330 @@ pub async fn model_get(
 
     Ok(())
 }
+
+#[derive(Clone, Debug)]
+struct LayoutInfo {
+    layout_type: LayoutInfoType,
+    name: String,
+    fields: Vec<FieldLayoutInfo>,
+}
+
+#[derive(Clone, Debug)]
+enum LayoutInfoType {
+    Struct,
+    Enum,
+    Tuple,
+    Array,
+}
+
+#[derive(Clone, Debug)]
+struct FieldLayoutInfo {
+    selector: String,
+    name: String,
+    layout: String,
+}
+
+fn format_fixed(layout: &Vec<u8>) -> String {
+    format!("[{}]", layout.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", "))
+}
+
+fn format_layout_ref(type_name: &str) -> String {
+    format!("layout({type_name})")
+}
+
+fn format_selector(selector: String) -> String {
+    if selector.starts_with("0x") {
+        if selector.len() > 14 {
+            format!("[{}...{}]", &selector[0..8], &selector[selector.len() - 7..])
+        } else {
+            format!("[{}]", selector)
+        }
+    } else {
+        selector
+    }
+}
+
+fn format_name(name: String) -> String {
+    if !name.is_empty() {
+        format!(" {} ", name)
+    } else {
+        name
+    }
+}
+
+fn format_field(selector: String, name: String, layout: String) -> String {
+    format!("    {:<20}{:<18}: {}", format_selector(selector), format_name(name), layout)
+}
+
+fn format_field_layout(
+    layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+) -> String {
+    match layout {
+        dojo_world::contracts::model::abigen::model::Layout::Fixed(x) => format_fixed(&x),
+        dojo_world::contracts::model::abigen::model::Layout::ByteArray => {
+            "layout(ByteArray)".to_string()
+        }
+        _ => format_layout_ref(&get_name_from_schema(schema)),
+    }
+}
+
+fn is_layout_in_list(list: &Vec<LayoutInfo>, name: &String) -> bool {
+    list.iter().any(|x| x.name.eq(name))
+}
+
+fn get_name_from_schema(schema: &dojo_types::schema::Ty) -> String {
+    match schema {
+        dojo_types::schema::Ty::Struct(s) => s.name.clone(),
+        dojo_types::schema::Ty::Enum(e) => e.name.clone(),
+        dojo_types::schema::Ty::Primitive(p) => match p {
+            dojo_types::primitive::Primitive::U8(_) => "u8".to_string(),
+            dojo_types::primitive::Primitive::U16(_) => "u16".to_string(),
+            dojo_types::primitive::Primitive::U32(_) => "u32".to_string(),
+            dojo_types::primitive::Primitive::U64(_) => "u64".to_string(),
+            dojo_types::primitive::Primitive::U128(_) => "u128".to_string(),
+            dojo_types::primitive::Primitive::U256(_) => "u256".to_string(),
+            dojo_types::primitive::Primitive::USize(_) => "usize".to_string(),
+            dojo_types::primitive::Primitive::Bool(_) => "bool".to_string(),
+            dojo_types::primitive::Primitive::Felt252(_) => "felt252".to_string(),
+            dojo_types::primitive::Primitive::ClassHash(_) => "ClassHash".to_string(),
+            dojo_types::primitive::Primitive::ContractAddress(_) => "ContractAddress".to_string(),
+        },
+        dojo_types::schema::Ty::Tuple(t) => {
+            format!(
+                "({})",
+                t.iter().map(|x| get_name_from_schema(x)).collect::<Vec<_>>().join(", ")
+            )
+        }
+        dojo_types::schema::Ty::Array(a) => format!("Array<{}>", get_name_from_schema(&a[0])),
+        _ => "".to_string(),
+    }
+}
+
+fn get_printable_layout_list_from_struct(
+    field_layouts: &Vec<dojo_world::contracts::model::abigen::model::FieldLayout>,
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    match schema {
+        dojo_types::schema::Ty::Struct(ss) => {
+            let name = get_name_from_schema(&schema);
+
+            // proces main struct
+            if !is_layout_in_list(layout_list, &name) {
+                layout_list.push(LayoutInfo {
+                    layout_type: LayoutInfoType::Struct,
+                    name,
+                    fields: field_layouts
+                        .iter()
+                        .zip(ss.children.iter().filter(|x| !x.key))
+                        .map(|(l, m)| FieldLayoutInfo {
+                            selector: format!("{:#x}", l.selector),
+                            name: m.name.clone(),
+                            layout: format_field_layout(&l.layout, &m.ty),
+                        })
+                        .collect::<Vec<_>>(),
+                });
+            }
+
+            // process members
+            for (member_layout, member) in
+                field_layouts.iter().zip(ss.children.iter().filter(|x| !x.key))
+            {
+                get_printable_layout_list(&member_layout.layout, &member.ty, layout_list);
+            }
+        }
+        _ => {}
+    };
+}
+
+fn get_printable_layout_list_from_enum(
+    field_layouts: &Vec<dojo_world::contracts::model::abigen::model::FieldLayout>,
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    match schema {
+        dojo_types::schema::Ty::Enum(se) => {
+            let name = get_name_from_schema(&schema);
+
+            // proces main enum
+            if !is_layout_in_list(layout_list, &name) {
+                layout_list.push(LayoutInfo {
+                    layout_type: LayoutInfoType::Enum,
+                    name,
+                    fields: field_layouts
+                        .iter()
+                        .zip(se.options.iter())
+                        .map(|(l, o)| FieldLayoutInfo {
+                            selector: format!("{:#x}", l.selector),
+                            name: o.name.to_string(),
+                            layout: format_field_layout(&l.layout, &o.ty),
+                        })
+                        .collect::<Vec<_>>(),
+                });
+            }
+
+            // process variants
+            for (variant_layout, variant) in field_layouts.iter().zip(se.options.iter()) {
+                get_printable_layout_list(&variant_layout.layout, &variant.ty, layout_list);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn get_printable_layout_list_from_tuple(
+    item_layouts: &Vec<dojo_world::contracts::model::abigen::model::Layout>,
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    match schema {
+        dojo_types::schema::Ty::Tuple(st) => {
+            let name = get_name_from_schema(&schema);
+
+            // process tuple
+            if !is_layout_in_list(layout_list, &name) {
+                layout_list.push(LayoutInfo {
+                    layout_type: LayoutInfoType::Tuple,
+                    name,
+                    fields: item_layouts
+                        .iter()
+                        .enumerate()
+                        .zip(st.iter())
+                        .map(|((i, l), s)| FieldLayoutInfo {
+                            selector: format!("{:#x}", i),
+                            name: "".to_string(),
+                            layout: format_field_layout(l, s),
+                        })
+                        .collect::<Vec<_>>(),
+                });
+            }
+
+            // process tuple items
+            for (item_layout, item_schema) in item_layouts.iter().zip(st.iter()) {
+                get_printable_layout_list(&item_layout, &item_schema, layout_list);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn get_printable_layout_list_from_array(
+    item_layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    match schema {
+        dojo_types::schema::Ty::Array(sa) => {
+            let name = get_name_from_schema(&schema);
+
+            // process array
+            if !is_layout_in_list(layout_list, &name) {
+                layout_list.push(LayoutInfo {
+                    layout_type: LayoutInfoType::Array,
+                    name,
+                    fields: vec![
+                        FieldLayoutInfo {
+                            selector: "Length".to_string(),
+                            name: "".to_string(),
+                            layout: "[32]".to_string(),
+                        },
+                        FieldLayoutInfo {
+                            selector: "[ItemIndex]".to_string(),
+                            name: "".to_string(),
+                            layout: format_field_layout(item_layout, &sa[0]),
+                        },
+                    ],
+                });
+            }
+
+            // process array item
+            get_printable_layout_list(&item_layout, &sa[0], layout_list);
+        }
+        _ => {}
+    }
+}
+
+fn get_printable_layout_list(
+    root_layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    match root_layout {
+        dojo_world::contracts::model::abigen::model::Layout::Struct(ls) => {
+            get_printable_layout_list_from_struct(ls, schema, layout_list);
+        }
+        dojo_world::contracts::model::abigen::model::Layout::Enum(le) => {
+            get_printable_layout_list_from_enum(le, schema, layout_list);
+        }
+        dojo_world::contracts::model::abigen::model::Layout::Tuple(lt) => {
+            get_printable_layout_list_from_tuple(lt, schema, layout_list);
+        }
+        dojo_world::contracts::model::abigen::model::Layout::Array(la) => {
+            get_printable_layout_list_from_array(&la[0], schema, layout_list);
+        }
+        _ => {}
+    };
+}
+
+fn print_layout_info(layout_info: LayoutInfo) {
+    let fields = layout_info
+        .fields
+        .into_iter()
+        .map(|f| format_field(f.selector, f.name, f.layout))
+        .collect::<Vec<_>>();
+    let layout_title = match layout_info.layout_type {
+        LayoutInfoType::Struct => format!("Struct {} {{", layout_info.name),
+        LayoutInfoType::Enum => format!("Enum {} {{", layout_info.name),
+        LayoutInfoType::Tuple => format!("{} (", layout_info.name),
+        LayoutInfoType::Array => format!("{} (", layout_info.name),
+    };
+    let end_token = match layout_info.layout_type {
+        LayoutInfoType::Struct => '}',
+        LayoutInfoType::Enum => '}',
+        LayoutInfoType::Tuple => ')',
+        LayoutInfoType::Array => ')',
+    };
+
+    println!(
+        "{layout_title}
+{}
+{end_token}\n",
+        fields.join("\n")
+    );
+}
+
+// print the full Layout tree
+fn deep_print_layout(
+    layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+) {
+    let mut layout_list = vec![];
+    get_printable_layout_list(&layout, &schema, &mut layout_list);
+
+    for l in layout_list {
+        print_layout_info(l);
+    }
+}
+
+/*
+    Struct S1 {
+        [0x123...345] (field_name): layout(S2),
+        [0x123...345] (field_name): layout((u8, u32))
+        [0x456...768]: [8, 16, ..., 251]
+        [0x456...768]: layout(Array<u32>)
+    }
+
+    (u8, u32)
+        [0]: [8]
+        [1]: [32]
+
+    Array<u32>
+        []: array length
+        [item_index]: [32]
+
+
+    Enum E1 {
+        [0]:
+    }
+*/


### PR DESCRIPTION
- automatically generate introspect for models if not already specified
- improve enum layout & size functions
- rework sozo model commands:
   - `sozo model schema <MODEL_NAME>` should display the model schema,
   - `sozo model layout <MODEL_NAME>` should display how the model is stored in the world storage (i.e should show the model layout),
   - `sozo model get <MODEL_NAME> <KEYS>` should display a model record identified by its keys.