### PR TITLE
feat(torii-grpc): support multiple entity models in queries & complex keys clause for subscriptions + queries

### DIFF
--- a/crates/dojo-bindgen/src/lib.rs
+++ b/crates/dojo-bindgen/src/lib.rs
@@ -283,7 +283,7 @@ mod tests {
             gather_dojo_data(&manifest_path, "dojo_example", "dev", dojo_metadata.skip_migration)
                 .unwrap();
 
-        assert_eq!(data.models.len(), 7);
+        assert_eq!(data.models.len(), 8);
 
         assert_eq!(data.world.name, "dojo_example");
 

--- a/crates/dojo-world/src/manifest/manifest_test.rs
+++ b/crates/dojo-world/src/manifest/manifest_test.rs
@@ -419,10 +419,10 @@ fn fetch_remote_manifest() {
         DeploymentManifest::load_from_remote(provider, world_address).await.unwrap()
     });
 
-    assert_eq!(local_manifest.models.len(), 7);
+    assert_eq!(local_manifest.models.len(), 8);
     assert_eq!(local_manifest.contracts.len(), 3);
 
-    assert_eq!(remote_manifest.models.len(), 7);
+    assert_eq!(remote_manifest.models.len(), 8);
     assert_eq!(remote_manifest.contracts.len(), 3);
 
     // compute diff from local and remote manifest

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -17,10 +17,10 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet_crypto::FieldElement;
 use tokio::sync::RwLock as AsyncRwLock;
-use torii_grpc::client::{EntityUpdateStreaming, EventUpdateStreaming, ModelDiffsStreaming};
-use torii_grpc::proto::world::{RetrieveEntitiesResponse, RetrieveEventsResponse};
-use torii_grpc::types::schema::{Entity, SchemaError};
-use torii_grpc::types::{Event, EventQuery, KeysClause, Query};
+use torii_grpc::client::{EntityUpdateStreaming, ModelDiffsStreaming};
+use torii_grpc::proto::world::RetrieveEntitiesResponse;
+use torii_grpc::types::schema::Entity;
+use torii_grpc::types::{EntityKeysClause, ModelKeysClause, Query};
 use torii_relay::client::EventLoop;
 use torii_relay::types::Message;
 
