### PR TITLE
refactor(sozo): dont use explicit account type

### DIFF
--- a/bin/sozo/src/commands/dev.rs
+++ b/bin/sozo/src/commands/dev.rs
@@ -19,10 +19,8 @@ use scarb::compiler::{CairoCompilationUnit, CompilationUnit, CompilationUnitAttr
 use scarb::core::{Config, Workspace};
 use scarb::ops::{FeaturesOpts, FeaturesSelector};
 use sozo_ops::migration;
-use starknet::accounts::SingleOwnerAccount;
+use starknet::accounts::ConnectedAccount;
 use starknet::core::types::FieldElement;
-use starknet::providers::Provider;
-use starknet::signers::Signer;
 use tracing::{error, trace};
 
 use super::migrate::setup_env;
@@ -225,17 +223,18 @@ fn build(context: &mut DevContext<'_>) -> Result<()> {
 }
 
 // TODO: fix me
-async fn migrate<P, S>(
+async fn migrate<A>(
     mut world_address: Option<FieldElement>,
-    account: &SingleOwnerAccount<P, S>,
+    account: A,
     name: &str,
     ws: &Workspace<'_>,
     previous_manifest: Option<DeploymentManifest>,
     skip_migration: Option<Vec<String>>,
 ) -> Result<(DeploymentManifest, Option<FieldElement>)>
 where
-    P: Provider + Sync + Send + 'static,
-    S: Signer + Sync + Send + 'static,
+    A: ConnectedAccount + Sync + Send,
+    A::Provider: Send,
+    A::SignError: 'static,
 {
     let target_dir = ws.target_dir().path_existent().unwrap();
     let target_dir = target_dir.join(ws.config().profile().as_str());

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use futures::FutureExt;
 use starknet::accounts::{
-    Account, AccountDeployment, AccountError, AccountFactory, AccountFactoryError,
-    ConnectedAccount, Declaration, Execution,
+    AccountDeployment, AccountError, AccountFactory, AccountFactoryError, ConnectedAccount,
+    Declaration, Execution,
 };
 use starknet::core::types::{
     DeclareTransactionResult, DeployAccountTransactionResult, ExecutionResult, FieldElement,
@@ -349,10 +349,9 @@ pub trait TransactionExt<T> {
     async fn send_with_cfg(self, txn_config: &TxnConfig) -> Result<Self::R, Self::U>;
 }
 
-impl<'a, T> TransactionExt<T> for Execution<'a, T>
+impl<T> TransactionExt<T> for Execution<'_, T>
 where
     T: ConnectedAccount + Sync,
-    <T as Account>::SignError: 'a,
 {
     type R = InvokeTransactionResult;
     type U = AccountError<T::SignError>;

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use futures::FutureExt;
 use starknet::accounts::{
-    AccountDeployment, AccountError, AccountFactory, AccountFactoryError, ConnectedAccount,
-    Declaration, Execution,
+    Account, AccountDeployment, AccountError, AccountFactory, AccountFactoryError,
+    ConnectedAccount, Declaration, Execution,
 };
 use starknet::core::types::{
     DeclareTransactionResult, DeployAccountTransactionResult, ExecutionResult, FieldElement,
@@ -349,9 +349,10 @@ pub trait TransactionExt<T> {
     async fn send_with_cfg(self, txn_config: &TxnConfig) -> Result<Self::R, Self::U>;
 }
 
-impl<T> TransactionExt<T> for Execution<'_, T>
+impl<'a, T> TransactionExt<T> for Execution<'a, T>
 where
     T: ConnectedAccount + Sync,
+    <T as Account>::SignError: 'a,
 {
     type R = InvokeTransactionResult;
     type U = AccountError<T::SignError>;

--- a/crates/sozo/ops/src/auth.rs
+++ b/crates/sozo/ops/src/auth.rs
@@ -7,7 +7,7 @@ use dojo_world::contracts::{cairo_utils, WorldContractReader};
 use dojo_world::migration::TxnConfig;
 use dojo_world::utils::TransactionExt;
 use scarb_ui::Ui;
-use starknet::accounts::ConnectedAccount;
+use starknet::accounts::{Account, ConnectedAccount};
 use starknet::core::types::{BlockId, BlockTag};
 use starknet::core::utils::{get_selector_from_name, parse_cairo_short_string};
 use starknet_crypto::FieldElement;
@@ -88,14 +88,15 @@ impl FromStr for OwnerResource {
     }
 }
 
-pub async fn grant_writer<A>(
-    ui: &Ui,
+pub async fn grant_writer<'a, A>(
+    ui: &'a Ui,
     world: &WorldContract<A>,
     models_contracts: Vec<ModelContract>,
     txn_config: TxnConfig,
 ) -> Result<()>
 where
-    A: ConnectedAccount + Sync + Send + 'static,
+    A: ConnectedAccount + Sync + Send,
+    <A as Account>::SignError: 'static,
 {
     let mut calls = Vec::new();
 

--- a/crates/sozo/ops/src/migration/auto_auth.rs
+++ b/crates/sozo/ops/src/migration/auto_auth.rs
@@ -10,10 +10,7 @@ use super::ui::MigrationUi;
 use super::MigrationOutput;
 use crate::auth::{grant_writer, ModelContract};
 
-pub async fn auto_authorize<
-    // 'a,
-    A,
->(
+pub async fn auto_authorize<A>(
     ws: &Workspace<'_>,
     world: &WorldContract<A>,
     txn_config: &TxnConfig,

--- a/crates/sozo/ops/src/migration/auto_auth.rs
+++ b/crates/sozo/ops/src/migration/auto_auth.rs
@@ -10,15 +10,19 @@ use super::ui::MigrationUi;
 use super::MigrationOutput;
 use crate::auth::{grant_writer, ModelContract};
 
-pub async fn auto_authorize<'a, A>(
+pub async fn auto_authorize<
+    // 'a,
+    A,
+>(
     ws: &Workspace<'_>,
-    world: &'a WorldContract<A>,
+    world: &WorldContract<A>,
     txn_config: &TxnConfig,
     local_manifest: &BaseManifest,
     migration_output: &MigrationOutput,
 ) -> Result<()>
 where
-    A: ConnectedAccount + Sync + Send + 'static,
+    A: ConnectedAccount + Sync + Send,
+    A::SignError: 'static,
 {
     let ui = ws.config().ui();
 

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -50,19 +50,24 @@ pub struct ContractMigrationOutput {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn migrate<P, S>(
+pub async fn migrate<
+    A, // P, S
+>(
     ws: &Workspace<'_>,
     world_address: Option<FieldElement>,
     rpc_url: String,
-    account: SingleOwnerAccount<P, S>,
+    // account: SingleOwnerAccount<P, S>,
+    account: A,
     name: &str,
     dry_run: bool,
     txn_config: TxnConfig,
     skip_manifests: Option<Vec<String>>,
 ) -> Result<()>
 where
-    P: Provider + Sync + Send + 'static,
-    S: Signer + Sync + Send + 'static,
+    A: ConnectedAccount + Sync + Send,
+    A::Provider: Send,
+    A::SignError: 'static, // P: Provider + Sync + Send + 'static,
+                           // S: Signer + Sync + Send + 'static,
 {
     let ui = ws.config().ui();
 

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -12,10 +12,8 @@ use dojo_world::manifest::{
 use dojo_world::migration::world::WorldDiff;
 use dojo_world::migration::{DeployOutput, TxnConfig, UpgradeOutput};
 use scarb::core::Workspace;
-use starknet::accounts::{ConnectedAccount, SingleOwnerAccount};
+use starknet::accounts::ConnectedAccount;
 use starknet::core::types::FieldElement;
-use starknet::providers::Provider;
-use starknet::signers::Signer;
 
 mod auto_auth;
 mod migrate;

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -48,13 +48,10 @@ pub struct ContractMigrationOutput {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn migrate<
-    A, // P, S
->(
+pub async fn migrate<A>(
     ws: &Workspace<'_>,
     world_address: Option<FieldElement>,
     rpc_url: String,
-    // account: SingleOwnerAccount<P, S>,
     account: A,
     name: &str,
     dry_run: bool,
@@ -64,8 +61,7 @@ pub async fn migrate<
 where
     A: ConnectedAccount + Sync + Send,
     A::Provider: Send,
-    A::SignError: 'static, // P: Provider + Sync + Send + 'static,
-                           // S: Signer + Sync + Send + 'static,
+    A::SignError: 'static,
 {
     let ui = ws.config().ui();
 

--- a/crates/sozo/ops/src/migration/utils.rs
+++ b/crates/sozo/ops/src/migration/utils.rs
@@ -5,9 +5,8 @@ use dojo_world::manifest::{
     OVERLAYS_DIR,
 };
 use scarb_ui::Ui;
-use starknet::accounts::{ConnectedAccount, SingleOwnerAccount};
-use starknet::providers::Provider;
-use starknet::signers::Signer;
+use starknet::accounts::ConnectedAccount;
+
 use starknet_crypto::FieldElement;
 
 use super::ui::MigrationUi;

--- a/crates/sozo/ops/src/migration/utils.rs
+++ b/crates/sozo/ops/src/migration/utils.rs
@@ -15,16 +15,21 @@ use super::ui::MigrationUi;
 /// Loads:
 ///     - `BaseManifest` from filesystem
 ///     - `DeployedManifest` from onchain dataa if `world_address` is `Some`
-pub(super) async fn load_world_manifests<P, S>(
+pub(super) async fn load_world_manifests<
+    A, // P, S
+>(
     profile_dir: &Utf8PathBuf,
-    account: &SingleOwnerAccount<P, S>,
+    // account: &SingleOwnerAccount<P, S>,
+    account: A,
     world_address: Option<FieldElement>,
     ui: &Ui,
     skip_migration: Option<Vec<String>>,
 ) -> Result<(BaseManifest, Option<DeploymentManifest>)>
 where
-    P: Provider + Sync + Send,
-    S: Signer + Sync + Send,
+    A: ConnectedAccount + Sync + Send,
+    <A as ConnectedAccount>::Provider: Send,
+    // P: Provider + Sync + Send,
+    // S: Signer + Sync + Send,
 {
     ui.print_step(1, "🌎", "Building World state...");
 

--- a/crates/sozo/ops/src/migration/utils.rs
+++ b/crates/sozo/ops/src/migration/utils.rs
@@ -6,7 +6,6 @@ use dojo_world::manifest::{
 };
 use scarb_ui::Ui;
 use starknet::accounts::ConnectedAccount;
-
 use starknet_crypto::FieldElement;
 
 use super::ui::MigrationUi;
@@ -14,11 +13,8 @@ use super::ui::MigrationUi;
 /// Loads:
 ///     - `BaseManifest` from filesystem
 ///     - `DeployedManifest` from onchain dataa if `world_address` is `Some`
-pub(super) async fn load_world_manifests<
-    A, // P, S
->(
+pub(super) async fn load_world_manifests<A>(
     profile_dir: &Utf8PathBuf,
-    // account: &SingleOwnerAccount<P, S>,
     account: A,
     world_address: Option<FieldElement>,
     ui: &Ui,
@@ -27,8 +23,6 @@ pub(super) async fn load_world_manifests<
 where
     A: ConnectedAccount + Sync + Send,
     <A as ConnectedAccount>::Provider: Send,
-    // P: Provider + Sync + Send,
-    // S: Signer + Sync + Send,
 {
     ui.print_step(1, "🌎", "Building World state...");
 

--- a/examples/spawn-and-move/Scarb.lock
+++ b/examples/spawn-and-move/Scarb.lock
@@ -10,7 +10,7 @@ dependencies = [
 
 [[package]]
 name = "dojo_examples"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dojo",
 ]


### PR DESCRIPTION
# Description

Replace instances of `SingleOwnerAccount` at parts of `sozo` that requires an account, with the `ConnectedAccount` trait instead. Removing the constraint of having an explicit account type for `sozo`.

This is part of the effort to generalize the account type in `sozo` so that we can use an account type other than `SingleOwnerAccount` in `sozo`.

This PR doesn't generalize the type at the CLI level.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
