### PR TITLE
refactor(torii-client): remove storage packed size check

### DIFF
--- a/crates/torii/client/src/client/error.rs
+++ b/crates/torii/client/src/client/error.rs
@@ -8,11 +8,6 @@ pub enum Error {
     SubscriptionUninitialized,
     #[error("Unknown model: {0}")]
     UnknownModel(String),
-    #[error(
-        "Invalid amount of values for model {model}. Expected {expected_value_len} values, got \
-         {actual_value_len}"
-    )]
-    InvalidModelValuesLen { model: String, expected_value_len: usize, actual_value_len: usize },
     #[error("Parsing error: {0}")]
     Parse(#[from] ParseError),
     #[error(transparent)]

--- a/crates/torii/client/src/client/storage.rs
+++ b/crates/torii/client/src/client/storage.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -152,7 +151,6 @@ mod tests {
     use starknet::core::utils::cairo_short_string_to_felt;
     use starknet::macros::felt;
 
-    use crate::client::error::Error;
     use crate::utils::compute_all_storage_addresses;
 
     fn create_dummy_metadata() -> WorldMetadata {
@@ -175,36 +173,6 @@ mod tests {
     fn create_dummy_storage() -> super::ModelStorage {
         let metadata = Arc::new(RwLock::new(create_dummy_metadata()));
         super::ModelStorage::new(metadata)
-    }
-
-    #[test]
-    fn err_if_set_values_too_many() {
-        let storage = create_dummy_storage();
-        let keys = vec![felt!("0x12345")];
-        let values = vec![felt!("1"), felt!("2"), felt!("3"), felt!("4"), felt!("5")];
-        let model = cairo_short_string_to_felt("Position").unwrap();
-        let result = storage.set_model_storage(model, keys, values);
-
-        assert!(storage.storage.read().is_empty());
-        matches!(
-            result,
-            Err(Error::InvalidModelValuesLen { actual_value_len: 5, expected_value_len: 4, .. })
-        );
-    }
-
-    #[test]
-    fn err_if_set_values_too_few() {
-        let storage = create_dummy_storage();
-        let keys = vec![felt!("0x12345")];
-        let values = vec![felt!("1"), felt!("2")];
-        let model = cairo_short_string_to_felt("Position").unwrap();
-        let result = storage.set_model_storage(model, keys, values);
-
-        assert!(storage.storage.read().is_empty());
-        matches!(
-            result,
-            Err(Error::InvalidModelValuesLen { actual_value_len: 2, expected_value_len: 4, .. })
-        );
     }
 
     #[test]

--- a/crates/torii/client/src/client/storage.rs
+++ b/crates/torii/client/src/client/storage.rs
@@ -86,28 +86,6 @@ impl ModelStorage {
         raw_keys: Vec<FieldElement>,
         raw_values: Vec<FieldElement>,
     ) -> Result<(), Error> {
-        let model_name =
-            parse_cairo_short_string(&model).map_err(ParseError::ParseCairoShortString)?;
-
-        let model_packed_size = self
-            .metadata
-            .read()
-            .model(&model_name)
-            .map(|model| model.packed_size)
-            .ok_or(Error::UnknownModel(model_name.clone()))?;
-
-        match raw_values.len().cmp(&(model_packed_size as usize)) {
-            Ordering::Greater | Ordering::Less => {
-                return Err(Error::InvalidModelValuesLen {
-                    model: model_name,
-                    actual_value_len: raw_values.len(),
-                    expected_value_len: model_packed_size as usize,
-                });
-            }
-
-            Ordering::Equal => {}
-        }
-
         let storage_addresses = self.get_model_storage_addresses(model, &raw_keys)?;
         self.set_storages_at(storage_addresses.into_iter().zip(raw_values).collect());
         self.index_model(model, raw_keys);


### PR DESCRIPTION
Packed size can now be 0 with the new layout, thus we cannot really trust the packed size to check that the number of provided values is correct. Remvoed the check