### PR TITLE
fix: override `block_id` method of ConnectedAccount for SozoAccount

### DIFF
--- a/bin/sozo/src/commands/options/account/type.rs
+++ b/bin/sozo/src/commands/options/account/type.rs
@@ -7,7 +7,7 @@ use starknet::accounts::{
     RawDeclaration, RawExecution, RawLegacyDeclaration, SingleOwnerAccount,
 };
 use starknet::core::types::contract::legacy::LegacyContractClass;
-use starknet::core::types::{FieldElement, FlattenedSierraClass};
+use starknet::core::types::{BlockId, FieldElement, FlattenedSierraClass};
 use starknet::providers::Provider;
 use starknet::signers::LocalWallet;
 
@@ -157,6 +157,14 @@ where
             Self::Standard(account) => account.provider(),
             #[cfg(feature = "controller")]
             Self::Controller(account) => account.provider(),
+        }
+    }
+
+    fn block_id(&self) -> BlockId {
+        match self {
+            Self::Standard(account) => account.block_id(),
+            #[cfg(feature = "controller")]
+            Self::Controller(account) => account.block_id(),
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced account options with a new method to retrieve `BlockId`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->