### PR TITLE
feat: sozo init remove git

### DIFF
--- a/bin/sozo/src/commands/init.rs
+++ b/bin/sozo/src/commands/init.rs
@@ -15,6 +15,9 @@ pub struct InitArgs {
 
     #[arg(help = "Parse a full git url or a url path", default_value = "dojoengine/dojo-starter")]
     template: String,
+
+    #[arg(long, help = "Initialize a new Git repository")]
+    git: bool,
 }
 
 impl InitArgs {
@@ -58,7 +61,7 @@ impl InitArgs {
         set_current_dir(&target_dir)?;
 
         // Modify the git history.
-        modify_git_history(&repo_url)?;
+        modify_git_history(&repo_url, self.git)?;
 
         config.ui().print("\n🎉 Successfully created a new ⛩️ Dojo project!");
 
@@ -83,7 +86,7 @@ fn clone_repo(url: &str, path: &Path, config: &Config) -> Result<()> {
     Ok(())
 }
 
-fn modify_git_history(url: &str) -> Result<()> {
+fn modify_git_history(url: &str, init_git: bool) -> Result<()> {
     trace!("Modifying Git history.");
     let git_output = Command::new("git").args(["rev-parse", "--short", "HEAD"]).output()?.stdout;
     let commit_hash = String::from_utf8(git_output)?;
@@ -91,11 +94,13 @@ fn modify_git_history(url: &str) -> Result<()> {
 
     fs::remove_dir_all(".git")?;
 
-    Command::new("git").arg("init").output()?;
-    Command::new("git").args(["add", "--all"]).output()?;
+    if init_git {
+        Command::new("git").arg("init").output()?;
+        Command::new("git").args(["add", "--all"]).output()?;
 
-    let commit_msg = format!("chore: init from {} at {}", url, commit_hash.trim());
-    Command::new("git").args(["commit", "-m", &commit_msg]).output()?;
+        let commit_msg = format!("chore: init from {} at {}", url, commit_hash.trim());
+        Command::new("git").args(["commit", "-m", &commit_msg]).output()?;
+    }
 
     trace!("Git history modified.");
     Ok(())

--- a/bin/sozo/src/commands/init.rs
+++ b/bin/sozo/src/commands/init.rs
@@ -93,6 +93,9 @@ fn modify_git_history(url: &str, init_git: bool) -> Result<()> {
     trace!(commit_hash = commit_hash.trim());
 
     fs::remove_dir_all(".git")?;
+    if Path::new(".github").exists() {
+        fs::remove_dir_all(".github")?;
+    }
 
     if init_git {
         Command::new("git").arg("init").output()?;


### PR DESCRIPTION
# Description

This PR disables the initialisation of git by default when running `sozo init`. To initialise git, the `--git` flag needs to specified.

## Related issue

Fixes #2128 

## Tests

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

- [ ] README.md
- [x] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to initialize a Git repository when setting up your project.
- **Enhancements**
  - Improved project setup process to optionally include Git initialization and commit initial changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->