### PR TITLE
update sozo auth command + auto-auth feature

### DIFF
--- a/bin/sozo/src/commands/auth.rs
+++ b/bin/sozo/src/commands/auth.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
+use dojo_world::manifest::utils::get_default_namespace_from_ws;
 use dojo_world::metadata::Environment;
 use scarb::core::Config;
 use scarb_ui::Ui;
@@ -63,6 +64,9 @@ impl AuthArgs {
         let env_metadata = utils::load_metadata_from_config(config)?;
         trace!(metadata=?env_metadata, "Loaded environment.");
 
+        let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
+        let default_namespace = get_default_namespace_from_ws(&ws);
+
         match self.command {
             AuthCommand::Grant { kind, world, starknet, account, transaction } => {
                 config.tokio_handle().block_on(grant(
@@ -74,6 +78,7 @@ impl AuthArgs {
                     kind,
                     transaction,
                     config,
+                    &default_namespace,
                 ))
             }
             AuthCommand::Revoke { kind, world, starknet, account, transaction } => {
@@ -86,6 +91,7 @@ impl AuthArgs {
                     kind,
                     transaction,
                     config,
+                    &default_namespace,
                 ))
             }
         }
@@ -94,26 +100,38 @@ impl AuthArgs {
 
 #[derive(Debug, Subcommand)]
 pub enum AuthKind {
-    #[command(about = "Grant a contract permission to write to a model.")]
+    #[command(about = "Grant a contract permission to write to a resource (contract, model or \
+                       namespace).")]
     Writer {
         #[arg(num_args = 1..)]
         #[arg(required = true)]
-        #[arg(value_name = "model,contract_address")]
-        #[arg(help = "A list of models and contract address to grant write access to. Comma \
-                      separated values to indicate model name and contract address e.g. \
-                      model_name,path::to::contract model_name,contract_address ")]
-        models_contracts: Vec<auth::ModelContract>,
+        #[arg(value_name = "resource,contract_tag_or_address")]
+        #[arg(help = "A list of resource/contract couples to grant write access to.
+Comma separated values to indicate resource identifier and contract tag or address.
+A resource identifier must use the following format: \
+                      <contract|c|namespace|ns|model|m>:<tag_or_name>.\n
+Some examples:
+   model:dojo_examples-Moves,0x1234
+   m:Moves,0x1234
+   ns:dojo_examples,actions
+")]
+        models_contracts: Vec<auth::ResourceWriter>,
     },
-    #[command(about = "Grant ownership of a resource.")]
+    #[command(about = "Grant ownership of a resource (contract, model or namespace).")]
     Owner {
         #[arg(num_args = 1..)]
         #[arg(required = true)]
         #[arg(value_name = "resource,owner_address")]
-        #[arg(help = "A list of owners and resources to grant ownership to. Comma separated \
-                      values to indicate owner address and resource e.g. \
-                      contract:path::to::contract,0x1234 contract:contract_address,0x1111, \
-                      model:model_name,0xbeef")]
-        owners_resources: Vec<auth::OwnerResource>,
+        #[arg(help = "A list of resources and owners to grant ownership to.
+Comma separated values to indicate resource identifier and owner address.
+A resource identifier must use the following format: \
+                      <contract|c|namespace|ns|model|m>:<tag_or_name>.\n
+Some examples:
+   model:dojo_examples-Moves,0x1234
+   m:Moves,0x1234
+   ns:dojo_examples,0xbeef
+")]
+        owners_resources: Vec<auth::ResourceOwner>,
     },
 }
 
@@ -127,6 +145,7 @@ pub async fn grant(
     kind: AuthKind,
     transaction: TransactionOptions,
     config: &Config,
+    default_namespace: &str,
 ) -> Result<()> {
     trace!(?kind, ?world, ?starknet, ?account, ?transaction, "Executing Grant command.");
     let world =
@@ -138,14 +157,16 @@ pub async fn grant(
                 contracts=?models_contracts,
                 "Granting Writer permissions."
             );
-            auth::grant_writer(ui, &world, models_contracts, transaction.into()).await
+            auth::grant_writer(ui, &world, models_contracts, transaction.into(), default_namespace)
+                .await
         }
         AuthKind::Owner { owners_resources } => {
             trace!(
                 resources=?owners_resources,
                 "Granting Owner permissions."
             );
-            auth::grant_owner(ui, &world, owners_resources, transaction.into()).await
+            auth::grant_owner(ui, &world, owners_resources, transaction.into(), default_namespace)
+                .await
         }
     }
 }
