### PR TITLE
refactor(torii-grpc): empty hashed keys in subscription match all entities

### DIFF
--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -109,7 +109,7 @@ impl Service {
             // matches the key pattern of the subscriber.
             match &sub.keys {
                 Some(EntityKeysClause::HashedKeys(hashed_keys)) => {
-                    if !hashed_keys.contains(&hashed) {
+                    if !hashed_keys.is_empty() && !hashed_keys.contains(&hashed) {
                         continue;
                     }
                 }

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -108,7 +108,7 @@ impl Service {
             // matches the key pattern of the subscriber.
             match &sub.keys {
                 Some(EntityKeysClause::HashedKeys(hashed_keys)) => {
-                    if !hashed_keys.contains(&hashed) {
+                    if !hashed_keys.is_empty() && !hashed_keys.contains(&hashed) {
                         continue;
                     }
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability by adding a condition to verify that `hashed_keys` is not empty before checking for specific keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->