### PR TITLE
fix(migrate): when `init_calldata` depends on contract that was already deployed

### DIFF
--- a/crates/dojo-world/src/migration/strategy.rs
+++ b/crates/dojo-world/src/migration/strategy.rs
@@ -14,12 +14,18 @@ use super::world::WorldDiff;
 use super::MigrationType;
 
 #[derive(Debug, Clone)]
+pub enum MigrationMetadata {
+    Contract(ContractDiff),
+}
+
+#[derive(Debug, Clone)]
 pub struct MigrationStrategy {
     pub world_address: Option<FieldElement>,
     pub world: Option<ContractMigration>,
     pub base: Option<ClassMigration>,
     pub contracts: Vec<ContractMigration>,
     pub models: Vec<ClassMigration>,
+    pub metadata: HashMap<String, MigrationMetadata>,
 }
 
 #[derive(Debug)]
@@ -61,23 +67,29 @@ impl MigrationStrategy {
     }
 
     pub fn resolve_variable(&mut self, world_address: FieldElement) -> Result<()> {
-        let contracts_clone = self.contracts.clone();
         for contract in self.contracts.iter_mut() {
             for field in contract.diff.init_calldata.iter_mut() {
                 if let Some(dependency) = field.strip_prefix("$contract_address:") {
-                    let dependency_contract =
-                        contracts_clone.iter().find(|c| c.diff.name == dependency).unwrap();
-                    let contract_address = get_contract_address(
-                        generate_salt(&dependency_contract.diff.name),
-                        dependency_contract.diff.base_class_hash,
-                        &[],
-                        world_address,
-                    );
-                    *field = contract_address.to_string();
+                    let dependency_contract = self.metadata.get(dependency).unwrap();
+
+                    match dependency_contract {
+                        MigrationMetadata::Contract(c) => {
+                            let contract_address = get_contract_address(
+                                generate_salt(&c.name),
+                                c.base_class_hash,
+                                &[],
+                                world_address,
+                            );
+                            *field = contract_address.to_string();
+                        }
+                    }
                 } else if let Some(dependency) = field.strip_prefix("$class_hash:") {
-                    let dependency_contract =
-                        contracts_clone.iter().find(|c| c.diff.name == dependency).unwrap();
-                    *field = dependency_contract.diff.local_class_hash.to_string();
+                    let dependency_contract = self.metadata.get(dependency).unwrap();
+                    match dependency_contract {
+                        MigrationMetadata::Contract(c) => {
+                            *field = c.local_class_hash.to_string();
+                        }
+                    }
                 }
             }
         }
@@ -94,6 +106,7 @@ pub fn prepare_for_migration(
     target_dir: &Utf8PathBuf,
     diff: WorldDiff,
 ) -> Result<MigrationStrategy> {
+    let mut metadata = HashMap::new();
     let entries = fs::read_dir(target_dir).with_context(|| {
         format!(
             "Failed trying to read target directory ({target_dir})\nNOTE: build files are profile \
@@ -122,8 +135,12 @@ pub fn prepare_for_migration(
     // else we need to evaluate which contracts need to be migrated.
     let mut world = evaluate_contract_to_migrate(&diff.world, &artifact_paths, false)?;
     let base = evaluate_class_to_migrate(&diff.base, &artifact_paths, world.is_some())?;
-    let contracts =
-        evaluate_contracts_to_migrate(&diff.contracts, &artifact_paths, world.is_some())?;
+    let contracts = evaluate_contracts_to_migrate(
+        &diff.contracts,
+        &artifact_paths,
+        &mut metadata,
+        world.is_some(),
+    )?;
     let models = evaluate_models_to_migrate(&diff.models, &artifact_paths, world.is_some())?;
 
     // If world needs to be migrated, then we expect the `seed` to be provided.
@@ -151,7 +168,7 @@ pub fn prepare_for_migration(
         world.contract_address = generated_world_address;
     }
 
-    Ok(MigrationStrategy { world_address, world, base, contracts, models })
+    Ok(MigrationStrategy { world_address, world, base, contracts, models, metadata })
 }
 
 fn evaluate_models_to_migrate(
@@ -191,11 +208,13 @@ fn evaluate_class_to_migrate(
 fn evaluate_contracts_to_migrate(
     contracts: &[ContractDiff],
     artifact_paths: &HashMap<String, PathBuf>,
+    metadata: &mut HashMap<String, MigrationMetadata>,
     world_contract_will_migrate: bool,
 ) -> Result<Vec<ContractMigration>> {
     let mut comps_to_migrate = vec![];
 
     for c in contracts {
+        metadata.insert(c.name.clone(), MigrationMetadata::Contract(c.clone()));
         match c.remote_class_hash {
             Some(remote) if remote == c.local_class_hash && !world_contract_will_migrate => {
                 continue;

--- a/examples/spawn-and-move/Scarb.lock
+++ b/examples/spawn-and-move/Scarb.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "dojo_examples"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dojo",
 ]


### PR DESCRIPTION
# Description

fix the case when `init_calldata` of a contract depended on a contract that was already deployed, which caused it not to be included in `MigrationStrategy`

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
