### PR TITLE
Fix #2100

### DIFF
--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -397,6 +397,7 @@ impl<P: Provider + Sync> Relay<P> {
                         ServerEvent::Identify(identify::Event::Received {
                             info: identify::Info { observed_addr, .. },
                             peer_id,
+                            ..
                         }) => {
                             info!(
                                 target: LOG_TARGET,


### PR DESCRIPTION
# Description

Add `..` to ignore the missing field when handling the relevant swarm event. 

This should fix the related issue listed below. However, I'm still unsure why the error is not caught during build phase. Maybe the `libp2p` dependency is locked to some older version? It didn't seem like it when I was going through the `.toml` files but maybe I missed something. 

<!--
A description of what this PR is solving.
-->

## Related issue
 Fixes #2100 
<!--
Please link related issues:
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [x] No, because I need help

Tried running the test, but it was taking too long and I think it started hanging here:
```
test providers::fork::state::tests::test_get_nonce has been running for over 60 seconds
```

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

A very minor fix was made that shouldn't need documentation

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments
