### PR TITLE
feat(katana): dedup fork request

### DIFF
--- a/crates/katana/storage/provider/src/providers/fork/backend.rs
+++ b/crates/katana/storage/provider/src/providers/fork/backend.rs
@@ -111,7 +111,6 @@ impl BackendRequest {
 
 type BackendRequestFuture = BoxFuture<'static, ()>;
 
-
 // Identifier for pending requests.
 // This is used for request deduplication.
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
@@ -119,7 +118,7 @@ enum BackendRequestIdentifier {
     Nonce(ContractAddress),
     Class(ClassHash),
     ClassHash(ContractAddress),
-    Storage((ContractAddress, StorageKey))
+    Storage((ContractAddress, StorageKey)),
 }
 
 /// The backend for the forked provider.
@@ -655,13 +654,13 @@ pub(crate) mod test_utils {
     }
 
     // Starts a TCP server that never close the connection.
-    pub fn start_tcp_server() {
+    pub fn start_tcp_server(addr: String) {
         use tokio::runtime::Builder;
 
         let (tx, rx) = sync_channel::<()>(1);
         thread::spawn(move || {
             Builder::new_current_thread().enable_all().build().unwrap().block_on(async move {
-                let listener = TcpListener::bind("127.0.0.1:8080").await.unwrap();
+                let listener = TcpListener::bind(addr).await.unwrap();
                 let mut connections = Vec::new();
 
                 tx.send(()).unwrap();
@@ -702,7 +701,7 @@ mod tests {
     #[test]
     fn handle_incoming_requests() {
         // start a mock remote network
-        start_tcp_server();
+        start_tcp_server("127.0.0.1:8080".to_string());
 
         let handle = create_forked_backend("http://127.0.0.1:8080", 1);
 
@@ -721,7 +720,7 @@ mod tests {
         });
         let h3 = handle.clone();
         thread::spawn(move || {
-            h3.get_compiled_class_hash(felt!("0x1")).expect(ERROR_SEND_REQUEST);
+            h3.get_compiled_class_hash(felt!("0x2")).expect(ERROR_SEND_REQUEST);
         });
         let h4 = handle.clone();
         thread::spawn(move || {
@@ -738,6 +737,261 @@ mod tests {
         // check request are handled
         let stats = handle.stats().expect(ERROR_STATS);
         assert_eq!(stats, 5, "Backend should have 5 ongoing requests.")
+    }
+
+    #[test]
+    fn get_nonce_request_should_be_deduplicated() {
+        // start a mock remote network
+        start_tcp_server("127.0.0.1:8081".to_string());
+
+        let handle = create_forked_backend("http://127.0.0.1:8081", 1);
+
+        // check no pending requests
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 0, "Backend should not have any ongoing requests.");
+
+        // send requests to the backend
+        let h1 = handle.clone();
+        thread::spawn(move || {
+            h1.get_nonce(felt!("0x1").into()).expect(ERROR_SEND_REQUEST);
+        });
+        let h2 = handle.clone();
+        thread::spawn(move || {
+            h2.get_nonce(felt!("0x1").into()).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h3 = handle.clone();
+        thread::spawn(move || {
+            h3.get_nonce(felt!("0x2").into()).expect(ERROR_SEND_REQUEST);
+        });
+
+        // wait for the requests to be handled
+        thread::sleep(Duration::from_secs(1));
+
+        // check request are handled
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 2, "Backend should only have 2 ongoing requests.")
+    }
+
+    #[test]
+    fn get_class_at_request_should_be_deduplicated() {
+        // start a mock remote network
+        start_tcp_server("127.0.0.1:8082".to_string());
+
+        let handle = create_forked_backend("http://127.0.0.1:8082", 1);
+
+        // check no pending requests
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 0, "Backend should not have any ongoing requests.");
+
+        // send requests to the backend
+        let h1 = handle.clone();
+        thread::spawn(move || {
+            h1.get_class_at(felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        let h2 = handle.clone();
+        thread::spawn(move || {
+            h2.get_class_at(felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h3 = handle.clone();
+        thread::spawn(move || {
+            h3.get_class_at(felt!("0x2")).expect(ERROR_SEND_REQUEST);
+        });
+
+        // wait for the requests to be handled
+        thread::sleep(Duration::from_secs(1));
+
+        // check request are handled
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 2, "Backend should only have 2 ongoing requests.")
+    }
+
+    #[test]
+    fn get_compiled_class_hash_request_should_be_deduplicated() {
+        // start a mock remote network
+        start_tcp_server("127.0.0.1:8083".to_string());
+
+        let handle = create_forked_backend("http://127.0.0.1:8083", 1);
+
+        // check no pending requests
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 0, "Backend should not have any ongoing requests.");
+
+        // send requests to the backend
+        let h1 = handle.clone();
+        thread::spawn(move || {
+            h1.get_compiled_class_hash(felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        let h2 = handle.clone();
+        thread::spawn(move || {
+            h2.get_compiled_class_hash(felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h3 = handle.clone();
+        thread::spawn(move || {
+            h3.get_compiled_class_hash(felt!("0x2")).expect(ERROR_SEND_REQUEST);
+        });
+
+        // wait for the requests to be handled
+        thread::sleep(Duration::from_secs(1));
+
+        // check request are handled
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 2, "Backend should only have 2 ongoing requests.")
+    }
+
+    #[test]
+    fn get_class_at_and_get_compiled_class_hash_request_should_be_deduplicated() {
+        // start a mock remote network
+        start_tcp_server("127.0.0.1:8084".to_string());
+
+        let handle = create_forked_backend("http://127.0.0.1:8084", 1);
+
+        // check no pending requests
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 0, "Backend should not have any ongoing requests.");
+
+        // send requests to the backend
+        let h1 = handle.clone();
+        thread::spawn(move || {
+            h1.get_class_at(felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        // Since this also calls to the same request as the previous one, it should be deduped
+        let h2 = handle.clone();
+        thread::spawn(move || {
+            h2.get_compiled_class_hash(felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h3 = handle.clone();
+        thread::spawn(move || {
+            h3.get_class_at(felt!("0x2")).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h4 = handle.clone();
+        thread::spawn(move || {
+            h4.get_compiled_class_hash(felt!("0x3")).expect(ERROR_SEND_REQUEST);
+        });
+
+        // wait for the requests to be handled
+        thread::sleep(Duration::from_secs(1));
+
+        // check request are handled
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 3, "Backend should only have 3 ongoing requests.")
+    }
+
+    #[test]
+    fn get_class_hash_at_request_should_be_deduplicated() {
+        // start a mock remote network
+        start_tcp_server("127.0.0.1:8085".to_string());
+
+        let handle = create_forked_backend("http://127.0.0.1:8085", 1);
+
+        // check no pending requests
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 0, "Backend should not have any ongoing requests.");
+
+        // send requests to the backend
+        let h1 = handle.clone();
+        thread::spawn(move || {
+            h1.get_class_hash_at(felt!("0x1").into()).expect(ERROR_SEND_REQUEST);
+        });
+        let h2 = handle.clone();
+        thread::spawn(move || {
+            h2.get_class_hash_at(felt!("0x1").into()).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h3 = handle.clone();
+        thread::spawn(move || {
+            h3.get_class_hash_at(felt!("0x2").into()).expect(ERROR_SEND_REQUEST);
+        });
+
+        // wait for the requests to be handled
+        thread::sleep(Duration::from_secs(1));
+
+        // check request are handled
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 2, "Backend should only have 2 ongoing requests.")
+    }
+
+    #[test]
+    fn get_storage_request_should_be_deduplicated() {
+        // start a mock remote network
+        start_tcp_server("127.0.0.1:8086".to_string());
+
+        let handle = create_forked_backend("http://127.0.0.1:8086", 1);
+
+        // check no pending requests
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 0, "Backend should not have any ongoing requests.");
+
+        // send requests to the backend
+        let h1 = handle.clone();
+        thread::spawn(move || {
+            h1.get_storage(felt!("0x1").into(), felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        let h2 = handle.clone();
+        thread::spawn(move || {
+            h2.get_storage(felt!("0x1").into(), felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h3 = handle.clone();
+        thread::spawn(move || {
+            h3.get_storage(felt!("0x2").into(), felt!("0x3")).expect(ERROR_SEND_REQUEST);
+        });
+
+        // wait for the requests to be handled
+        thread::sleep(Duration::from_secs(1));
+
+        // check request are handled
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 2, "Backend should only have 2 ongoing requests.")
+    }
+
+    #[test]
+    fn get_storage_request_on_same_address_with_different_key_should_be_deduplicated() {
+        // start a mock remote network
+        start_tcp_server("127.0.0.1:8087".to_string());
+
+        let handle = create_forked_backend("http://127.0.0.1:8087", 1);
+
+        // check no pending requests
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 0, "Backend should not have any ongoing requests.");
+
+        // send requests to the backend
+        let h1 = handle.clone();
+        thread::spawn(move || {
+            h1.get_storage(felt!("0x1").into(), felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        let h2 = handle.clone();
+        thread::spawn(move || {
+            h2.get_storage(felt!("0x1").into(), felt!("0x1")).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h3 = handle.clone();
+        thread::spawn(move || {
+            h3.get_storage(felt!("0x1").into(), felt!("0x3")).expect(ERROR_SEND_REQUEST);
+        });
+        // Different request, should be counted
+        let h4 = handle.clone();
+        thread::spawn(move || {
+            h4.get_storage(felt!("0x1").into(), felt!("0x6")).expect(ERROR_SEND_REQUEST);
+        });
+
+        // Same request as the last one, shouldn't be counted
+        let h5 = handle.clone();
+        thread::spawn(move || {
+            h5.get_storage(felt!("0x1").into(), felt!("0x6")).expect(ERROR_SEND_REQUEST);
+        });
+
+        // wait for the requests to be handled
+        thread::sleep(Duration::from_secs(1));
+
+        // check request are handled
+        let stats = handle.stats().expect(ERROR_STATS);
+        assert_eq!(stats, 3, "Backend should only have 3 ongoing requests.")
     }
 
     #[test]

--- a/crates/katana/storage/provider/src/providers/fork/backend.rs
+++ b/crates/katana/storage/provider/src/providers/fork/backend.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::pin::Pin;
 use std::sync::mpsc::{
     channel as oneshot, Receiver as OneshotReceiver, RecvError, Sender as OneshotSender,
@@ -118,8 +118,10 @@ type BackendRequestFuture = BoxFuture<'static, ()>;
 pub struct Backend<P> {
     /// The Starknet RPC provider that will be used to fetch data from.
     provider: Arc<P>,
+    // Set that keep track of current requests, for dedup purposes.
+    request_dedup_set: HashSet<String>,
     /// Requests that are currently being poll.
-    pending_requests: Vec<BackendRequestFuture>,
+    pending_requests: Vec<(String, BackendRequestFuture)>,
     /// Requests that are queued to be polled.
     queued_requests: VecDeque<BackendRequest>,
     /// A channel for receiving requests from the [BackendHandle]s.
@@ -168,6 +170,7 @@ where
             block,
             incoming: rx,
             provider: Arc::new(provider),
+            request_dedup_set: HashSet::new(),
             pending_requests: Vec::new(),
             queued_requests: VecDeque::new(),
         };
@@ -181,63 +184,88 @@ where
         let block = self.block;
         let provider = self.provider.clone();
 
+        // Check if there are similar requests in the queue before sending the request
         match request {
             BackendRequest::Nonce(Request { payload, sender }) => {
-                let fut = Box::pin(async move {
-                    let res = provider
-                        .get_nonce(block, FieldElement::from(payload))
-                        .await
-                        .map_err(BackendError::StarknetProvider);
+                let req_key = format!("nonce_{}", payload);
 
-                    sender.send(res).expect("failed to send nonce result")
-                });
+                if !self.request_dedup_set.contains(&req_key) {
+                    let fut = Box::pin(async move {
+                        let res = provider
+                            .get_nonce(block, FieldElement::from(payload))
+                            .await
+                            .map_err(BackendError::StarknetProvider);
 
-                self.pending_requests.push(fut);
+                        sender.send(res).expect("failed to send nonce result")
+                    });
+
+                    self.pending_requests.push((req_key.clone(), fut));
+                    self.request_dedup_set.insert(req_key);
+                }
             }
 
             BackendRequest::Storage(Request { payload: (addr, key), sender }) => {
-                let fut = Box::pin(async move {
-                    let res = provider
-                        .get_storage_at(FieldElement::from(addr), key, block)
-                        .await
-                        .map_err(BackendError::StarknetProvider);
+                let req_key = format!("storage_{}_{}", addr, key);
 
-                    sender.send(res).expect("failed to send storage result")
-                });
+                if !self.request_dedup_set.contains(&req_key) {
+                    let fut = Box::pin(async move {
+                        let res = provider
+                            .get_storage_at(FieldElement::from(addr), key, block)
+                            .await
+                            .map_err(BackendError::StarknetProvider);
 
-                self.pending_requests.push(fut);
+                        sender.send(res).expect("failed to send storage result")
+                    });
+
+                    self.pending_requests.push((req_key.clone(), fut));
+                    self.request_dedup_set.insert(req_key);
+                }
             }
 
             BackendRequest::ClassHash(Request { payload, sender }) => {
-                let fut = Box::pin(async move {
-                    let res = provider
-                        .get_class_hash_at(block, FieldElement::from(payload))
-                        .await
-                        .map_err(BackendError::StarknetProvider);
+                let req_key = format!("classhash_{}", payload);
 
-                    sender.send(res).expect("failed to send class hash result")
-                });
+                if !self.request_dedup_set.contains(&req_key) {
+                    let fut = Box::pin(async move {
+                        let res = provider
+                            .get_class_hash_at(block, FieldElement::from(payload))
+                            .await
+                            .map_err(BackendError::StarknetProvider);
 
-                self.pending_requests.push(fut);
+                        sender.send(res).expect("failed to send class hash result")
+                    });
+
+                    self.pending_requests.push((req_key.clone(), fut));
+                    self.request_dedup_set.insert(req_key);
+                }
             }
 
             BackendRequest::Class(Request { payload, sender }) => {
-                let fut = Box::pin(async move {
-                    let res = provider
-                        .get_class(block, payload)
-                        .await
-                        .map_err(BackendError::StarknetProvider);
+                let req_key = format!("class_{}", payload);
 
-                    sender.send(res).expect("failed to send class result")
-                });
+                if !self.request_dedup_set.contains(&req_key) {
+                    let fut = Box::pin(async move {
+                        let res = provider
+                            .get_class(block, payload)
+                            .await
+                            .map_err(BackendError::StarknetProvider);
 
-                self.pending_requests.push(fut);
+                        sender.send(res).expect("failed to send class result")
+                    });
+
+                    self.pending_requests.push((req_key.clone(), fut));
+                    self.request_dedup_set.insert(req_key);
+                }
             }
 
             #[cfg(test)]
             BackendRequest::Stats(sender) => {
+                // let req_key = "stats";
+                // if !self.request_dedup_set.contains(req_key) {
                 let total_ongoing_request = self.pending_requests.len();
                 sender.send(total_ongoing_request).expect("failed to send backend stats");
+                // self.request_dedup_set.insert(req_key.to_string());
+                // }
             }
         }
     }
@@ -274,11 +302,13 @@ where
 
             // poll all pending requests
             for n in (0..pin.pending_requests.len()).rev() {
-                let mut fut = pin.pending_requests.swap_remove(n);
+                let (fut_key, mut fut) = pin.pending_requests.swap_remove(n);
                 // poll the future and if the future is still pending, push it back to the
                 // pending requests so that it will be polled again
                 if fut.poll_unpin(cx).is_pending() {
-                    pin.pending_requests.push(fut);
+                    pin.pending_requests.push((fut_key.clone(), fut));
+                } else {
+                    pin.request_dedup_set.remove(&fut_key);
                 }
             }
 
@@ -732,6 +762,12 @@ mod tests {
             StateProvider::class_hash_of_contract(&provider, ADDR_1).unwrap(),
             Some(ADDR_1_CLASS_HASH)
         );
+    }
+
+    #[test]
+    fn requests_should_be_deduped() {
+        let backend = create_forked_backend(LOCAL_RPC_URL, 1);
+        let provider = SharedStateProvider(Arc::new(CacheStateDb::new(backend)));
     }
 
     // TODO: unignore this once we have separate the spawning of the backend thread from the backend

--- a/crates/katana/storage/provider/src/providers/fork/backend.rs
+++ b/crates/katana/storage/provider/src/providers/fork/backend.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::pin::Pin;
 use std::sync::mpsc::{
     channel as oneshot, Receiver as OneshotReceiver, RecvError, Sender as OneshotSender,
@@ -111,6 +111,17 @@ impl BackendRequest {
 
 type BackendRequestFuture = BoxFuture<'static, ()>;
 
+
+// Identifier for pending requests.
+// This is used for request deduplication.
+#[derive(Eq, Hash, PartialEq, Clone, Copy, Debug)]
+enum BackendRequestIdentifier {
+    Nonce(ContractAddress),
+    Class(ClassHash),
+    ClassHash(ContractAddress),
+    Storage((ContractAddress, StorageKey))
+}
+
 /// The backend for the forked provider.
 ///
 /// It is responsible for processing [requests](BackendRequest) to fetch data from the remote
@@ -119,9 +130,9 @@ pub struct Backend<P> {
     /// The Starknet RPC provider that will be used to fetch data from.
     provider: Arc<P>,
     // Set that keep track of current requests, for dedup purposes.
-    request_dedup_set: HashSet<String>,
+    request_dedup_set: HashSet<BackendRequestIdentifier>,
     /// Requests that are currently being poll.
-    pending_requests: Vec<(String, BackendRequestFuture)>,
+    pending_requests: Vec<(BackendRequestIdentifier, BackendRequestFuture)>,
     /// Requests that are queued to be polled.
     queued_requests: VecDeque<BackendRequest>,
     /// A channel for receiving requests from the [BackendHandle]s.
@@ -187,7 +198,7 @@ where
         // Check if there are similar requests in the queue before sending the request
         match request {
             BackendRequest::Nonce(Request { payload, sender }) => {
-                let req_key = format!("nonce_{}", payload);
+                let req_key = BackendRequestIdentifier::Nonce(payload);
 
                 if !self.request_dedup_set.contains(&req_key) {
                     let fut = Box::pin(async move {
@@ -199,13 +210,13 @@ where
                         sender.send(res).expect("failed to send nonce result")
                     });
 
-                    self.pending_requests.push((req_key.clone(), fut));
+                    self.pending_requests.push((req_key, fut));
                     self.request_dedup_set.insert(req_key);
                 }
             }
 
             BackendRequest::Storage(Request { payload: (addr, key), sender }) => {
-                let req_key = format!("storage_{}_{}", addr, key);
+                let req_key = BackendRequestIdentifier::Storage((addr, key));
 
                 if !self.request_dedup_set.contains(&req_key) {
                     let fut = Box::pin(async move {
@@ -217,13 +228,13 @@ where
                         sender.send(res).expect("failed to send storage result")
                     });
 
-                    self.pending_requests.push((req_key.clone(), fut));
+                    self.pending_requests.push((req_key, fut));
                     self.request_dedup_set.insert(req_key);
                 }
             }
 
             BackendRequest::ClassHash(Request { payload, sender }) => {
-                let req_key = format!("classhash_{}", payload);
+                let req_key = BackendRequestIdentifier::ClassHash(payload);
 
                 if !self.request_dedup_set.contains(&req_key) {
                     let fut = Box::pin(async move {
@@ -235,13 +246,13 @@ where
                         sender.send(res).expect("failed to send class hash result")
                     });
 
-                    self.pending_requests.push((req_key.clone(), fut));
+                    self.pending_requests.push((req_key, fut));
                     self.request_dedup_set.insert(req_key);
                 }
             }
 
             BackendRequest::Class(Request { payload, sender }) => {
-                let req_key = format!("class_{}", payload);
+                let req_key = BackendRequestIdentifier::Class(payload);
 
                 if !self.request_dedup_set.contains(&req_key) {
                     let fut = Box::pin(async move {
@@ -253,19 +264,15 @@ where
                         sender.send(res).expect("failed to send class result")
                     });
 
-                    self.pending_requests.push((req_key.clone(), fut));
+                    self.pending_requests.push((req_key, fut));
                     self.request_dedup_set.insert(req_key);
                 }
             }
 
             #[cfg(test)]
             BackendRequest::Stats(sender) => {
-                // let req_key = "stats";
-                // if !self.request_dedup_set.contains(req_key) {
                 let total_ongoing_request = self.pending_requests.len();
                 sender.send(total_ongoing_request).expect("failed to send backend stats");
-                // self.request_dedup_set.insert(req_key.to_string());
-                // }
             }
         }
     }
@@ -306,7 +313,7 @@ where
                 // poll the future and if the future is still pending, push it back to the
                 // pending requests so that it will be polled again
                 if fut.poll_unpin(cx).is_pending() {
-                    pin.pending_requests.push((fut_key.clone(), fut));
+                    pin.pending_requests.push((fut_key, fut));
                 } else {
                     pin.request_dedup_set.remove(&fut_key);
                 }


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

Implements a request deduplication process via the use of a `HashSet` on the requests. This also requires adding a key for the `pending_requests` vector so we can add any pending requests that was popped back to the queue.

The key for the requests deduplication was originally implemented as a `String`, but changed to `Enum` after to enforce the possible types.

Considered `IndexMap` to reduce need to add an extra data structure, but since that requires adding a package and this should achieve the same result, kept this implementation.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #1465.

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [x] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

The tests for the changes I've made passed. However some seemingly unrelated tests are failing and I am not sure what's the exact issue. Hopefully its a setup issue and its only failing on my machine. 

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

Not sure docs is needed for this on the dojo book, but if needed I can add to it. For now only comments are added for explanation.

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [ ] I've requested a review after addressing the comments
