### PR TITLE
fix(katana-rpc): only include successful transactions in pending block

### DIFF
--- a/crates/katana/rpc/rpc/src/starknet.rs
+++ b/crates/katana/rpc/rpc/src/starknet.rs
@@ -228,10 +228,16 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                         sequencer_address: block_env.sequencer_address,
                     };
 
+                    // TODO(kariy): create a method that can perform this filtering for us instead
+                    // of doing it manually.
+
+                    // A block should only include successful transactions, we filter out the failed
+                    // ones (didn't pass validation stage).
                     let transactions = executor
                         .read()
                         .transactions()
                         .iter()
+                        .filter(|(_, receipt)| receipt.is_success())
                         .map(|(tx, _)| tx.hash)
                         .collect::<Vec<_>>();
 
@@ -307,10 +313,16 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                         sequencer_address: block_env.sequencer_address,
                     };
 
+                    // TODO(kariy): create a method that can perform this filtering for us instead
+                    // of doing it manually.
+
+                    // A block should only include successful transactions, we filter out the failed
+                    // ones (didn't pass validation stage).
                     let transactions = executor
                         .read()
                         .transactions()
                         .iter()
+                        .filter(|(_, receipt)| receipt.is_success())
                         .map(|(tx, _)| tx.clone())
                         .collect::<Vec<_>>();
 


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

Filter out transactions that failed (didn't pass validation) when building the pending block in `getBlockWithTxs` and `getBlockWithTxHashes`.

A block should only include transactions that passed validation and have been executed (regardless if the tx reverted or not).

TODO: Implement proper RPC testing

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [x] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [ ] I've requested a review after addressing the comments