@@ -160,6 +181,7 @@ pub async fn revoke(
     kind: AuthKind,
     transaction: TransactionOptions,
     config: &Config,
+    default_namespace: &str,
 ) -> Result<()> {
     trace!(?kind, ?world, ?starknet, ?account, ?transaction, "Executing Revoke command.");
     let world =
@@ -171,14 +193,16 @@ pub async fn revoke(
                 contracts=?models_contracts,
                 "Revoking Writer permissions."
             );
-            auth::revoke_writer(ui, &world, models_contracts, transaction.into()).await
+            auth::revoke_writer(ui, &world, models_contracts, transaction.into(), default_namespace)
+                .await
         }
         AuthKind::Owner { owners_resources } => {
             trace!(
                 resources=?owners_resources,
                 "Revoking Owner permissions."
             );
-            auth::revoke_owner(ui, &world, owners_resources, transaction.into()).await
+            auth::revoke_owner(ui, &world, owners_resources, transaction.into(), default_namespace)
+                .await
         }
     }
 }
@@ -187,50 +211,149 @@ pub async fn revoke(
 mod tests {
     use std::str::FromStr;
 
-    use dojo_world::contracts::cairo_utils;
     use starknet_crypto::FieldElement;
 
     use super::*;
 
     #[test]
-    fn test_owner_resource_from_str() {
-        // Test valid input
-        let input = "contract:path::to::contract,0x1234";
-        let expected_owner = FieldElement::from_hex_be("0x1234").unwrap();
-        let expected_resource = auth::ResourceType::Contract("path::to::contract".to_string());
-        let expected = auth::OwnerResource { owner: expected_owner, resource: expected_resource };
-        let result = auth::OwnerResource::from_str(input).unwrap();
-        assert_eq!(result, expected);
+    fn test_resource_type_from_str() {
+        let inputs = [
+            (
+                "contract:name:contract_name",
+                auth::ResourceType::Contract("name:contract_name".to_string()),
+            ),
+            ("c:0x1234", auth::ResourceType::Contract("0x1234".to_string())),
+            ("model:name:model_name", auth::ResourceType::Model("name:model_name".to_string())),
+            ("m:name:model_name", auth::ResourceType::Model("name:model_name".to_string())),
+            (
+                "namespace:namespace_name",
+                auth::ResourceType::Namespace("namespace_name".to_string()),
+            ),
+            ("ns:namespace_name", auth::ResourceType::Namespace("namespace_name".to_string())),
+        ];
 
-        // Test valid input with model
-        let input = "model:model_name,0x1234";
-        let expected_owner = FieldElement::from_hex_be("0x1234").unwrap();
-        let expected_model = cairo_utils::str_to_felt("model_name").unwrap();
-        let expected_resource = auth::ResourceType::Model(expected_model);
-        let expected = auth::OwnerResource { owner: expected_owner, resource: expected_resource };
-        let result = auth::OwnerResource::from_str(input).unwrap();
-        assert_eq!(result, expected);
+        for (input, expected) in inputs {
+            let res = auth::ResourceType::from_str(input);
+            assert!(res.is_ok(), "Unable to parse input '{input}'");
 
-        // Test invalid input
-        let input = "invalid_input";
-        let result = auth::OwnerResource::from_str(input);
-        assert!(result.is_err());
+            let resource = res.unwrap();
+            assert!(
+                resource == expected,
+                "Wrong resource type: expected: {:#?} got: {:#?}",
+                expected,
+                resource
+            );
+        }
     }
 
     #[test]
-    fn test_model_contract_from_str() {
-        // Test valid input
-        let input = "model_name,0x1234";
-        let expected_model = cairo_utils::str_to_felt("model_name").unwrap();
-        let expected_contract = "0x1234";
-        let expected =
-            auth::ModelContract { model: expected_model, contract: expected_contract.to_string() };
-        let result = auth::ModelContract::from_str(input).unwrap();
-        assert_eq!(result, expected);
+    fn test_resource_type_from_str_bad_resource_identifier() {
+        let input = "other:model_name";
+        let res = auth::ResourceType::from_str(input);
+        assert!(res.is_err(), "Bad identifier: This resource should not be accepted: '{input}'");
+    }
 
-        // Test invalid input
-        let input = "invalid_input";
-        let result = auth::ModelContract::from_str(input);
-        assert!(result.is_err());
+    #[test]
+    fn test_resource_type_from_str_bad_resource_format() {
+        let input = "model_name";
+        let res = auth::ResourceType::from_str(input);
+        assert!(res.is_err(), "Bad format: This resource should not be accepted: '{input}'");
+    }
+
+    #[test]
+    fn test_resource_writer_from_str() {
+        let inputs = [
+            (
+                "model:name:model_name,name:contract_name",
+                auth::ResourceWriter {
+                    resource: auth::ResourceType::Model("name:model_name".to_string()),
+                    tag_or_address: "name:contract_name".to_string(),
+                },
+            ),
+            (
+                "ns:namespace_name,0x1234",
+                auth::ResourceWriter {
+                    resource: auth::ResourceType::Namespace("namespace_name".to_string()),
+                    tag_or_address: "0x1234".to_string(),
+                },
+            ),
+        ];
+
+        for (input, expected) in inputs {
+            let res = auth::ResourceWriter::from_str(input);
+            assert!(res.is_ok(), "Unable to parse input '{input}'");
+
+            let writer = res.unwrap();
+            assert!(
+                writer == expected,
+                "Wrong resource writer: expected: {:#?} got: {:#?}",
+                expected,
+                writer
+            );
+        }
+    }
+
+    #[test]
+    fn test_resource_writer_from_str_bad_format() {
+        let input = "model_name";
+        let res = auth::ResourceWriter::from_str(input);
+        assert!(res.is_err(), "Bad format: This resource writer should not be accepted: '{input}'");
+    }
+
+    #[test]
+    fn test_resource_writer_from_str_bad_owner_address() {
+        let input = "model:model_name:bad_address";
+        let res = auth::ResourceWriter::from_str(input);
+        assert!(
+            res.is_err(),
+            "Bad address: This resource writer should not be accepted: '{input}'"
+        );
+    }
+
+    #[test]
+    fn test_resource_owner_from_str() {
+        let inputs = [
+            (
+                "model:name:model_name,0x1234",
+                auth::ResourceOwner {
+                    resource: auth::ResourceType::Model("name:model_name".to_string()),
+                    owner: FieldElement::from_hex_be("0x1234").unwrap(),
+                },
+            ),
+            (
+                "ns:namespace_name,0x1111",
+                auth::ResourceOwner {
+                    resource: auth::ResourceType::Namespace("namespace_name".to_string()),
+                    owner: FieldElement::from_hex_be("0x1111").unwrap(),
+                },
+            ),
+        ];
+
+        for (input, expected) in inputs {
+            let res = auth::ResourceOwner::from_str(input);
+            assert!(res.is_ok(), "Unable to parse input '{input}'");
+
+            let owner = res.unwrap();
+            assert!(
+                owner == expected,
+                "Wrong resource owner: expected: {:#?} got: {:#?}",
+                expected,
+                owner
+            );
+        }
+    }
+
+    #[test]
+    fn test_resource_owner_from_str_bad_format() {
+        let input = "model_name";
+        let res = auth::ResourceOwner::from_str(input);
+        assert!(res.is_err(), "Bad format: This resource owner should not be accepted: '{input}'");
+    }
+
+    #[test]
+    fn test_resource_owner_from_str_bad_owner_address() {
+        let input = "model:model_name:bad_address";
+        let res = auth::ResourceOwner::from_str(input);
+        assert!(res.is_err(), "Bad address: This resource owner should not be accepted: '{input}'");
     }
 }

--- a/crates/dojo-world/Cargo.toml
+++ b/crates/dojo-world/Cargo.toml
@@ -48,6 +48,6 @@ tokio.workspace = true
 
 [features]
 contracts = [ "dep:dojo-types", "dep:http" ]
-manifest = [ "contracts", "dep:dojo-types", "dep:url" ]
+manifest = [ "contracts", "dep:dojo-types", "dep:url", "dep:scarb" ]
 metadata = [ "dep:ipfs-api-backend-hyper", "dep:scarb", "dep:url" ]
 migration = [ "dep:tokio", "dep:scarb" ]

--- a/crates/dojo-world/src/contracts/model_test.rs
+++ b/crates/dojo-world/src/contracts/model_test.rs
@@ -82,7 +82,7 @@ async fn test_model() {
         felt!("0x059e57c16c3bc8c59a768a342496837275e399509366640620a0682826275a34")
     );
 
-    let moves = world.model_reader("Dojo", "Moves").await.unwrap();
+    let moves = world.model_reader("dojo_examples", "Moves").await.unwrap();
     let schema = moves.schema().await.unwrap();
 
     assert_eq!(

--- a/crates/dojo-world/src/manifest/utils.rs
+++ b/crates/dojo-world/src/manifest/utils.rs
@@ -10,6 +10,7 @@ pub const SELECTOR_CHUNK_SIZE: usize = 8;
 
 pub fn get_default_namespace_from_ws(ws: &Workspace<'_>) -> String {
     ws.current_package().unwrap().id.name.to_string()
+    // dojo metadata -> namespace.
 }
 
 pub fn capitalize(s: &str) -> String {

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -145,7 +145,7 @@ async fn get_full_dojo_metadata_from_workspace() {
         env.private_key.unwrap().eq("0x1800000000300000180000000000030000000000003006001800006600")
     );
 
-    assert!(env.world_address.is_none());
+    assert!(env.world_address.is_some());
 
     assert!(env.keystore_path.is_none());
     assert!(env.keystore_password.is_none());

--- a/crates/sozo/ops/src/events.rs
+++ b/crates/sozo/ops/src/events.rs
@@ -85,7 +85,6 @@ fn extract_events(
         events: &mut HashMap<String, Vec<Token>>,
         full_abi_path: &Utf8PathBuf,
     ) -> Result<()> {
-        println!("full_abi_path {:?}", full_abi_path);
         let abi_str = fs::read_to_string(full_abi_path)?;
 
         match AbiParser::tokens_from_abi_string(&abi_str, &HashMap::new()) {

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -161,24 +161,26 @@ where
         )
         .await?;
 
-        // TODO: temporary deactivate auto-auth because it should be adapted
-        // with the new namespace feature.
         let account = Arc::new(account);
         let world = WorldContract::new(world_address, account.clone());
         if let Some(migration_output) = migration_output {
-            // TODO
-            if false {
-                match auto_authorize(ws, &world, &txn_config, &local_manifest, &migration_output)
-                    .await
-                {
-                    Ok(()) => {
-                        ui.print_sub("Auto authorize completed successfully");
-                    }
-                    Err(e) => {
-                        ui.print_sub(format!("Failed to auto authorize with error: {e}"));
-                    }
-                };
-            }
+            match auto_authorize(
+                ws,
+                &world,
+                &txn_config,
+                &local_manifest,
+                &migration_output,
+                &default_namespace,
+            )
+            .await
+            {
+                Ok(()) => {
+                    ui.print_sub("Auto authorize completed successfully");
+                }
+                Err(e) => {
+                    ui.print_sub(format!("Failed to auto authorize with error: {e}"));
+                }
+            };
 
             //
             if !ws.config().offline() {

--- a/crates/sozo/ops/src/tests/migration.rs
+++ b/crates/sozo/ops/src/tests/migration.rs
@@ -354,7 +354,9 @@ async fn migrate_with_auto_authorize() {
     let world_address = migration.world_address().expect("must be present");
     let world = WorldContract::new(world_address, account);
 
-    let res = auto_authorize(&ws, &world, &txn_config, &manifest, &output).await;
+    let default_namespace = get_default_namespace_from_ws(&ws);
+    let res =
+        auto_authorize(&ws, &world, &txn_config, &manifest, &output, &default_namespace).await;
     assert!(res.is_ok());
 
     let provider = sequencer.provider();

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -27,7 +27,7 @@ rpc_url = "http://localhost:5050/"
 # Default account for katana with seed = 0
 account_address = "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03"
 private_key = "0x1800000000300000180000000000030000000000003006001800006600"
-#world_address = "0x104dd156d76aeab45146a10869637f161ca6cf9f804704f8bbb12ae5b1b5cfb"
+world_address = "0x104dd156d76aeab45146a10869637f161ca6cf9f804704f8bbb12ae5b1b5cfb"
 
 # `release` profile
 #

--- a/examples/spawn-and-move/manifests/dev/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/manifest.json
@@ -1502,7 +1502,10 @@
         }
       ],
       "reads": [],
-      "writes": [],
+      "writes": [
+        "dojo_examples-Moves",
+        "dojo_examples-Position"
+      ],
       "computed": [],
       "init_calldata": [],
       "tag": "dojo_examples-actions",

--- a/examples/spawn-and-move/manifests/dev/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/manifest.toml
@@ -29,7 +29,10 @@ original_class_hash = "0x7b394d087b5cf4f3b740253c591138bf98d177ef0d9b5c00b0477a1
 base_class_hash = "0x22f3e55b61d86c2ac5239fa3b3b8761f26b9a5c0b5f61ddbd5d756ced498b46"
 abi = "abis/deployments/contracts/dojo_examples-actions-40b6994c.json"
 reads = []
-writes = []
+writes = [
+    "dojo_examples-Moves",
+    "dojo_examples-Position",
+]
 computed = []
 init_calldata = []
 tag = "dojo_examples-actions"

--- a/examples/spawn-and-move/overlays/dev/actions.toml
+++ b/examples/spawn-and-move/overlays/dev/actions.toml
@@ -1,0 +1,2 @@
+tag = "dojo_examples-actions"
+writes = ["dojo_examples-Moves", "dojo_examples-Position"]


### PR DESCRIPTION
- Update the `sozo auth` command to take model/contract `tag` and the new `namespace` resource into account,
- Update the auto-auth feature.