### PR TITLE
fix(sozo): allow sozo build in workspace and proper error for other cases

### DIFF
--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -126,13 +126,13 @@ impl BuildArgs {
         };
         trace!(pluginManager=?bindgen, "Generating bindings.");
 
-        let ws = scarb::ops::read_workspace(config.manifest_path(), config).unwrap();
-        let dojo_metadata = dojo_metadata_from_workspace(&ws);
-
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(bindgen.generate(dojo_metadata.skip_migration))
-            .expect("Error generating bindings");
+        // Only generate bindgen if a current package is defined with dojo metadata.
+        if let Some(dojo_metadata) = dojo_metadata_from_workspace(&ws) {
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(bindgen.generate(dojo_metadata.skip_migration))
+                .expect("Error generating bindings");
+        };
 
         Ok(())
     }

--- a/bin/sozo/src/commands/clean.rs
+++ b/bin/sozo/src/commands/clean.rs
@@ -85,7 +85,10 @@ mod tests {
 
         let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
 
-        let dojo_metadata = dojo_metadata_from_workspace(&ws);
+        let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+            "No current package with dojo metadata found, migrate is not yet support for \
+             workspaces.",
+        );
 
         // Plan the migration to generate some manifests other than base.
         config.tokio_handle().block_on(async {

--- a/bin/sozo/src/commands/clean.rs
+++ b/bin/sozo/src/commands/clean.rs
@@ -86,8 +86,7 @@ mod tests {
         let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
 
         let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-            "No current package with dojo metadata found, migrate is not yet support for \
-             workspaces.",
+            "No current package with dojo metadata found, clean is not yet support for workspaces.",
         );
 
         // Plan the migration to generate some manifests other than base.

--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -50,7 +50,14 @@ pub struct DevArgs {
 impl DevArgs {
     pub fn run(self, config: &Config) -> Result<()> {
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
-        let dojo_metadata = dojo_metadata_from_workspace(&ws);
+        let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(&ws) {
+            metadata
+        } else {
+            return Err(anyhow!(
+                "No current package with dojo metadata found, migrate is not yet support for \
+                 workspaces."
+            ));
+        };
 
         let env_metadata = if config.manifest_path().exists() {
             dojo_metadata.env().cloned()

--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -54,7 +54,7 @@ impl DevArgs {
             metadata
         } else {
             return Err(anyhow!(
-                "No current package with dojo metadata found, migrate is not yet support for \
+                "No current package with dojo metadata found, dev is not yet support for \
                  workspaces."
             ));
         };

--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -76,7 +76,7 @@ impl DevArgs {
             RecursiveMode::Recursive,
         )?;
 
-        let name = self.name.unwrap_or_else(|| ws.root_package().unwrap().id.name.to_string());
+        let name = self.name.unwrap_or_else(|| ws.current_package().unwrap().id.name.to_string());
 
         let mut previous_manifest: Option<DeploymentManifest> = Option::None;
         let result = build(&mut context);

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -90,7 +90,7 @@ impl MigrateArgs {
         let MigrateArgs { name, world, starknet, account, .. } = self;
 
         let name = name.unwrap_or_else(|| {
-            ws.root_package().expect("Root package to be present").id.name.to_string()
+            ws.current_package().expect("Root package to be present").id.name.to_string()
         });
 
         let (world_address, account, rpc_url) = config.tokio_handle().block_on(async {

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -58,7 +58,12 @@ impl MigrateArgs {
     pub fn run(self, config: &Config) -> Result<()> {
         trace!(args = ?self);
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
-        let dojo_metadata = dojo_metadata_from_workspace(&ws);
+
+        let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(&ws) {
+            metadata
+        } else {
+            return Err(anyhow!("No current package with dojo metadata found, migrate is not yet support for workspaces."));
+        };
 
         // This variant is tested before the match on `self.command` to avoid
         // having the need to spin up a Katana to generate the files.

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -62,7 +62,10 @@ impl MigrateArgs {
         let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(&ws) {
             metadata
         } else {
-            return Err(anyhow!("No current package with dojo metadata found, migrate is not yet support for workspaces."));
+            return Err(anyhow!(
+                "No current package with dojo metadata found, migrate is not yet support for \
+                 workspaces."
+            ));
         };
 
         // This variant is tested before the match on `self.command` to avoid

--- a/bin/sozo/src/commands/print_env.rs
+++ b/bin/sozo/src/commands/print_env.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Args;
 use dojo_world::metadata::dojo_metadata_from_workspace;
 use scarb::core::Config;
@@ -26,8 +26,17 @@ impl PrintEnvArgs {
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
         let ui = ws.config().ui();
 
+        let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(&ws) {
+            metadata
+        } else {
+            return Err(anyhow!(
+                "No current package with dojo metadata found, migrate is not yet support for \
+                 workspaces."
+            ));
+        };
+
         let env_metadata = if config.manifest_path().exists() {
-            dojo_metadata_from_workspace(&ws).env().cloned()
+            dojo_metadata.env().cloned()
         } else {
             trace!("Manifest path does not exist.");
             None

--- a/bin/sozo/src/commands/print_env.rs
+++ b/bin/sozo/src/commands/print_env.rs
@@ -30,7 +30,7 @@ impl PrintEnvArgs {
             metadata
         } else {
             return Err(anyhow!(
-                "No current package with dojo metadata found, migrate is not yet support for \
+                "No current package with dojo metadata found, print-env is not yet support for \
                  workspaces."
             ));
         };

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use anyhow::{Error, Result};
+use anyhow::{anyhow, Error, Result};
 use camino::Utf8PathBuf;
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::contracts::WorldContractReader;
@@ -26,13 +26,18 @@ use crate::commands::options::world::WorldOptions;
 ///
 /// A [`Environment`] on success.
 pub fn load_metadata_from_config(config: &Config) -> Result<Option<Environment>, Error> {
-    let env_metadata = if config.manifest_path().exists() {
-        let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
-
-        dojo_metadata_from_workspace(&ws).env().cloned()
+    let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
+    let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(&ws) {
+        metadata
     } else {
-        None
+        return Err(anyhow!(
+            "No current package with dojo metadata found, migrate is not yet support for \
+             workspaces."
+        ));
     };
+
+    let env_metadata =
+        if config.manifest_path().exists() { dojo_metadata.env().cloned() } else { None };
 
     Ok(env_metadata)
 }

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -26,18 +26,21 @@ use crate::commands::options::world::WorldOptions;
 ///
 /// A [`Environment`] on success.
 pub fn load_metadata_from_config(config: &Config) -> Result<Option<Environment>, Error> {
-    let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
-    let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(&ws) {
-        metadata
-    } else {
-        return Err(anyhow!(
-            "No current package with dojo metadata found, migrate is not yet support for \
-             workspaces."
-        ));
-    };
+    let env_metadata = if config.manifest_path().exists() {
+        let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
+        let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(&ws) {
+            metadata
+        } else {
+            return Err(anyhow!(
+                "No current package with dojo metadata found, migrate is not yet support for \
+                 workspaces."
+            ));
+        };
 
-    let env_metadata =
-        if config.manifest_path().exists() { dojo_metadata.env().cloned() } else { None };
+        dojo_metadata.env().cloned()
+    } else {
+        None
+    };
 
     Ok(env_metadata)
 }

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -32,8 +32,7 @@ pub fn load_metadata_from_config(config: &Config) -> Result<Option<Environment>,
             metadata
         } else {
             return Err(anyhow!(
-                "No current package with dojo metadata found, migrate is not yet support for \
-                 workspaces."
+                "No current package with dojo metadata found, workspaces are not suppored yet."
             ));
         };
 

--- a/bin/sozo/tests/register_test.rs
+++ b/bin/sozo/tests/register_test.rs
@@ -21,9 +21,8 @@ async fn reregister_models() {
 
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     let target_path =
         ws.target_dir().path_existent().unwrap().join(ws.config().profile().to_string());

--- a/bin/sozo/tests/register_test.rs
+++ b/bin/sozo/tests/register_test.rs
@@ -21,7 +21,9 @@ async fn reregister_models() {
 
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     let target_path =
         ws.target_dir().path_existent().unwrap().join(ws.config().profile().to_string());

--- a/bin/sozo/tests/register_test.rs
+++ b/bin/sozo/tests/register_test.rs
@@ -29,7 +29,8 @@ async fn reregister_models() {
         ws.target_dir().path_existent().unwrap().join(ws.config().profile().to_string());
 
     let migration =
-        prepare_migration(source_project_dir, target_path, dojo_metadata.skip_migration).unwrap();
+        prepare_migration(source_project_dir.clone(), target_path, dojo_metadata.skip_migration)
+            .unwrap();
 
     let sequencer = KatanaRunner::new().expect("Failed to start runner.");
 
@@ -57,6 +58,8 @@ async fn reregister_models() {
         rpc_url,
         "--private-key",
         private_key,
+        "--manifest-path",
+        config.manifest_path().as_ref(),
     ];
 
     let assert = get_snapbox().args(args_vec.iter()).assert().success();

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -274,7 +274,10 @@ mod tests {
         );
 
         let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-        let dojo_metadata = dojo_metadata_from_workspace(&ws);
+        let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+            "No current package with dojo metadata found, migrate is not yet support for \
+             workspaces.",
+        );
 
         let data =
             gather_dojo_data(&manifest_path, "dojo_example", "dev", dojo_metadata.skip_migration)

--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -275,7 +275,7 @@ mod tests {
 
         let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
         let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-            "No current package with dojo metadata found, migrate is not yet support for \
+            "No current package with dojo metadata found, bindgen is not yet supported for \
              workspaces.",
         );
 

--- a/crates/dojo-bindgen/src/plugins/typescript_v2/mod.rs
+++ b/crates/dojo-bindgen/src/plugins/typescript_v2/mod.rs
@@ -655,7 +655,10 @@ mod tests {
         );
 
         let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-        let dojo_metadata = dojo_metadata_from_workspace(&ws);
+        let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+            "No current package with dojo metadata found, migrate is not yet support for \
+             workspaces.",
+        );
         let data =
             gather_dojo_data(&manifest_path, "dojo_examples", "dev", dojo_metadata.skip_migration)
                 .unwrap();

--- a/crates/dojo-bindgen/src/plugins/typescript_v2/mod.rs
+++ b/crates/dojo-bindgen/src/plugins/typescript_v2/mod.rs
@@ -656,7 +656,7 @@ mod tests {
 
         let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
         let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-            "No current package with dojo metadata found, migrate is not yet support for \
+            "No current package with dojo metadata found, bindgen is not yet support for \
              workspaces.",
         );
         let data =

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo/Scarb.lock
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo/Scarb.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "dojo"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dojo_plugin",
 ]

--- a/crates/dojo-test-utils/src/migration.rs
+++ b/crates/dojo-test-utils/src/migration.rs
@@ -34,7 +34,10 @@ pub fn prepare_migration(
     let mut world = WorldDiff::compute(manifest, None);
     world.update_order().unwrap();
 
-    prepare_for_migration(None, felt!("0x12345"), &target_dir, world)
+    let mut strat = prepare_for_migration(None, felt!("0x12345"), &target_dir, world).unwrap();
+    strat.resolve_variable(strat.world_address().unwrap()).unwrap();
+
+    Ok(strat)
 }
 
 pub fn prepare_migration_with_world_and_seed(

--- a/crates/dojo-world/src/contracts/model_test.rs
+++ b/crates/dojo-world/src/contracts/model_test.rs
@@ -26,9 +26,8 @@ async fn test_model() {
     let target_dir = manifest_dir.join("target").join("dev");
 
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     let world_address =
         deploy_world(&runner, &manifest_dir.into(), &target_dir, dojo_metadata.skip_migration)

--- a/crates/dojo-world/src/contracts/model_test.rs
+++ b/crates/dojo-world/src/contracts/model_test.rs
@@ -26,7 +26,9 @@ async fn test_model() {
     let target_dir = manifest_dir.join("target").join("dev");
 
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     let world_address =
         deploy_world(&runner, &manifest_dir.into(), &target_dir, dojo_metadata.skip_migration)

--- a/crates/dojo-world/src/contracts/world_test.rs
+++ b/crates/dojo-world/src/contracts/world_test.rs
@@ -30,7 +30,9 @@ async fn test_world_contract_reader() {
     let provider = account.provider();
 
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     let world_address = deploy_world(
         &runner,

--- a/crates/dojo-world/src/contracts/world_test.rs
+++ b/crates/dojo-world/src/contracts/world_test.rs
@@ -30,9 +30,8 @@ async fn test_world_contract_reader() {
     let provider = account.provider();
 
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     let world_address = deploy_world(
         &runner,

--- a/crates/dojo-world/src/manifest/manifest_test.rs
+++ b/crates/dojo-world/src/manifest/manifest_test.rs
@@ -384,9 +384,8 @@ fn fetch_remote_manifest() {
         compiler::copy_build_project_temp(source_project, dojo_core_path, true);
 
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     let artifacts_path = temp_project_dir.join(format!("target/{profile_name}"));
 

--- a/crates/dojo-world/src/manifest/manifest_test.rs
+++ b/crates/dojo-world/src/manifest/manifest_test.rs
@@ -384,7 +384,9 @@ fn fetch_remote_manifest() {
         compiler::copy_build_project_temp(source_project, dojo_core_path, true);
 
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     let artifacts_path = temp_project_dir.join(format!("target/{profile_name}"));
 

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -94,7 +94,12 @@ pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> DojoMetadata {
     let sources_dir = target_dir.join(profile.as_str()).join(SOURCES_DIR);
     let abis_dir = manifest_dir.join(ABIS_DIR).join(BASE_DIR);
 
-    let project_metadata = ws.current_package().unwrap().manifest.metadata.dojo();
+    let project_metadata = if let Some(current_package) = ws.root_package() {
+        current_package.manifest.metadata.dojo()
+    } else {
+        ProjectMetadata::default()
+    };
+
     let mut dojo_metadata = DojoMetadata {
         env: project_metadata.env.clone(),
         skip_migration: project_metadata.skip_migration.clone(),

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -85,7 +85,7 @@ pub fn project_to_world_metadata(project_metadata: Option<ProjectWorldMetadata>)
 ///
 /// # Returns
 /// A [`DojoMetadata`] object containing all Dojo metadata.
-pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> DojoMetadata {
+pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> Option<DojoMetadata> {
     let profile = ws.config().profile();
 
     let manifest_dir = ws.manifest_path().parent().unwrap().to_path_buf();
@@ -94,10 +94,12 @@ pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> DojoMetadata {
     let sources_dir = target_dir.join(profile.as_str()).join(SOURCES_DIR);
     let abis_dir = manifest_dir.join(ABIS_DIR).join(BASE_DIR);
 
-    let project_metadata = if let Some(current_package) = ws.root_package() {
+    let project_metadata = if let Ok(current_package) = ws.current_package() {
         current_package.manifest.metadata.dojo()
     } else {
-        ProjectMetadata::default()
+        // On workspaces, dojo metadata are not accessible because if no current package is defined
+        // (being the only package or using --package).
+        return None;
     };
 
     let mut dojo_metadata = DojoMetadata {
@@ -147,7 +149,7 @@ pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> DojoMetadata {
         }
     }
 
-    dojo_metadata
+    Some(dojo_metadata)
 }
 
 /// Metadata coming from project configuration (Scarb.toml)

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -121,9 +121,8 @@ async fn get_full_dojo_metadata_from_workspace() {
     let sources_dir = target_dir.join(profile.as_str()).join(SOURCES_DIR);
     let abis_dir = manifest_dir.join(ABIS_DIR).join(BASE_DIR);
 
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     // env
     assert!(dojo_metadata.env.is_some());

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -121,7 +121,9 @@ async fn get_full_dojo_metadata_from_workspace() {
     let sources_dir = target_dir.join(profile.as_str()).join(SOURCES_DIR);
     let abis_dir = manifest_dir.join(ABIS_DIR).join(BASE_DIR);
 
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     // env
     assert!(dojo_metadata.env.is_some());

--- a/crates/sozo/ops/src/migration/migrate.rs
+++ b/crates/sozo/ops/src/migration/migrate.rs
@@ -308,7 +308,14 @@ where
     ui.print_step(7, "🌐", "Uploading metadata...");
     ui.print(" ");
 
-    let dojo_metadata = dojo_metadata_from_workspace(ws);
+    let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(ws) {
+        metadata
+    } else {
+        return Err(anyhow!(
+            "No current package with dojo metadata found, migrate is not yet support for \
+             workspaces."
+        ));
+    };
     let mut ipfs = vec![];
     let mut resources = vec![];
 

--- a/crates/sozo/ops/src/migration/migrate.rs
+++ b/crates/sozo/ops/src/migration/migrate.rs
@@ -311,10 +311,7 @@ where
     let dojo_metadata = if let Some(metadata) = dojo_metadata_from_workspace(ws) {
         metadata
     } else {
-        return Err(anyhow!(
-            "No current package with dojo metadata found, migrate is not yet support for \
-             workspaces."
-        ));
+        return Err(anyhow!("No current package with dojo metadata found."));
     };
     let mut ipfs = vec![];
     let mut resources = vec![];

--- a/crates/sozo/ops/src/tests/migration.rs
+++ b/crates/sozo/ops/src/tests/migration.rs
@@ -164,7 +164,9 @@ async fn migrate_with_metadata() {
         .unwrap_or_else(|_| panic!("Unable to initialize the IPFS Client"))
         .with_credentials(IPFS_USERNAME, IPFS_PASSWORD);
 
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     // check world metadata
     let resource = world_reader.metadata(&FieldElement::ZERO).call().await.unwrap();

--- a/crates/sozo/ops/src/tests/migration.rs
+++ b/crates/sozo/ops/src/tests/migration.rs
@@ -164,9 +164,8 @@ async fn migrate_with_metadata() {
         .unwrap_or_else(|_| panic!("Unable to initialize the IPFS Client"))
         .with_credentials(IPFS_USERNAME, IPFS_PASSWORD);
 
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     // check world metadata
     let resource = world_reader.metadata(&FieldElement::ZERO).call().await.unwrap();

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -63,7 +63,9 @@ async fn test_load_from_remote() {
 
     let config = compiler::copy_tmp_config(&source_project_dir, &dojo_core_path);
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     let manifest_path = config.manifest_path();
     let base_dir = manifest_path.parent().unwrap();

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -63,9 +63,8 @@ async fn test_load_from_remote() {
 
     let config = compiler::copy_tmp_config(&source_project_dir, &dojo_core_path);
     let ws = scarb::ops::read_workspace(config.manifest_path(), &config).unwrap();
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     let manifest_path = config.manifest_path();
     let base_dir = manifest_path.parent().unwrap();

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -286,7 +286,9 @@ pub async fn spinup_types_test() -> Result<SqlitePool> {
 
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     let target_path = ws.target_dir().path_existent().unwrap().join(config.profile().to_string());
     let migration =

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -286,9 +286,8 @@ pub async fn spinup_types_test() -> Result<SqlitePool> {
 
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     let target_path = ws.target_dir().path_existent().unwrap().join(config.profile().to_string());
     let migration =

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -44,9 +44,8 @@ async fn test_entities_queries() {
 
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
-        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
-    );
+    let dojo_metadata =
+        dojo_metadata_from_workspace(&ws).expect("No current package with dojo metadata found.");
 
     let target_path = ws.target_dir().path_existent().unwrap().join(config.profile().to_string());
 

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -44,7 +44,9 @@ async fn test_entities_queries() {
 
     let ws = ops::read_workspace(config.manifest_path(), &config)
         .unwrap_or_else(|op| panic!("Error building workspace: {op:?}"));
-    let dojo_metadata = dojo_metadata_from_workspace(&ws);
+    let dojo_metadata = dojo_metadata_from_workspace(&ws).expect(
+        "No current package with dojo metadata found, migrate is not yet support for workspaces.",
+    );
 
     let target_path = ws.target_dir().path_existent().unwrap().join(config.profile().to_string());
 

--- a/examples/spawn-and-move/Scarb.lock
+++ b/examples/spawn-and-move/Scarb.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "dojo_examples"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dojo",
 ]


### PR DESCRIPTION
@lambda-0x sorry the `unwrap` escaped my review. Could you please take a look at this change + we need to add a demo workspace in the examples folder to have more test on that. Because building a workspace made this line crashes.

This is a hot fix, will add an issue for the workspace test with sozo.