### PR TITLE
[trick] to unlock toriiClient with safari/firefox

### DIFF
--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -3,7 +3,7 @@ use std::num::ParseIntError;
 
 use futures_util::stream::MapOk;
 use futures_util::{Stream, StreamExt, TryStreamExt};
-use starknet::core::types::{FromStrError, StateUpdate};
+use starknet::core::types::{FromStrError, StateDiff, StateUpdate};
 use starknet_crypto::FieldElement;
 
 use crate::proto::world::{
@@ -144,9 +144,11 @@ impl WorldClient {
             .map_err(Error::Grpc)
             .map(|res| res.into_inner())?;
 
-        Ok(ModelDiffsStreaming(stream.map_ok(Box::new(|res| {
-            let update = res.model_update.expect("qed; state update must exist");
-            TryInto::<StateUpdate>::try_into(update).expect("must able to serialize")
+        Ok(ModelDiffsStreaming(stream.map_ok(Box::new(|res| match res.model_update {
+            Some(update) => {
+                TryInto::<StateUpdate>::try_into(update).expect("must able to serialize")
+            }
+            None => empty_state_update(),
         }))))
     }
 }
@@ -182,5 +184,21 @@ impl Stream for EntityUpdateStreaming {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         self.0.poll_next_unpin(cx)
+    }
+}
+
+fn empty_state_update() -> StateUpdate {
+    StateUpdate {
+        block_hash: FieldElement::ZERO,
+        new_root: FieldElement::ZERO,
+        old_root: FieldElement::ZERO,
+        state_diff: StateDiff {
+            declared_classes: vec![],
+            deployed_contracts: vec![],
+            deprecated_declared_classes: vec![],
+            nonces: vec![],
+            replaced_classes: vec![],
+            storage_diffs: vec![],
+        },
     }
 }

--- a/crates/torii/server/src/proxy.rs
+++ b/crates/torii/server/src/proxy.rs
@@ -17,7 +17,7 @@ use tower::ServiceBuilder;
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::error;
 
-const DEFAULT_ALLOW_HEADERS: [&str; 12] = [
+const DEFAULT_ALLOW_HEADERS: [&str; 11] = [
     "accept",
     "origin",
     "content-type",
@@ -27,7 +27,6 @@ const DEFAULT_ALLOW_HEADERS: [&str; 12] = [
     "x-grpc-timeout",
     "x-user-agent",
     "connection",
-    "upgrade",
     "sec-websocket-key",
     "sec-websocket-version",
 ];


### PR DESCRIPTION
# Description

With local dojo & dojo.js

in dojo.js / torii-wasm / Cargo.toml
refer local dependencies for dojo crates

```
dojo-types = { path = "../../../../dojo/crates/dojo-types" }
torii-client = { path = "../../../../dojo/crates/torii/client" }
torii-grpc = { path = "../../../../dojo/crates/torii/grpc" }
torii-relay = { path = "../../../../dojo/crates/torii/libp2p" }
```
in dojo.js / torii-wasm / rust-toolchain.toml
update version to 
```
[toolchain]
channel = "1.76.0"
```

build dojo.js packages 'pnpm build'
build torii 
tested with dojo-starter & dojo.js/examples/react/react-app

## Related issue
https://github.com/dojoengine/dojo.js/issues/130

