### PR TITLE
refactor(torii-core): ignore invalid txs that are included in the pending block

### DIFF
--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -174,12 +174,11 @@ impl<P: Provider + Sync> Engine<P> {
                 Err(e) => {
                     match e.to_string().as_str() {
                         "TransactionHashNotFound" => {
-                            warn!(target: LOG_TARGET, error = %e, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Processing pending transaction.");
-                            // We failed to fetch the transaction, which might be due to us indexing
-                            // the pending transaction too fast. We will
-                            // fail silently and retry processing the transaction in the next
-                            // iteration.
-                            return Ok(pending_block_tx);
+                            // We failed to fetch the transaction, which is because
+                            // the transaction might not have passed the validation stage.
+                            // So we can safely ignore this transaction and not process it, as it
+                            // rejected. 
+                            warn!(target: LOG_TARGET, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Ignored failed pending transaction.");
                         }
                         _ => {
                             error!(target: LOG_TARGET, error = %e, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Processing pending transaction.");

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -177,7 +177,7 @@ impl<P: Provider + Sync> Engine<P> {
                             // We failed to fetch the transaction, which is because
                             // the transaction might not have passed the validation stage.
                             // So we can safely ignore this transaction and not process it, as it
-                            // rejected. 
+                            // rejected.
                             warn!(target: LOG_TARGET, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Ignored failed pending transaction.");
                         }
                         _ => {


### PR DESCRIPTION
#2074

**TODO**: with the new spec we can use getBlockWithReceipts to get all pending txns with their receipts so we wont need to do multiple calls to also fetch the events of the receipt.

A fix is also going to be applied to katana, so we should never encounter this warning, unless an old version of katana is used. Eitherway, if torii is using this fix, it will handle that edge case correctly