### PR TITLE
fix(torii): default index pending to true & and make polling_interval configurable

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use common::parse::{parse_socket_address, parse_url};
 use dojo_metrics::{metrics_process, prometheus_exporter};
 use dojo_world::contracts::world::WorldContractReader;
@@ -112,7 +112,7 @@ struct Args {
     events_chunk_size: u64,
 
     /// Enable indexing pending blocks
-    #[arg(long, default_value_t = true)]
+    #[arg(long, action = ArgAction::Set, default_value_t = true)]
     index_pending: bool,
 
     /// Polling interval in ms

--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -116,7 +116,7 @@ struct Args {
     index_pending: bool,
 
     /// Polling interval in ms
-    #[arg(long, default_value = "500")]
+    #[arg(long, default_value = "1000")]
     polling_interval: u64,
 }
 

--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -13,6 +13,7 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use clap::Parser;
 use common::parse::{parse_socket_address, parse_url};
@@ -111,8 +112,12 @@ struct Args {
     events_chunk_size: u64,
 
     /// Enable indexing pending blocks
-    #[arg(long)]
+    #[arg(long, default_value_t = true)]
     index_pending: bool,
+
+    /// Polling interval in ms
+    #[arg(long, default_value = "500")]
+    polling_interval: u64,
 }
 
 #[tokio::main]
@@ -184,7 +189,7 @@ async fn main() -> anyhow::Result<()> {
             start_block: args.start_block,
             events_chunk_size: args.events_chunk_size,
             index_pending: args.index_pending,
-            ..Default::default()
+            polling_interval: Duration::from_millis(args.polling_interval),
         },
         shutdown_tx.clone(),
         Some(block_tx),

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -34,7 +34,7 @@ pub(crate) const LOG_TARGET: &str = "tori_core::engine";
 
 #[derive(Debug)]
 pub struct EngineConfig {
-    pub block_time: Duration,
+    pub polling_interval: Duration,
     pub start_block: u64,
     pub events_chunk_size: u64,
     pub index_pending: bool,
@@ -43,10 +43,10 @@ pub struct EngineConfig {
 impl Default for EngineConfig {
     fn default() -> Self {
         Self {
-            block_time: Duration::from_secs(1),
+            polling_interval: Duration::from_millis(500),
             start_block: 0,
             events_chunk_size: 1000,
-            index_pending: false,
+            index_pending: true,
         }
     }
 }
@@ -112,7 +112,7 @@ impl<P: Provider + Sync> Engine<P> {
                             }
                         }
                     };
-                    sleep(self.config.block_time).await;
+                    sleep(self.config.polling_interval).await;
                 } => {}
             }
         }


### PR DESCRIPTION
# Description
-Index pending default to true, because that's what we want most of time
-Make polling_interval configurable, it was 1s, i changed default to 500ms
using 250ms make it feel near real time with subscriptions

## Related issue
None

## Tests

- [ ] Yes
- [X] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

