### PR TITLE
fix: fix RPC version checking

### DIFF
--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -201,8 +201,8 @@ fn is_compatible_version(provided_version: &str, expected_version: &str) -> Resu
         .map_err(|e| anyhow!("Failed to parse expected version '{}': {}", expected_version, e))?;
 
     // Specific backward compatibility rule: 0.6 is compatible with 0.7.
-    if (provided_ver.major == 0 && provided_ver.minor == 6)
-        && (expected_ver.major == 0 && expected_ver.minor == 7)
+    if (provided_ver.major == 0 && provided_ver.minor == 7)
+        && (expected_ver.major == 0 && expected_ver.minor == 6)
     {
         return Ok(true);
     }
@@ -235,7 +235,9 @@ mod tests {
 
     #[test]
     fn test_is_compatible_version_specific_backward_compatibility() {
-        assert!(is_compatible_version("0.6.0", "0.7.1").unwrap());
+        let node_version = "0.7.1";
+        let katana_version = "0.6.0";
+        assert!(is_compatible_version(node_version, katana_version).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
# Description

The version verification done by `sozo` is reversed, which causes a fail to migrate on `0.7.1` which should be backward compatible.

## Tests

- [x] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [x] I've requested a review after addressing the comments