@@ -56,7 +56,6 @@ impl Client {
         rpc_url: String,
         relay_url: String,
         world: FieldElement,
-        models_keys: Option<Vec<KeysClause>>,
     ) -> Result<Self, Error> {
         let mut grpc_client = torii_grpc::client::WorldClient::new(torii_url, world).await?;
 
@@ -72,23 +71,6 @@ impl Client {
         let rpc_url = url::Url::parse(&rpc_url).map_err(ParseError::Url)?;
         let provider = JsonRpcClient::new(HttpTransport::new(rpc_url));
         let world_reader = WorldContractReader::new(world, provider);
-
-        if let Some(keys) = models_keys {
-            subbed_models.add_models(keys)?;
-
-            // TODO: change this to querying the gRPC url instead
-            let subbed_models = subbed_models.models_keys.read().clone();
-            for keys in subbed_models {
-                let model_reader = world_reader.model_reader(&keys.model).await?;
-                let values = model_reader.entity_storage(&keys.keys).await?;
-
-                client_storage.set_model_storage(
-                    cairo_short_string_to_felt(&keys.model).unwrap(),
-                    keys.keys,
-                    values,
-                )?;
-            }
-        }
 
         Ok(Self {
             world_reader,
@@ -123,7 +105,7 @@ impl Client {
         self.metadata.read()
     }
 
-    pub fn subscribed_models(&self) -> RwLockReadGuard<'_, HashSet<KeysClause>> {
+    pub fn subscribed_models(&self) -> RwLockReadGuard<'_, HashSet<ModelKeysClause>> {
         self.subscribed_models.models_keys.read()
     }
 
@@ -163,20 +145,20 @@ impl Client {
     /// A direct stream to grpc subscribe entities
     pub async fn on_entity_updated(
         &self,
-        ids: Vec<FieldElement>,
+        clause: Option<EntityKeysClause>,
     ) -> Result<EntityUpdateStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
-        let stream = grpc_client.subscribe_entities(ids).await?;
+        let stream = grpc_client.subscribe_entities(clause).await?;
         Ok(stream)
     }
 
     /// A direct stream to grpc subscribe event messages
     pub async fn on_event_message_updated(
         &self,
-        ids: Vec<FieldElement>,
+        clause: Option<EntityKeysClause>,
     ) -> Result<EntityUpdateStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
-        let stream = grpc_client.subscribe_event_messages(ids).await?;
+        let stream = grpc_client.subscribe_event_messages(clause).await?;
         Ok(stream)
     }
 
@@ -196,7 +178,7 @@ impl Client {
     ///
     /// If the requested model is not among the synced models, it will attempt to fetch it from
     /// the RPC.
-    pub async fn model(&self, keys: &KeysClause) -> Result<Option<Ty>, Error> {
+    pub async fn model(&self, keys: &ModelKeysClause) -> Result<Option<Ty>, Error> {
         let Some(mut schema) = self.metadata.read().model(&keys.model).map(|m| m.schema.clone())
         else {
             return Ok(None);
@@ -232,7 +214,7 @@ impl Client {
     /// Initiate the model subscriptions and returns a [SubscriptionService] which when await'ed
     /// will execute the subscription service and starts the syncing process.
     pub async fn start_subscription(&self) -> Result<SubscriptionService, Error> {
-        let models_keys: Vec<KeysClause> =
+        let models_keys: Vec<ModelKeysClause> =
             self.subscribed_models.models_keys.read().clone().into_iter().collect();
         let sub_res_stream = self.initiate_subscription(models_keys).await?;
 
@@ -250,7 +232,7 @@ impl Client {
     /// Adds entities to the list of entities to be synced.
     ///
     /// NOTE: This will establish a new subscription stream with the server.
-    pub async fn add_models_to_sync(&self, models_keys: Vec<KeysClause>) -> Result<(), Error> {
+    pub async fn add_models_to_sync(&self, models_keys: Vec<ModelKeysClause>) -> Result<(), Error> {
         for keys in &models_keys {
             self.initiate_model(&keys.model, keys.keys.clone()).await?;
         }
@@ -271,7 +253,10 @@ impl Client {
     /// Removes models from the list of models to be synced.
     ///
     /// NOTE: This will establish a new subscription stream with the server.
-    pub async fn remove_models_to_sync(&self, models_keys: Vec<KeysClause>) -> Result<(), Error> {
+    pub async fn remove_models_to_sync(
+        &self,
+        models_keys: Vec<ModelKeysClause>,
+    ) -> Result<(), Error> {
         self.subscribed_models.remove_models(models_keys)?;
 
         let updated_entities =
@@ -291,7 +276,7 @@ impl Client {
 
     async fn initiate_subscription(
         &self,
-        keys: Vec<KeysClause>,
+        keys: Vec<ModelKeysClause>,
     ) -> Result<ModelDiffsStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
         let stream = grpc_client.subscribe_model_diffs(keys).await?;

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -17,10 +17,10 @@ use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
 use starknet_crypto::FieldElement;
 use tokio::sync::RwLock as AsyncRwLock;
-use torii_grpc::client::{EntityUpdateStreaming, ModelDiffsStreaming};
-use torii_grpc::proto::world::RetrieveEntitiesResponse;
-use torii_grpc::types::schema::Entity;
-use torii_grpc::types::{EntityKeysClause, ModelKeysClause, Query};
+use torii_grpc::client::{EntityUpdateStreaming, EventUpdateStreaming, ModelDiffsStreaming};
+use torii_grpc::proto::world::{RetrieveEntitiesResponse, RetrieveEventsResponse};
+use torii_grpc::types::schema::{Entity, SchemaError};
+use torii_grpc::types::{EntityKeysClause, Event, EventQuery, KeysClause, ModelKeysClause, Query};
 use torii_relay::client::EventLoop;
 use torii_relay::types::Message;
 
@@ -164,7 +164,7 @@ impl Client {
 
     pub async fn on_starknet_event(
         &self,
-        keys: Option<Vec<FieldElement>>,
+        keys: Option<KeysClause>,
     ) -> Result<EventUpdateStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
         let stream = grpc_client.subscribe_events(keys).await?;

--- a/crates/torii/client/src/client/subscription.rs
+++ b/crates/torii/client/src/client/subscription.rs
@@ -12,7 +12,7 @@ use starknet::core::types::{StateDiff, StateUpdate};
 use starknet::core::utils::cairo_short_string_to_felt;
 use starknet_crypto::FieldElement;
 use torii_grpc::client::ModelDiffsStreaming;
-use torii_grpc::types::KeysClause;
+use torii_grpc::types::ModelKeysClause;
 
 use crate::client::error::{Error, ParseError};
 use crate::client::storage::ModelStorage;
@@ -24,13 +24,13 @@ pub enum SubscriptionEvent {
 
 pub struct SubscribedModels {
     metadata: Arc<RwLock<WorldMetadata>>,
-    pub(crate) models_keys: RwLock<HashSet<KeysClause>>,
+    pub(crate) models_keys: RwLock<HashSet<ModelKeysClause>>,
     /// All the relevant storage addresses derived from the subscribed models
     pub(crate) subscribed_storage_addresses: RwLock<HashSet<FieldElement>>,
 }
 
 impl SubscribedModels {
-    pub(crate) fn is_synced(&self, keys: &KeysClause) -> bool {
+    pub(crate) fn is_synced(&self, keys: &ModelKeysClause) -> bool {
         self.models_keys.read().contains(keys)
     }
 
@@ -42,21 +42,21 @@ impl SubscribedModels {
         }
     }
 
-    pub(crate) fn add_models(&self, models_keys: Vec<KeysClause>) -> Result<(), Error> {
+    pub(crate) fn add_models(&self, models_keys: Vec<ModelKeysClause>) -> Result<(), Error> {
         for keys in models_keys {
             Self::add_model(self, keys)?;
         }
         Ok(())
     }
 
-    pub(crate) fn remove_models(&self, entities_keys: Vec<KeysClause>) -> Result<(), Error> {
+    pub(crate) fn remove_models(&self, entities_keys: Vec<ModelKeysClause>) -> Result<(), Error> {
         for keys in entities_keys {
             Self::remove_model(self, keys)?;
         }
         Ok(())
     }
 
-    pub(crate) fn add_model(&self, keys: KeysClause) -> Result<(), Error> {
+    pub(crate) fn add_model(&self, keys: ModelKeysClause) -> Result<(), Error> {
         if !self.models_keys.write().insert(keys.clone()) {
             return Ok(());
         }
@@ -83,7 +83,7 @@ impl SubscribedModels {
         Ok(())
     }
 
-    pub(crate) fn remove_model(&self, keys: KeysClause) -> Result<(), Error> {
+    pub(crate) fn remove_model(&self, keys: ModelKeysClause) -> Result<(), Error> {
         if !self.models_keys.write().remove(&keys) {
             return Ok(());
         }
@@ -247,7 +247,7 @@ mod tests {
     use parking_lot::RwLock;
     use starknet::core::utils::cairo_short_string_to_felt;
     use starknet::macros::felt;
-    use torii_grpc::types::KeysClause;
+    use torii_grpc::types::ModelKeysClause;
 
     use crate::utils::compute_all_storage_addresses;
 
@@ -283,7 +283,7 @@ mod tests {
 
         let metadata = self::create_dummy_metadata();
 
-        let keys = KeysClause { model: model_name, keys };
+        let keys = ModelKeysClause { model: model_name, keys };
 
         let subscribed_models = super::SubscribedModels::new(Arc::new(RwLock::new(metadata)));
         subscribed_models.add_models(vec![keys.clone()]).expect("able to add model");

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -228,13 +228,15 @@ impl Sql {
                                VALUES (?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET \
                                updated_at=CURRENT_TIMESTAMP, event_id=EXCLUDED.event_id RETURNING \
                                *";
-        let event_message_updated: EventMessageUpdated = sqlx::query_as(insert_entities)
+        let mut event_message_updated: EventMessageUpdated = sqlx::query_as(insert_entities)
             .bind(&entity_id)
             .bind(&keys_str)
             .bind(event_id)
             .bind(utc_dt_string_from_timestamp(block_timestamp))
             .fetch_one(&self.pool)
             .await?;
+
+        event_message_updated.updated_model = Some(entity.clone());
 
         let path = vec![entity.name()];
         self.build_set_entity_queries_recursive(

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -123,7 +123,7 @@ async fn test_load_from_remote() {
 
     let _block_timestamp = 1710754478_u64;
     let models = sqlx::query("SELECT * FROM models").fetch_all(&pool).await.unwrap();
-    assert_eq!(models.len(), 7);
+    assert_eq!(models.len(), 8);
 
     let (id, name, packed_size, unpacked_size): (String, String, u8, u8) = sqlx::query_as(
         "SELECT id, name, packed_size, unpacked_size FROM models WHERE name = 'Position'",

--- a/crates/torii/core/src/types.rs
+++ b/crates/torii/core/src/types.rs
@@ -52,6 +52,10 @@ pub struct EventMessage {
     pub executed_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+
+    // this should never be None. as a EventMessage cannot be deleted
+    #[sqlx(skip)]
+    pub updated_model: Option<Ty>,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -114,6 +114,7 @@ message EntityKeysClause {
 message KeysClause {
     repeated bytes keys = 1;
     PatternMatching pattern_matching = 2;
+    optional string model = 3;
 }
 
 message HashedKeysClause {

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -114,7 +114,7 @@ message EntityKeysClause {
 message KeysClause {
     repeated bytes keys = 1;
     PatternMatching pattern_matching = 2;
-    optional string model = 3;
+    repeated string models = 3;
 }
 
 message HashedKeysClause {

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -85,7 +85,7 @@ message Query {
 }
 
 message EventQuery {
-    KeysClause keys =1;
+    KeysClause keys = 1;
     uint32 limit = 2;
     uint32 offset = 3;
 }
@@ -112,11 +112,12 @@ message EntityKeysClause {
 }
 
 message KeysClause {
-    repeated bytes keys = 2;
+    repeated bytes keys = 1;
+    PatternMatching pattern_matching = 2;
 }
 
 message HashedKeysClause {
-    repeated bytes hashed_keys = 2;
+    repeated bytes hashed_keys = 1;
 }
 
 message MemberClause {
@@ -130,6 +131,11 @@ message CompositeClause {
     string model = 1;
     LogicalOperator operator = 2;
     repeated Clause clauses = 3;
+}
+
+enum PatternMatching {
+    FixedLen = 0;
+    VariableLen = 1;
 }
 
 enum LogicalOperator {

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -85,7 +85,7 @@ message Query {
 }
 
 message EventQuery {
-    EventKeysClause keys =1;
+    KeysClause keys =1;
     uint32 limit = 2;
     uint32 offset = 3;
 }
@@ -103,12 +103,19 @@ message HashedKeysClause {
     repeated bytes hashed_keys = 1;
 }
 
-message EventKeysClause {
-    repeated bytes keys = 1;
+message ModelKeysClause {
+    string model = 1;
+    repeated bytes keys = 2;
+}
+
+message EntityKeysClause {
+    oneof clause_type {
+        HashedKeysClause hashed_keys = 1;
+        KeysClause keys = 2;
+    }
 }
 
 message KeysClause {
-    string model = 1;
     repeated bytes keys = 2;
 }
 

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -99,10 +99,6 @@ message Clause {
     }
 }
 
-message HashedKeysClause {
-    repeated bytes hashed_keys = 1;
-}
-
 message ModelKeysClause {
     string model = 1;
     repeated bytes keys = 2;
@@ -117,6 +113,10 @@ message EntityKeysClause {
 
 message KeysClause {
     repeated bytes keys = 2;
+}
+
+message HashedKeysClause {
+    repeated bytes hashed_keys = 2;
 }
 
 message MemberClause {

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -83,7 +83,7 @@ message RetrieveEventsResponse {
 }
 
 message SubscribeEventsRequest {
-    types.EventKeysClause keys = 1;
+    types.KeysClause keys = 1;
 }
 
 message SubscribeEventsResponse {

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -56,7 +56,7 @@ message SubscribeEntitiesRequest {
 }
 
 message SubscribeEventMessagesRequest {
-    types.EntityKeysClause hashed_keys = 1;
+    types.EntityKeysClause clause = 1;
 }
 
 message SubscribeEntityResponse {

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -43,7 +43,7 @@ message MetadataResponse {
 
 message SubscribeModelsRequest {
     // The list of model keys to subscribe to.
-    repeated types.KeysClause models_keys = 1;
+    repeated types.ModelKeysClause models_keys = 1;
 }
 
 message SubscribeModelsResponse {
@@ -52,11 +52,11 @@ message SubscribeModelsResponse {
 }
 
 message SubscribeEntitiesRequest {
-    repeated bytes hashed_keys = 1;
+    types.EntityKeysClause clause = 1;
 }
 
 message SubscribeEventMessagesRequest {
-    repeated bytes hashed_keys = 1;
+    types.EntityKeysClause hashed_keys = 1;
 }
 
 message SubscribeEntityResponse {

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -14,7 +14,7 @@ use crate::proto::world::{
     SubscribeModelsRequest, SubscribeModelsResponse,
 };
 use crate::types::schema::{self, Entity, SchemaError};
-use crate::types::{Event, EventQuery, KeysClause, Query};
+use crate::types::{EntityKeysClause, ModelKeysClause, Query};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -105,12 +105,12 @@ impl WorldClient {
     /// Subscribe to entities updates of a World.
     pub async fn subscribe_entities(
         &mut self,
-        hashed_keys: Vec<FieldElement>,
+        clause: Option<EntityKeysClause>,
     ) -> Result<EntityUpdateStreaming, Error> {
-        let hashed_keys = hashed_keys.iter().map(|hashed| hashed.to_bytes_be().to_vec()).collect();
+        let clause = clause.map(|c| c.into());
         let stream = self
             .inner
-            .subscribe_entities(SubscribeEntitiesRequest { hashed_keys })
+            .subscribe_entities(SubscribeEntitiesRequest { clause })
             .await
             .map_err(Error::Grpc)
             .map(|res| res.into_inner())?;
@@ -124,12 +124,12 @@ impl WorldClient {
     /// Subscribe to event messages of a World.
     pub async fn subscribe_event_messages(
         &mut self,
-        hashed_keys: Vec<FieldElement>,
+        clause: Option<EntityKeysClause>,
     ) -> Result<EntityUpdateStreaming, Error> {
-        let hashed_keys = hashed_keys.iter().map(|hashed| hashed.to_bytes_be().to_vec()).collect();
+        let clause = clause.map(|c| c.into());
         let stream = self
             .inner
-            .subscribe_event_messages(SubscribeEntitiesRequest { hashed_keys })
+            .subscribe_event_messages(SubscribeEntitiesRequest { clause })
             .await
             .map_err(Error::Grpc)
             .map(|res| res.into_inner())?;
@@ -165,7 +165,7 @@ impl WorldClient {
     /// Subscribe to the model diff for a set of models of a World.
     pub async fn subscribe_model_diffs(
         &mut self,
-        models_keys: Vec<KeysClause>,
+        models_keys: Vec<ModelKeysClause>,
     ) -> Result<ModelDiffsStreaming, Error> {
         let stream = self
             .inner

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -6,7 +6,6 @@ use futures_util::{Stream, StreamExt, TryStreamExt};
 use starknet::core::types::{FromStrError, StateDiff, StateUpdate};
 use starknet_crypto::FieldElement;
 
-use crate::proto::types::EventKeysClause;
 use crate::proto::world::{
     world_client, MetadataRequest, RetrieveEntitiesRequest, RetrieveEntitiesResponse,
     RetrieveEventsRequest, RetrieveEventsResponse, SubscribeEntitiesRequest,
@@ -14,7 +13,7 @@ use crate::proto::world::{
     SubscribeModelsRequest, SubscribeModelsResponse,
 };
 use crate::types::schema::{self, Entity, SchemaError};
-use crate::types::{EntityKeysClause, ModelKeysClause, Query};
+use crate::types::{EntityKeysClause, Event, EventQuery, KeysClause, ModelKeysClause, Query};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -143,11 +142,9 @@ impl WorldClient {
     /// Subscribe to the events of a World.
     pub async fn subscribe_events(
         &mut self,
-        keys: Option<Vec<FieldElement>>,
+        keys: Option<KeysClause>
     ) -> Result<EventUpdateStreaming, Error> {
-        let keys = keys.map(|keys| EventKeysClause {
-            keys: keys.iter().map(|key| key.to_bytes_be().to_vec()).collect(),
-        });
+        let keys = keys.map(|c| c.into());
 
         let stream = self
             .inner

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -142,7 +142,7 @@ impl WorldClient {
     /// Subscribe to the events of a World.
     pub async fn subscribe_events(
         &mut self,
-        keys: Option<KeysClause>
+        keys: Option<KeysClause>,
     ) -> Result<EventUpdateStreaming, Error> {
         let keys = keys.map(|c| c.into());
 

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -330,7 +330,10 @@ impl DojoWorld {
                     .map_err(ParseError::FromByteSliceError)?)
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        let keys_pattern = keys.join("/") + "/%";
+        let mut keys_pattern = keys.join("/");
+        if keys_clause.pattern_matching == proto::types::PatternMatching::VariableLen as i32 {
+            keys_pattern += "/%";
+        }
 
         // total count of rows that matches keys_pattern without limit and offset
         let count_query = format!(
@@ -421,7 +424,10 @@ impl DojoWorld {
                     .map_err(ParseError::FromByteSliceError)?)
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        let keys_pattern = keys.join("/") + "/%";
+        let mut keys_pattern = keys.join("/");
+        if keys_clause.pattern_matching == proto::types::PatternMatching::VariableLen as i32 {
+            keys_pattern += "/%";
+        }
 
         let events_query = r#"
             SELECT keys, data, transaction_hash

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -330,10 +330,12 @@ impl DojoWorld {
                     .map_err(ParseError::FromByteSliceError)?)
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        let mut keys_pattern = keys.join("/");
+        let mut keys_pattern = keys.join("/") + "/";
         if keys_clause.pattern_matching == proto::types::PatternMatching::VariableLen as i32 {
-            keys_pattern += "/%";
+            keys_pattern += "%";
         }
+
+        println!("keys_pattern: {}", keys_pattern);
 
         // total count of rows that matches keys_pattern without limit and offset
         let count_query = format!(
@@ -424,9 +426,9 @@ impl DojoWorld {
                     .map_err(ParseError::FromByteSliceError)?)
             })
             .collect::<Result<Vec<_>, Error>>()?;
-        let mut keys_pattern = keys.join("/");
+        let mut keys_pattern = keys.join("/") + "/";
         if keys_clause.pattern_matching == proto::types::PatternMatching::VariableLen as i32 {
-            keys_pattern += "/%";
+            keys_pattern += "%";
         }
 
         let events_query = r#"

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -342,7 +342,6 @@ impl DojoWorld {
             r#"
             SELECT count(*)
             FROM {table}
-            WHERE {table}.keys REGEXP ?
         "#
         );
 
@@ -350,9 +349,15 @@ impl DojoWorld {
             count_query += &format!(
                 r#"
                 JOIN {model_relation_table} ON {table}.id = {model_relation_table}.entity_id
-                WHERE {model_relation_table}.model_id = '{:#x}'
+                WHERE {model_relation_table}.model_id = '{:#x}' AND {table}.keys REGEXP ?
             "#,
                 get_selector_from_name(&model).map_err(ParseError::NonAsciiName)?
+            );
+        } else {
+            count_query += &format!(
+                r#"
+                WHERE {table}.keys REGEXP ?
+            "#
             );
         }
 

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -323,7 +323,7 @@ impl DojoWorld {
             .iter()
             .map(|bytes| {
                 if bytes.is_empty() {
-                    return Ok("%".to_string());
+                    return Ok("0x%".to_string());
                 }
                 Ok(FieldElement::from_byte_slice_be(bytes)
                     .map(|felt| format!("{felt:#x}"))
@@ -416,7 +416,7 @@ impl DojoWorld {
             .iter()
             .map(|bytes| {
                 if bytes.is_empty() {
-                    return Ok("%".to_string());
+                    return Ok("0x%".to_string());
                 }
 
                 Ok(FieldElement::from_byte_slice_be(bytes)

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -335,8 +335,6 @@ impl DojoWorld {
             keys_pattern += "%";
         }
 
-        println!("keys_pattern: {}", keys_pattern);
-
         // total count of rows that matches keys_pattern without limit and offset
         let count_query = format!(
             r#"

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -600,7 +600,7 @@ impl DojoWorld {
         &self,
         keys: Option<proto::types::EntityKeysClause>,
     ) -> Result<Receiver<Result<proto::world::SubscribeEntityResponse, tonic::Status>>, Error> {
-        self.entity_manager.add_subscriber(keys).await
+        self.entity_manager.add_subscriber(keys.map(|keys| keys.try_into().unwrap())).await
     }
 
     async fn retrieve_entities(
@@ -677,7 +677,7 @@ impl DojoWorld {
         &self,
         keys: Option<proto::types::EntityKeysClause>,
     ) -> Result<Receiver<Result<proto::world::SubscribeEntityResponse, tonic::Status>>, Error> {
-        self.event_message_manager.add_subscriber(keys).await
+        self.event_message_manager.add_subscriber(keys.map(|keys| keys.try_into().unwrap())).await
     }
 
     async fn retrieve_event_messages(
@@ -763,20 +763,9 @@ impl DojoWorld {
 
     async fn subscribe_events(
         &self,
-        clause: proto::types::EventKeysClause,
+        clause: proto::types::KeysClause,
     ) -> Result<Receiver<Result<proto::world::SubscribeEventsResponse, tonic::Status>>, Error> {
-        self.event_manager
-            .add_subscriber(
-                clause
-                    .keys
-                    .iter()
-                    .map(|key| {
-                        FieldElement::from_byte_slice_be(key)
-                            .map_err(ParseError::FromByteSliceError)
-                    })
-                    .collect::<Result<Vec<_>, _>>()?,
-            )
-            .await
+        self.event_manager.add_subscriber(clause.try_into().unwrap()).await
     }
 
     fn map_row_to_entity(

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -267,7 +267,7 @@ impl DojoWorld {
             sqlx::query_as(&query).bind(limit).bind(offset).fetch_all(&self.pool).await?;
 
         let mut entities = Vec::with_capacity(db_entities.len());
-        for (entity_id, models_str) in db_entities {
+        for (entity_id, models_str) in &db_entities {
             let model_ids: Vec<&str> = models_str.split(',').collect();
             let schemas = self.model_cache.schemas(model_ids).await?;
 
@@ -279,10 +279,10 @@ impl DojoWorld {
                 Some(&format!("{table}.id = ?")),
             )?;
 
-            let row = sqlx::query(&entity_query).bind(&entity_id).fetch_one(&self.pool).await?;
+            let row = sqlx::query(&entity_query).bind(entity_id).fetch_one(&self.pool).await?;
             let mut arrays_rows = HashMap::new();
             for (name, query) in arrays_queries {
-                let rows = sqlx::query(&query).bind(&entity_id).fetch_all(&self.pool).await?;
+                let rows = sqlx::query(&query).bind(entity_id).fetch_all(&self.pool).await?;
                 arrays_rows.insert(name, rows);
             }
 
@@ -333,7 +333,7 @@ impl DojoWorld {
                     JOIN {model_relation_table} ON {table}.id = {model_relation_table}.entity_id
                     WHERE {model_relation_table}.model_id = '{:#x}' AND {table}.keys REGEXP ?
                 "#,
-                    get_selector_from_name(&model).map_err(ParseError::NonAsciiName)?
+                    get_selector_from_name(model).map_err(ParseError::NonAsciiName)?
                 )
             } else {
                 format!(
@@ -367,7 +367,7 @@ impl DojoWorld {
                 r#"
                 HAVING INSTR(model_ids, '{:#x}') > 0
             "#,
-                get_selector_from_name(&model).map_err(ParseError::NonAsciiName)?
+                get_selector_from_name(model).map_err(ParseError::NonAsciiName)?
             );
         }
 
@@ -398,10 +398,10 @@ impl DojoWorld {
                 Some(&format!("{table}.id = ?")),
             )?;
 
-            let row = sqlx::query(&entity_query).bind(&entity_id).fetch_one(&self.pool).await?;
+            let row = sqlx::query(&entity_query).bind(entity_id).fetch_one(&self.pool).await?;
             let mut arrays_rows = HashMap::new();
             for (name, query) in arrays_queries {
-                let rows = sqlx::query(&query).bind(&entity_id).fetch_all(&self.pool).await?;
+                let rows = sqlx::query(&query).bind(entity_id).fetch_all(&self.pool).await?;
                 arrays_rows.insert(name, rows);
             }
 

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -496,7 +496,10 @@ impl DojoWorld {
             &schemas,
             table,
             entity_relation_column,
-            Some(&format!("{table_name}.{column_name} {comparison_operator} ? ORDER BY {table}.event_id DESC LIMIT ? OFFSET ?")),
+            Some(&format!(
+                "{table_name}.{column_name} {comparison_operator} ? ORDER BY {table}.event_id \
+                 DESC LIMIT ? OFFSET ?"
+            )),
             None,
         )?;
 
@@ -864,10 +867,8 @@ impl proto::world::world_server::World for DojoWorld {
         request: Request<SubscribeEntitiesRequest>,
     ) -> ServiceResult<Self::SubscribeEntitiesStream> {
         let SubscribeEntitiesRequest { clause } = request.into_inner();
-        let rx = self
-            .subscribe_entities(clause)
-            .await
-            .map_err(|e| Status::internal(e.to_string()))?;
+        let rx =
+            self.subscribe_entities(clause).await.map_err(|e| Status::internal(e.to_string()))?;
 
         Ok(Response::new(Box::pin(ReceiverStream::new(rx)) as Self::SubscribeEntitiesStream))
     }

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -115,6 +115,12 @@ impl Service {
                 Some(EntityKeysClause::Keys(clause)) => {
                     // if the key pattern doesnt match our subscribers key pattern, skip
                     // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
+                    if clause.pattern_matching == PatternMatching::FixedLen
+                        && keys.len() != clause.keys.len()
+                    {
+                        continue;
+                    }
+
                     if !keys.iter().enumerate().all(|(idx, key)| {
                         // this is going to be None if our key pattern overflows the subscriber
                         // key pattern in this case we should skip
@@ -128,7 +134,10 @@ impl Service {
                                     key == sub_key
                                 }
                             }
-                            None => clause.pattern_matching == PatternMatching::VariableLen,
+                            // we overflowed the subscriber key pattern
+                            // but we're in VariableLen pattern matching
+                            // so we should match all next keys
+                            None => true,
                         }
                     }) {
                         continue;

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -102,24 +102,36 @@ impl Service {
             if let Some(proto::types::EntityKeysClause { clause_type: Some(clause) }) = &sub.keys {
                 match clause {
                     proto::types::entity_keys_clause::ClauseType::HashedKeys(hashed_keys) => {
-                        let hashed_keys = hashed_keys.hashed_keys.iter().map(|bytes| {
-                            FieldElement::from_byte_slice_be(bytes)
-                        }).collect::<Result<Vec<_>, _>>().map_err(ParseError::FromByteSliceError)?;
+                        let hashed_keys = hashed_keys
+                            .hashed_keys
+                            .iter()
+                            .map(|bytes| FieldElement::from_byte_slice_be(bytes))
+                            .collect::<Result<Vec<_>, _>>()
+                            .map_err(ParseError::FromByteSliceError)?;
 
                         if !hashed_keys.contains(&hashed) {
                             continue;
                         }
                     }
                     proto::types::entity_keys_clause::ClauseType::Keys(clause) => {
-                        let sub_keys = clause.keys.iter().map(|bytes| {
-                            FieldElement::from_byte_slice_be(bytes)
-                        }).collect::<Result<Vec<_>, _>>().map_err(ParseError::FromByteSliceError)?;
+                        let sub_keys = clause
+                            .keys
+                            .iter()
+                            .map(|bytes| FieldElement::from_byte_slice_be(bytes))
+                            .collect::<Result<Vec<_>, _>>()
+                            .map_err(ParseError::FromByteSliceError)?;
 
                         if !keys.iter().enumerate().all(|(idx, key)| {
                             let sub_key = sub_keys.get(idx);
 
                             match sub_key {
-                                Some(sub_key) => key == sub_key,
+                                Some(sub_key) => {
+                                    if sub_key == &FieldElement::ZERO {
+                                        true
+                                    } else {
+                                        key == sub_key
+                                    }
+                                }
                                 None => true,
                             }
                         }) {

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::RwLock;
 use torii_core::cache::ModelCache;
 use torii_core::error::{Error, ParseError};
-use torii_core::model::{build_sql_query, map_row_to_ty};
+use torii_core::model::build_sql_query;
 use torii_core::simple_broker::SimpleBroker;
 use torii_core::sql::FELT_DELIMITER;
 use torii_core::types::Entity;
@@ -22,6 +22,7 @@ use tracing::{error, trace};
 
 use crate::proto;
 use crate::proto::world::SubscribeEntityResponse;
+use crate::server::map_row_to_entity;
 use crate::types::{EntityKeysClause, PatternMatching};
 
 pub(crate) const LOG_TARGET: &str = "torii::grpc::server::subscriptions::entity";
@@ -115,11 +116,11 @@ impl Service {
                 Some(EntityKeysClause::Keys(clause)) => {
                     // if we have a model clause, then we need to check that the entity
                     // has an updated model and that the model name matches the clause
-                    if let Some(model) = &clause.model {
-                        if let Some(updated_model) = &entity.updated_model {
-                            if updated_model.name() != model.clone() {
-                                continue;
-                            }
+                    if let Some(updated_model) = &entity.updated_model {
+                        if !clause.models.is_empty()
+                            && !clause.models.contains(&updated_model.name())
+                        {
+                            continue;
                         }
                     }
 
@@ -199,24 +200,8 @@ impl Service {
                 arrays_rows.insert(name, row);
             }
 
-            let models = schemas
-                .into_iter()
-                .map(|mut s| {
-                    map_row_to_ty("", &s.name(), &mut s, &row, &arrays_rows)?;
-
-                    Ok(s.as_struct()
-                        .expect("schema should be a struct")
-                        .to_owned()
-                        .try_into()
-                        .unwrap())
-                })
-                .collect::<Result<Vec<_>, Error>>()?;
-
             let resp = proto::world::SubscribeEntityResponse {
-                entity: Some(proto::types::Entity {
-                    hashed_keys: hashed.to_bytes_be().to_vec(),
-                    models,
-                }),
+                entity: Some(map_row_to_entity(&row, &arrays_rows, &schemas)?),
             };
 
             if sub.sender.send(Ok(resp)).await.is_err() {

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -16,11 +16,13 @@ use torii_core::cache::ModelCache;
 use torii_core::error::{Error, ParseError};
 use torii_core::model::{build_sql_query, map_row_to_ty};
 use torii_core::simple_broker::SimpleBroker;
+use torii_core::sql::FELT_DELIMITER;
 use torii_core::types::Entity;
 use tracing::{error, trace};
 
 use crate::proto;
 use crate::proto::world::SubscribeEntityResponse;
+use crate::server::{DojoWorld, ENTITIES_ENTITY_RELATION_COLUMN, ENTITIES_MODEL_RELATION_TABLE, ENTITIES_TABLE};
 
 pub(crate) const LOG_TARGET: &str = "torii::grpc::server::subscriptions::entity";
 
@@ -61,88 +63,50 @@ impl EntityManager {
 
 #[must_use = "Service does nothing unless polled"]
 pub struct Service {
-    pool: Pool<Sqlite>,
-    subs_manager: Arc<EntityManager>,
-    model_cache: Arc<ModelCache>,
+    world: Arc<DojoWorld>,
     simple_broker: Pin<Box<dyn Stream<Item = Entity> + Send>>,
 }
 
 impl Service {
     pub fn new(
-        pool: Pool<Sqlite>,
-        subs_manager: Arc<EntityManager>,
-        model_cache: Arc<ModelCache>,
+        world: Arc<DojoWorld>,
     ) -> Self {
         Self {
-            pool,
-            subs_manager,
-            model_cache,
+            world,
             simple_broker: Box::pin(SimpleBroker::<Entity>::subscribe()),
         }
     }
 
     async fn publish_updates(
-        subs: Arc<EntityManager>,
-        cache: Arc<ModelCache>,
-        pool: Pool<Sqlite>,
-        hashed_keys: &str,
+        world: &DojoWorld,
+        entity: &Entity,
     ) -> Result<(), Error> {
         let mut closed_stream = Vec::new();
+        let keys = entity
+            .keys
+            .trim_end_matches(FELT_DELIMITER)
+            .split(FELT_DELIMITER)
+            .map(FieldElement::from_str)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ParseError::FromStr)?;
 
-        for (idx, sub) in subs.subscribers.read().await.iter() {
-            let hashed = FieldElement::from_str(hashed_keys).map_err(ParseError::FromStr)?;
-            // publish all updates if ids is empty or only ids that are subscribed to
-            if sub.hashed_keys.is_empty() || sub.hashed_keys.contains(&hashed) {
-                let models_query = r#"
-                    SELECT group_concat(entity_model.model_id) as model_ids
-                    FROM entities
-                    JOIN entity_model ON entities.id = entity_model.entity_id
-                    WHERE entities.id = ?
-                    GROUP BY entities.id
-                "#;
-                let (model_ids,): (String,) =
-                    sqlx::query_as(models_query).bind(hashed_keys).fetch_one(&pool).await?;
-                let model_ids: Vec<&str> = model_ids.split(',').collect();
-                let schemas = cache.schemas(model_ids).await?;
+        for (idx, sub) in world.entity_manager.subscribers.read().await.iter() {
+            let entities = match sub.keys {
+                Some(proto::types::EntityKeysClause{clause_type: Some(proto::types::entity_keys_clause::ClauseType::HashedKeys(clause))}) => world.query_by_hashed_keys(ENTITIES_TABLE, ENTITIES_MODEL_RELATION_TABLE, ENTITIES_ENTITY_RELATION_COLUMN, Some(clause), None, None).await?,
+                Some(proto::types::EntityKeysClause{clause_type: Some(proto::types::entity_keys_clause::ClauseType::Keys(clause))}) => world.query_by_keys(ENTITIES_TABLE, ENTITIES_MODEL_RELATION_TABLE, ENTITIES_ENTITY_RELATION_COLUMN, clause, None, None).await?,
+                Some(proto::types::EntityKeysClause{clause_type: None}) => world.query_by_hashed_keys(ENTITIES_TABLE, ENTITIES_MODEL_RELATION_TABLE, ENTITIES_ENTITY_RELATION_COLUMN, None, None, None).await?,
+                None => world.query_by_hashed_keys(ENTITIES_TABLE, ENTITIES_MODEL_RELATION_TABLE, ENTITIES_ENTITY_RELATION_COLUMN, None, None, None).await?,
+            };
 
-                let (entity_query, arrays_queries) = build_sql_query(
-                    &schemas,
-                    "entities",
-                    "entity_id",
-                    Some("entities.id = ?"),
-                    Some("entities.id = ?"),
-                )?;
+            let resp = proto::world::SubscribeEntityResponse {
+                entity: Some(proto::types::Entity {
+                    hashed_keys: hashed.to_bytes_be().to_vec(),
+                    models,
+                }),
+            };
 
-                let row = sqlx::query(&entity_query).bind(hashed_keys).fetch_one(&pool).await?;
-                let mut arrays_rows = HashMap::new();
-                for (name, query) in arrays_queries {
-                    let row = sqlx::query(&query).bind(hashed_keys).fetch_all(&pool).await?;
-                    arrays_rows.insert(name, row);
-                }
-
-                let models = schemas
-                    .into_iter()
-                    .map(|mut s| {
-                        map_row_to_ty("", &s.name(), &mut s, &row, &arrays_rows)?;
-
-                        Ok(s.as_struct()
-                            .expect("schema should be a struct")
-                            .to_owned()
-                            .try_into()
-                            .unwrap())
-                    })
-                    .collect::<Result<Vec<_>, Error>>()?;
-
-                let resp = proto::world::SubscribeEntityResponse {
-                    entity: Some(proto::types::Entity {
-                        hashed_keys: hashed.to_bytes_be().to_vec(),
-                        models,
-                    }),
-                };
-
-                if sub.sender.send(Ok(resp)).await.is_err() {
-                    closed_stream.push(*idx);
-                }
+            if sub.sender.send(Ok(resp)).await.is_err() {
+                closed_stream.push(*idx);
             }
         }
 
@@ -162,11 +126,8 @@ impl Future for Service {
         let pin = self.get_mut();
 
         while let Poll::Ready(Some(entity)) = pin.simple_broker.poll_next_unpin(cx) {
-            let subs = Arc::clone(&pin.subs_manager);
-            let cache = Arc::clone(&pin.model_cache);
-            let pool = pin.pool.clone();
             tokio::spawn(async move {
-                if let Err(e) = Service::publish_updates(subs, cache, pool, &entity.id).await {
+                if let Err(e) = Service::publish_updates(&self.world, &entity).await {
                     error!(target = LOG_TARGET, error = %e, "Publishing entity update.");
                 }
             });

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -121,7 +121,7 @@ impl Service {
                             }
                         }
                     }
-                    
+
                     // if the key pattern doesnt match our subscribers key pattern, skip
                     // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
                     if clause.pattern_matching == PatternMatching::FixedLen

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -24,8 +24,8 @@ use crate::proto::world::SubscribeEntityResponse;
 
 pub(crate) const LOG_TARGET: &str = "torii::grpc::server::subscriptions::event_message";
 pub struct EventMessagesSubscriber {
-    /// Entity ids that the subscriber is interested in
-    hashed_keys: HashSet<FieldElement>,
+    /// Entity keys that the subscriber is interested in
+    keys: Vec<FieldElement>,
     /// The channel to send the response back to the subscriber.
     sender: Sender<Result<proto::world::SubscribeEntityResponse, tonic::Status>>,
 }
@@ -38,7 +38,7 @@ pub struct EventMessageManager {
 impl EventMessageManager {
     pub async fn add_subscriber(
         &self,
-        hashed_keys: Vec<FieldElement>,
+        keys: Vec<FieldElement>,
     ) -> Result<Receiver<Result<proto::world::SubscribeEntityResponse, tonic::Status>>, Error> {
         let id = rand::thread_rng().gen::<usize>();
         let (sender, receiver) = channel(1);
@@ -50,7 +50,7 @@ impl EventMessageManager {
 
         self.subscribers.write().await.insert(
             id,
-            EventMessagesSubscriber { hashed_keys: hashed_keys.iter().cloned().collect(), sender },
+            EventMessagesSubscriber { keys, sender },
         );
 
         Ok(receiver)

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -112,6 +112,16 @@ impl Service {
                     }
                 }
                 Some(EntityKeysClause::Keys(clause)) => {
+                    // if we have a model clause, then we need to check that the entity
+                    // has an updated model and that the model name matches the clause
+                    if let Some(model) = &clause.model {
+                        if let Some(updated_model) = &entity.updated_model {
+                            if updated_model.name() != model.clone() {
+                                continue;
+                            }
+                        }
+                    }
+                    
                     // if the key pattern doesnt match our subscribers key pattern, skip
                     // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
                     if clause.pattern_matching == PatternMatching::FixedLen

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -22,11 +22,12 @@ use tracing::{error, trace};
 
 use crate::proto;
 use crate::proto::world::SubscribeEntityResponse;
+use crate::types::{EntityKeysClause, PatternMatching};
 
 pub(crate) const LOG_TARGET: &str = "torii::grpc::server::subscriptions::event_message";
 pub struct EventMessagesSubscriber {
     /// Entity keys that the subscriber is interested in
-    keys: Option<proto::types::EntityKeysClause>,
+    keys: Option<EntityKeysClause>,
     /// The channel to send the response back to the subscriber.
     sender: Sender<Result<proto::world::SubscribeEntityResponse, tonic::Status>>,
 }
@@ -39,7 +40,7 @@ pub struct EventMessageManager {
 impl EventMessageManager {
     pub async fn add_subscriber(
         &self,
-        keys: Option<proto::types::EntityKeysClause>,
+        keys: Option<EntityKeysClause>,
     ) -> Result<Receiver<Result<proto::world::SubscribeEntityResponse, tonic::Status>>, Error> {
         let id = rand::thread_rng().gen::<usize>();
         let (sender, receiver) = channel(1);
@@ -104,51 +105,38 @@ impl Service {
 
             // If we have a clause of keys, then check that the key pattern of the entity
             // matches the key pattern of the subscriber.
-            if let Some(proto::types::EntityKeysClause { clause_type: Some(clause) }) = &sub.keys {
-                match clause {
-                    proto::types::entity_keys_clause::ClauseType::HashedKeys(hashed_keys) => {
-                        let hashed_keys = hashed_keys
-                            .hashed_keys
-                            .iter()
-                            .map(|bytes| FieldElement::from_byte_slice_be(bytes))
-                            .collect::<Result<Vec<_>, _>>()
-                            .map_err(ParseError::FromByteSliceError)?;
-
-                        if !hashed_keys.contains(&hashed) {
-                            continue;
-                        }
-                    }
-                    proto::types::entity_keys_clause::ClauseType::Keys(clause) => {
-                        let sub_keys = clause
-                            .keys
-                            .iter()
-                            .map(|bytes| FieldElement::from_byte_slice_be(bytes))
-                            .collect::<Result<Vec<_>, _>>()
-                            .map_err(ParseError::FromByteSliceError)?;
-
-                        // if the key pattern doesnt match our subscribers key pattern, skip
-                        // ["", "0x0"] would match with keys ["0x...", "0x0"]
-                        if !keys.iter().enumerate().all(|(idx, key)| {
-                            // this is going to be None if our key pattern overflows the subscriber
-                            // key pattern in this case we should skip
-                            let sub_key = sub_keys.get(idx);
-
-                            match sub_key {
-                                Some(sub_key) => {
-                                    if sub_key == &FieldElement::ZERO {
-                                        true
-                                    } else {
-                                        key == sub_key
-                                    }
-                                }
-                                None => false,
-                            }
-                        }) {
-                            continue;
-                        }
+            match &sub.keys {
+                Some(EntityKeysClause::HashedKeys(hashed_keys)) => {
+                    if !hashed_keys.contains(&hashed) {
+                        continue;
                     }
                 }
+                Some(EntityKeysClause::Keys(clause)) => {
+                    // if the key pattern doesnt match our subscribers key pattern, skip
+                    // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
+                    if !keys.iter().enumerate().all(|(idx, key)| {
+                        // this is going to be None if our key pattern overflows the subscriber
+                        // key pattern in this case we should skip
+                        let sub_key = clause.keys.get(idx);
+
+                        match sub_key {
+                            Some(sub_key) => {
+                                if sub_key == &FieldElement::ZERO {
+                                    true
+                                } else {
+                                    key == sub_key
+                                }
+                            }
+                            None => clause.pattern_matching == PatternMatching::VariableLen,
+                        }
+                    }) {
+                        continue;
+                    }
+                }
+                // if None, then we are interested in all entities
+                None => {}
             }
+
             // publish all updates if ids is empty or only ids that are subscribed to
             let models_query = r#"
                     SELECT group_concat(event_model.model_id) as model_ids

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -98,6 +98,12 @@ impl Service {
             .map_err(ParseError::FromStr)?;
 
         for (idx, sub) in subs.subscribers.read().await.iter() {
+            // Check if the subscriber is interested in this entity
+            // If we have a clause of hashed keys, then check that the id of the entity
+            // is in the list of hashed keys.
+
+            // If we have a clause of keys, then check that the key pattern of the entity
+            // matches the key pattern of the subscriber.
             if let Some(proto::types::EntityKeysClause { clause_type: Some(clause) }) = &sub.keys {
                 match clause {
                     proto::types::entity_keys_clause::ClauseType::HashedKeys(hashed_keys) => {
@@ -120,7 +126,11 @@ impl Service {
                             .collect::<Result<Vec<_>, _>>()
                             .map_err(ParseError::FromByteSliceError)?;
 
+                        // if the key pattern doesnt match our subscribers key pattern, skip
+                        // ["", "0x0"] would match with keys ["0x...", "0x0"]
                         if !keys.iter().enumerate().all(|(idx, key)| {
+                            // this is going to be None if our key pattern overflows the subscriber
+                            // key pattern in this case we should skip
                             let sub_key = sub_keys.get(idx);
 
                             match sub_key {
@@ -131,7 +141,7 @@ impl Service {
                                         key == sub_key
                                     }
                                 }
-                                None => true,
+                                None => false,
                             }
                         }) {
                             continue;

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -124,7 +124,13 @@ impl Service {
                             let sub_key = sub_keys.get(idx);
 
                             match sub_key {
-                                Some(sub_key) => key == sub_key,
+                                Some(sub_key) => {
+                                    if sub_key == &FieldElement::ZERO {
+                                        true
+                                    } else {
+                                        key == sub_key
+                                    }
+                                }
                                 None => true,
                             }
                         }) {

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -114,6 +114,12 @@ impl Service {
                 Some(EntityKeysClause::Keys(clause)) => {
                     // if the key pattern doesnt match our subscribers key pattern, skip
                     // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
+                    if clause.pattern_matching == PatternMatching::FixedLen
+                        && keys.len() != clause.keys.len()
+                    {
+                        continue;
+                    }
+
                     if !keys.iter().enumerate().all(|(idx, key)| {
                         // this is going to be None if our key pattern overflows the subscriber
                         // key pattern in this case we should skip
@@ -127,7 +133,10 @@ impl Service {
                                     key == sub_key
                                 }
                             }
-                            None => clause.pattern_matching == PatternMatching::VariableLen,
+                            // we overflowed the subscriber key pattern
+                            // but we're in VariableLen pattern matching
+                            // so we should match all next keys
+                            None => true,
                         }
                     }) {
                         continue;

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -17,7 +17,7 @@ use torii_core::error::{Error, ParseError};
 use torii_core::model::{build_sql_query, map_row_to_ty};
 use torii_core::simple_broker::SimpleBroker;
 use torii_core::sql::FELT_DELIMITER;
-use torii_core::types::{Entity, EventMessage};
+use torii_core::types::EventMessage;
 use tracing::{error, trace};
 
 use crate::proto;

--- a/crates/torii/grpc/src/server/subscriptions/model_diff.rs
+++ b/crates/torii/grpc/src/server/subscriptions/model_diff.rs
@@ -21,7 +21,7 @@ use tracing::{debug, error, trace};
 use super::error::SubscriptionError;
 use crate::proto;
 use crate::proto::world::SubscribeModelsResponse;
-use crate::types::KeysClause;
+use crate::types::ModelKeysClause;
 
 pub(crate) const LOG_TARGET: &str = "torii::grpc::server::subscriptions::model_diff";
 
@@ -62,7 +62,7 @@ impl StateDiffManager {
         let storage_addresses = reqs
             .into_iter()
             .map(|req| {
-                let keys: KeysClause =
+                let keys: ModelKeysClause =
                     req.keys.try_into().map_err(ParseError::FromByteSliceError)?;
 
                 let base = poseidon_hash_many(&[

--- a/crates/torii/grpc/src/server/subscriptions/model_diff.rs
+++ b/crates/torii/grpc/src/server/subscriptions/model_diff.rs
@@ -32,7 +32,7 @@ pub struct ModelMetadata {
 
 pub struct ModelDiffRequest {
     pub model: ModelMetadata,
-    pub keys: proto::types::KeysClause,
+    pub keys: proto::types::ModelKeysClause,
 }
 
 impl ModelDiffRequest {}

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -121,7 +121,7 @@ async fn test_entities_queries() {
             KeysClause {
                 keys: vec![account.address().to_bytes_be().to_vec()],
                 pattern_matching: 0,
-                model: None,
+                models: vec![],
             },
             Some(1),
             None,

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -26,9 +26,9 @@ use torii_core::processors::register_model::RegisterModelProcessor;
 use torii_core::processors::store_set_record::StoreSetRecordProcessor;
 use torii_core::sql::Sql;
 
+use crate::proto::types::KeysClause;
 use crate::server::DojoWorld;
 use crate::types::schema::Entity;
-use crate::types::KeysClause;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_entities_queries() {
@@ -116,9 +116,12 @@ async fn test_entities_queries() {
             "entities",
             "entity_model",
             "entity_id",
-            KeysClause { model: "Moves".to_string(), keys: vec![account.address()] }.into(),
-            1,
-            0,
+            KeysClause {
+                keys: vec![account.address()].iter().map(|k| k.to_bytes_be().to_vec()).collect(),
+            }
+            .into(),
+            Some(1),
+            None,
         )
         .await
         .unwrap()

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -116,7 +116,10 @@ async fn test_entities_queries() {
             "entities",
             "entity_model",
             "entity_id",
-            KeysClause { keys: vec![account.address().to_bytes_be().to_vec()], pattern_matching: 0 },
+            KeysClause {
+                keys: vec![account.address().to_bytes_be().to_vec()],
+                pattern_matching: 0,
+            },
             Some(1),
             None,
         )

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -119,6 +119,7 @@ async fn test_entities_queries() {
             KeysClause {
                 keys: vec![account.address().to_bytes_be().to_vec()],
                 pattern_matching: 0,
+                model: None,
             },
             Some(1),
             None,

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -116,7 +116,7 @@ async fn test_entities_queries() {
             "entities",
             "entity_model",
             "entity_id",
-            KeysClause { keys: vec![account.address().to_bytes_be().to_vec()] },
+            KeysClause { keys: vec![account.address().to_bytes_be().to_vec()], pattern_matching: 0 },
             Some(1),
             None,
         )

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -116,10 +116,7 @@ async fn test_entities_queries() {
             "entities",
             "entity_model",
             "entity_id",
-            KeysClause {
-                keys: vec![account.address()].iter().map(|k| k.to_bytes_be().to_vec()).collect(),
-            }
-            .into(),
+            KeysClause { keys: vec![account.address().to_bytes_be().to_vec()] },
             Some(1),
             None,
         )

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -32,8 +32,10 @@ use crate::types::schema::Entity;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_entities_queries() {
-    let options =
-        SqliteConnectOptions::from_str("sqlite::memory:").unwrap().create_if_missing(true);
+    let options = SqliteConnectOptions::from_str("sqlite::memory:")
+        .unwrap()
+        .create_if_missing(true)
+        .with_regexp();
     let pool = SqlitePoolOptions::new().max_connections(5).connect_with(options).await.unwrap();
     sqlx::migrate!("../migrations").run(&pool).await.unwrap();
 

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -199,10 +199,7 @@ impl TryFrom<proto::types::KeysClause> for KeysClause {
             .map(|k| FieldElement::from_byte_slice_be(&k))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Self {
-            keys,
-            pattern_matching: value.pattern_matching().into(),
-        })
+        Ok(Self { keys, pattern_matching: value.pattern_matching().into() })
     }
 }
 

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -31,7 +31,6 @@ pub enum Clause {
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
 pub struct KeysClause {
-    pub model: String,
     pub keys: Vec<FieldElement>,
 }
 

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -45,7 +45,7 @@ pub struct ModelKeysClause {
 pub struct KeysClause {
     pub keys: Vec<FieldElement>,
     pub pattern_matching: PatternMatching,
-    pub model: Option<String>,
+    pub models: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
@@ -186,7 +186,7 @@ impl From<KeysClause> for proto::types::KeysClause {
         Self {
             keys: value.keys.iter().map(|k| k.to_bytes_be().into()).collect(),
             pattern_matching: value.pattern_matching as i32,
-            model: value.model,
+            models: value.models,
         }
     }
 }
@@ -201,7 +201,7 @@ impl TryFrom<proto::types::KeysClause> for KeysClause {
             .map(|k| FieldElement::from_byte_slice_be(k))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Self { keys, pattern_matching: value.pattern_matching().into(), model: value.model })
+        Ok(Self { keys, pattern_matching: value.pattern_matching().into(), models: value.models })
     }
 }
 

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -196,7 +196,7 @@ impl TryFrom<proto::types::KeysClause> for KeysClause {
         let keys = value
             .keys
             .iter()
-            .map(|k| FieldElement::from_byte_slice_be(&k))
+            .map(|k| FieldElement::from_byte_slice_be(k))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self { keys, pattern_matching: value.pattern_matching().into() })

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -45,6 +45,7 @@ pub struct ModelKeysClause {
 pub struct KeysClause {
     pub keys: Vec<FieldElement>,
     pub pattern_matching: PatternMatching,
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
@@ -185,6 +186,7 @@ impl From<KeysClause> for proto::types::KeysClause {
         Self {
             keys: value.keys.iter().map(|k| k.to_bytes_be().into()).collect(),
             pattern_matching: value.pattern_matching as i32,
+            model: value.model,
         }
     }
 }
@@ -199,7 +201,7 @@ impl TryFrom<proto::types::KeysClause> for KeysClause {
             .map(|k| FieldElement::from_byte_slice_be(k))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Self { keys, pattern_matching: value.pattern_matching().into() })
+        Ok(Self { keys, pattern_matching: value.pattern_matching().into(), model: value.model })
     }
 }
 

--- a/crates/torii/types-test/Scarb.lock
+++ b/crates/torii/types-test/Scarb.lock
@@ -15,7 +15,7 @@ source = "git+https://github.com/dojoengine/dojo?tag=v0.7.2#3da5cad9fdd39b81551e
 
 [[package]]
 name = "types_test"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "dojo",
 ]

--- a/examples/spawn-and-move/manifests/dev/abis/base/contracts/dojo_examples_actions_actions.json
+++ b/examples/spawn-and-move/manifests/dev/abis/base/contracts/dojo_examples_actions_actions.json
@@ -225,6 +225,22 @@
         "inputs": [],
         "outputs": [],
         "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_player_server_profile",
+        "inputs": [
+          {
+            "name": "server_id",
+            "type": "core::integer::u32"
+          },
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
       }
     ]
   },

--- a/examples/spawn-and-move/manifests/dev/abis/base/models/dojo_examples_models_server_profile.json
+++ b/examples/spawn-and-move/manifests/dev/abis/base/models/dojo_examples_models_server_profile.json
@@ -1,0 +1,367 @@
+[
+  {
+    "type": "impl",
+    "name": "DojoModelImpl",
+    "interface_name": "dojo::model::IModel"
+  },
+  {
+    "type": "struct",
+    "name": "core::byte_array::ByteArray",
+    "members": [
+      {
+        "name": "data",
+        "type": "core::array::Array::<core::bytes_31::bytes31>"
+      },
+      {
+        "name": "pending_word",
+        "type": "core::felt252"
+      },
+      {
+        "name": "pending_word_len",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "core::option::Option::<core::integer::u32>",
+    "variants": [
+      {
+        "name": "Some",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "None",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::integer::u8>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::integer::u8>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::FieldLayout",
+    "members": [
+      {
+        "name": "selector",
+        "type": "core::felt252"
+      },
+      {
+        "name": "layout",
+        "type": "dojo::database::introspect::Layout"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::FieldLayout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::Layout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::Layout>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::database::introspect::Layout",
+    "variants": [
+      {
+        "name": "Fixed",
+        "type": "core::array::Span::<core::integer::u8>"
+      },
+      {
+        "name": "Struct",
+        "type": "core::array::Span::<dojo::database::introspect::FieldLayout>"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::database::introspect::Layout>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::database::introspect::Layout>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      },
+      {
+        "name": "Enum",
+        "type": "core::array::Span::<dojo::database::introspect::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::felt252>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::felt252>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Member",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "ty",
+        "type": "dojo::database::introspect::Ty"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::Member>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Struct",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<dojo::database::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<(core::felt252, dojo::database::introspect::Ty)>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<(core::felt252, dojo::database::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Enum",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<(core::felt252, dojo::database::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::Ty>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::Ty>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::database::introspect::Ty",
+    "variants": [
+      {
+        "name": "Primitive",
+        "type": "core::felt252"
+      },
+      {
+        "name": "Struct",
+        "type": "dojo::database::introspect::Struct"
+      },
+      {
+        "name": "Enum",
+        "type": "dojo::database::introspect::Enum"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::database::introspect::Ty>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::database::introspect::Ty>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::model::IModel",
+    "items": [
+      {
+        "type": "function",
+        "name": "selector",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "version",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u8"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "unpacked_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "packed_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "layout",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::database::introspect::Layout"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "schema",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::database::introspect::Ty"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "server_profileImpl",
+    "interface_name": "dojo_examples::models::Iserver_profile"
+  },
+  {
+    "type": "struct",
+    "name": "dojo_examples::models::ServerProfile",
+    "members": [
+      {
+        "name": "player",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "server_id",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "name",
+        "type": "core::byte_array::ByteArray"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo_examples::models::Iserver_profile",
+    "items": [
+      {
+        "type": "function",
+        "name": "ensure_abi",
+        "inputs": [
+          {
+            "name": "model",
+            "type": "dojo_examples::models::ServerProfile"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "dojo_examples::models::server_profile::Event",
+    "kind": "enum",
+    "variants": []
+  }
+]

--- a/examples/spawn-and-move/manifests/dev/abis/deployments/contracts/dojo_examples_actions_actions.json
+++ b/examples/spawn-and-move/manifests/dev/abis/deployments/contracts/dojo_examples_actions_actions.json
@@ -225,6 +225,22 @@
         "inputs": [],
         "outputs": [],
         "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_player_server_profile",
+        "inputs": [
+          {
+            "name": "server_id",
+            "type": "core::integer::u32"
+          },
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
       }
     ]
   },

--- a/examples/spawn-and-move/manifests/dev/abis/deployments/models/dojo_examples_models_server_profile.json
+++ b/examples/spawn-and-move/manifests/dev/abis/deployments/models/dojo_examples_models_server_profile.json
@@ -1,0 +1,367 @@
+[
+  {
+    "type": "impl",
+    "name": "DojoModelImpl",
+    "interface_name": "dojo::model::IModel"
+  },
+  {
+    "type": "struct",
+    "name": "core::byte_array::ByteArray",
+    "members": [
+      {
+        "name": "data",
+        "type": "core::array::Array::<core::bytes_31::bytes31>"
+      },
+      {
+        "name": "pending_word",
+        "type": "core::felt252"
+      },
+      {
+        "name": "pending_word_len",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "core::option::Option::<core::integer::u32>",
+    "variants": [
+      {
+        "name": "Some",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "None",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::integer::u8>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::integer::u8>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::FieldLayout",
+    "members": [
+      {
+        "name": "selector",
+        "type": "core::felt252"
+      },
+      {
+        "name": "layout",
+        "type": "dojo::database::introspect::Layout"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::FieldLayout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::Layout>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::Layout>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::database::introspect::Layout",
+    "variants": [
+      {
+        "name": "Fixed",
+        "type": "core::array::Span::<core::integer::u8>"
+      },
+      {
+        "name": "Struct",
+        "type": "core::array::Span::<dojo::database::introspect::FieldLayout>"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::database::introspect::Layout>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::database::introspect::Layout>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      },
+      {
+        "name": "Enum",
+        "type": "core::array::Span::<dojo::database::introspect::FieldLayout>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<core::felt252>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<core::felt252>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Member",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "ty",
+        "type": "dojo::database::introspect::Ty"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::Member>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Struct",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<dojo::database::introspect::Member>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<(core::felt252, dojo::database::introspect::Ty)>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<(core::felt252, dojo::database::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "dojo::database::introspect::Enum",
+    "members": [
+      {
+        "name": "name",
+        "type": "core::felt252"
+      },
+      {
+        "name": "attrs",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "children",
+        "type": "core::array::Span::<(core::felt252, dojo::database::introspect::Ty)>"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::array::Span::<dojo::database::introspect::Ty>",
+    "members": [
+      {
+        "name": "snapshot",
+        "type": "@core::array::Array::<dojo::database::introspect::Ty>"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "dojo::database::introspect::Ty",
+    "variants": [
+      {
+        "name": "Primitive",
+        "type": "core::felt252"
+      },
+      {
+        "name": "Struct",
+        "type": "dojo::database::introspect::Struct"
+      },
+      {
+        "name": "Enum",
+        "type": "dojo::database::introspect::Enum"
+      },
+      {
+        "name": "Tuple",
+        "type": "core::array::Span::<dojo::database::introspect::Ty>"
+      },
+      {
+        "name": "Array",
+        "type": "core::array::Span::<dojo::database::introspect::Ty>"
+      },
+      {
+        "name": "ByteArray",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo::model::IModel",
+    "items": [
+      {
+        "type": "function",
+        "name": "selector",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "version",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u8"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "unpacked_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "packed_size",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::option::Option::<core::integer::u32>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "layout",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::database::introspect::Layout"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "schema",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "dojo::database::introspect::Ty"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "server_profileImpl",
+    "interface_name": "dojo_examples::models::Iserver_profile"
+  },
+  {
+    "type": "struct",
+    "name": "dojo_examples::models::ServerProfile",
+    "members": [
+      {
+        "name": "player",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "server_id",
+        "type": "core::integer::u32"
+      },
+      {
+        "name": "name",
+        "type": "core::byte_array::ByteArray"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "dojo_examples::models::Iserver_profile",
+    "items": [
+      {
+        "type": "function",
+        "name": "ensure_abi",
+        "inputs": [
+          {
+            "name": "model",
+            "type": "dojo_examples::models::ServerProfile"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "dojo_examples::models::server_profile::Event",
+    "kind": "enum",
+    "variants": []
+  }
+]

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples_actions_actions.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x3b42f80dc8ac4628b0ed6c89af9055314c0aa2192ea0d9601f262138a1e50c3"
-original_class_hash = "0x3b42f80dc8ac4628b0ed6c89af9055314c0aa2192ea0d9601f262138a1e50c3"
+class_hash = "0x7d70dda5cb8dcb697ccc2c129254c554e8994f1b231527f7641a14706af016f"
+original_class_hash = "0x7d70dda5cb8dcb697ccc2c129254c554e8994f1b231527f7641a14706af016f"
 base_class_hash = "0x0"
 abi = "manifests/dev/abis/base/contracts/dojo_examples_actions_actions.json"
 reads = []

--- a/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_server_profile.toml
+++ b/examples/spawn-and-move/manifests/dev/base/models/dojo_examples_models_server_profile.toml
@@ -1,0 +1,20 @@
+kind = "DojoModel"
+class_hash = "0x6dc51a232ffcfaa02646636daf1b8acab8121fa69458258da8df1620aff07ab"
+original_class_hash = "0x6dc51a232ffcfaa02646636daf1b8acab8121fa69458258da8df1620aff07ab"
+abi = "manifests/dev/abis/base/models/dojo_examples_models_server_profile.json"
+name = "dojo_examples::models::server_profile"
+
+[[members]]
+name = "player"
+type = "ContractAddress"
+key = true
+
+[[members]]
+name = "server_id"
+type = "u32"
+key = true
+
+[[members]]
+name = "name"
+type = "ByteArray"
+key = false

--- a/examples/spawn-and-move/manifests/dev/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/manifest.json
@@ -1020,8 +1020,8 @@
     {
       "kind": "DojoContract",
       "address": "0x5c70a663d6b48d8e4c6aaa9572e3735a732ac3765700d470463e670587852af",
-      "class_hash": "0x3b42f80dc8ac4628b0ed6c89af9055314c0aa2192ea0d9601f262138a1e50c3",
-      "original_class_hash": "0x3b42f80dc8ac4628b0ed6c89af9055314c0aa2192ea0d9601f262138a1e50c3",
+      "class_hash": "0x7d70dda5cb8dcb697ccc2c129254c554e8994f1b231527f7641a14706af016f",
+      "original_class_hash": "0x7d70dda5cb8dcb697ccc2c129254c554e8994f1b231527f7641a14706af016f",
       "base_class_hash": "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46",
       "abi": [
         {
@@ -1248,6 +1248,22 @@
               "type": "function",
               "name": "reset_player_config",
               "inputs": [],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "set_player_server_profile",
+              "inputs": [
+                {
+                  "name": "server_id",
+                  "type": "core::integer::u32"
+                },
+                {
+                  "name": "name",
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
               "outputs": [],
               "state_mutability": "external"
             }
@@ -4059,6 +4075,396 @@
         }
       ],
       "name": "dojo_examples::models::position"
+    },
+    {
+      "kind": "DojoModel",
+      "members": [
+        {
+          "name": "player",
+          "type": "ContractAddress",
+          "key": true
+        },
+        {
+          "name": "server_id",
+          "type": "u32",
+          "key": true
+        },
+        {
+          "name": "name",
+          "type": "ByteArray",
+          "key": false
+        }
+      ],
+      "class_hash": "0x6dc51a232ffcfaa02646636daf1b8acab8121fa69458258da8df1620aff07ab",
+      "original_class_hash": "0x6dc51a232ffcfaa02646636daf1b8acab8121fa69458258da8df1620aff07ab",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "DojoModelImpl",
+          "interface_name": "dojo::model::IModel"
+        },
+        {
+          "type": "struct",
+          "name": "core::byte_array::ByteArray",
+          "members": [
+            {
+              "name": "data",
+              "type": "core::array::Array::<core::bytes_31::bytes31>"
+            },
+            {
+              "name": "pending_word",
+              "type": "core::felt252"
+            },
+            {
+              "name": "pending_word_len",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "core::option::Option::<core::integer::u32>",
+          "variants": [
+            {
+              "name": "Some",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "None",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::integer::u8>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::integer::u8>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::FieldLayout",
+          "members": [
+            {
+              "name": "selector",
+              "type": "core::felt252"
+            },
+            {
+              "name": "layout",
+              "type": "dojo::database::introspect::Layout"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<dojo::database::introspect::FieldLayout>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<dojo::database::introspect::FieldLayout>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<dojo::database::introspect::Layout>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<dojo::database::introspect::Layout>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Layout",
+          "variants": [
+            {
+              "name": "Fixed",
+              "type": "core::array::Span::<core::integer::u8>"
+            },
+            {
+              "name": "Struct",
+              "type": "core::array::Span::<dojo::database::introspect::FieldLayout>"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<dojo::database::introspect::Layout>"
+            },
+            {
+              "name": "Array",
+              "type": "core::array::Span::<dojo::database::introspect::Layout>"
+            },
+            {
+              "name": "ByteArray",
+              "type": "()"
+            },
+            {
+              "name": "Enum",
+              "type": "core::array::Span::<dojo::database::introspect::FieldLayout>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<core::felt252>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<core::felt252>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Member",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "ty",
+              "type": "dojo::database::introspect::Ty"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<dojo::database::introspect::Member>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<dojo::database::introspect::Member>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Struct",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<dojo::database::introspect::Member>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<(core::felt252, dojo::database::introspect::Ty)>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<(core::felt252, dojo::database::introspect::Ty)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "dojo::database::introspect::Enum",
+          "members": [
+            {
+              "name": "name",
+              "type": "core::felt252"
+            },
+            {
+              "name": "attrs",
+              "type": "core::array::Span::<core::felt252>"
+            },
+            {
+              "name": "children",
+              "type": "core::array::Span::<(core::felt252, dojo::database::introspect::Ty)>"
+            }
+          ]
+        },
+        {
+          "type": "struct",
+          "name": "core::array::Span::<dojo::database::introspect::Ty>",
+          "members": [
+            {
+              "name": "snapshot",
+              "type": "@core::array::Array::<dojo::database::introspect::Ty>"
+            }
+          ]
+        },
+        {
+          "type": "enum",
+          "name": "dojo::database::introspect::Ty",
+          "variants": [
+            {
+              "name": "Primitive",
+              "type": "core::felt252"
+            },
+            {
+              "name": "Struct",
+              "type": "dojo::database::introspect::Struct"
+            },
+            {
+              "name": "Enum",
+              "type": "dojo::database::introspect::Enum"
+            },
+            {
+              "name": "Tuple",
+              "type": "core::array::Span::<dojo::database::introspect::Ty>"
+            },
+            {
+              "name": "Array",
+              "type": "core::array::Span::<dojo::database::introspect::Ty>"
+            },
+            {
+              "name": "ByteArray",
+              "type": "()"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::model::IModel",
+          "items": [
+            {
+              "type": "function",
+              "name": "selector",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "version",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::integer::u8"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "unpacked_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::option::Option::<core::integer::u32>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "packed_size",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::option::Option::<core::integer::u32>"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "layout",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::database::introspect::Layout"
+                }
+              ],
+              "state_mutability": "view"
+            },
+            {
+              "type": "function",
+              "name": "schema",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::database::introspect::Ty"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "server_profileImpl",
+          "interface_name": "dojo_examples::models::Iserver_profile"
+        },
+        {
+          "type": "struct",
+          "name": "dojo_examples::models::ServerProfile",
+          "members": [
+            {
+              "name": "player",
+              "type": "core::starknet::contract_address::ContractAddress"
+            },
+            {
+              "name": "server_id",
+              "type": "core::integer::u32"
+            },
+            {
+              "name": "name",
+              "type": "core::byte_array::ByteArray"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo_examples::models::Iserver_profile",
+          "items": [
+            {
+              "type": "function",
+              "name": "ensure_abi",
+              "inputs": [
+                {
+                  "name": "model",
+                  "type": "dojo_examples::models::ServerProfile"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo_examples::models::server_profile::Event",
+          "kind": "enum",
+          "variants": []
+        }
+      ],
+      "name": "dojo_examples::models::server_profile"
     },
     {
       "kind": "DojoModel",

--- a/examples/spawn-and-move/manifests/dev/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/manifest.toml
@@ -22,8 +22,8 @@ name = "dojo::base::base"
 [[contracts]]
 kind = "DojoContract"
 address = "0x5c70a663d6b48d8e4c6aaa9572e3735a732ac3765700d470463e670587852af"
-class_hash = "0x3b42f80dc8ac4628b0ed6c89af9055314c0aa2192ea0d9601f262138a1e50c3"
-original_class_hash = "0x3b42f80dc8ac4628b0ed6c89af9055314c0aa2192ea0d9601f262138a1e50c3"
+class_hash = "0x7d70dda5cb8dcb697ccc2c129254c554e8994f1b231527f7641a14706af016f"
+original_class_hash = "0x7d70dda5cb8dcb697ccc2c129254c554e8994f1b231527f7641a14706af016f"
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "manifests/dev/abis/deployments/contracts/dojo_examples_actions_actions.json"
 reads = []
@@ -190,6 +190,28 @@ key = true
 [[models.members]]
 name = "vec"
 type = "Vec2"
+key = false
+
+[[models]]
+kind = "DojoModel"
+class_hash = "0x6dc51a232ffcfaa02646636daf1b8acab8121fa69458258da8df1620aff07ab"
+original_class_hash = "0x6dc51a232ffcfaa02646636daf1b8acab8121fa69458258da8df1620aff07ab"
+abi = "manifests/dev/abis/deployments/models/dojo_examples_models_server_profile.json"
+name = "dojo_examples::models::server_profile"
+
+[[models.members]]
+name = "player"
+type = "ContractAddress"
+key = true
+
+[[models.members]]
+name = "server_id"
+type = "u32"
+key = true
+
+[[models.members]]
+name = "name"
+type = "ByteArray"
 key = false
 
 [[models]]

--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -7,6 +7,7 @@ trait IActions {
     fn set_player_config(ref world: IWorldDispatcher, name: ByteArray);
     fn get_player_position(world: @IWorldDispatcher) -> Position;
     fn reset_player_config(ref world: IWorldDispatcher);
+    fn set_player_server_profile(ref world: IWorldDispatcher, server_id: u32, name: ByteArray);
 }
 
 #[dojo::interface]
@@ -21,7 +22,9 @@ mod actions {
     use super::IActionsComputed;
 
     use starknet::{ContractAddress, get_caller_address};
-    use dojo_examples::models::{Position, Moves, Direction, Vec2, PlayerConfig, PlayerItem};
+    use dojo_examples::models::{
+        Position, Moves, Direction, Vec2, PlayerConfig, PlayerItem, ServerProfile
+    };
     use dojo_examples::utils::next_position;
 
     #[derive(Copy, Drop, Serde)]
@@ -109,6 +112,11 @@ mod actions {
             assert(config.favorite_item == Option::Some(0), 'bad favorite item');
             let empty_string: ByteArray = "";
             assert(config.name == empty_string, 'bad name');
+        }
+
+        fn set_player_server_profile(ref world: IWorldDispatcher, server_id: u32, name: ByteArray) {
+            let player = get_caller_address();
+            set!(world, ServerProfile { player, server_id, name });
         }
 
         fn get_player_position(world: @IWorldDispatcher) -> Position {

--- a/examples/spawn-and-move/src/models.cairo
+++ b/examples/spawn-and-move/src/models.cairo
@@ -86,6 +86,16 @@ struct PlayerConfig {
     favorite_item: Option<u32>,
 }
 
+#[derive(Drop, Serde)]
+#[dojo::model]
+struct ServerProfile {
+    #[key]
+    player: ContractAddress,
+    #[key]
+    server_id: u32,
+    name: ByteArray,
+}
+
 trait Vec2Trait {
     fn is_zero(self: Vec2) -> bool;
     fn is_equal(self: Vec2, b: Vec2) -> bool;


### PR DESCRIPTION
# Description

adds support for KeysClause on subscriptions, to match all entities with a certain key pattern. This will allow for more control over the subscriptions. Like subscribing for entities with a specific game_id or a pattern of specific keys.  

Also refactor the entities queries to reuse them for subscriptions and oher small changes. The new entities queries use the complex keys clause that can take in a key pattern with a pattern matching type for complex keys queries.

This also makes the queries support entities of multiple models, like an entity with Game model and entities with PlayerGame + PlayerPosition models. 

## Related issue

#1983 

