### PR TITLE
replace {WORLD,BASE}_CONTRACT_NAME by {WORLD,BASE}_CONTRACT_TAG

### DIFF
--- a/crates/dojo-world/src/manifest/manifest_test.rs
+++ b/crates/dojo-world/src/manifest/manifest_test.rs
@@ -60,7 +60,7 @@ fn parse_registered_model_events() {
                 class_hash: felt!("0x5555"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns", "modelA")).unwrap(),
+            get_filename_from_tag(&get_tag("ns", "modelA")),
         ),
         Manifest::new(
             DojoModel {
@@ -68,7 +68,7 @@ fn parse_registered_model_events() {
                 class_hash: felt!("0x6666"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns", "modelB")).unwrap(),
+            get_filename_from_tag(&get_tag("ns", "modelB")),
         ),
     ];
 
@@ -107,7 +107,7 @@ fn parse_deployed_contracts_events_without_upgrade() {
                 tag: get_tag("ns1", "c1"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns1", "c1")).unwrap(),
+            get_filename_from_tag(&get_tag("ns1", "c1")),
         ),
         Manifest::new(
             DojoContract {
@@ -116,7 +116,7 @@ fn parse_deployed_contracts_events_without_upgrade() {
                 tag: get_tag("ns2", "c2"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns2", "c2")).unwrap(),
+            get_filename_from_tag(&get_tag("ns2", "c2")),
         ),
         Manifest::new(
             DojoContract {
@@ -125,7 +125,7 @@ fn parse_deployed_contracts_events_without_upgrade() {
                 tag: get_tag("ns3", "c3"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns3", "c3")).unwrap(),
+            get_filename_from_tag(&get_tag("ns3", "c3")),
         ),
     ];
 
@@ -149,7 +149,7 @@ fn parse_deployed_contracts_events_with_upgrade() {
                 tag: get_tag("ns1", "c1"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns1", "c1")).unwrap(),
+            get_filename_from_tag(&get_tag("ns1", "c1")),
         ),
         Manifest::new(
             DojoContract {
@@ -158,7 +158,7 @@ fn parse_deployed_contracts_events_with_upgrade() {
                 tag: get_tag("ns2", "c2"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns2", "c2")).unwrap(),
+            get_filename_from_tag(&get_tag("ns2", "c2")),
         ),
         Manifest::new(
             DojoContract {
@@ -167,7 +167,7 @@ fn parse_deployed_contracts_events_with_upgrade() {
                 tag: get_tag("ns3", "c3"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns3", "c3")).unwrap(),
+            get_filename_from_tag(&get_tag("ns3", "c3")),
         ),
     ];
 
@@ -226,7 +226,7 @@ fn events_without_block_number_arent_parsed() {
                 tag: get_tag("ns1", "c1"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns1", "c1")).unwrap(),
+            get_filename_from_tag(&get_tag("ns1", "c1")),
         ),
         Manifest::new(
             DojoContract {
@@ -235,7 +235,7 @@ fn events_without_block_number_arent_parsed() {
                 tag: get_tag("ns2", "c2"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns2", "c2")).unwrap(),
+            get_filename_from_tag(&get_tag("ns2", "c2")),
         ),
         Manifest::new(
             DojoContract {
@@ -244,7 +244,7 @@ fn events_without_block_number_arent_parsed() {
                 tag: get_tag("ns3", "c3"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("ns3", "c3")).unwrap(),
+            get_filename_from_tag(&get_tag("ns3", "c3")),
         ),
     ];
 

--- a/crates/dojo-world/src/manifest/utils.rs
+++ b/crates/dojo-world/src/manifest/utils.rs
@@ -49,28 +49,17 @@ pub fn ensure_namespace(tag: &str, default_namespace: &str) -> String {
     if tag.contains(TAG_SEPARATOR) { tag.to_string() } else { get_tag(default_namespace, tag) }
 }
 
-pub fn get_filename_from_tag(tag: &str) -> Result<String> {
+pub fn get_filename_from_tag(tag: &str) -> String {
     if [format!("dojo{TAG_SEPARATOR}world").as_str(), format!("dojo{TAG_SEPARATOR}base").as_str()]
         .contains(&tag)
     {
-        return Ok(tag.to_string());
+        return tag.to_string();
     }
 
     let mut selector = format!("{:x}", compute_model_selector_from_tag(tag));
     selector.truncate(SELECTOR_CHUNK_SIZE);
 
-    Ok(format!("{tag}{TAG_SEPARATOR}{selector}"))
-}
-
-// TODO: should not be useful with a standard WORLD/BASE name
-pub fn get_filename_from_special_contract_name(name: &str) -> String {
-    get_filename_from_tag(&get_tag_from_special_contract_name(name)).unwrap()
-}
-
-// TODO: should not be useful with a standard WORLD/BASE name
-pub fn get_tag_from_special_contract_name(name: &str) -> String {
-    let parts = name.split(CONTRACT_NAME_SEPARATOR).collect::<Vec<_>>();
-    format!("{}{TAG_SEPARATOR}{}", parts.first().unwrap(), parts.last().unwrap())
+    format!("{tag}{TAG_SEPARATOR}{selector}")
 }
 
 pub fn compute_bytearray_hash(namespace: &str) -> FieldElement {

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::json;
 use url::Url;
 
-use crate::manifest::utils::{get_filename_from_special_contract_name, get_filename_from_tag};
-use crate::manifest::{BaseManifest, CONTRACTS_DIR, MODELS_DIR, WORLD_CONTRACT_NAME};
+use crate::manifest::utils::get_filename_from_tag;
+use crate::manifest::{BaseManifest, CONTRACTS_DIR, MODELS_DIR, WORLD_CONTRACT_TAG};
 
 #[cfg(test)]
 #[path = "metadata_test.rs"]
@@ -110,7 +110,7 @@ pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> Option<DojoMetadata> 
     let world_artifact = build_artifact_from_filename(
         &abi_dir,
         &source_dir,
-        &get_filename_from_special_contract_name(WORLD_CONTRACT_NAME),
+        &get_filename_from_tag(WORLD_CONTRACT_TAG),
     );
 
     // inialize Dojo world metadata with world metadata coming from project configuration
@@ -131,7 +131,7 @@ pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> Option<DojoMetadata> 
                         artifacts: build_artifact_from_filename(
                             &abi_model_dir,
                             &source_model_dir,
-                            &get_filename_from_tag(&tag).unwrap(),
+                            &get_filename_from_tag(&tag),
                         ),
                     },
                 );
@@ -148,7 +148,7 @@ pub fn dojo_metadata_from_workspace(ws: &Workspace<'_>) -> Option<DojoMetadata> 
                         artifacts: build_artifact_from_filename(
                             &abi_contract_dir,
                             &source_contract_dir,
-                            &get_filename_from_tag(&tag).unwrap(),
+                            &get_filename_from_tag(&tag),
                         ),
                     },
                 );

--- a/crates/dojo-world/src/metadata_test.rs
+++ b/crates/dojo-world/src/metadata_test.rs
@@ -6,8 +6,8 @@ use dojo_test_utils::compiler;
 use scarb::ops;
 use url::Url;
 
-use crate::manifest::utils::{get_filename_from_special_contract_name, TAG_SEPARATOR};
-use crate::manifest::{CONTRACTS_DIR, MODELS_DIR, WORLD_CONTRACT_NAME};
+use crate::manifest::utils::{get_filename_from_tag, TAG_SEPARATOR};
+use crate::manifest::{CONTRACTS_DIR, MODELS_DIR, WORLD_CONTRACT_TAG};
 use crate::metadata::{
     dojo_metadata_from_workspace, ArtifactMetadata, ProjectMetadata, Uri, WorldMetadata, ABIS_DIR,
     BASE_DIR, MANIFESTS_DIR,
@@ -162,7 +162,7 @@ async fn get_full_dojo_metadata_from_workspace() {
     assert!(dojo_metadata.world.website.is_none());
     assert!(dojo_metadata.world.socials.is_none());
 
-    let world_filename = get_filename_from_special_contract_name(WORLD_CONTRACT_NAME);
+    let world_filename = get_filename_from_tag(WORLD_CONTRACT_TAG);
     assert!(dojo_metadata.world.artifacts.abi.is_some(), "No abi for {world_filename}");
     let abi = dojo_metadata.world.artifacts.abi.unwrap();
     assert_eq!(

--- a/crates/dojo-world/src/migration/strategy.rs
+++ b/crates/dojo-world/src/migration/strategy.rs
@@ -186,7 +186,7 @@ fn evaluate_class_to_migrate(
             Ok(None)
         }
         _ => {
-            let path = find_artifact_path(&get_filename_from_tag(&class.tag)?, artifact_paths)?;
+            let path = find_artifact_path(&get_filename_from_tag(&class.tag), artifact_paths)?;
             Ok(Some(ClassMigration { diff: class.clone(), artifact_path: path.clone() }))
         }
     }
@@ -207,7 +207,7 @@ fn evaluate_contracts_to_migrate(
                 continue;
             }
             _ => {
-                let path = find_artifact_path(&get_filename_from_tag(&c.tag)?, artifact_paths)?;
+                let path = find_artifact_path(&get_filename_from_tag(&c.tag), artifact_paths)?;
                 comps_to_migrate.push(ContractMigration {
                     diff: c.clone(),
                     artifact_path: path.clone(),
@@ -230,7 +230,7 @@ fn evaluate_contract_to_migrate(
         || contract.remote_class_hash.is_none()
         || matches!(contract.remote_class_hash, Some(remote_hash) if remote_hash != contract.local_class_hash)
     {
-        let path = find_artifact_path(&get_filename_from_tag(&contract.tag)?, artifact_paths)?;
+        let path = find_artifact_path(&get_filename_from_tag(&contract.tag), artifact_paths)?;
 
         Ok(Some(ContractMigration {
             diff: contract.clone(),

--- a/crates/dojo-world/src/migration/world.rs
+++ b/crates/dojo-world/src/migration/world.rs
@@ -9,9 +9,9 @@ use topological_sort::TopologicalSort;
 use super::class::ClassDiff;
 use super::contract::ContractDiff;
 use super::StateDiff;
-use crate::manifest::utils::{ensure_namespace, get_tag_from_special_contract_name};
+use crate::manifest::utils::ensure_namespace;
 use crate::manifest::{
-    BaseManifest, DeploymentManifest, ManifestMethods, BASE_CONTRACT_NAME, WORLD_CONTRACT_NAME,
+    BaseManifest, DeploymentManifest, ManifestMethods, BASE_CONTRACT_TAG, WORLD_CONTRACT_TAG,
 };
 
 #[cfg(test)]
@@ -75,14 +75,14 @@ impl WorldDiff {
             .collect::<Vec<_>>();
 
         let base = ClassDiff {
-            tag: get_tag_from_special_contract_name(BASE_CONTRACT_NAME),
+            tag: BASE_CONTRACT_TAG.to_string(),
             local_class_hash: *local.base.inner.class_hash(),
             original_class_hash: *local.base.inner.original_class_hash(),
             remote_class_hash: remote.as_ref().map(|m| *m.base.inner.class_hash()),
         };
 
         let world = ContractDiff {
-            tag: get_tag_from_special_contract_name(WORLD_CONTRACT_NAME),
+            tag: WORLD_CONTRACT_TAG.to_string(),
             local_class_hash: *local.world.inner.class_hash(),
             original_class_hash: *local.world.inner.original_class_hash(),
             base_class_hash: *local.base.inner.class_hash(),

--- a/crates/dojo-world/src/migration/world_test.rs
+++ b/crates/dojo-world/src/migration/world_test.rs
@@ -1,21 +1,19 @@
 use starknet::macros::felt;
 
 use super::*;
-use crate::manifest::utils::{
-    get_filename_from_special_contract_name, get_filename_from_tag, get_tag,
-};
+use crate::manifest::utils::{get_filename_from_tag, get_tag};
 use crate::manifest::{BaseManifest, Class, DojoContract, DojoModel, Manifest};
 
 #[test]
 fn no_diff_when_local_and_remote_are_equal() {
     let world_contract = Manifest::new(
         Class { class_hash: 66_u32.into(), ..Default::default() },
-        get_filename_from_special_contract_name(WORLD_CONTRACT_NAME),
+        get_filename_from_tag(WORLD_CONTRACT_TAG),
     );
 
     let base_contract = Manifest::new(
         Class { class_hash: 77_u32.into(), ..Default::default() },
-        get_filename_from_special_contract_name(BASE_CONTRACT_NAME),
+        get_filename_from_tag(BASE_CONTRACT_TAG),
     );
 
     let models = vec![Manifest::new(
@@ -45,12 +43,12 @@ fn no_diff_when_local_and_remote_are_equal() {
 fn diff_when_local_and_remote_are_different() {
     let world_contract = Manifest::new(
         Class { class_hash: 66_u32.into(), ..Default::default() },
-        get_filename_from_special_contract_name(WORLD_CONTRACT_NAME),
+        get_filename_from_tag(WORLD_CONTRACT_TAG),
     );
 
     let base_contract = Manifest::new(
         Class { class_hash: 77_u32.into(), ..Default::default() },
-        get_filename_from_special_contract_name(BASE_CONTRACT_NAME),
+        get_filename_from_tag(BASE_CONTRACT_TAG),
     );
 
     let models = vec![
@@ -61,7 +59,7 @@ fn diff_when_local_and_remote_are_different() {
                 class_hash: felt!("0x11"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("dojo_mock", "model")).unwrap(),
+            get_filename_from_tag(&get_tag("dojo_mock", "model")),
         ),
         Manifest::new(
             DojoModel {
@@ -70,7 +68,7 @@ fn diff_when_local_and_remote_are_different() {
                 class_hash: felt!("0x22"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("dojo_mock", "model2")).unwrap(),
+            get_filename_from_tag(&get_tag("dojo_mock", "model2")),
         ),
     ];
 
@@ -82,7 +80,7 @@ fn diff_when_local_and_remote_are_different() {
                 class_hash: felt!("0x11"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("dojo_mock", "model")).unwrap(),
+            get_filename_from_tag(&get_tag("dojo_mock", "model")),
         ),
         Manifest::new(
             DojoModel {
@@ -92,7 +90,7 @@ fn diff_when_local_and_remote_are_different() {
                 class_hash: felt!("0x33"),
                 ..Default::default()
             },
-            get_filename_from_tag(&get_tag("dojo_mock", "model2")).unwrap(),
+            get_filename_from_tag(&get_tag("dojo_mock", "model2")),
         ),
     ];
 
@@ -104,7 +102,7 @@ fn diff_when_local_and_remote_are_different() {
                 address: Some(felt!("0x2222")),
                 ..DojoContract::default()
             },
-            get_filename_from_tag(&get_tag("dojo_mock", "my_contract")).unwrap(),
+            get_filename_from_tag(&get_tag("dojo_mock", "my_contract")),
         ),
         Manifest::new(
             DojoContract {
@@ -113,7 +111,7 @@ fn diff_when_local_and_remote_are_different() {
                 address: Some(felt!("4444")),
                 ..DojoContract::default()
             },
-            get_filename_from_tag(&get_tag("dojo_mock", "my_contract2")).unwrap(),
+            get_filename_from_tag(&get_tag("dojo_mock", "my_contract2")),
         ),
     ];
 

--- a/crates/sozo/ops/src/events.rs
+++ b/crates/sozo/ops/src/events.rs
@@ -6,10 +6,10 @@ use cainome::cairo_serde::{ByteArray, CairoSerde};
 use cainome::parser::tokens::{CompositeInner, CompositeInnerKind, CoreBasic, Token};
 use cainome::parser::AbiParser;
 use camino::Utf8PathBuf;
-use dojo_world::manifest::utils::get_filename_from_special_contract_name;
+use dojo_world::manifest::utils::get_filename_from_tag;
 use dojo_world::manifest::{
-    AbiFormat, DeploymentManifest, ManifestMethods, BASE_CONTRACT_NAME, MANIFESTS_DIR, TARGET_DIR,
-    WORLD_CONTRACT_NAME,
+    AbiFormat, DeploymentManifest, ManifestMethods, BASE_CONTRACT_TAG, MANIFESTS_DIR, TARGET_DIR,
+    WORLD_CONTRACT_TAG,
 };
 use starknet::core::types::{BlockId, EventFilter, FieldElement};
 use starknet::core::utils::{parse_cairo_short_string, starknet_keccak};
@@ -122,12 +122,12 @@ fn extract_events(
 
     // Read the world and base ABI from scarb artifacts as the
     // manifest does not include them (at least base is not included).
-    let world_abi_path = target_dir
-        .join(format!("{}.json", get_filename_from_special_contract_name(WORLD_CONTRACT_NAME)));
+    let world_abi_path =
+        target_dir.join(format!("{}.json", get_filename_from_tag(WORLD_CONTRACT_TAG)));
     process_abi(&mut events_map, &world_abi_path)?;
 
-    let base_abi_path = target_dir
-        .join(format!("{}.json", get_filename_from_special_contract_name(BASE_CONTRACT_NAME)));
+    let base_abi_path =
+        target_dir.join(format!("{}.json", get_filename_from_tag(BASE_CONTRACT_TAG)));
     process_abi(&mut events_map, &base_abi_path)?;
 
     Ok(events_map)

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -3,12 +3,10 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use dojo_world::contracts::WorldContract;
-use dojo_world::manifest::utils::{
-    get_default_namespace_from_ws, get_tag_from_special_contract_name,
-};
+use dojo_world::manifest::utils::get_default_namespace_from_ws;
 use dojo_world::manifest::{
     BaseManifest, OverlayClass, OverlayDojoContract, OverlayDojoModel, OverlayManifest,
-    BASE_CONTRACT_NAME, BASE_DIR, MANIFESTS_DIR, OVERLAYS_DIR, WORLD_CONTRACT_NAME,
+    BASE_CONTRACT_TAG, BASE_DIR, MANIFESTS_DIR, OVERLAYS_DIR, WORLD_CONTRACT_TAG,
 };
 use dojo_world::migration::world::WorldDiff;
 use dojo_world::migration::{DeployOutput, TxnConfig, UpgradeOutput};
@@ -212,13 +210,10 @@ pub fn generate_overlays(ws: &Workspace<'_>) -> Result<()> {
 
     let default_overlay = OverlayManifest {
         world: Some(OverlayClass {
-            tag: get_tag_from_special_contract_name(WORLD_CONTRACT_NAME),
+            tag: WORLD_CONTRACT_TAG.to_string(),
             original_class_hash: None,
         }),
-        base: Some(OverlayClass {
-            tag: get_tag_from_special_contract_name(BASE_CONTRACT_NAME),
-            original_class_hash: None,
-        }),
+        base: Some(OverlayClass { tag: BASE_CONTRACT_TAG.to_string(), original_class_hash: None }),
         contracts: base_manifest
             .contracts
             .iter()

--- a/crates/sozo/ops/src/tests/migration.rs
+++ b/crates/sozo/ops/src/tests/migration.rs
@@ -7,7 +7,7 @@ use dojo_world::contracts::{WorldContract, WorldContractReader};
 use dojo_world::manifest::utils::{compute_model_selector_from_tag, get_default_namespace_from_ws};
 use dojo_world::manifest::{
     BaseManifest, DeploymentManifest, OverlayManifest, BASE_DIR, MANIFESTS_DIR, OVERLAYS_DIR,
-    WORLD_CONTRACT_NAME,
+    WORLD_CONTRACT_TAG,
 };
 use dojo_world::metadata::{
     dojo_metadata_from_workspace, ArtifactMetadata, DojoMetadata, Uri, WorldMetadata,
@@ -279,7 +279,7 @@ async fn migrate_with_metadata() {
 
     // check world metadata
     let resource = world_reader.metadata(&FieldElement::ZERO).call().await.unwrap();
-    let element_name = WORLD_CONTRACT_NAME.to_string();
+    let element_name = WORLD_CONTRACT_TAG.to_string();
 
     let full_uri = resource.metadata_uri.to_string().unwrap();
     let resource_bytes = get_ipfs_resource_data(&client, &element_name, &full_uri).await;


### PR DESCRIPTION
`WORLD_CONTRACT_NAME` and `BASE_CONTRACT_NAME` are 2 legacy constants to refer to the `world` and `base` contract name with the old format (`dojo::world::world` and `dojo::base::base`).

This PR transforms them to `WORLD_CONTRACT_TAG` and `BASE_CONTRACT_TAG` which refer to the their tag with the new format (`dojo-world` and `dojo-tag`).

For some specific cases where the Cairo qualified path is required, the constants `WORLD_QUALIFIED_PATH` and `BASE_QUALIFIED_PATH` are still available.