### PR TITLE
fix(torii-core): silently retry fetching pending txn until we have it

### DIFF
--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -178,7 +178,7 @@ impl<P: Provider + Sync> Engine<P> {
                             // the transaction might not have been processed fast enough by the
                             // provider. So we can fail silently and try
                             // again in the next iteration.
-                            warn!(target: LOG_TARGET, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Retrieving pending transaction.");
+                            warn!(target: LOG_TARGET, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Retrieving pending transaction receipt.");
                             return Ok(pending_block_tx);
                         }
                         _ => {

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -175,10 +175,10 @@ impl<P: Provider + Sync> Engine<P> {
                     match e.to_string().as_str() {
                         "TransactionHashNotFound" => {
                             // We failed to fetch the transaction, which is because
-                            // the transaction might not have passed the validation stage.
-                            // So we can safely ignore this transaction and not process it, as it
-                            // rejected.
-                            warn!(target: LOG_TARGET, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Ignored failed pending transaction.");
+                            // the transaction might not have been processed fast enough by the provider.
+                            // So we can fail silently and try again in the next iteration.
+                            warn!(target: LOG_TARGET, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Retrieving pending transaction.");
+                            return Ok(pending_block_tx);
                         }
                         _ => {
                             error!(target: LOG_TARGET, error = %e, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Processing pending transaction.");

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -175,8 +175,9 @@ impl<P: Provider + Sync> Engine<P> {
                     match e.to_string().as_str() {
                         "TransactionHashNotFound" => {
                             // We failed to fetch the transaction, which is because
-                            // the transaction might not have been processed fast enough by the provider.
-                            // So we can fail silently and try again in the next iteration.
+                            // the transaction might not have been processed fast enough by the
+                            // provider. So we can fail silently and try
+                            // again in the next iteration.
                             warn!(target: LOG_TARGET, transaction_hash = %format!("{:#x}", transaction.transaction_hash()), "Retrieving pending transaction.");
                             return Ok(pending_block_tx);
                         }


### PR DESCRIPTION
reintroduce retry logic for failing to fetch pending txns as we should never fail to retrieve them #2123 

Closes #2123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of pending transactions by retrying fetch operations when encountering a "TransactionHashNotFound" error, ensuring better reliability and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->