### PR TITLE
Sozo model layout and commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-32-cores
     container:
       image: ghcr.io/dojoengine/dojo-dev:v0.7.0-alpha.4
     steps:
@@ -20,7 +20,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo build -r --bin katana
-          KATANA_RUNNER_BIN=$(pwd)/target/release/katana cargo llvm-cov nextest --no-report --all-features --workspace --exclude katana --build-jobs 10
+          KATANA_RUNNER_BIN=$(pwd)/target/release/katana cargo llvm-cov nextest --no-report --all-features --workspace --exclude katana --build-jobs 20
           cargo llvm-cov nextest --no-report -p katana
           # TODO(kariy): uncomment this line when `sir` feature support Cairo 2.6.3
           # cargo llvm-cov nextest --no-report -p katana --no-default-features --features sir

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13429,6 +13429,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "hex",
+ "katana-runner",
  "lazy_static",
  "log",
  "once_cell",

--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -41,6 +41,36 @@ pub enum ModelCommand {
         starknet: StarknetOptions,
     },
 
+    #[command(about = "The Dojo storage system uses the poseidon_hash function to compute \
+                       hashes, called 'hash' in the following documentation.
+        
+        How storage locations are computed ?
+
+        model key               = hash(model_keys)
+
+        fixed layout key        = parent_key
+        struct layout field key = hash(parent_key, field_selector)
+        tuple layout item key   = hash(parent_key, item_index)
+        enum layout 
+                    variant key = parent_key
+                    data key    = hash(parent_key, variant_index)
+        array layout
+                    length key  = parent_key
+                    item key    = hash(parent_key, item_index)
+        byte array layout       = parent_key
+
+        final storage location  = hash('dojo_storage', model_selector, record_key)")]
+    Layout {
+        #[arg(help = "The name of the model")]
+        name: String,
+
+        #[command(flatten)]
+        world: WorldOptions,
+
+        #[command(flatten)]
+        starknet: StarknetOptions,
+    },
+
     #[command(about = "Retrieve the schema for a model")]
     Schema {
         #[arg(help = "The name of the model")]
@@ -91,6 +121,11 @@ impl ModelArgs {
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
                     model::model_contract_address(name, world_address, provider).await
+                }
+                ModelCommand::Layout { name, starknet, world } => {
+                    let world_address = world.address(env_metadata.as_ref()).unwrap();
+                    let provider = starknet.provider(env_metadata.as_ref()).unwrap();
+                    model::model_layout(name, world_address, provider).await
                 }
                 ModelCommand::Schema { name, to_json, starknet, world } => {
                     let world_address = world.address(env_metadata.as_ref()).unwrap();

--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -41,9 +41,10 @@ pub enum ModelCommand {
         starknet: StarknetOptions,
     },
 
-    #[command(about = "The Dojo storage system uses the poseidon_hash function to compute \
-                       hashes, called 'hash' in the following documentation.
-        
+    #[command(about = "Displays the model's layout into dojo storage.\n
+The Dojo storage system uses the poseidon_hash function to compute
+hashes, called 'hash' in the following documentation.
+
         How storage locations are computed ?
 
         model key               = hash(model_keys)

--- a/crates/dojo-core/src/base_test.cairo
+++ b/crates/dojo-core/src/base_test.cairo
@@ -145,7 +145,7 @@ mod invalid_model {
     impl InvalidModelSelector of super::IMetadataOnly<ContractState> {
         fn selector(self: @ContractState) -> felt252 {
             // Pre-computed address of a contract deployed through the world.
-            0x455fe9471cb954574b16581868043841391545b9225af00bf545f9acf923295
+            0x24be6107cad9928e8b80e1404af473b1641f146114af53bef99152a382c53c0
         }
 
         fn name(self: @ContractState) -> ByteArray {

--- a/crates/dojo-core/src/base_test.cairo
+++ b/crates/dojo-core/src/base_test.cairo
@@ -160,7 +160,7 @@ mod invalid_model {
         fn selector(self: @ContractState) -> felt252 {
             // NOTE: Need to update this value if address changes
             // Pre-computed address of a contract deployed through the world.
-            0x3dc3b5d2f73350ccda67b655bfae01e747c5db6e6f570743ee2867649da2a73
+            0x15f0ffa36184d74ead97aa501b09aed53ee7236e364997a0c21879194340ab6
         }
 
         fn name(self: @ContractState) -> ByteArray {

--- a/crates/dojo-core/src/database/introspect.cairo
+++ b/crates/dojo-core/src/database/introspect.cairo
@@ -204,9 +204,9 @@ impl Introspect_option<T, +Introspect<T>> of Introspect<Option<T>> {
         Layout::Enum(
             array![
                 FieldLayout { // Some
-                selector: 0, layout: Introspect::<T>::layout() },
+                 selector: 0, layout: Introspect::<T>::layout() },
                 FieldLayout { // None
-                selector: 1, layout: Layout::Fixed(array![].span()) },
+                 selector: 1, layout: Layout::Fixed(array![].span()) },
             ]
                 .span()
         )

--- a/crates/dojo-core/src/database/introspect.cairo
+++ b/crates/dojo-core/src/database/introspect.cairo
@@ -16,7 +16,7 @@ enum Layout {
     ByteArray,
     // there is one layout per variant.
     // the `selector` field identifies the variant
-    // the `layout` field defines the full variant layout (variant value + optional variant data)
+    // the `layout` defines the variant data (could be empty for variant without data).
     Enum: Span<FieldLayout>,
 }
 
@@ -203,18 +203,10 @@ impl Introspect_option<T, +Introspect<T>> of Introspect<Option<T>> {
     fn layout() -> Layout {
         Layout::Enum(
             array![
-                FieldLayout {
-                    // Some
-                    selector: 0,
-                    layout: Layout::Tuple(
-                        array![Layout::Fixed(array![8].span()), Introspect::<T>::layout()].span()
-                    )
-                },
-                FieldLayout {
-                    // None
-                    selector: 1,
-                    layout: Layout::Tuple(array![Layout::Fixed(array![8].span())].span())
-                },
+                FieldLayout { // Some
+                selector: 0, layout: Introspect::<T>::layout() },
+                FieldLayout { // None
+                selector: 1, layout: Layout::Fixed(array![].span()) },
             ]
                 .span()
         )

--- a/crates/dojo-core/src/database/introspect_test.cairo
+++ b/crates/dojo-core/src/database/introspect_test.cairo
@@ -193,8 +193,8 @@ fn test_layout_of_enum_without_variant_data() {
     let layout = Introspect::<EnumNoData>::layout();
     let expected = _enum(array![ // One
     Option::None, // Two
-    Option::None, // Three
-    Option::None,]);
+     Option::None, // Three
+     Option::None,]);
 
     assert!(layout == expected);
 }

--- a/crates/dojo-core/src/database/introspect_test.cairo
+++ b/crates/dojo-core/src/database/introspect_test.cairo
@@ -298,7 +298,7 @@ fn test_layout_of_packed_enum() {
 fn test_layout_of_inner_packed_enum() {
     let layout = Introspect::<EnumInnerPacked>::layout();
     let expected = Layout::Fixed(array![8, 8, 32, 32, 32, 32].span());
-    
+
     assert!(layout == expected);
 }
 

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -984,9 +984,17 @@ mod world {
             let variant = *values.at(offset);
             assert(variant.into() < 256_u256, 'invalid variant value');
 
+            // and write it
+            database::set(model, key, values, offset, array![251].span());
+            offset += 1;
+
             // find the corresponding layout and then write the full variant
+            let variant_data_key = Self::_field_key(key, variant);
+
             match Self::_find_variant_layout(variant, variant_layouts) {
-                Option::Some(layout) => Self::_write_layout(model, key, values, ref offset, layout),
+                Option::Some(layout) => Self::_write_layout(
+                    model, variant_data_key, values, ref offset, layout
+                ),
                 Option::None => panic!("Unable to find the variant layout")
             };
         }
@@ -1087,16 +1095,21 @@ mod world {
         }
 
         fn _delete_enum_layout(model: felt252, key: felt252, variant_layouts: Span<FieldLayout>) {
-            // read the variant value first which is the first stored felt252
+            // read the variant value
             let res = database::get(model, key, array![251].span());
             assert(res.len() == 1, 'internal database error');
 
             let variant = *res.at(0);
             assert(variant.into() < 256_u256, 'invalid variant value');
 
+            // reset the variant value
+            database::delete(model, key, array![251].span());
+
             // find the corresponding layout and the delete the full variant
+            let variant_data_key = Self::_field_key(key, variant);
+
             match Self::_find_variant_layout(variant, variant_layouts) {
-                Option::Some(layout) => Self::_delete_layout(model, key, layout),
+                Option::Some(layout) => Self::_delete_layout(model, variant_data_key, layout),
                 Option::None => panic!("Unable to find the variant layout")
             };
         }
@@ -1260,18 +1273,22 @@ mod world {
             ref read_data: Array<felt252>,
             variant_layouts: Span<FieldLayout>
         ) {
-            // read the variant value first, which is the first element of the tuple
-            // (because an enum is stored as a tuple).
-            let variant_key = Self::_field_key(key, 0);
-            let res = database::get(model, variant_key, array![8].span());
+            // read the variant value first
+            let res = database::get(model, key, array![8].span());
             assert(res.len() == 1, 'internal database error');
 
             let variant = *res.at(0);
             assert(variant.into() < 256_u256, 'invalid variant value');
 
-            // find the corresponding layout and the read the full variant
+            read_data.append(variant);
+
+            // find the corresponding layout and the read the variant data
+            let variant_data_key = Self::_field_key(key, variant);
+
             match Self::_find_variant_layout(variant, variant_layouts) {
-                Option::Some(layout) => Self::_read_layout(model, key, ref read_data, layout),
+                Option::Some(layout) => Self::_read_layout(
+                    model, variant_data_key, ref read_data, layout
+                ),
                 Option::None => panic!("Unable to find the variant layout")
             };
         }

--- a/crates/dojo-lang/src/introspect/layout.rs
+++ b/crates/dojo-lang/src/introspect/layout.rs
@@ -56,7 +56,9 @@ pub fn build_variant_layouts(
             let selector = format!("{i}");
 
             let variant_layout = match v.type_clause(db) {
-                OptionTypeClause::Empty(_) => "".to_string(),
+                OptionTypeClause::Empty(_) => {
+                    "dojo::database::introspect::Layout::Fixed(array![].span())".to_string()
+                }
                 OptionTypeClause::TypeClause(type_clause) => {
                     get_layout_from_type_clause(db, diagnostics, &type_clause)
                 }
@@ -65,12 +67,7 @@ pub fn build_variant_layouts(
             format!(
                 "dojo::database::introspect::FieldLayout {{
                     selector: {selector},
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            {variant_layout}
-                        ].span()
-                    )
+                    layout: {variant_layout}
                 }}"
             )
         })

--- a/crates/dojo-lang/src/introspect/layout.rs
+++ b/crates/dojo-lang/src/introspect/layout.rs
@@ -180,7 +180,7 @@ pub fn build_item_layout_from_type(
     }
 }
 
-pub fn is_custom_layout(layout: &String) -> bool {
+pub fn is_custom_layout(layout: &str) -> bool {
     layout.starts_with("dojo::database::introspect::Introspect::")
 }
 
@@ -203,7 +203,7 @@ pub fn build_packed_struct_layout(
         .flatten()
         .collect::<Vec<_>>();
 
-    if layouts.iter().any(is_custom_layout) {
+    if layouts.iter().any(|v| is_custom_layout(v.as_str())) {
         generate_cairo_code_for_fixed_layout_with_custom_types(&layouts)
     } else {
         format!(
@@ -217,7 +217,7 @@ pub fn build_packed_struct_layout(
     }
 }
 
-pub fn generate_cairo_code_for_fixed_layout_with_custom_types(layouts: &Vec<String>) -> String {
+pub fn generate_cairo_code_for_fixed_layout_with_custom_types(layouts: &[String]) -> String {
     let layouts_repr = layouts
         .iter()
         .map(|l| {
@@ -284,16 +284,16 @@ pub fn build_packed_enum_layout(
     // don't forget the store the variant value
     variant_layout.insert(0, "8".to_string());
 
-    if variant_layout.iter().any(is_custom_layout) {
+    if variant_layout.iter().any(|v| is_custom_layout(v.as_str())) {
         generate_cairo_code_for_fixed_layout_with_custom_types(&variant_layout)
     } else {
-        let layout_repr = format!("{}", variant_layout.join(","));
         format!(
             "dojo::database::introspect::Layout::Fixed(
                 array![
-                {layout_repr}
+                {}
                 ].span()
             )",
+            variant_layout.join(",")
         )
     }
 }

--- a/crates/dojo-lang/src/introspect/mod.rs
+++ b/crates/dojo-lang/src/introspect/mod.rs
@@ -21,7 +21,7 @@ pub fn handle_introspect_struct(
     packed: bool,
 ) -> RewriteNode {
     let struct_name = struct_ast.name(db).text(db).into();
-    let struct_size = size::compute_struct_layout_size(db, &struct_ast);
+    let struct_size = size::compute_struct_layout_size(db, &struct_ast, packed);
     let ty = ty::build_struct_ty(db, &struct_name, &struct_ast);
 
     let layout = if packed {
@@ -76,7 +76,7 @@ pub fn handle_introspect_enum(
     };
 
     let (gen_types, gen_impls) = build_generic_types_and_impls(db, enum_ast.generic_params(db));
-    let enum_size = size::compute_enum_layout_size(&variant_sizes);
+    let enum_size = size::compute_enum_layout_size(&variant_sizes, packed);
     let ty = ty::build_enum_ty(db, &enum_name, &enum_ast);
 
     generate_introspect(&enum_name, &enum_size, &gen_types, gen_impls, &layout, &ty)

--- a/crates/dojo-lang/src/introspect/mod.rs
+++ b/crates/dojo-lang/src/introspect/mod.rs
@@ -25,14 +25,7 @@ pub fn handle_introspect_struct(
     let ty = ty::build_struct_ty(db, &struct_name, &struct_ast);
 
     let layout = if packed {
-        format!(
-            "dojo::database::introspect::Layout::Fixed(
-            array![
-            {}
-            ].span()
-        )",
-            layout::build_packed_struct_layout(db, diagnostics, &struct_ast)
-        )
+        layout::build_packed_struct_layout(db, diagnostics, &struct_ast)
     } else {
         format!(
             "dojo::database::introspect::Layout::Struct(
@@ -61,14 +54,7 @@ pub fn handle_introspect_enum(
 
     let layout = if packed {
         if size::is_enum_packable(&variant_sizes) {
-            format!(
-                "dojo::database::introspect::Layout::Fixed(
-                array![
-                {}
-                ].span()
-            )",
-                layout::build_packed_enum_layout(db, diagnostics, &enum_ast)
-            )
+            layout::build_packed_enum_layout(db, diagnostics, &enum_ast)
         } else {
             diagnostics.push(PluginDiagnostic {
                 stable_ptr: enum_ast.name(db).stable_ptr().0,
@@ -115,7 +101,6 @@ impl $name$Introspect<$generics$> of \
         $size$
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         $layout$
     }

--- a/crates/dojo-lang/src/introspect/size.rs
+++ b/crates/dojo-lang/src/introspect/size.rs
@@ -53,8 +53,16 @@ pub fn is_enum_packable(variant_sizes: &[(Vec<String>, u32, bool)]) -> bool {
     if variant_sizes.is_empty() {
         return true;
     }
+
+    let v0_sizes = variant_sizes[0].0.clone();
     let v0_fixed_size = variant_sizes[0].1;
-    variant_sizes.iter().all(|vs| vs.0.is_empty() && vs.1 == v0_fixed_size && !vs.2)
+
+    variant_sizes.iter().all(|vs| {
+        vs.0.len() == v0_sizes.len()
+            && vs.0.iter().zip(v0_sizes.iter()).all(|(a, b)| a == b)
+            && vs.1 == v0_fixed_size
+            && !vs.2
+    })
 }
 
 pub fn compute_enum_layout_size(variant_sizes: &[(Vec<String>, u32, bool)]) -> String {

--- a/crates/dojo-lang/src/introspect/size.rs
+++ b/crates/dojo-lang/src/introspect/size.rs
@@ -32,29 +32,47 @@ pub fn compute_struct_layout_size(db: &dyn SyntaxGroup, struct_ast: &ItemStruct)
     build_size_function_body(&mut sizes, cumulated_sizes, is_dynamic_size)
 }
 
-pub fn compute_enum_layout_size(
+pub fn compute_enum_variant_sizes(
     db: &dyn SyntaxGroup,
     enum_ast: &ItemEnum,
-    identical_variants: bool,
-) -> String {
-    if identical_variants {
-        match enum_ast.variants(db).elements(db).first() {
-            Some(first_variant) => {
-                let (mut sizes, cumulated_sizes, is_dynamic_size) =
-                    match first_variant.type_clause(db) {
-                        OptionTypeClause::Empty(_) => (vec![], 0, false),
-                        OptionTypeClause::TypeClause(type_clause) => {
-                            get_field_size_from_type_clause(db, &type_clause)
-                        }
-                    };
-
-                // add 8 bits to store the variant identifier
-                sizes.insert(0, "8".to_string());
-
-                build_size_function_body(&mut sizes, cumulated_sizes, is_dynamic_size)
+) -> Vec<(Vec<String>, u32, bool)> {
+    enum_ast
+        .variants(db)
+        .elements(db)
+        .iter()
+        .map(|v| match v.type_clause(db) {
+            OptionTypeClause::Empty(_) => (vec![], 0, false),
+            OptionTypeClause::TypeClause(type_clause) => {
+                get_field_size_from_type_clause(db, &type_clause)
             }
-            None => "Option::None".to_string(),
-        }
+        })
+        .collect::<Vec<_>>()
+}
+
+pub fn is_enum_packable(variant_sizes: &[(Vec<String>, u32, bool)]) -> bool {
+    if variant_sizes.is_empty() {
+        return true;
+    }
+    let v0_fixed_size = variant_sizes[0].1;
+    variant_sizes.iter().all(|vs| vs.0.is_empty() && vs.1 == v0_fixed_size && !vs.2)
+}
+
+pub fn compute_enum_layout_size(variant_sizes: &[(Vec<String>, u32, bool)]) -> String {
+    if variant_sizes.is_empty() {
+        return "Option::None".to_string();
+    }
+
+    let v0 = variant_sizes[0].clone();
+    let identical_variants =
+        variant_sizes.iter().all(|vs| vs.0 == v0.0 && vs.1 == v0.1 && vs.2 == v0.2);
+
+    if identical_variants {
+        let (mut sizes, mut cumulated_sizes, is_dynamic_size) = v0;
+
+        // add one felt252 to store the variant identifier
+        cumulated_sizes += 1;
+
+        build_size_function_body(&mut sizes, cumulated_sizes, is_dynamic_size)
     } else {
         "Option::None".to_string()
     }

--- a/crates/dojo-lang/src/introspect/utils.rs
+++ b/crates/dojo-lang/src/introspect/utils.rs
@@ -1,9 +1,5 @@
 use std::collections::HashMap;
 
-use cairo_lang_syntax::node::ast::ItemEnum;
-use cairo_lang_syntax::node::db::SyntaxGroup;
-use cairo_lang_syntax::node::TypedSyntaxNode;
-
 #[derive(Clone, Default)]
 pub struct TypeIntrospection(pub usize, pub Vec<usize>);
 
@@ -92,16 +88,6 @@ pub fn get_tuple_item_types(ty: &str) -> Vec<String> {
     }
 
     items
-}
-
-pub fn are_enum_variants_identical(db: &dyn SyntaxGroup, enum_ast: &ItemEnum) -> bool {
-    let variants = enum_ast
-        .variants(db)
-        .elements(db)
-        .iter()
-        .map(|v| v.as_syntax_node().get_text(db))
-        .collect::<Vec<_>>();
-    variants.iter().all(|item| item == &variants[0])
 }
 
 #[test]

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo_world_world.toml
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo_world_world.toml
@@ -1,5 +1,5 @@
 kind = "Class"
-class_hash = "0x34aafe3ca8fd1aec61deea58541aefd0ec6647299939ad96e4cd3a79c47bb8e"
-original_class_hash = "0x34aafe3ca8fd1aec61deea58541aefd0ec6647299939ad96e4cd3a79c47bb8e"
+class_hash = "0x1fafbe78a4676c8998d2de2053bc2fba24aebbd4fb86f03ff6af87ad3314092"
+original_class_hash = "0x1fafbe78a4676c8998d2de2053bc2fba24aebbd4fb86f03ff6af87ad3314092"
 abi = "manifests/dev/abis/base/dojo_world_world.json"
 name = "dojo::world::world"

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo_world_world.toml
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo_world_world.toml
@@ -1,5 +1,5 @@
 kind = "Class"
-class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
-original_class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
+class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
+original_class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 abi = "manifests/dev/abis/base/dojo_world_world.json"
 name = "dojo::world::world"

--- a/crates/dojo-lang/src/plugin_test_data/introspect
+++ b/crates/dojo-lang/src/plugin_test_data/introspect
@@ -220,7 +220,7 @@ struct StructNotPackable1 {
 }
 
 #[derive(IntrospectPacked)]
-struct StructPackableWithWarning {
+struct StructPackableWithInnerPacked {
     x: u8,
     y: StructPacked1
 }
@@ -247,7 +247,7 @@ enum EnumPacked3 {
 
 
 #[derive(IntrospectPacked)]
-enum EnumPackableWithWarning {
+enum EnumPackableWithInnerPacked {
     a: StructPacked1,
     b: StructPacked1,
 }
@@ -475,7 +475,7 @@ struct StructNotPackable1 {
 }
 
 #[derive(IntrospectPacked)]
-struct StructPackableWithWarning {
+struct StructPackableWithInnerPacked {
     x: u8,
     y: StructPacked1
 }
@@ -502,7 +502,7 @@ enum EnumPacked3 {
 
 
 #[derive(IntrospectPacked)]
-enum EnumPackableWithWarning {
+enum EnumPackableWithInnerPacked {
     a: StructPacked1,
     b: StructPacked1,
 }
@@ -711,15 +711,15 @@ impl EnumWithStructIntrospect<> of dojo::database::introspect::Introspect<EnumWi
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec2>::size(),
+                    dojo::database::introspect::Introspect::<Vec2>::size(),
 Option::Some(1)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -976,15 +976,15 @@ impl EnumWithComplexTupleIntrospect<> of dojo::database::introspect::Introspect<
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec2>::size(),
+                    dojo::database::introspect::Introspect::<Vec2>::size(),
 Option::Some(2)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -1119,15 +1119,15 @@ impl EnumCustomIntrospect<> of dojo::database::introspect::Introspect<EnumCustom
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec2>::size(),
+                    dojo::database::introspect::Introspect::<Vec2>::size(),
 Option::Some(1)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -1185,16 +1185,16 @@ impl EnumTupleMixIntrospect<> of dojo::database::introspect::Introspect<EnumTupl
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec2>::size(),
+                    dojo::database::introspect::Introspect::<Vec2>::size(),
 dojo::database::introspect::Introspect::<EnumCustom>::size(),
 Option::Some(2)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -1384,15 +1384,15 @@ impl StructWithStructIntrospect<> of dojo::database::introspect::Introspect<Stru
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec2>::size(),
+                    dojo::database::introspect::Introspect::<Vec2>::size(),
 Option::Some(1)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -1671,16 +1671,16 @@ impl StructWithComplexTupleIntrospect<> of dojo::database::introspect::Introspec
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec2>::size(),
+                    dojo::database::introspect::Introspect::<Vec2>::size(),
 dojo::database::introspect::Introspect::<EnumCustom>::size(),
 Option::Some(2)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -1817,16 +1817,16 @@ impl StructWithNestedTuplesIntrospect<> of dojo::database::introspect::Introspec
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec2>::size(),
+                    dojo::database::introspect::Introspect::<Vec2>::size(),
 dojo::database::introspect::Introspect::<EnumCustom>::size(),
 Option::Some(3)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -2226,15 +2226,15 @@ impl EnumWithBadOptionIntrospect<> of dojo::database::introspect::Introspect<Enu
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size(),
+                    dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size(),
 Option::Some(1)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -2651,19 +2651,17 @@ dojo::database::introspect::Member {
     }
 }
 
-impl StructPackableWithWarningIntrospect<> of dojo::database::introspect::Introspect<StructPackableWithWarning<>> {
+impl StructPackableWithInnerPackedIntrospect<> of dojo::database::introspect::Introspect<StructPackableWithInnerPacked<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<StructPacked1>::size(),
+                    dojo::database::introspect::Introspect::<StructPacked1>::size(),
 Option::Some(1)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -2700,7 +2698,7 @@ dojo::database::introspect::Introspect::<StructPacked1>::layout()
     fn ty() -> dojo::database::introspect::Ty {
         dojo::database::introspect::Ty::Struct(
             dojo::database::introspect::Struct {
-                name: 'StructPackableWithWarning',
+                name: 'StructPackableWithInnerPacked',
                 attrs: array![].span(),
                 children: array![
                 dojo::database::introspect::Member {
@@ -2817,19 +2815,17 @@ dojo::database::introspect::Introspect::<u128>::ty()
     }
 }
 
-impl EnumPackableWithWarningIntrospect<> of dojo::database::introspect::Introspect<EnumPackableWithWarning<>> {
+impl EnumPackableWithInnerPackedIntrospect<> of dojo::database::introspect::Introspect<EnumPackableWithInnerPacked<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<StructPacked1>::size(),
+                    dojo::database::introspect::Introspect::<StructPacked1>::size(),
 Option::Some(1)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {
@@ -2866,7 +2862,7 @@ dojo::database::introspect::Introspect::<StructPacked1>::layout()
     fn ty() -> dojo::database::introspect::Ty {
         dojo::database::introspect::Ty::Enum(
             dojo::database::introspect::Enum {
-                name: 'EnumPackableWithWarning',
+                name: 'EnumPackableWithInnerPacked',
                 attrs: array![].span(),
                 children: array![
                 ('a', dojo::database::introspect::Introspect::<StructPacked1>::ty()),

--- a/crates/dojo-lang/src/plugin_test_data/introspect
+++ b/crates/dojo-lang/src/plugin_test_data/introspect
@@ -14,8 +14,8 @@ struct Vec2 {
 
 #[derive(Serde, Copy, Drop, Introspect)]
 enum PlainEnum {
-    Left: (),
-    Right: (),
+    Left,
+    Right,
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
@@ -55,9 +55,9 @@ enum EnumWithComplexTuple {
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
-enum EnumTupleOnePrimitive {
-    Left: (u16,),
-    Right: (u16,),
+enum EnumWithPrimitive {
+    Left: u32,
+    Right: u32,
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
@@ -262,8 +262,8 @@ struct Vec2 {
 
 #[derive(Serde, Copy, Drop, Introspect)]
 enum PlainEnum {
-    Left: (),
-    Right: (),
+    Left,
+    Right,
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
@@ -303,9 +303,9 @@ enum EnumWithComplexTuple {
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
-enum EnumTupleOnePrimitive {
-    Left: (u16,),
-    Right: (u16,),
+enum EnumWithPrimitive {
+    Left: u32,
+    Right: u32,
 }
 
 #[derive(Serde, Copy, Drop, Introspect)]
@@ -583,7 +583,7 @@ impl PlainEnumDrop of core::traits::Drop::<PlainEnum>;
 impl PlainEnumIntrospect<> of dojo::database::introspect::Introspect<PlainEnum<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(1)
     }
 
     #[inline(always)]
@@ -592,29 +592,11 @@ impl PlainEnumIntrospect<> of dojo::database::introspect::Introspect<PlainEnum<>
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
-            array![
-            
-            ].span()
-        )
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Layout::Fixed(array![].span())
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
-            array![
-            
-            ].span()
-        )
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Layout::Fixed(array![].span())
                 }
             ].span()
         )
@@ -627,16 +609,8 @@ dojo::database::introspect::FieldLayout {
                 name: 'PlainEnum',
                 attrs: array![].span(),
                 children: array![
-                ('Left', dojo::database::introspect::Ty::Tuple(
-            array![
-            
-            ].span()
-        )),
-('Right', dojo::database::introspect::Ty::Tuple(
-            array![
-            
-            ].span()
-        ))
+                ('Left', dojo::database::introspect::Ty::Tuple(array![].span())),
+('Right', dojo::database::introspect::Ty::Tuple(array![].span()))
 
                 ].span()
             }
@@ -667,7 +641,7 @@ impl EnumWithPrimitiveDrop of core::traits::Drop::<EnumWithPrimitive>;
 impl EnumWithPrimitiveIntrospect<> of dojo::database::introspect::Introspect<EnumWithPrimitive<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(2)
     }
 
     #[inline(always)]
@@ -676,21 +650,11 @@ impl EnumWithPrimitiveIntrospect<> of dojo::database::introspect::Introspect<Enu
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<u32>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<u32>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 }
             ].span()
         )
@@ -735,7 +699,16 @@ impl EnumWithStructDrop of core::traits::Drop::<EnumWithStruct>;
 impl EnumWithStructIntrospect<> of dojo::database::introspect::Introspect<EnumWithStruct<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+Option::Some(1)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -744,21 +717,11 @@ impl EnumWithStructIntrospect<> of dojo::database::introspect::Introspect<EnumWi
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 }
             ].span()
         )
@@ -812,21 +775,11 @@ impl EnumWithSimpleArrayIntrospect<> of dojo::database::introspect::Introspect<E
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Array<u32>>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Array<u32>>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Array<u32>>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Array<u32>>::layout()
                 }
             ].span()
         )
@@ -888,21 +841,11 @@ impl EnumWithByteArrayIntrospect<> of dojo::database::introspect::Introspect<Enu
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<ByteArray>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<ByteArray>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<ByteArray>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<ByteArray>::layout()
                 }
             ].span()
         )
@@ -947,7 +890,7 @@ impl EnumWithSimpleTupleDrop of core::traits::Drop::<EnumWithSimpleTuple>;
 impl EnumWithSimpleTupleIntrospect<> of dojo::database::introspect::Introspect<EnumWithSimpleTuple<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(4)
     }
 
     #[inline(always)]
@@ -957,30 +900,20 @@ impl EnumWithSimpleTupleIntrospect<> of dojo::database::introspect::Introspect<E
             dojo::database::introspect::FieldLayout {
                     selector: 0,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<u256>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<u256>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -1035,7 +968,16 @@ impl EnumWithComplexTupleDrop of core::traits::Drop::<EnumWithComplexTuple>;
 impl EnumWithComplexTupleIntrospect<> of dojo::database::introspect::Introspect<EnumWithComplexTuple<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+Option::Some(2)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -1045,30 +987,20 @@ impl EnumWithComplexTupleIntrospect<> of dojo::database::introspect::Introspect<
             dojo::database::introspect::FieldLayout {
                     selector: 0,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<Vec2>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<u8>::layout(),
 dojo::database::introspect::Introspect::<Vec2>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -1099,31 +1031,31 @@ dojo::database::introspect::Introspect::<Vec2>::ty()
         )
     }
 }
-impl EnumTupleOnePrimitiveSerde of core::serde::Serde::<EnumTupleOnePrimitive> {
-    fn serialize(self: @EnumTupleOnePrimitive, ref output: core::array::Array<felt252>) {
+impl EnumWithPrimitiveSerde of core::serde::Serde::<EnumWithPrimitive> {
+    fn serialize(self: @EnumWithPrimitive, ref output: core::array::Array<felt252>) {
         match self {
-            EnumTupleOnePrimitive::Left(x) => { core::serde::Serde::serialize(@0, ref output); core::serde::Serde::serialize(x, ref output); },
-            EnumTupleOnePrimitive::Right(x) => { core::serde::Serde::serialize(@1, ref output); core::serde::Serde::serialize(x, ref output); },
+            EnumWithPrimitive::Left(x) => { core::serde::Serde::serialize(@0, ref output); core::serde::Serde::serialize(x, ref output); },
+            EnumWithPrimitive::Right(x) => { core::serde::Serde::serialize(@1, ref output); core::serde::Serde::serialize(x, ref output); },
         }
     }
-    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<EnumTupleOnePrimitive> {
+    fn deserialize(ref serialized: core::array::Span<felt252>) -> core::option::Option<EnumWithPrimitive> {
         let idx: felt252 = core::serde::Serde::deserialize(ref serialized)?;
         core::option::Option::Some(
             match idx {
-                0 => EnumTupleOnePrimitive::Left(core::serde::Serde::deserialize(ref serialized)?),
-                1 => EnumTupleOnePrimitive::Right(core::serde::Serde::deserialize(ref serialized)?),
+                0 => EnumWithPrimitive::Left(core::serde::Serde::deserialize(ref serialized)?),
+                1 => EnumWithPrimitive::Right(core::serde::Serde::deserialize(ref serialized)?),
                 _ => { return core::option::Option::None; }
             }
         )
     }
 }
-impl EnumTupleOnePrimitiveCopy of core::traits::Copy::<EnumTupleOnePrimitive>;
-impl EnumTupleOnePrimitiveDrop of core::traits::Drop::<EnumTupleOnePrimitive>;
+impl EnumWithPrimitiveCopy of core::traits::Copy::<EnumWithPrimitive>;
+impl EnumWithPrimitiveDrop of core::traits::Drop::<EnumWithPrimitive>;
 
-impl EnumTupleOnePrimitiveIntrospect<> of dojo::database::introspect::Introspect<EnumTupleOnePrimitive<>> {
+impl EnumWithPrimitiveIntrospect<> of dojo::database::introspect::Introspect<EnumWithPrimitive<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(2)
     }
 
     #[inline(always)]
@@ -1132,29 +1064,11 @@ impl EnumTupleOnePrimitiveIntrospect<> of dojo::database::introspect::Introspect
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
-            array![
-            dojo::database::introspect::Introspect::<u16>::layout()
-            ].span()
-        )
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
-            array![
-            dojo::database::introspect::Introspect::<u16>::layout()
-            ].span()
-        )
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 }
             ].span()
         )
@@ -1164,19 +1078,11 @@ dojo::database::introspect::FieldLayout {
     fn ty() -> dojo::database::introspect::Ty {
         dojo::database::introspect::Ty::Enum(
             dojo::database::introspect::Enum {
-                name: 'EnumTupleOnePrimitive',
+                name: 'EnumWithPrimitive',
                 attrs: array![].span(),
                 children: array![
-                ('Left', dojo::database::introspect::Ty::Tuple(
-            array![
-            dojo::database::introspect::Introspect::<u16>::ty()
-            ].span()
-        )),
-('Right', dojo::database::introspect::Ty::Tuple(
-            array![
-            dojo::database::introspect::Introspect::<u16>::ty()
-            ].span()
-        ))
+                ('Left', dojo::database::introspect::Introspect::<u32>::ty()),
+('Right', dojo::database::introspect::Introspect::<u32>::ty())
 
                 ].span()
             }
@@ -1207,7 +1113,16 @@ impl EnumCustomDrop of core::traits::Drop::<EnumCustom>;
 impl EnumCustomIntrospect<> of dojo::database::introspect::Introspect<EnumCustom<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+Option::Some(1)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -1216,21 +1131,11 @@ impl EnumCustomIntrospect<> of dojo::database::introspect::Introspect<EnumCustom
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Vec2>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Vec2>::layout()
                 }
             ].span()
         )
@@ -1275,7 +1180,17 @@ impl EnumTupleMixDrop of core::traits::Drop::<EnumTupleMix>;
 impl EnumTupleMixIntrospect<> of dojo::database::introspect::Introspect<EnumTupleMix<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<Vec2>::size(),
+dojo::database::introspect::Introspect::<EnumCustom>::size(),
+Option::Some(2)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
     }
 
     #[inline(always)]
@@ -1285,32 +1200,22 @@ impl EnumTupleMixIntrospect<> of dojo::database::introspect::Introspect<EnumTupl
             dojo::database::introspect::FieldLayout {
                     selector: 0,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<Vec2>::layout(),
 dojo::database::introspect::Introspect::<u64>::layout(),
 dojo::database::introspect::Introspect::<EnumCustom>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<Vec2>::layout(),
 dojo::database::introspect::Introspect::<u64>::layout(),
 dojo::database::introspect::Introspect::<EnumCustom>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -1378,35 +1283,20 @@ impl EnumWithDifferentVariantDataIntrospect<> of dojo::database::introspect::Int
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Layout::Fixed(array![].span())
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 1,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<u32>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<u32>::layout()
                 },
 dojo::database::introspect::FieldLayout {
                     selector: 2,
                     layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Layout::Tuple(
             array![
             dojo::database::introspect::Introspect::<Vec2>::layout(),
 dojo::database::introspect::Introspect::<u64>::layout()
             ].span()
         )
-                        ].span()
-                    )
                 }
             ].span()
         )
@@ -2347,8 +2237,8 @@ impl EnumWithBadOptionIntrospect<> of dojo::database::introspect::Introspect<Enu
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        8,
-dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size()
+                        dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size(),
+Option::Some(1)
                     ];
 
                     if dojo::database::utils::any_none(@sizes) {
@@ -2364,12 +2254,7 @@ dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size()
             array![
             dojo::database::introspect::FieldLayout {
                     selector: 0,
-                    layout: dojo::database::introspect::Layout::Tuple(
-                        array![
-                            dojo::database::introspect::Layout::Fixed(array![8].span()),
-                            dojo::database::introspect::Introspect::<Option<(u8, u16)>>::layout()
-                        ].span()
-                    )
+                    layout: dojo::database::introspect::Introspect::<Option<(u8, u16)>>::layout()
                 }
             ].span()
         )
@@ -2841,12 +2726,16 @@ dojo::database::introspect::Member {
 impl EnumPacked1Introspect<> of dojo::database::introspect::Introspect<EnumPacked1<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(1)
     }
 
     #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
-        ERROR
+        dojo::database::introspect::Layout::Fixed(
+                array![
+                8,
+                ].span()
+            )
     }
 
     #[inline(always)]
@@ -2869,12 +2758,16 @@ impl EnumPacked1Introspect<> of dojo::database::introspect::Introspect<EnumPacke
 impl EnumPacked2Introspect<> of dojo::database::introspect::Introspect<EnumPacked2<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(2)
     }
 
     #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
-        ERROR
+        dojo::database::introspect::Layout::Fixed(
+                array![
+                8,8
+                ].span()
+            )
     }
 
     #[inline(always)]
@@ -2897,12 +2790,16 @@ impl EnumPacked2Introspect<> of dojo::database::introspect::Introspect<EnumPacke
 impl EnumPacked3Introspect<> of dojo::database::introspect::Introspect<EnumPacked3<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
-        Option::None
+        Option::Some(3)
     }
 
     #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
-        ERROR
+        dojo::database::introspect::Layout::Fixed(
+                array![
+                8,128,128
+                ].span()
+            )
     }
 
     #[inline(always)]
@@ -2994,22 +2891,7 @@ error: For now, field with custom type cannot be packed
     y: StructPacked1
      ^*************^
 
-error: To be packed, all variants must have exactly the same layout.
- --> test_src/lib.cairo:223:6
-enum EnumPacked1 {
-     ^*********^
-
-error: To be packed, all variants must have exactly the same layout.
- --> test_src/lib.cairo:230:6
-enum EnumPacked2 {
-     ^*********^
-
-error: To be packed, all variants must have exactly the same layout.
- --> test_src/lib.cairo:237:6
-enum EnumPacked3 {
-     ^*********^
-
-error: To be packed, all variants must have exactly the same layout.
+error: To be packed, all variants must have fixed layout of same size.
  --> test_src/lib.cairo:243:6
 enum EnumNotPackable1 {
      ^**************^

--- a/crates/dojo-lang/src/plugin_test_data/introspect
+++ b/crates/dojo-lang/src/plugin_test_data/introspect
@@ -220,7 +220,7 @@ struct StructNotPackable1 {
 }
 
 #[derive(IntrospectPacked)]
-struct StructNotPackable2 {
+struct StructPackableWithWarning {
     x: u8,
     y: StructPacked1
 }
@@ -243,6 +243,13 @@ enum EnumPacked2 {
 enum EnumPacked3 {
     a: (u128, u128),
     b: u256,
+}
+
+
+#[derive(IntrospectPacked)]
+enum EnumPackableWithWarning {
+    a: StructPacked1,
+    b: StructPacked1,
 }
 
 #[derive(IntrospectPacked)]
@@ -468,7 +475,7 @@ struct StructNotPackable1 {
 }
 
 #[derive(IntrospectPacked)]
-struct StructNotPackable2 {
+struct StructPackableWithWarning {
     x: u8,
     y: StructPacked1
 }
@@ -491,6 +498,13 @@ enum EnumPacked2 {
 enum EnumPacked3 {
     a: (u128, u128),
     b: u256,
+}
+
+
+#[derive(IntrospectPacked)]
+enum EnumPackableWithWarning {
+    a: StructPacked1,
+    b: StructPacked1,
 }
 
 #[derive(IntrospectPacked)]
@@ -519,7 +533,6 @@ impl Vec2Introspect<> of dojo::database::introspect::Introspect<Vec2<>> {
         Option::Some(2)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -586,7 +599,6 @@ impl PlainEnumIntrospect<> of dojo::database::introspect::Introspect<PlainEnum<>
         Option::Some(1)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -644,7 +656,6 @@ impl EnumWithPrimitiveIntrospect<> of dojo::database::introspect::Introspect<Enu
         Option::Some(2)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -711,7 +722,6 @@ Option::Some(1)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -769,7 +779,6 @@ impl EnumWithSimpleArrayIntrospect<> of dojo::database::introspect::Introspect<E
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -835,7 +844,6 @@ impl EnumWithByteArrayIntrospect<> of dojo::database::introspect::Introspect<Enu
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -893,7 +901,6 @@ impl EnumWithSimpleTupleIntrospect<> of dojo::database::introspect::Introspect<E
         Option::Some(4)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -980,7 +987,6 @@ Option::Some(2)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -1058,7 +1064,6 @@ impl EnumWithPrimitiveIntrospect<> of dojo::database::introspect::Introspect<Enu
         Option::Some(2)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -1125,7 +1130,6 @@ Option::Some(1)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -1193,7 +1197,6 @@ Option::Some(2)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -1277,7 +1280,6 @@ impl EnumWithDifferentVariantDataIntrospect<> of dojo::database::introspect::Int
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -1332,7 +1334,6 @@ impl StructWithPrimitivesIntrospect<> of dojo::database::introspect::Introspect<
         Option::Some(2)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1394,7 +1395,6 @@ Option::Some(1)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1447,7 +1447,6 @@ impl StructWithSimpleArrayIntrospect<> of dojo::database::introspect::Introspect
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1504,7 +1503,6 @@ impl StructWithByteArrayIntrospect<> of dojo::database::introspect::Introspect<S
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1557,7 +1555,6 @@ impl StructWithComplexArrayIntrospect<> of dojo::database::introspect::Introspec
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1614,7 +1611,6 @@ impl StructWithSimpleTupleIntrospect<> of dojo::database::introspect::Introspect
         Option::Some(4)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1687,7 +1683,6 @@ Option::Some(2)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1752,7 +1747,6 @@ impl StructWithNestedArraysIntrospect<> of dojo::database::introspect::Introspec
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1835,7 +1829,6 @@ Option::Some(3)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1918,7 +1911,6 @@ impl StructWithNestedTuplesAndByteArrayIntrospect<> of dojo::database::introspec
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2001,7 +1993,6 @@ impl StructWithNestedEverythingIntrospect<> of dojo::database::introspect::Intro
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2134,7 +2125,6 @@ impl GenericStructIntrospect<T, impl TIntrospect: dojo::database::introspect::In
         dojo::database::introspect::Introspect::<T>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2183,7 +2173,6 @@ impl StructWithBadOptionIntrospect<> of dojo::database::introspect::Introspect<S
         dojo::database::introspect::Introspect::<Option<(u8, u16)>>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2248,7 +2237,6 @@ Option::Some(1)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -2281,7 +2269,6 @@ impl EnumIncompatibleAttrsIntrospect<> of dojo::database::introspect::Introspect
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -2311,7 +2298,6 @@ impl EnumIncompatibleAttrsIntrospect<> of dojo::database::introspect::Introspect
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
                 array![
@@ -2341,7 +2327,6 @@ impl StructIncompatibleAttrsIntrospect<> of dojo::database::introspect::Introspe
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2371,7 +2356,6 @@ impl StructIncompatibleAttrsIntrospect<> of dojo::database::introspect::Introspe
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
             array![
@@ -2401,7 +2385,6 @@ impl StructIncompatibleAttrs2Introspect<> of dojo::database::introspect::Introsp
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2431,7 +2414,6 @@ impl StructIncompatibleAttrs2Introspect<> of dojo::database::introspect::Introsp
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
             array![
@@ -2461,7 +2443,6 @@ impl EnumIncompatibleAttrs2Introspect<> of dojo::database::introspect::Introspec
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Enum(
             array![
@@ -2491,7 +2472,6 @@ impl EnumIncompatibleAttrs2Introspect<> of dojo::database::introspect::Introspec
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
                 array![
@@ -2521,7 +2501,6 @@ impl StructPacked1Introspect<> of dojo::database::introspect::Introspect<StructP
         Option::Some(1)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
             array![
@@ -2555,7 +2534,6 @@ impl StructPacked2Introspect<> of dojo::database::introspect::Introspect<StructP
         Option::Some(3)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
             array![
@@ -2594,7 +2572,6 @@ impl StructPacked3Introspect<> of dojo::database::introspect::Introspect<StructP
         Option::Some(4)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
             array![
@@ -2638,7 +2615,6 @@ impl StructNotPackable1Introspect<> of dojo::database::introspect::Introspect<St
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
             array![
@@ -2675,7 +2651,7 @@ dojo::database::introspect::Member {
     }
 }
 
-impl StructNotPackable2Introspect<> of dojo::database::introspect::Introspect<StructNotPackable2<>> {
+impl StructPackableWithWarningIntrospect<> of dojo::database::introspect::Introspect<StructPackableWithWarning<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
@@ -2690,20 +2666,41 @@ Option::Some(1)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
-        dojo::database::introspect::Layout::Fixed(
-            array![
-            8,ERROR
-            ].span()
-        )
+        let mut layouts = array![
+            dojo::database::introspect::Layout::Fixed(array![8].span()),
+dojo::database::introspect::Introspect::<StructPacked1>::layout()
+        ];
+        let mut merged_layout = ArrayTrait::<u8>::new();
+
+        loop {
+            match ArrayTrait::pop_front(ref layouts) {
+                Option::Some(mut layout) => {
+                    match layout {
+                        dojo::database::introspect::Layout::Fixed(mut l) => {
+                            loop {
+                                match SpanTrait::pop_front(ref l) {
+                                    Option::Some(x) => merged_layout.append(*x),
+                                    Option::None(_) => { break; }
+                                };
+                            };
+                        },
+                        _ => panic!("A packed model layout must contain Fixed layouts only."),
+                    };
+                },
+                Option::None(_) => { break; }
+            };
+        };
+
+        dojo::database::introspect::Layout::Fixed(merged_layout.span())
+        
     }
 
     #[inline(always)]
     fn ty() -> dojo::database::introspect::Ty {
         dojo::database::introspect::Ty::Struct(
             dojo::database::introspect::Struct {
-                name: 'StructNotPackable2',
+                name: 'StructPackableWithWarning',
                 attrs: array![].span(),
                 children: array![
                 dojo::database::introspect::Member {
@@ -2729,11 +2726,10 @@ impl EnumPacked1Introspect<> of dojo::database::introspect::Introspect<EnumPacke
         Option::Some(1)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
                 array![
-                8,
+                8
                 ].span()
             )
     }
@@ -2761,7 +2757,6 @@ impl EnumPacked2Introspect<> of dojo::database::introspect::Introspect<EnumPacke
         Option::Some(2)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
                 array![
@@ -2793,7 +2788,6 @@ impl EnumPacked3Introspect<> of dojo::database::introspect::Introspect<EnumPacke
         Option::Some(3)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Fixed(
                 array![
@@ -2823,13 +2817,73 @@ dojo::database::introspect::Introspect::<u128>::ty()
     }
 }
 
+impl EnumPackableWithWarningIntrospect<> of dojo::database::introspect::Introspect<EnumPackableWithWarning<>> {
+    #[inline(always)]
+    fn size() -> Option<usize> {
+        let sizes : Array<Option<usize>> = array![
+                        dojo::database::introspect::Introspect::<StructPacked1>::size(),
+Option::Some(1)
+                    ];
+
+                    if dojo::database::utils::any_none(@sizes) {
+                        return Option::None;
+                    }
+                    Option::Some(dojo::database::utils::sum(sizes))
+                    
+    }
+
+    fn layout() -> dojo::database::introspect::Layout {
+        let mut layouts = array![
+            dojo::database::introspect::Layout::Fixed(array![8].span()),
+dojo::database::introspect::Introspect::<StructPacked1>::layout()
+        ];
+        let mut merged_layout = ArrayTrait::<u8>::new();
+
+        loop {
+            match ArrayTrait::pop_front(ref layouts) {
+                Option::Some(mut layout) => {
+                    match layout {
+                        dojo::database::introspect::Layout::Fixed(mut l) => {
+                            loop {
+                                match SpanTrait::pop_front(ref l) {
+                                    Option::Some(x) => merged_layout.append(*x),
+                                    Option::None(_) => { break; }
+                                };
+                            };
+                        },
+                        _ => panic!("A packed model layout must contain Fixed layouts only."),
+                    };
+                },
+                Option::None(_) => { break; }
+            };
+        };
+
+        dojo::database::introspect::Layout::Fixed(merged_layout.span())
+        
+    }
+
+    #[inline(always)]
+    fn ty() -> dojo::database::introspect::Ty {
+        dojo::database::introspect::Ty::Enum(
+            dojo::database::introspect::Enum {
+                name: 'EnumPackableWithWarning',
+                attrs: array![].span(),
+                children: array![
+                ('a', dojo::database::introspect::Introspect::<StructPacked1>::ty()),
+('b', dojo::database::introspect::Introspect::<StructPacked1>::ty())
+
+                ].span()
+            }
+        )
+    }
+}
+
 impl EnumNotPackable1Introspect<> of dojo::database::introspect::Introspect<EnumNotPackable1<>> {
     #[inline(always)]
     fn size() -> Option<usize> {
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         ERROR
     }
@@ -2886,12 +2940,7 @@ error: Array field cannot be packed.
     y: Array<u32>
      ^**********^
 
-error: For now, field with custom type cannot be packed
- --> test_src/lib.cairo:219:6
-    y: StructPacked1
-     ^*************^
-
 error: To be packed, all variants must have fixed layout of same size.
- --> test_src/lib.cairo:243:6
+ --> test_src/lib.cairo:250:6
 enum EnumNotPackable1 {
      ^**************^

--- a/crates/dojo-lang/src/plugin_test_data/model
+++ b/crates/dojo-lang/src/plugin_test_data/model
@@ -3180,15 +3180,15 @@ impl ModelWithTupleNoPrimitivesIntrospect<> of dojo::database::introspect::Intro
     #[inline(always)]
     fn size() -> Option<usize> {
         let sizes : Array<Option<usize>> = array![
-                        dojo::database::introspect::Introspect::<Vec3>::size(),
+                    dojo::database::introspect::Introspect::<Vec3>::size(),
 Option::Some(3)
-                    ];
+                ];
 
-                    if dojo::database::utils::any_none(@sizes) {
-                        return Option::None;
-                    }
-                    Option::Some(dojo::database::utils::sum(sizes))
-                    
+                if dojo::database::utils::any_none(@sizes) {
+                    return Option::None;
+                }
+                Option::Some(dojo::database::utils::sum(sizes))
+                
     }
 
     fn layout() -> dojo::database::introspect::Layout {

--- a/crates/dojo-lang/src/plugin_test_data/model
+++ b/crates/dojo-lang/src/plugin_test_data/model
@@ -277,7 +277,6 @@ impl BadModelMultipleAttrIntrospect<> of dojo::database::introspect::Introspect<
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -319,7 +318,6 @@ impl BadModelMultipleVersionsIntrospect<> of dojo::database::introspect::Introsp
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -496,7 +494,6 @@ impl BadModelBadVersionTypeIntrospect<> of dojo::database::introspect::Introspec
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -673,7 +670,6 @@ impl BadModelNoVersionValueIntrospect<> of dojo::database::introspect::Introspec
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -850,7 +846,6 @@ impl BadModelUnexpectedArgWithValueIntrospect<> of dojo::database::introspect::I
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1027,7 +1022,6 @@ impl BadModelUnexpectedArgIntrospect<> of dojo::database::introspect::Introspect
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1204,7 +1198,6 @@ impl BadModelNotSupportedVersionIntrospect<> of dojo::database::introspect::Intr
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1381,7 +1374,6 @@ impl Modelv0Introspect<> of dojo::database::introspect::Introspect<Modelv0<>> {
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1558,7 +1550,6 @@ impl PositionIntrospect<> of dojo::database::introspect::Introspect<Position<>> 
         dojo::database::introspect::Introspect::<Vec3>::size()
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1735,7 +1726,6 @@ impl RolesIntrospect<> of dojo::database::introspect::Introspect<Roles<>> {
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -1912,7 +1902,6 @@ impl OnlyKeyModelIntrospect<> of dojo::database::introspect::Introspect<OnlyKeyM
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2081,7 +2070,6 @@ impl U256KeyModelIntrospect<> of dojo::database::introspect::Introspect<U256KeyM
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2250,7 +2238,6 @@ impl PlayerIntrospect<> of dojo::database::introspect::Introspect<Player<>> {
         Option::Some(1)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2432,7 +2419,6 @@ impl ModelWithSimpleArrayIntrospect<> of dojo::database::introspect::Introspect<
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2623,7 +2609,6 @@ impl ModelWithByteArrayIntrospect<> of dojo::database::introspect::Introspect<Mo
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -2810,7 +2795,6 @@ impl ModelWithComplexArrayIntrospect<> of dojo::database::introspect::Introspect
         Option::None
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -3001,7 +2985,6 @@ impl ModelWithTupleIntrospect<> of dojo::database::introspect::Introspect<ModelW
         Option::Some(4)
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![
@@ -3208,7 +3191,6 @@ Option::Some(3)
                     
     }
 
-    #[inline(always)]
     fn layout() -> dojo::database::introspect::Layout {
         dojo::database::introspect::Layout::Struct(
             array![

--- a/crates/dojo-types/src/schema.rs
+++ b/crates/dojo-types/src/schema.rs
@@ -245,59 +245,6 @@ impl<'a> Iterator for TyIter<'a> {
     }
 }
 
-// parse the Ty tree from its root and extract Ty to print.
-// (basically, structs and enums)
-fn get_printable_ty_list(root_ty: &Ty, ty_list: &mut Vec<Ty>) {
-    match root_ty {
-        Ty::Primitive(_) => {}
-        Ty::ByteArray(_) => {}
-        Ty::Struct(s) => {
-            if !ty_list.contains(root_ty) {
-                ty_list.push(root_ty.clone());
-            }
-
-            for member in &s.children {
-                if !ty_list.contains(&member.ty) {
-                    get_printable_ty_list(&member.ty, ty_list);
-                }
-            }
-        }
-        Ty::Enum(e) => {
-            if !ty_list.contains(root_ty) {
-                ty_list.push(root_ty.clone());
-            }
-
-            for child in &e.options {
-                if !ty_list.contains(&child.ty) {
-                    get_printable_ty_list(&child.ty, ty_list);
-                }
-            }
-        }
-        Ty::Tuple(tuple) => {
-            for item_ty in tuple {
-                if !ty_list.contains(item_ty) {
-                    get_printable_ty_list(item_ty, ty_list);
-                }
-            }
-        }
-        Ty::Array(items_ty) => {
-            if !ty_list.contains(&items_ty[0]) {
-                get_printable_ty_list(&items_ty[0], ty_list)
-            }
-        }
-    };
-}
-
-// print the full Ty tree
-pub fn deep_print_ty(root: Ty) {
-    let mut ty_list = vec![];
-    get_printable_ty_list(&root, &mut ty_list);
-
-    for ty in ty_list {
-        println!("{}\n\n", ty);
-    }
-}
-
 impl std::fmt::Display for Ty {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = self

--- a/crates/dojo-world/src/contracts/model_test.rs
+++ b/crates/dojo-world/src/contracts/model_test.rs
@@ -65,7 +65,7 @@ async fn test_model() {
 
     assert_eq!(
         position.class_hash(),
-        felt!("0x03c3632f38ab3ba550bd3c596e2af55002d43bc76b7b660a3a57b49795307c58")
+        felt!("0x03ab26e88be7885877f93964880ccb63a8acd8e58f941c48bef52f191fa79868")
     );
 
     let moves = world.model_reader("Moves").await.unwrap();

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -147,7 +147,7 @@ async fn get_full_dojo_metadata_from_workspace() {
     assert!(env.world_address.is_some());
     assert_eq!(
         env.world_address.unwrap(),
-        "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7"
+        "0x26a8d9f2ac0348182bea206d913908ef77e439416713592ebc85941a69048d6"
     );
 
     assert!(env.keystore_path.is_none());

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -145,10 +145,9 @@ async fn get_full_dojo_metadata_from_workspace() {
     );
 
     assert!(env.world_address.is_some());
-    assert!(
-        env.world_address
-            .unwrap()
-            .eq("0x1c958955aedbc7b8e2f051767d3369168e88bc5074b0f39e5f8cd2539138281")
+    assert_eq!(
+        env.world_address.unwrap(),
+        "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7"
     );
 
     assert!(env.keystore_path.is_none());

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -127,19 +127,11 @@ fn format_layout_ref(type_name: &str) -> String {
 }
 
 fn format_selector(selector: String) -> String {
-    if selector.starts_with("0x") {
-        format!("[{}]", selector)
-    } else {
-        selector
-    }
+    if selector.starts_with("0x") { format!("[{}]", selector) } else { selector }
 }
 
 fn format_name(name: String) -> String {
-    if !name.is_empty() {
-        format!(" {} ", name)
-    } else {
-        name
-    }
+    if !name.is_empty() { format!(" {} ", name) } else { name }
 }
 
 fn format_field(selector: String, name: String, layout: String) -> String {
@@ -386,11 +378,7 @@ fn deep_print_layout(
 }
 
 fn _start_indent(level: usize, start_indent: bool) -> String {
-    if start_indent {
-        INDENT.repeat(level)
-    } else {
-        "".to_string()
-    }
+    if start_indent { INDENT.repeat(level) } else { "".to_string() }
 }
 
 fn format_primitive(
@@ -399,7 +387,7 @@ fn format_primitive(
     level: usize,
     start_indent: bool,
 ) -> String {
-    let mut _p = p.clone();
+    let mut _p = *p;
     let _ = _p.deserialize(values);
 
     format!("{}{}", _start_indent(level, start_indent), _p.to_sql_value().unwrap())
@@ -443,7 +431,7 @@ fn format_array(
 }
 
 fn format_tuple(
-    items: &Vec<dojo_types::schema::Ty>,
+    items: &[dojo_types::schema::Ty],
     values: &mut Vec<FieldElement>,
     level: usize,
     start_indent: bool,
@@ -466,7 +454,7 @@ fn format_struct(
     let fields = schema
         .children
         .iter()
-        .map(|m| format_field_value(&m, values, level + 1))
+        .map(|m| format_field_value(m, values, level + 1))
         .collect::<Vec<_>>();
 
     format!(
@@ -485,8 +473,7 @@ fn format_enum(
 ) -> String {
     let variant_index: u8 = values.remove(0).try_into().unwrap();
     let variant_index: usize = variant_index.into();
-    let variant_name =
-        format!("{}::{}", schema.name, schema.options[variant_index].name.to_string());
+    let variant_name = format!("{}::{}", schema.name, schema.options[variant_index].name);
     let variant_data =
         format_record_value(&schema.options[variant_index].ty, values, level + 1, true);
 
@@ -546,7 +533,7 @@ fn get_ty_repr(ty: &Ty) -> String {
 
 // to verify if a Ty has already been processed (i.e is in the list),
 // just compare their type representation.
-fn is_ty_already_in_list(ty_list: &Vec<Ty>, ty: &Ty) -> bool {
+fn is_ty_already_in_list(ty_list: &[Ty], ty: &Ty) -> bool {
     let ty_repr = get_ty_repr(ty);
     ty_list.iter().any(|t| get_ty_repr(t).eq(&ty_repr))
 }
@@ -595,7 +582,7 @@ fn get_printable_ty_list(root_ty: &Ty, ty_list: &mut Vec<Ty>) {
 }
 
 pub fn format_ty_field(name: &String, ty: &Ty, is_key: bool) -> String {
-    let ty_repr = get_ty_repr(&ty);
+    let ty_repr = get_ty_repr(ty);
     let ty_repr = if ty_repr.is_empty() { "".to_string() } else { format!(": {ty_repr}") };
     let key_repr = if is_key { "  #[key]\n".to_string() } else { "".to_string() };
 

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -448,6 +448,10 @@ fn format_tuple(
     level: usize,
     start_indent: bool,
 ) -> String {
+    if items.is_empty() {
+        return "".to_string();
+    }
+
     let items_repr = items
         .iter()
         .map(|x| format_record_value(x, values, level + 1, true))
@@ -489,12 +493,16 @@ fn format_enum(
     let variant_data =
         format_record_value(&schema.options[variant_index].ty, values, level + 1, true);
 
-    format!(
-        "{}{variant_name}(\n{}\n{})",
-        _start_indent(level, start_indent),
-        variant_data,
-        INDENT.repeat(level)
-    )
+    if variant_data.is_empty() {
+        format!("{}{variant_name}", _start_indent(level, start_indent),)
+    } else {
+        format!(
+            "{}{variant_name}(\n{}\n{})",
+            _start_indent(level, start_indent),
+            variant_data,
+            INDENT.repeat(level)
+        )
+    }
 }
 
 fn format_record_value(

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -52,9 +52,8 @@ pub async fn model_layout(
     let layout = match model.layout().await {
         Ok(x) => x,
         Err(_) => anyhow::bail!(
-            "[Incorrect layout]\n\
-            The model is packed but contains at least one custom type field which is not packed.\n\
-            Please check your model to fix this."
+            "[Incorrect layout]\nThe model is packed but contains at least one custom type field \
+             which is not packed.\nPlease check your model to fix this."
         ),
     };
     let schema = model.schema().await?;
@@ -134,19 +133,11 @@ fn format_layout_ref(type_name: &str) -> String {
 }
 
 fn format_selector(selector: String) -> String {
-    if selector.starts_with("0x") {
-        format!("[{}]", selector)
-    } else {
-        selector
-    }
+    if selector.starts_with("0x") { format!("[{}]", selector) } else { selector }
 }
 
 fn format_name(name: String) -> String {
-    if !name.is_empty() {
-        format!(" {} ", name)
-    } else {
-        name
-    }
+    if !name.is_empty() { format!(" {} ", name) } else { name }
 }
 
 fn format_field(selector: String, name: String, layout: String) -> String {
@@ -205,7 +196,7 @@ fn get_printable_layout_list_from_struct(
     if let dojo_types::schema::Ty::Struct(ss) = schema {
         let name = get_name_from_schema(schema);
 
-        // proces main struct
+        // process main struct
         if !is_layout_in_list(layout_list, &name) {
             layout_list.push(LayoutInfo {
                 layout_type: LayoutInfoType::Struct,
@@ -399,11 +390,7 @@ fn deep_print_layout(
 }
 
 fn _start_indent(level: usize, start_indent: bool) -> String {
-    if start_indent {
-        INDENT.repeat(level)
-    } else {
-        "".to_string()
-    }
+    if start_indent { INDENT.repeat(level) } else { "".to_string() }
 }
 
 fn format_primitive(

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -128,11 +128,7 @@ fn format_layout_ref(type_name: &str) -> String {
 
 fn format_selector(selector: String) -> String {
     if selector.starts_with("0x") {
-        if selector.len() > 14 {
-            format!("[{}...{}]", &selector[0..8], &selector[selector.len() - 7..])
-        } else {
-            format!("[{}]", selector)
-        }
+        format!("[{}]", selector)
     } else {
         selector
     }

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -1,9 +1,14 @@
 use anyhow::Result;
+use cainome::cairo_serde::{ByteArray, CairoSerde};
+use dojo_types::schema::deep_print_ty;
 use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{BlockId, BlockTag, FieldElement};
+use starknet::core::utils::get_selector_from_name;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
+
+const INDENT: &str = "    ";
 
 pub async fn model_class_hash(
     name: String,
@@ -35,6 +40,23 @@ pub async fn model_contract_address(
     Ok(())
 }
 
+pub async fn model_layout(
+    name: String,
+    world_address: FieldElement,
+    provider: JsonRpcClient<HttpTransport>,
+) -> Result<()> {
+    let mut world_reader = WorldContractReader::new(world_address, &provider);
+    world_reader.set_block(BlockId::Tag(BlockTag::Pending));
+
+    let model = world_reader.model_reader(&name).await?;
+    let layout = model.layout().await?;
+    let schema = model.schema().await?;
+
+    deep_print_layout(&name, &layout, &schema);
+
+    Ok(())
+}
+
 pub async fn model_schema(
     name: String,
     world_address: FieldElement,
@@ -50,7 +72,7 @@ pub async fn model_schema(
     if to_json {
         println!("{}", serde_json::to_string_pretty(&schema)?)
     } else {
-        println!("{schema}");
+        deep_print_ty(schema);
     }
 
     Ok(())
@@ -66,9 +88,445 @@ pub async fn model_get(
     world_reader.set_block(BlockId::Tag(BlockTag::Pending));
 
     let model = world_reader.model_reader(&name).await?;
-    let entity = model.entity(&keys).await?;
+    let schema = model.schema().await?;
+    let values = model.entity_storage(&keys).await?;
 
-    println!("{entity}");
+    deep_print_record(&schema, &keys, &values);
 
     Ok(())
+}
+
+#[derive(Clone, Debug)]
+struct LayoutInfo {
+    layout_type: LayoutInfoType,
+    name: String,
+    fields: Vec<FieldLayoutInfo>,
+}
+
+#[derive(Clone, Debug)]
+enum LayoutInfoType {
+    Struct,
+    Enum,
+    Tuple,
+    Array,
+}
+
+#[derive(Clone, Debug)]
+struct FieldLayoutInfo {
+    selector: String,
+    name: String,
+    layout: String,
+}
+
+fn format_fixed(layout: &[u8]) -> String {
+    format!("[{}]", layout.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", "))
+}
+
+fn format_layout_ref(type_name: &str) -> String {
+    format!("layout({type_name})")
+}
+
+fn format_selector(selector: String) -> String {
+    if selector.starts_with("0x") {
+        if selector.len() > 14 {
+            format!("[{}...{}]", &selector[0..8], &selector[selector.len() - 7..])
+        } else {
+            format!("[{}]", selector)
+        }
+    } else {
+        selector
+    }
+}
+
+fn format_name(name: String) -> String {
+    if !name.is_empty() {
+        format!(" {} ", name)
+    } else {
+        name
+    }
+}
+
+fn format_field(selector: String, name: String, layout: String) -> String {
+    let layout = if layout.eq("[]") { "".to_string() } else { format!(": {layout}") };
+
+    format!("{INDENT}{:<20}{:<18}{}", format_selector(selector), format_name(name), layout)
+}
+
+fn format_field_layout(
+    layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+) -> String {
+    match layout {
+        dojo_world::contracts::model::abigen::model::Layout::Fixed(x) => format_fixed(x),
+        dojo_world::contracts::model::abigen::model::Layout::ByteArray => {
+            "layout(ByteArray)".to_string()
+        }
+        _ => format_layout_ref(&get_name_from_schema(schema)),
+    }
+}
+
+fn is_layout_in_list(list: &[LayoutInfo], name: &String) -> bool {
+    list.iter().any(|x| x.name.eq(name))
+}
+
+fn get_name_from_schema(schema: &dojo_types::schema::Ty) -> String {
+    match schema {
+        dojo_types::schema::Ty::Struct(s) => s.name.clone(),
+        dojo_types::schema::Ty::Enum(e) => e.name.clone(),
+        dojo_types::schema::Ty::Primitive(p) => match p {
+            dojo_types::primitive::Primitive::U8(_) => "u8".to_string(),
+            dojo_types::primitive::Primitive::U16(_) => "u16".to_string(),
+            dojo_types::primitive::Primitive::U32(_) => "u32".to_string(),
+            dojo_types::primitive::Primitive::U64(_) => "u64".to_string(),
+            dojo_types::primitive::Primitive::U128(_) => "u128".to_string(),
+            dojo_types::primitive::Primitive::U256(_) => "u256".to_string(),
+            dojo_types::primitive::Primitive::USize(_) => "usize".to_string(),
+            dojo_types::primitive::Primitive::Bool(_) => "bool".to_string(),
+            dojo_types::primitive::Primitive::Felt252(_) => "felt252".to_string(),
+            dojo_types::primitive::Primitive::ClassHash(_) => "ClassHash".to_string(),
+            dojo_types::primitive::Primitive::ContractAddress(_) => "ContractAddress".to_string(),
+        },
+        dojo_types::schema::Ty::Tuple(t) => {
+            format!("({})", t.iter().map(get_name_from_schema).collect::<Vec<_>>().join(", "))
+        }
+        dojo_types::schema::Ty::Array(a) => format!("Array<{}>", get_name_from_schema(&a[0])),
+        _ => "".to_string(),
+    }
+}
+
+fn get_printable_layout_list_from_struct(
+    field_layouts: &[dojo_world::contracts::model::abigen::model::FieldLayout],
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    if let dojo_types::schema::Ty::Struct(ss) = schema {
+        let name = get_name_from_schema(schema);
+
+        // proces main struct
+        if !is_layout_in_list(layout_list, &name) {
+            layout_list.push(LayoutInfo {
+                layout_type: LayoutInfoType::Struct,
+                name,
+                fields: field_layouts
+                    .iter()
+                    .zip(ss.children.iter().filter(|x| !x.key))
+                    .map(|(l, m)| FieldLayoutInfo {
+                        selector: format!("{:#x}", l.selector),
+                        name: m.name.clone(),
+                        layout: format_field_layout(&l.layout, &m.ty),
+                    })
+                    .collect::<Vec<_>>(),
+            });
+        }
+
+        // process members
+        for (member_layout, member) in
+            field_layouts.iter().zip(ss.children.iter().filter(|x| !x.key))
+        {
+            get_printable_layout_list(&member_layout.layout, &member.ty, layout_list);
+        }
+    };
+}
+
+fn get_printable_layout_list_from_enum(
+    field_layouts: &[dojo_world::contracts::model::abigen::model::FieldLayout],
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    if let dojo_types::schema::Ty::Enum(se) = schema {
+        let name = get_name_from_schema(schema);
+
+        // proces main enum
+        if !is_layout_in_list(layout_list, &name) {
+            layout_list.push(LayoutInfo {
+                layout_type: LayoutInfoType::Enum,
+                name,
+                fields: field_layouts
+                    .iter()
+                    .zip(se.options.iter())
+                    .map(|(l, o)| FieldLayoutInfo {
+                        selector: format!("{:#x}", l.selector),
+                        name: o.name.to_string(),
+                        layout: format_field_layout(&l.layout, &o.ty),
+                    })
+                    .collect::<Vec<_>>(),
+            });
+        }
+
+        // process variants
+        for (variant_layout, variant) in field_layouts.iter().zip(se.options.iter()) {
+            get_printable_layout_list(&variant_layout.layout, &variant.ty, layout_list);
+        }
+    }
+}
+
+fn get_printable_layout_list_from_tuple(
+    item_layouts: &[dojo_world::contracts::model::abigen::model::Layout],
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    if let dojo_types::schema::Ty::Tuple(st) = schema {
+        let name = get_name_from_schema(schema);
+
+        // process tuple
+        if !is_layout_in_list(layout_list, &name) {
+            layout_list.push(LayoutInfo {
+                layout_type: LayoutInfoType::Tuple,
+                name,
+                fields: item_layouts
+                    .iter()
+                    .enumerate()
+                    .zip(st.iter())
+                    .map(|((i, l), s)| FieldLayoutInfo {
+                        selector: format!("{:#x}", i),
+                        name: "".to_string(),
+                        layout: format_field_layout(l, s),
+                    })
+                    .collect::<Vec<_>>(),
+            });
+        }
+
+        // process tuple items
+        for (item_layout, item_schema) in item_layouts.iter().zip(st.iter()) {
+            get_printable_layout_list(item_layout, item_schema, layout_list);
+        }
+    }
+}
+
+fn get_printable_layout_list_from_array(
+    item_layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    if let dojo_types::schema::Ty::Array(sa) = schema {
+        let name = get_name_from_schema(schema);
+
+        // process array
+        if !is_layout_in_list(layout_list, &name) {
+            layout_list.push(LayoutInfo {
+                layout_type: LayoutInfoType::Array,
+                name,
+                fields: vec![FieldLayoutInfo {
+                    selector: "[ItemIndex]".to_string(),
+                    name: "".to_string(),
+                    layout: format_field_layout(item_layout, &sa[0]),
+                }],
+            });
+        }
+
+        // process array item
+        get_printable_layout_list(item_layout, &sa[0], layout_list);
+    }
+}
+
+fn get_printable_layout_list(
+    root_layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+    layout_list: &mut Vec<LayoutInfo>,
+) {
+    match root_layout {
+        dojo_world::contracts::model::abigen::model::Layout::Struct(ls) => {
+            get_printable_layout_list_from_struct(ls, schema, layout_list);
+        }
+        dojo_world::contracts::model::abigen::model::Layout::Enum(le) => {
+            get_printable_layout_list_from_enum(le, schema, layout_list);
+        }
+        dojo_world::contracts::model::abigen::model::Layout::Tuple(lt) => {
+            get_printable_layout_list_from_tuple(lt, schema, layout_list);
+        }
+        dojo_world::contracts::model::abigen::model::Layout::Array(la) => {
+            get_printable_layout_list_from_array(&la[0], schema, layout_list);
+        }
+        _ => {}
+    };
+}
+
+fn print_layout_info(layout_info: LayoutInfo) {
+    let fields = layout_info
+        .fields
+        .into_iter()
+        .map(|f| format_field(f.selector, f.name, f.layout))
+        .collect::<Vec<_>>();
+    let layout_title = match layout_info.layout_type {
+        LayoutInfoType::Struct => format!("Struct {} {{", layout_info.name),
+
+        LayoutInfoType::Enum => {
+            format!("{:<42}: [251] (variant id)", format!("Enum {} {{", layout_info.name))
+        }
+        LayoutInfoType::Tuple => format!("{} (", layout_info.name),
+        LayoutInfoType::Array => {
+            format!("{:<42}: [32] (length)", format!("{} (", layout_info.name))
+        }
+    };
+    let end_token = match layout_info.layout_type {
+        LayoutInfoType::Struct => '}',
+        LayoutInfoType::Enum => '}',
+        LayoutInfoType::Tuple => ')',
+        LayoutInfoType::Array => ')',
+    };
+
+    println!(
+        "{layout_title}
+{}
+{end_token}\n",
+        fields.join("\n")
+    );
+}
+
+// print the full Layout tree
+fn deep_print_layout(
+    name: &String,
+    layout: &dojo_world::contracts::model::abigen::model::Layout,
+    schema: &dojo_types::schema::Ty,
+) {
+    let mut layout_list = vec![];
+    get_printable_layout_list(layout, schema, &mut layout_list);
+
+    println!("\n{} selector: {}\n", name, get_selector_from_name(name).unwrap());
+
+    for l in layout_list {
+        print_layout_info(l);
+    }
+}
+
+fn _start_indent(level: usize, start_indent: bool) -> String {
+    if start_indent {
+        INDENT.repeat(level)
+    } else {
+        "".to_string()
+    }
+}
+
+fn format_primitive(
+    p: &dojo_types::primitive::Primitive,
+    values: &mut Vec<FieldElement>,
+    level: usize,
+    start_indent: bool,
+) -> String {
+    let mut _p = p.clone();
+    let _ = _p.deserialize(values);
+
+    format!("{}{}", _start_indent(level, start_indent), _p.to_sql_value().unwrap())
+}
+
+fn format_byte_array(values: &mut Vec<FieldElement>, level: usize, start_indent: bool) -> String {
+    let bytearray = ByteArray::cairo_deserialize(values, 0).unwrap();
+    values.drain(0..ByteArray::cairo_serialized_size(&bytearray));
+
+    format!("{}{}", _start_indent(level, start_indent), ByteArray::to_string(&bytearray).unwrap())
+}
+
+fn format_field_value(
+    member: &dojo_types::schema::Member,
+    values: &mut Vec<FieldElement>,
+    level: usize,
+) -> String {
+    let field_repr = format_record_value(&member.ty, values, level, false);
+    format!("{}{:<16}: {field_repr}", INDENT.repeat(level), member.name)
+}
+
+fn format_array(
+    item: &dojo_types::schema::Ty,
+    values: &mut Vec<FieldElement>,
+    level: usize,
+    start_indent: bool,
+) -> String {
+    let length: u32 = values.remove(0).try_into().unwrap();
+    let mut items = vec![];
+
+    for _ in 0..length {
+        items.push(format_record_value(item, values, level + 1, true));
+    }
+
+    format!(
+        "{}[\n{}\n{}]",
+        _start_indent(level, start_indent),
+        items.join(",\n"),
+        INDENT.repeat(level)
+    )
+}
+
+fn format_tuple(
+    items: &Vec<dojo_types::schema::Ty>,
+    values: &mut Vec<FieldElement>,
+    level: usize,
+    start_indent: bool,
+) -> String {
+    let items_repr = items
+        .iter()
+        .map(|x| format_record_value(x, values, level + 1, true))
+        .collect::<Vec<_>>()
+        .join(",\n");
+
+    format!("{}(\n{}\n{})", _start_indent(level, start_indent), items_repr, INDENT.repeat(level))
+}
+
+fn format_struct(
+    schema: &dojo_types::schema::Struct,
+    values: &mut Vec<FieldElement>,
+    level: usize,
+    start_indent: bool,
+) -> String {
+    let fields = schema
+        .children
+        .iter()
+        .map(|m| format_field_value(&m, values, level + 1))
+        .collect::<Vec<_>>();
+
+    format!(
+        "{}{{\n{}\n{}}}",
+        _start_indent(level, start_indent),
+        fields.join(",\n"),
+        INDENT.repeat(level)
+    )
+}
+
+fn format_enum(
+    schema: &dojo_types::schema::Enum,
+    values: &mut Vec<FieldElement>,
+    level: usize,
+    start_indent: bool,
+) -> String {
+    let variant_index: u8 = values.remove(0).try_into().unwrap();
+    let variant_index: usize = variant_index.into();
+    let variant_name =
+        format!("{}::{}", schema.name, schema.options[variant_index].name.to_string());
+    let variant_data =
+        format_record_value(&schema.options[variant_index].ty, values, level + 1, true);
+
+    format!(
+        "{}{variant_name}(\n{}\n{})",
+        _start_indent(level, start_indent),
+        variant_data,
+        INDENT.repeat(level)
+    )
+}
+
+fn format_record_value(
+    schema: &dojo_types::schema::Ty,
+    values: &mut Vec<FieldElement>,
+    level: usize,
+    start_indent: bool,
+) -> String {
+    match schema {
+        dojo_types::schema::Ty::Primitive(p) => format_primitive(p, values, level, start_indent),
+        dojo_types::schema::Ty::ByteArray(_) => format_byte_array(values, level, start_indent),
+        dojo_types::schema::Ty::Struct(s) => format_struct(s, values, level, start_indent),
+        dojo_types::schema::Ty::Enum(e) => format_enum(e, values, level, start_indent),
+        dojo_types::schema::Ty::Array(a) => format_array(&a[0], values, level, start_indent),
+        dojo_types::schema::Ty::Tuple(t) => format_tuple(t, values, level, start_indent),
+    }
+}
+
+// print the structured record values
+fn deep_print_record(
+    schema: &dojo_types::schema::Ty,
+    keys: &[FieldElement],
+    values: &[FieldElement],
+) {
+    let mut model_values = vec![];
+    model_values.extend(keys);
+    model_values.extend(values);
+
+    println!("{}", format_record_value(schema, &mut model_values, 0, true));
 }

--- a/crates/torii/core/Cargo.toml
+++ b/crates/torii/core/Cargo.toml
@@ -43,3 +43,4 @@ camino.workspace = true
 dojo-test-utils = { path = "../../dojo-test-utils" }
 scarb.workspace = true
 sozo = { path = "../../../bin/sozo" }
+katana-runner.workspace = true

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -3,12 +3,10 @@ use std::str::FromStr;
 use camino::Utf8PathBuf;
 use dojo_test_utils::compiler;
 use dojo_test_utils::migration::prepare_migration;
-use dojo_test_utils::sequencer::{
-    get_default_test_starknet_config, SequencerConfig, TestSequencer,
-};
 use dojo_world::contracts::world::WorldContractReader;
 use dojo_world::migration::TxnConfig;
 use dojo_world::utils::TransactionWaiter;
+use katana_runner::KatanaRunner;
 use scarb::ops;
 use sozo_ops::migration::execute_strategy;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
@@ -70,14 +68,13 @@ async fn test_load_from_remote() {
 
     let migration = prepare_migration(base_dir.into(), target_dir.into()).unwrap();
 
-    let sequencer =
-        TestSequencer::start(SequencerConfig::default(), get_default_test_starknet_config()).await;
+    let sequencer = KatanaRunner::new().expect("Failed to start runner.");
 
     let provider = JsonRpcClient::new(HttpTransport::new(sequencer.url()));
 
     let world = WorldContractReader::new(migration.world_address().unwrap(), &provider);
 
-    let mut account = sequencer.account();
+    let mut account = sequencer.account(0);
     account.set_block_id(BlockId::Tag(BlockTag::Pending));
 
     let ws = ops::read_workspace(config.manifest_path(), &config)
@@ -138,7 +135,7 @@ async fn test_load_from_remote() {
     assert_eq!(id, format!("{:#x}", get_selector_from_name("Moves").unwrap()));
     assert_eq!(name, "Moves");
     assert_eq!(packed_size, 0);
-    assert_eq!(unpacked_size, 0);
+    assert_eq!(unpacked_size, 2);
 
     let (id, name, packed_size, unpacked_size): (String, String, u8, u8) = sqlx::query_as(
         "SELECT id, name, packed_size, unpacked_size FROM models WHERE name = 'PlayerConfig'",

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -125,7 +125,7 @@ async fn test_load_from_remote() {
 
     assert_eq!(id, format!("{:#x}", get_selector_from_name("Position").unwrap()));
     assert_eq!(name, "Position");
-    assert_eq!(packed_size, 0);
+    assert_eq!(packed_size, 1);
     assert_eq!(unpacked_size, 2);
 
     let (id, name, packed_size, unpacked_size): (String, String, u8, u8) = sqlx::query_as(

--- a/crates/torii/types-test/manifests/dev/base/dojo_world_world.toml
+++ b/crates/torii/types-test/manifests/dev/base/dojo_world_world.toml
@@ -1,5 +1,5 @@
 kind = "Class"
-class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
-original_class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
+class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
+original_class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 abi = "manifests/dev/abis/base/dojo_world_world.json"
 name = "dojo::world::world"

--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -254,7 +254,7 @@ EOF
 }
 
 usage() {
-  cat 1>&2 <<EOF
+  cat 1>&2 <<'EOF'
 The installer for Dojo.
 
 Update or revert to a specific Dojo version with ease.

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -25,4 +25,4 @@ rpc_url = "http://localhost:5050/"
 # Default account for katana with seed = 0
 account_address = "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03"
 private_key = "0x1800000000300000180000000000030000000000003006001800006600"
-world_address = "0x1c958955aedbc7b8e2f051767d3369168e88bc5074b0f39e5f8cd2539138281"
+world_address = "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7"

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -25,4 +25,4 @@ rpc_url = "http://localhost:5050/"
 # Default account for katana with seed = 0
 account_address = "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03"
 private_key = "0x1800000000300000180000000000030000000000003006001800006600"
-#world_address = "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7"
+world_address = "0x26a8d9f2ac0348182bea206d913908ef77e439416713592ebc85941a69048d6"

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x5b617d120767e91d40621dd939b092f48975a8fa1c5236ac68f97a4ffaf45b"
-original_class_hash = "0x5b617d120767e91d40621dd939b092f48975a8fa1c5236ac68f97a4ffaf45b"
+class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
+original_class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
 base_class_hash = "0x0"
 abi = "manifests/dev/abis/base/contracts/dojo_examples_actions_actions.json"
 reads = []

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
-original_class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
+class_hash = "0x46aa979b337556783c2acdef3fa467a56de71eaa981f8dda540f44f6a13ff2f"
+original_class_hash = "0x46aa979b337556783c2acdef3fa467a56de71eaa981f8dda540f44f6a13ff2f"
 base_class_hash = "0x0"
 abi = "manifests/dev/abis/base/contracts/dojo_examples_actions_actions.json"
 reads = []

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
-original_class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
+class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
+original_class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
 base_class_hash = "0x0"
 abi = "manifests/dev/abis/base/contracts/dojo_examples_actions_actions.json"
 reads = []

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
-original_class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
+class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
+original_class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
 base_class_hash = "0x0"
 abi = "manifests/dev/abis/base/contracts/dojo_examples_actions_actions.json"
 reads = []

--- a/examples/spawn-and-move/manifests/dev/base/dojo_world_world.toml
+++ b/examples/spawn-and-move/manifests/dev/base/dojo_world_world.toml
@@ -1,5 +1,5 @@
 kind = "Class"
-class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
-original_class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
+class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
+original_class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 abi = "manifests/dev/abis/base/dojo_world_world.json"
 name = "dojo::world::world"

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_actions_actions_moved.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_actions_actions_moved.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
-original_class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
+class_hash = "0x6f85952ceeb7783fb265a4b2d235db48e7a36357bbce7a56997ca5798c95187"
+original_class_hash = "0x6f85952ceeb7783fb265a4b2d235db48e7a36357bbce7a56997ca5798c95187"
 abi = "manifests/dev/abis/base/models/dojo_examples_actions_actions_moved.json"
 name = "dojo_examples::actions::actions::moved"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_actions_actions_moved.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_actions_actions_moved.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x5508ab47983d4842a780fe483cb9ba5d24ad4b8d0196f767cd5983398b9f4c4"
-original_class_hash = "0x5508ab47983d4842a780fe483cb9ba5d24ad4b8d0196f767cd5983398b9f4c4"
+class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
+original_class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
 abi = "manifests/dev/abis/base/models/dojo_examples_actions_actions_moved.json"
 name = "dojo_examples::actions::actions::moved"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_emote_message.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_emote_message.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x3c690e6a69960642e2e276299c04ee4eb57f8dabb0f59dc96b09faf39c82a9"
-original_class_hash = "0x3c690e6a69960642e2e276299c04ee4eb57f8dabb0f59dc96b09faf39c82a9"
+class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
+original_class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_emote_message.json"
 name = "dojo_examples::models::emote_message"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_emote_message.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_emote_message.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
-original_class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
+class_hash = "0x3e8f99f02409b7bc3dfffba58ee3807e3fb3513a2dcac1b0bd1f1118ea79ecc"
+original_class_hash = "0x3e8f99f02409b7bc3dfffba58ee3807e3fb3513a2dcac1b0bd1f1118ea79ecc"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_emote_message.json"
 name = "dojo_examples::models::emote_message"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_moves.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_moves.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x6eeffc6c72945b6ef419d3c67ed377408437782fdc41fa7a52339cd30d6c563"
-original_class_hash = "0x6eeffc6c72945b6ef419d3c67ed377408437782fdc41fa7a52339cd30d6c563"
+class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
+original_class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_moves.json"
 name = "dojo_examples::models::moves"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_moves.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_moves.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
-original_class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
+class_hash = "0x402d1ee5171aac681d16fa8c248a0498678082152e0f4c416776a71fc270684"
+original_class_hash = "0x402d1ee5171aac681d16fa8c248a0498678082152e0f4c416776a71fc270684"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_moves.json"
 name = "dojo_examples::models::moves"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_player_config.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_player_config.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
-original_class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
+class_hash = "0x596f2ea7f78e3828f6daa798a271ef0a98741967afa40e680c2d80879be7d09"
+original_class_hash = "0x596f2ea7f78e3828f6daa798a271ef0a98741967afa40e680c2d80879be7d09"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_player_config.json"
 name = "dojo_examples::models::player_config"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_player_config.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_player_config.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x74e835af876c9f95977537b91d60d656f6ff2a4a8b2bb8d47448f345980f612"
-original_class_hash = "0x74e835af876c9f95977537b91d60d656f6ff2a4a8b2bb8d47448f345980f612"
+class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
+original_class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_player_config.json"
 name = "dojo_examples::models::player_config"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_position.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_position.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x3c3632f38ab3ba550bd3c596e2af55002d43bc76b7b660a3a57b49795307c58"
-original_class_hash = "0x3c3632f38ab3ba550bd3c596e2af55002d43bc76b7b660a3a57b49795307c58"
+class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
+original_class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_position.json"
 name = "dojo_examples::models::position"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_position.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_position.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
-original_class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
+class_hash = "0x3ab26e88be7885877f93964880ccb63a8acd8e58f941c48bef52f191fa79868"
+original_class_hash = "0x3ab26e88be7885877f93964880ccb63a8acd8e58f941c48bef52f191fa79868"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_position.json"
 name = "dojo_examples::models::position"
 

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_position.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_position.toml
@@ -1,6 +1,6 @@
 kind = "DojoModel"
-class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
-original_class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
+class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
+original_class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
 abi = "manifests/dev/abis/base/models/dojo_examples_models_position.json"
 name = "dojo_examples::models::position"
 

--- a/examples/spawn-and-move/manifests/dev/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/manifest.json
@@ -952,8 +952,8 @@
       }
     ],
     "address": "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7",
-    "transaction_hash": "0x166d25db4fe4ac14dc2d3419cbd9a9d338a10fbbfdf2dbe2150e65bbffabb09",
-    "block_number": 3,
+    "transaction_hash": null,
+    "block_number": null,
     "seed": "dojo_examples",
     "metadata": {
       "profile_name": "dev",
@@ -972,8 +972,8 @@
     {
       "kind": "DojoContract",
       "address": "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332",
-      "class_hash": "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75",
-      "original_class_hash": "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75",
+      "class_hash": "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350",
+      "original_class_hash": "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -1271,8 +1271,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0",
-      "original_class_hash": "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0",
+      "class_hash": "0x6f85952ceeb7783fb265a4b2d235db48e7a36357bbce7a56997ca5798c95187",
+      "original_class_hash": "0x6f85952ceeb7783fb265a4b2d235db48e7a36357bbce7a56997ca5798c95187",
       "abi": [
         {
           "type": "impl",
@@ -1678,8 +1678,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c",
-      "original_class_hash": "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c",
+      "class_hash": "0x3e8f99f02409b7bc3dfffba58ee3807e3fb3513a2dcac1b0bd1f1118ea79ecc",
+      "original_class_hash": "0x3e8f99f02409b7bc3dfffba58ee3807e3fb3513a2dcac1b0bd1f1118ea79ecc",
       "abi": [
         {
           "type": "impl",
@@ -2090,8 +2090,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9",
-      "original_class_hash": "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9",
+      "class_hash": "0x402d1ee5171aac681d16fa8c248a0498678082152e0f4c416776a71fc270684",
+      "original_class_hash": "0x402d1ee5171aac681d16fa8c248a0498678082152e0f4c416776a71fc270684",
       "abi": [
         {
           "type": "impl",
@@ -2511,8 +2511,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881",
-      "original_class_hash": "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881",
+      "class_hash": "0x596f2ea7f78e3828f6daa798a271ef0a98741967afa40e680c2d80879be7d09",
+      "original_class_hash": "0x596f2ea7f78e3828f6daa798a271ef0a98741967afa40e680c2d80879be7d09",
       "abi": [
         {
           "type": "impl",
@@ -2914,8 +2914,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x3c3632f38ab3ba550bd3c596e2af55002d43bc76b7b660a3a57b49795307c58",
-      "original_class_hash": "0x3c3632f38ab3ba550bd3c596e2af55002d43bc76b7b660a3a57b49795307c58",
+      "class_hash": "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4",
+      "original_class_hash": "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4",
       "abi": [
         {
           "type": "impl",

--- a/examples/spawn-and-move/manifests/dev/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/manifest.json
@@ -972,8 +972,8 @@
     {
       "kind": "DojoContract",
       "address": "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332",
-      "class_hash": "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db",
-      "original_class_hash": "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db",
+      "class_hash": "0x46aa979b337556783c2acdef3fa467a56de71eaa981f8dda540f44f6a13ff2f",
+      "original_class_hash": "0x46aa979b337556783c2acdef3fa467a56de71eaa981f8dda540f44f6a13ff2f",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -2914,8 +2914,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d",
-      "original_class_hash": "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d",
+      "class_hash": "0x3ab26e88be7885877f93964880ccb63a8acd8e58f941c48bef52f191fa79868",
+      "original_class_hash": "0x3ab26e88be7885877f93964880ccb63a8acd8e58f941c48bef52f191fa79868",
       "abi": [
         {
           "type": "impl",

--- a/examples/spawn-and-move/manifests/dev/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/manifest.json
@@ -952,8 +952,8 @@
       }
     ],
     "address": "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7",
-    "transaction_hash": null,
-    "block_number": null,
+    "transaction_hash": "0x166d25db4fe4ac14dc2d3419cbd9a9d338a10fbbfdf2dbe2150e65bbffabb09",
+    "block_number": 3,
     "seed": "dojo_examples",
     "metadata": {
       "profile_name": "dev",
@@ -972,8 +972,8 @@
     {
       "kind": "DojoContract",
       "address": "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332",
-      "class_hash": "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350",
-      "original_class_hash": "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350",
+      "class_hash": "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db",
+      "original_class_hash": "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -2914,8 +2914,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4",
-      "original_class_hash": "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4",
+      "class_hash": "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d",
+      "original_class_hash": "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d",
       "abi": [
         {
           "type": "impl",

--- a/examples/spawn-and-move/manifests/dev/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/manifest.json
@@ -1,8 +1,8 @@
 {
   "world": {
     "kind": "WorldContract",
-    "class_hash": "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0",
-    "original_class_hash": "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0",
+    "class_hash": "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42",
+    "original_class_hash": "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42",
     "abi": [
       {
         "type": "impl",
@@ -951,8 +951,8 @@
         ]
       }
     ],
-    "address": "0x1c958955aedbc7b8e2f051767d3369168e88bc5074b0f39e5f8cd2539138281",
-    "transaction_hash": "0x703e38b6957635cccc0f9ddddd43356025f260de7f3593523157838e4443281",
+    "address": "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7",
+    "transaction_hash": "0x166d25db4fe4ac14dc2d3419cbd9a9d338a10fbbfdf2dbe2150e65bbffabb09",
     "block_number": 3,
     "seed": "dojo_examples",
     "metadata": {
@@ -971,9 +971,9 @@
   "contracts": [
     {
       "kind": "DojoContract",
-      "address": "0x21d87b58131a6879752e3b658d658fe3a80a42d85228ba8aec5220c4a5c364c",
-      "class_hash": "0x5b617d120767e91d40621dd939b092f48975a8fa1c5236ac68f97a4ffaf45b",
-      "original_class_hash": "0x5b617d120767e91d40621dd939b092f48975a8fa1c5236ac68f97a4ffaf45b",
+      "address": "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332",
+      "class_hash": "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75",
+      "original_class_hash": "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -1271,8 +1271,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x5508ab47983d4842a780fe483cb9ba5d24ad4b8d0196f767cd5983398b9f4c4",
-      "original_class_hash": "0x5508ab47983d4842a780fe483cb9ba5d24ad4b8d0196f767cd5983398b9f4c4",
+      "class_hash": "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0",
+      "original_class_hash": "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0",
       "abi": [
         {
           "type": "impl",
@@ -1678,8 +1678,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x3c690e6a69960642e2e276299c04ee4eb57f8dabb0f59dc96b09faf39c82a9",
-      "original_class_hash": "0x3c690e6a69960642e2e276299c04ee4eb57f8dabb0f59dc96b09faf39c82a9",
+      "class_hash": "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c",
+      "original_class_hash": "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c",
       "abi": [
         {
           "type": "impl",
@@ -2090,8 +2090,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x6eeffc6c72945b6ef419d3c67ed377408437782fdc41fa7a52339cd30d6c563",
-      "original_class_hash": "0x6eeffc6c72945b6ef419d3c67ed377408437782fdc41fa7a52339cd30d6c563",
+      "class_hash": "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9",
+      "original_class_hash": "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9",
       "abi": [
         {
           "type": "impl",
@@ -2511,8 +2511,8 @@
           "key": false
         }
       ],
-      "class_hash": "0x74e835af876c9f95977537b91d60d656f6ff2a4a8b2bb8d47448f345980f612",
-      "original_class_hash": "0x74e835af876c9f95977537b91d60d656f6ff2a4a8b2bb8d47448f345980f612",
+      "class_hash": "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881",
+      "original_class_hash": "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881",
       "abi": [
         {
           "type": "impl",

--- a/examples/spawn-and-move/manifests/dev/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/manifest.toml
@@ -4,6 +4,8 @@ class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 original_class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 abi = "manifests/dev/abis/deployments/dojo_world_world.json"
 address = "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7"
+transaction_hash = "0x166d25db4fe4ac14dc2d3419cbd9a9d338a10fbbfdf2dbe2150e65bbffabb09"
+block_number = 3
 seed = "dojo_examples"
 name = "dojo::world::world"
 
@@ -20,8 +22,8 @@ name = "dojo::base::base"
 [[contracts]]
 kind = "DojoContract"
 address = "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332"
-class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
-original_class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
+class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
+original_class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/dojo_examples_actions_actions.json"
 reads = []
@@ -117,8 +119,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
-original_class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
+class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
+original_class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_position.json"
 name = "dojo_examples::models::position"
 

--- a/examples/spawn-and-move/manifests/dev/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/manifest.toml
@@ -22,8 +22,8 @@ name = "dojo::base::base"
 [[contracts]]
 kind = "DojoContract"
 address = "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332"
-class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
-original_class_hash = "0xbddade338ad0bce95fa2ba1e4c20011b8e41834f3466dfce7f216f68fc02db"
+class_hash = "0x46aa979b337556783c2acdef3fa467a56de71eaa981f8dda540f44f6a13ff2f"
+original_class_hash = "0x46aa979b337556783c2acdef3fa467a56de71eaa981f8dda540f44f6a13ff2f"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/dojo_examples_actions_actions.json"
 reads = []
@@ -119,8 +119,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
-original_class_hash = "0x25ce30625931b27840eb14450119a44f43a8dc61d001291b82b4177c32739d"
+class_hash = "0x3ab26e88be7885877f93964880ccb63a8acd8e58f941c48bef52f191fa79868"
+original_class_hash = "0x3ab26e88be7885877f93964880ccb63a8acd8e58f941c48bef52f191fa79868"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_position.json"
 name = "dojo_examples::models::position"
 

--- a/examples/spawn-and-move/manifests/dev/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/manifest.toml
@@ -4,8 +4,6 @@ class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 original_class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 abi = "manifests/dev/abis/deployments/dojo_world_world.json"
 address = "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7"
-transaction_hash = "0x166d25db4fe4ac14dc2d3419cbd9a9d338a10fbbfdf2dbe2150e65bbffabb09"
-block_number = 3
 seed = "dojo_examples"
 name = "dojo::world::world"
 
@@ -22,8 +20,8 @@ name = "dojo::base::base"
 [[contracts]]
 kind = "DojoContract"
 address = "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332"
-class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
-original_class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
+class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
+original_class_hash = "0x48ed399f7c97f0feb664fe40c49fa377b1c468a867187eb3795ba9e3c527350"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/dojo_examples_actions_actions.json"
 reads = []
@@ -36,8 +34,8 @@ name = "dojo_examples::actions::actions"
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
-original_class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
+class_hash = "0x6f85952ceeb7783fb265a4b2d235db48e7a36357bbce7a56997ca5798c95187"
+original_class_hash = "0x6f85952ceeb7783fb265a4b2d235db48e7a36357bbce7a56997ca5798c95187"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_actions_actions_moved.json"
 name = "dojo_examples::actions::actions::moved"
 
@@ -53,8 +51,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
-original_class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
+class_hash = "0x3e8f99f02409b7bc3dfffba58ee3807e3fb3513a2dcac1b0bd1f1118ea79ecc"
+original_class_hash = "0x3e8f99f02409b7bc3dfffba58ee3807e3fb3513a2dcac1b0bd1f1118ea79ecc"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_emote_message.json"
 name = "dojo_examples::models::emote_message"
 
@@ -70,8 +68,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
-original_class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
+class_hash = "0x402d1ee5171aac681d16fa8c248a0498678082152e0f4c416776a71fc270684"
+original_class_hash = "0x402d1ee5171aac681d16fa8c248a0498678082152e0f4c416776a71fc270684"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_moves.json"
 name = "dojo_examples::models::moves"
 
@@ -92,8 +90,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
-original_class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
+class_hash = "0x596f2ea7f78e3828f6daa798a271ef0a98741967afa40e680c2d80879be7d09"
+original_class_hash = "0x596f2ea7f78e3828f6daa798a271ef0a98741967afa40e680c2d80879be7d09"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_player_config.json"
 name = "dojo_examples::models::player_config"
 
@@ -119,8 +117,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x3c3632f38ab3ba550bd3c596e2af55002d43bc76b7b660a3a57b49795307c58"
-original_class_hash = "0x3c3632f38ab3ba550bd3c596e2af55002d43bc76b7b660a3a57b49795307c58"
+class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
+original_class_hash = "0x3c2b9c39d54296772e3eb7c4e449c8005b3ab3f4405044f4462e96ff78132b4"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_position.json"
 name = "dojo_examples::models::position"
 

--- a/examples/spawn-and-move/manifests/dev/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/manifest.toml
@@ -1,10 +1,10 @@
 [world]
 kind = "WorldContract"
-class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
-original_class_hash = "0x64728e0c0713811c751930f8d3292d683c23f107c89b0a101425d9e80adb1c0"
+class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
+original_class_hash = "0x76300ed1823da50dc55c15e7b605bb2f85d6f87d6bf75a0ddf7b41aa55b9b42"
 abi = "manifests/dev/abis/deployments/dojo_world_world.json"
-address = "0x1c958955aedbc7b8e2f051767d3369168e88bc5074b0f39e5f8cd2539138281"
-transaction_hash = "0x703e38b6957635cccc0f9ddddd43356025f260de7f3593523157838e4443281"
+address = "0x7a2b168dbd3ebada04c0ea21b787f5ef00ff234af9705afe4e147638cb671b7"
+transaction_hash = "0x166d25db4fe4ac14dc2d3419cbd9a9d338a10fbbfdf2dbe2150e65bbffabb09"
 block_number = 3
 seed = "dojo_examples"
 name = "dojo::world::world"
@@ -21,9 +21,9 @@ name = "dojo::base::base"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x21d87b58131a6879752e3b658d658fe3a80a42d85228ba8aec5220c4a5c364c"
-class_hash = "0x5b617d120767e91d40621dd939b092f48975a8fa1c5236ac68f97a4ffaf45b"
-original_class_hash = "0x5b617d120767e91d40621dd939b092f48975a8fa1c5236ac68f97a4ffaf45b"
+address = "0x3d98f476995748a86acc5cd598aadd9d40933ea962b2425cdafb13d3c634332"
+class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
+original_class_hash = "0x6abb9359c7d630ab0235a56311c1c9aab7404da4dcd704862a10a771cc99f75"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/dojo_examples_actions_actions.json"
 reads = []
@@ -36,8 +36,8 @@ name = "dojo_examples::actions::actions"
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x5508ab47983d4842a780fe483cb9ba5d24ad4b8d0196f767cd5983398b9f4c4"
-original_class_hash = "0x5508ab47983d4842a780fe483cb9ba5d24ad4b8d0196f767cd5983398b9f4c4"
+class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
+original_class_hash = "0x19c51dad3da2fd731ca12e93b078bacf5bb442d15a4520cdd821a134f6378c0"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_actions_actions_moved.json"
 name = "dojo_examples::actions::actions::moved"
 
@@ -53,8 +53,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x3c690e6a69960642e2e276299c04ee4eb57f8dabb0f59dc96b09faf39c82a9"
-original_class_hash = "0x3c690e6a69960642e2e276299c04ee4eb57f8dabb0f59dc96b09faf39c82a9"
+class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
+original_class_hash = "0x6e7ac5a463f48c1284293f060ef4366b18e60b27497f0c0b36e597e52eb7c8c"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_emote_message.json"
 name = "dojo_examples::models::emote_message"
 
@@ -70,8 +70,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x6eeffc6c72945b6ef419d3c67ed377408437782fdc41fa7a52339cd30d6c563"
-original_class_hash = "0x6eeffc6c72945b6ef419d3c67ed377408437782fdc41fa7a52339cd30d6c563"
+class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
+original_class_hash = "0x7c7e03b42eb07d3ce697efea04a111e4b6ba32d49431340f532b6e0418f32f9"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_moves.json"
 name = "dojo_examples::models::moves"
 
@@ -92,8 +92,8 @@ key = false
 
 [[models]]
 kind = "DojoModel"
-class_hash = "0x74e835af876c9f95977537b91d60d656f6ff2a4a8b2bb8d47448f345980f612"
-original_class_hash = "0x74e835af876c9f95977537b91d60d656f6ff2a4a8b2bb8d47448f345980f612"
+class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
+original_class_hash = "0x121a1bcb1a1e1260550da81f9b3fdef0e1bdb6c100196edde0f968a32878881"
 abi = "manifests/dev/abis/deployments/models/dojo_examples_models_player_config.json"
 name = "dojo_examples::models::player_config"
 

--- a/examples/spawn-and-move/src/models.cairo
+++ b/examples/spawn-and-move/src/models.cairo
@@ -47,7 +47,7 @@ struct Moves {
     last_direction: Direction
 }
 
-#[derive(Copy, Drop, Serde, Introspect)]
+#[derive(Copy, Drop, Serde, IntrospectPacked)]
 struct Vec2 {
     x: u32,
     y: u32

--- a/examples/spawn-and-move/src/models.cairo
+++ b/examples/spawn-and-move/src/models.cairo
@@ -53,7 +53,11 @@ struct Vec2 {
     y: u32
 }
 
-#[derive(Copy, Drop, Serde)]
+// If `Vec2` wasn't packed, the `Position` would be invalid,
+// and a runtime error would be thrown.
+// Any field that is a custom type into a `IntrospectPacked` type
+// must be packed.
+#[derive(Copy, Drop, Serde, IntrospectPacked)]
 #[dojo::model]
 struct Position {
     #[key]
@@ -61,6 +65,8 @@ struct Position {
     vec: Vec2,
 }
 
+// Every field inside a model must derive `Introspect` or `IntrospectPacked`.
+// `IntrospectPacked` can also be used into models that are only using `Introspect`.
 #[derive(Copy, Drop, Serde, Introspect)]
 struct PlayerItem {
     item_id: u32,


### PR DESCRIPTION
 Dojo layout improvements:

- automatically add `Introspect` attribute to dojo::model if not yet present
- update sozo model commands with:
    - `sozo model schema <MODEL_NAME>` to get the full model schema,
    - `sozo model layout <MODEL_NAME` to get the full model layout used to store,
      model records in the Dojo world storage,
    - `sozo model get <MODEL_NAME> <KEYS>` to get the full values of a model record.
- improvement of the Enum layout.