### PR TITLE
feat(core): model get/set functions

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -33,6 +33,7 @@ use torii_core::processors::register_model::RegisterModelProcessor;
 use torii_core::processors::store_del_record::StoreDelRecordProcessor;
 use torii_core::processors::store_set_record::StoreSetRecordProcessor;
 use torii_core::processors::store_transaction::StoreTransactionProcessor;
+use torii_core::processors::store_update_record::StoreUpdateRecordProcessor;
 use torii_core::simple_broker::SimpleBroker;
 use torii_core::sql::Sql;
 use torii_core::types::Model;
@@ -170,6 +171,7 @@ async fn main() -> anyhow::Result<()> {
             Box::new(MetadataUpdateProcessor),
             Box::new(StoreDelRecordProcessor),
             Box::new(EventMessageProcessor),
+            Box::new(StoreUpdateRecordProcessor),
         ],
         transaction: vec![Box::new(StoreTransactionProcessor)],
         ..Processors::default()

--- a/crates/dojo-core/src/lib.cairo
+++ b/crates/dojo-core/src/lib.cairo
@@ -7,6 +7,8 @@ mod database;
 mod database_test;
 mod interfaces;
 mod model;
+#[cfg(test)]
+mod model_test;
 mod contract;
 mod packing;
 #[cfg(test)]

--- a/crates/dojo-core/src/model.cairo
+++ b/crates/dojo-core/src/model.cairo
@@ -1,10 +1,32 @@
-use dojo::world::IWorldDispatcher;
+use dojo::world::{IWorldDispatcher, ModelIndex};
 use starknet::SyscallResult;
 
+/// Trait that is implemented at Cairo level for each struct that is a model.
+trait ModelEntity<T> {
+    fn id(self: @T) -> felt252;
+    fn values(self: @T) -> Span<felt252>;
+    fn from_values(entity_id: felt252, values: Span<felt252>) -> T;
+    fn get(world: IWorldDispatcher, entity_id: felt252) -> T;
+    fn update(self: @T, world: IWorldDispatcher);
+    fn delete(self: @T, world: IWorldDispatcher);
+    fn get_member(
+        world: IWorldDispatcher, entity_id: felt252, member_id: felt252,
+    ) -> Span<felt252>;
+    fn set_member(self: @T, world: IWorldDispatcher, member_id: felt252, values: Span<felt252>,);
+}
+
 trait Model<T> {
-    fn entity(
-        world: IWorldDispatcher, keys: Span<felt252>, layout: dojo::database::introspect::Layout
-    ) -> T;
+    fn get(world: IWorldDispatcher, keys: Span<felt252>) -> T;
+    // Note: `get` is implemented with a generated trait because it takes
+    // the list of model keys as separated parameters.
+    fn set(self: @T, world: IWorldDispatcher);
+    fn delete(self: @T, world: IWorldDispatcher);
+
+    fn get_member(
+        world: IWorldDispatcher, keys: Span<felt252>, member_id: felt252,
+    ) -> Span<felt252>;
+
+    fn set_member(self: @T, world: IWorldDispatcher, member_id: felt252, values: Span<felt252>,);
 
     /// Returns the name of the model as it was written in Cairo code.
     fn name() -> ByteArray;
@@ -25,6 +47,7 @@ trait Model<T> {
     fn name_hash() -> felt252;
     fn namespace_hash() -> felt252;
 
+    fn entity_id(self: @T) -> felt252;
     fn keys(self: @T) -> Span<felt252>;
     fn values(self: @T) -> Span<felt252>;
     fn layout() -> dojo::database::introspect::Layout;

--- a/crates/dojo-core/src/model_test.cairo
+++ b/crates/dojo-core/src/model_test.cairo
@@ -1,0 +1,198 @@
+use dojo::test_utils::{spawn_test_world};
+use dojo::world::{IWorldDispatcher, IWorldDispatcherTrait};
+
+// Utils
+fn deploy_world() -> IWorldDispatcher {
+    spawn_test_world("dojo", array![])
+}
+
+#[derive(Copy, Drop, Serde)]
+#[dojo::model]
+struct Foo {
+    #[key]
+    k1: u8,
+    #[key]
+    k2: felt252,
+    v1: u128,
+    v2: u32
+}
+
+#[test]
+fn test_id() {
+    let mvalues = FooEntity { __id: 1, v1: 3, v2: 4 };
+    assert!(mvalues.id() == 1);
+}
+
+#[test]
+fn test_values() {
+    let mvalues = FooEntity { __id: 1, v1: 3, v2: 4 };
+    let expected_values = array![3, 4].span();
+
+    let values = dojo::model::ModelEntity::<FooEntity>::values(@mvalues);
+    assert!(expected_values == values);
+}
+
+#[test]
+fn test_from_values() {
+    let values = array![3, 4].span();
+
+    let model_entity = dojo::model::ModelEntity::<FooEntity>::from_values(1, values);
+    assert!(model_entity.__id == 1 && model_entity.v1 == 3 && model_entity.v2 == 4);
+}
+
+#[test]
+#[should_panic(expected: "ModelEntity `FooEntity`: deserialization failed.")]
+fn test_from_values_bad_data() {
+    let values = array![3].span();
+    let _ = dojo::model::ModelEntity::<FooEntity>::from_values(1, values);
+}
+
+#[test]
+fn test_get_and_update_entity() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    foo.set(world);
+
+    let entity_id = foo.entity_id();
+    let mut entity = FooEntityTrait::get(world, entity_id);
+    assert!(entity.__id == entity_id && entity.v1 == entity.v1 && entity.v2 == entity.v2);
+
+    entity.v1 = 12;
+    entity.v2 = 18;
+
+    entity.update(world);
+
+    let read_values = FooEntityTrait::get(world, entity_id);
+    assert!(read_values.v1 == entity.v1 && read_values.v2 == entity.v2);
+}
+
+#[test]
+fn test_delete_entity() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    foo.set(world);
+
+    let entity_id = foo.entity_id();
+    let mut entity = FooEntityTrait::get(world, entity_id);
+    entity.delete(world);
+
+    let read_values = FooEntityTrait::get(world, entity_id);
+    assert!(read_values.v1 == 0 && read_values.v2 == 0);
+}
+
+#[test]
+fn test_get_and_set_member_from_entity() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    foo.set(world);
+
+    let v1_raw_value: Span<felt252> = dojo::model::ModelEntity::<
+        FooEntity
+    >::get_member(world, foo.entity_id(), selector!("v1"));
+
+    assert!(v1_raw_value.len() == 1);
+    assert!(*v1_raw_value.at(0) == 3);
+
+    let entity = FooEntityTrait::get(world, foo.entity_id());
+    entity.set_member(world, selector!("v1"), array![42].span());
+
+    let entity = FooEntityTrait::get(world, foo.entity_id());
+    assert!(entity.v1 == 42);
+}
+
+#[test]
+fn test_get_and_set_field_name() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    foo.set(world);
+
+    let v1 = FooEntityTrait::get_v1(world, foo.entity_id());
+    assert!(foo.v1 == v1);
+
+    let entity = FooEntityTrait::get(world, foo.entity_id());
+    entity.set_v1(world, 42);
+
+    let v1 = FooEntityTrait::get_v1(world, foo.entity_id());
+    assert!(v1 == 42);
+}
+
+#[test]
+fn test_get_and_set_from_model() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    foo.set(world);
+
+    let read_entity = FooTrait::get(world, foo.k1, foo.k2);
+
+    assert!(
+        foo.k1 == read_entity.k1
+            && foo.k2 == read_entity.k2
+            && foo.v1 == read_entity.v1
+            && foo.v2 == read_entity.v2
+    );
+}
+
+#[test]
+fn test_delete_from_model() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    foo.set(world);
+    foo.delete(world);
+
+    let read_entity = FooTrait::get(world, foo.k1, foo.k2);
+    assert!(
+        read_entity.k1 == foo.k1
+            && read_entity.k2 == foo.k2
+            && read_entity.v1 == 0
+            && read_entity.v2 == 0
+    );
+}
+
+#[test]
+fn test_get_and_set_member_from_model() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    let keys = array![foo.k1.into(), foo.k2.into()].span();
+    foo.set(world);
+
+    let v1_raw_value = dojo::model::Model::<Foo>::get_member(world, keys, selector!("v1"));
+
+    assert!(v1_raw_value.len() == 1);
+    assert!(*v1_raw_value.at(0) == 3);
+
+    foo.set_member(world, selector!("v1"), array![42].span());
+    let foo = FooTrait::get(world, foo.k1, foo.k2);
+    assert!(foo.v1 == 42);
+}
+
+#[test]
+fn test_get_and_set_field_name_from_model() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+
+    let foo = Foo { k1: 1, k2: 2, v1: 3, v2: 4 };
+    foo.set(world);
+
+    let v1 = FooTrait::get_v1(world, foo.k1, foo.k2);
+    assert!(v1 == 3);
+
+    foo.set_v1(world, 42);
+
+    let v1 = FooTrait::get_v1(world, foo.k1, foo.k2);
+    assert!(v1 == 42);
+}
+

--- a/crates/dojo-core/src/utils.cairo
+++ b/crates/dojo-core/src/utils.cairo
@@ -4,3 +4,53 @@ fn hash(data: @ByteArray) -> felt252 {
     Serde::serialize(data, ref serialized);
     poseidon::poseidon_hash_span(serialized.span())
 }
+
+/// Computes the entity id from the keys.
+///
+/// # Arguments
+///
+/// * `keys` - The keys of the entity.
+///
+/// # Returns
+///
+/// The entity id.
+fn entity_id_from_keys(keys: Span<felt252>) -> felt252 {
+    poseidon::poseidon_hash_span(keys)
+}
+
+/// Find the layout of a model field based on its selector.
+/// 
+/// # Arguments
+/// 
+/// * `model_layout` - The full model layout (must be a Layout::Struct).
+/// *  `member_selector` - The model field selector.
+/// 
+/// # Returns
+/// Some(Layout) if the field layout has been found, None otherwise. 
+fn find_model_field_layout(
+    model_layout: dojo::database::introspect::Layout, member_selector: felt252
+) -> Option<dojo::database::introspect::Layout> {
+    match model_layout {
+        dojo::database::introspect::Layout::Struct(struct_layout) => {
+            let mut i = 0;
+            let layout = loop {
+                if i >= struct_layout.len() {
+                    break Option::None;
+                }
+
+                let field_layout = *struct_layout.at(i);
+                if field_layout.selector == member_selector {
+                    break Option::Some(field_layout.layout);
+                }
+                i += 1;
+            };
+
+            layout
+        },
+        _ => {
+            // should never happen as model layouts are always struct layouts.
+            panic_with_felt252('Unexpected model layout');
+            Option::None
+        }
+    }
+}

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -863,7 +863,7 @@ mod world {
                     entity_id, member_id
                 )) => {
                     self._write_model_member(model_selector, entity_id, member_id, values, layout);
-                    // TODO: here we need a new event update and see how Torii can process that.
+                // TODO: here we need a new event update and see how Torii can process that.
                 }
             }
         }

--- a/crates/dojo-core/src/world.cairo
+++ b/crates/dojo-core/src/world.cairo
@@ -862,7 +862,8 @@ mod world {
                 ModelIndex::MemberId((
                     entity_id, member_id
                 )) => {
-                    self._write_model_member(model_selector, entity_id, member_id, values, layout)
+                    self._write_model_member(model_selector, entity_id, member_id, values, layout);
+                    // TODO: here we need a new event update and see how Torii can process that.
                 }
             }
         }

--- a/crates/dojo-core/src/world_test.cairo
+++ b/crates/dojo-core/src/world_test.cairo
@@ -22,6 +22,7 @@ use dojo::config::component::Config::{
 };
 use dojo::model::Model;
 use dojo::benchmarks::{Character, GasCounterImpl};
+use dojo::utils::entity_id_from_keys;
 
 #[derive(Introspect, Copy, Drop, Serde)]
 enum OneEnum {
@@ -324,7 +325,7 @@ mod bar {
                 .read()
                 .delete_entity(
                     dojo::model::Model::<Foo>::selector(),
-                    array![get_caller_address().into()].span(),
+                    dojo::model::ModelIndex::Keys(array![get_caller_address().into()].span()),
                     dojo::model::Model::<Foo>::layout()
                 );
         }
@@ -975,6 +976,20 @@ fn test_can_call_init() {
 }
 
 #[test]
+fn test_set_entity_by_id() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+    let selector = dojo::model::Model::<Foo>::selector();
+    let entity_id = entity_id_from_keys(array![0x01234].span());
+    let values = create_foo();
+    let layout = dojo::model::Model::<Foo>::layout();
+
+    world.set_entity(selector, dojo::model::ModelIndex::Id(entity_id), values, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Id(entity_id), layout);
+    assert_array(read_values, values);
+}
+
+#[test]
 fn test_set_entity_with_fixed_layout() {
     let world = deploy_world();
     world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
@@ -983,8 +998,8 @@ fn test_set_entity_with_fixed_layout() {
     let values = create_foo();
     let layout = dojo::model::Model::<Foo>::layout();
 
-    world.set_entity(selector, get_key_test(), values, layout);
-    let read_values = world.entity(selector, keys, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(get_key_test()), values, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -998,9 +1013,9 @@ fn test_set_entity_with_struct_layout() {
     let values = create_struct_simple_model();
     let layout = dojo::model::Model::<StructSimpleModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -1014,9 +1029,9 @@ fn test_set_entity_with_struct_tuple_layout() {
     let values = create_struct_with_tuple();
     let layout = dojo::model::Model::<StructWithTuple>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -1031,16 +1046,16 @@ fn test_set_entity_with_struct_enum_layout() {
     let layout = dojo::model::Model::<StructWithEnum>::layout();
 
     // test with the first variant
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 
     // then override with the second variant
     let values = create_struct_with_enum_second_variant();
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -1054,9 +1069,9 @@ fn test_set_entity_with_struct_simple_array_layout() {
     let values = create_struct_simple_array_model();
     let layout = dojo::model::Model::<StructSimpleArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -1070,9 +1085,9 @@ fn test_set_entity_with_struct_complex_array_layout() {
     let values = create_struct_complex_array_model();
     let layout = dojo::model::Model::<StructComplexArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -1086,9 +1101,9 @@ fn test_set_entity_with_struct_layout_and_byte_array() {
     let values = create_struct_byte_array_model();
     let layout = dojo::model::Model::<StructByteArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -1102,9 +1117,9 @@ fn test_set_entity_with_nested_elements() {
     let values = create_struct_nested_model();
     let layout = dojo::model::Model::<StructNestedModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 }
 
@@ -1130,17 +1145,36 @@ fn test_set_entity_with_struct_generics_enum_layout() {
     let layout = dojo::model::Model::<StructWithGeneric>::layout();
 
     // test with the first variant
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
 
     // then override with the second variant
     let values = create_struct_generic_second_variant();
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
     assert_array(read_values, values);
+}
+
+#[test]
+fn test_delete_entity_by_id() {
+    let world = deploy_world();
+    world.register_model(foo::TEST_CLASS_HASH.try_into().unwrap());
+    let selector = dojo::model::Model::<Foo>::selector();
+    let entity_id = entity_id_from_keys(get_key_test());
+    let values = create_foo();
+    let layout = dojo::model::Model::<Foo>::layout();
+
+    world.set_entity(selector, dojo::model::ModelIndex::Id(entity_id), values, layout);
+
+    world.delete_entity(selector, dojo::model::ModelIndex::Id(entity_id), layout);
+
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Id(entity_id), layout);
+
+    assert!(read_values.len() == values.len());
+    assert_empty_array(read_values);
 }
 
 #[test]
@@ -1152,11 +1186,11 @@ fn test_delete_entity_with_fixed_layout() {
     let values = create_foo();
     let layout = dojo::model::Model::<Foo>::layout();
 
-    world.set_entity(selector, get_key_test(), values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(get_key_test()), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     assert!(read_values.len() == values.len());
     assert_empty_array(read_values);
@@ -1172,11 +1206,11 @@ fn test_delete_entity_with_simple_struct_layout() {
     let values = create_struct_simple_model();
     let layout = dojo::model::Model::<StructSimpleModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     assert!(read_values.len() == values.len());
     assert_empty_array(read_values);
@@ -1192,11 +1226,11 @@ fn test_delete_entity_with_struct_simple_array_layout() {
     let values = create_struct_simple_array_model();
     let layout = dojo::model::Model::<StructSimpleArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     // array length set to 0, so the expected value span is shorter than the initial values
     let expected_values = array![0, 0, 0].span();
@@ -1216,11 +1250,11 @@ fn test_delete_entity_with_complex_array_struct_layout() {
 
     let layout = dojo::model::Model::<StructComplexArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     // array length set to 0, so the expected value span is shorter than the initial values
     let expected_values = array![0, 0, 0, 0, 0, 0, 0, 0, 0, 0].span();
@@ -1239,12 +1273,12 @@ fn test_delete_entity_with_struct_tuple_layout() {
     let values = create_struct_with_tuple();
     let layout = dojo::model::Model::<StructWithTuple>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     let expected_values = array![0, 0].span();
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     assert!(read_values.len() == expected_values.len());
     assert_empty_array(read_values);
@@ -1261,12 +1295,12 @@ fn test_delete_entity_with_struct_enum_layout() {
     let layout = dojo::model::Model::<StructWithEnum>::layout();
 
     // test with the first variant
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     let expected_values = array![0, 0, 0].span();
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     assert!(read_values.len() == expected_values.len());
     assert_empty_array(read_values);
@@ -1282,12 +1316,12 @@ fn test_delete_entity_with_struct_layout_and_byte_array() {
     let values = create_struct_byte_array_model();
     let layout = dojo::model::Model::<StructByteArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     let expected_values = array![0, 0, 0, 0].span();
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     assert!(read_values.len() == expected_values.len());
     assert_empty_array(read_values);
@@ -1303,12 +1337,12 @@ fn test_delete_entity_with_nested_elements() {
     let values = create_struct_nested_model();
     let layout = dojo::model::Model::<StructNestedModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     let expected_values = array![0, 0, 0, 0, 0, 0, 0, 0, 0].span();
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     assert!(read_values.len() == expected_values.len());
     assert_empty_array(read_values);
@@ -1324,12 +1358,12 @@ fn test_delete_entity_with_struct_generics_enum_layout() {
     let values = create_struct_generic_first_variant();
     let layout = dojo::model::Model::<StructWithGeneric>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 
-    world.delete_entity(selector, keys, layout);
+    world.delete_entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     let expected_values = array![0, 0].span();
-    let read_values = world.entity(selector, keys, layout);
+    let read_values = world.entity(selector, dojo::model::ModelIndex::Keys(keys), layout);
 
     assert!(read_values.len() == expected_values.len());
     assert_empty_array(read_values);
@@ -1348,7 +1382,7 @@ fn test_set_entity_with_unexpected_array_model_layout() {
     world
         .set_entity(
             dojo::model::Model::<StructSimpleArrayModel>::selector(),
-            array![].span(),
+            dojo::model::ModelIndex::Keys(array![].span()),
             array![].span(),
             layout
         );
@@ -1367,7 +1401,7 @@ fn test_set_entity_with_unexpected_tuple_model_layout() {
     world
         .set_entity(
             dojo::model::Model::<StructSimpleArrayModel>::selector(),
-            array![].span(),
+            dojo::model::ModelIndex::Keys(array![].span()),
             array![].span(),
             layout
         );
@@ -1385,7 +1419,9 @@ fn test_delete_entity_with_unexpected_array_model_layout() {
 
     world
         .delete_entity(
-            dojo::model::Model::<StructSimpleArrayModel>::selector(), array![].span(), layout
+            dojo::model::Model::<StructSimpleArrayModel>::selector(),
+            dojo::model::ModelIndex::Keys(array![].span()),
+            layout
         );
 }
 
@@ -1401,7 +1437,9 @@ fn test_delete_entity_with_unexpected_tuple_model_layout() {
 
     world
         .delete_entity(
-            dojo::model::Model::<StructSimpleArrayModel>::selector(), array![].span(), layout
+            dojo::model::Model::<StructSimpleArrayModel>::selector(),
+            dojo::model::ModelIndex::Keys(array![].span()),
+            layout
         );
 }
 
@@ -1415,7 +1453,12 @@ fn test_get_entity_with_unexpected_array_model_layout() {
         array![dojo::database::introspect::Introspect::<felt252>::layout()].span()
     );
 
-    world.entity(dojo::model::Model::<StructSimpleArrayModel>::selector(), array![].span(), layout);
+    world
+        .entity(
+            dojo::model::Model::<StructSimpleArrayModel>::selector(),
+            dojo::model::ModelIndex::Keys(array![].span()),
+            layout
+        );
 }
 
 #[test]
@@ -1428,7 +1471,12 @@ fn test_get_entity_with_unexpected_tuple_model_layout() {
         array![dojo::database::introspect::Introspect::<felt252>::layout()].span()
     );
 
-    world.entity(dojo::model::Model::<StructSimpleArrayModel>::selector(), array![].span(), layout);
+    world
+        .entity(
+            dojo::model::Model::<StructSimpleArrayModel>::selector(),
+            dojo::model::ModelIndex::Keys(array![].span()),
+            layout
+        );
 }
 
 
@@ -1442,7 +1490,7 @@ fn test_set_entity_with_bad_values_length_error_for_array_layout() {
     let keys = get_key_test();
     let layout = dojo::model::Model::<StructSimpleArrayModel>::layout();
 
-    world.set_entity(selector, keys, array![1].span(), layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), array![1].span(), layout);
 }
 
 #[test]
@@ -1459,7 +1507,7 @@ fn test_set_entity_with_too_big_array_length() {
         .span();
     let layout = dojo::model::Model::<StructSimpleArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 }
 
 #[test]
@@ -1476,7 +1524,7 @@ fn test_set_entity_with_struct_layout_and_bad_byte_array_length() {
         .span();
     let layout = dojo::model::Model::<StructByteArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 }
 
 #[test]
@@ -1490,7 +1538,7 @@ fn test_set_entity_with_struct_layout_and_bad_value_length_for_byte_array() {
     let values: Span<felt252> = array![1, 3, 'first', 'second', 'third', 'pending'].span();
     let layout = dojo::model::Model::<StructByteArrayModel>::layout();
 
-    world.set_entity(selector, keys, values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(keys), values, layout);
 }
 
 fn write_foo_record(world: dojo::world::IWorldDispatcher) {
@@ -1498,7 +1546,7 @@ fn write_foo_record(world: dojo::world::IWorldDispatcher) {
     let values = create_foo();
     let layout = dojo::model::Model::<Foo>::layout();
 
-    world.set_entity(selector, get_key_test(), values, layout);
+    world.set_entity(selector, dojo::model::ModelIndex::Keys(get_key_test()), values, layout);
 }
 
 #[test]

--- a/crates/dojo-lang/src/inline_macros/delete.rs
+++ b/crates/dojo-lang/src/inline_macros/delete.rs
@@ -145,12 +145,9 @@ impl InlineMacroExprPlugin for DeleteMacro {
 
             builder.add_str(&format!(
                 "
-                let __delete_macro_value__ = {};
-                {}.delete_entity(
-                    dojo::model::Model::instance_selector(@__delete_macro_value__),
-                    dojo::model::Model::keys(@__delete_macro_value__),
-                    dojo::model::Model::instance_layout(@__delete_macro_value__)
-                );",
+                let __delete_model_instance__ = {};
+                dojo::model::Model::delete(@__delete_model_instance__, {});
+                ",
                 entity,
                 world.as_syntax_node().get_text(db),
             ));

--- a/crates/dojo-lang/src/inline_macros/get.rs
+++ b/crates/dojo-lang/src/inline_macros/get.rs
@@ -109,9 +109,7 @@ impl InlineMacroExprPlugin for GetMacro {
 
             builder.add_str(&format!(
                 "\n
-                let __{model}_layout__ = dojo::model::Model::<{model}>::layout();
-                let __{model}: {model} = dojo::model::Model::entity({}, __get_macro_keys__, \
-                 __{model}_layout__);\n",
+                let __{model}: {model} = dojo::model::Model::get({}, __get_macro_keys__);\n",
                 world.as_syntax_node().get_text(db),
             ));
         }

--- a/crates/dojo-lang/src/inline_macros/set.rs
+++ b/crates/dojo-lang/src/inline_macros/set.rs
@@ -160,12 +160,8 @@ impl InlineMacroExprPlugin for SetMacro {
             builder.add_str(&format!(
                 "
                 let __set_model_instance__ = {};
-                {}.set_entity(
-                    dojo::model::Model::instance_selector(@__set_model_instance__),
-                    dojo::model::Model::keys(@__set_model_instance__),
-                    dojo::model::Model::values(@__set_model_instance__),
-                    dojo::model::Model::instance_layout(@__set_model_instance__),
-                );",
+                dojo::model::Model::set(@__set_model_instance__, {});
+                ",
                 entity,
                 world.as_syntax_node().get_text(db),
             ));

--- a/crates/dojo-lang/src/introspect/layout.rs
+++ b/crates/dojo-lang/src/introspect/layout.rs
@@ -27,7 +27,7 @@ pub fn build_field_layouts(
             }
 
             let field_name = m.name(db).text(db);
-            let field_selector = get_selector_from_name(field_name.as_str()).unwrap().to_string();
+            let field_selector = get_selector_from_name(&field_name.to_string()).unwrap();
             let field_layout = get_layout_from_type_clause(db, diagnostics, &m.type_clause(db));
             Some(format!(
                 "dojo::database::introspect::FieldLayout {{

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/abis/dojo-world.json
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/abis/dojo-world.json
@@ -47,6 +47,24 @@
     ]
   },
   {
+    "type": "enum",
+    "name": "dojo::world::ModelIndex",
+    "variants": [
+      {
+        "name": "Keys",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "Id",
+        "type": "core::felt252"
+      },
+      {
+        "name": "MemberId",
+        "type": "(core::felt252, core::felt252)"
+      }
+    ]
+  },
+  {
     "type": "struct",
     "name": "core::array::Span::<core::integer::u8>",
     "members": [
@@ -298,12 +316,12 @@
         "name": "entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -322,12 +340,12 @@
         "name": "set_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "values",
@@ -346,12 +364,12 @@
         "name": "delete_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -937,6 +955,28 @@
   },
   {
     "type": "event",
+    "name": "dojo::world::world::StoreUpdateRecord",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "table",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "entity_id",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "values",
+        "type": "core::array::Span::<core::felt252>",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
     "name": "dojo::world::world::StoreDelRecord",
     "kind": "struct",
     "members": [
@@ -946,8 +986,8 @@
         "kind": "data"
       },
       {
-        "name": "keys",
-        "type": "core::array::Span::<core::felt252>",
+        "name": "entity_id",
+        "type": "core::felt252",
         "kind": "data"
       }
     ]
@@ -1109,6 +1149,11 @@
       {
         "name": "StoreSetRecord",
         "type": "dojo::world::world::StoreSetRecord",
+        "kind": "nested"
+      },
+      {
+        "name": "StoreUpdateRecord",
+        "type": "dojo::world::world::StoreUpdateRecord",
         "kind": "nested"
       },
       {

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo-world.toml
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo-world.toml
@@ -1,6 +1,6 @@
 kind = "Class"
-class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
-original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
+original_class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
 abi = "manifests/dev/base/abis/dojo-world.json"
 tag = "dojo-world"
 manifest_name = "dojo-world"

--- a/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo-world.toml
+++ b/crates/dojo-lang/src/manifest_test_data/compiler_cairo/manifests/dev/base/dojo-world.toml
@@ -1,6 +1,6 @@
 kind = "Class"
-class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
-original_class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
+class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
 abi = "manifests/dev/base/abis/dojo-world.json"
 tag = "dojo-world"
 manifest_name = "dojo-world"

--- a/crates/dojo-lang/src/semantics/test_data/get
+++ b/crates/dojo-lang/src/semantics/test_data/get
@@ -197,26 +197,11 @@ Block(
             Let(
                 StatementLet {
                     pattern: Variable(
-                        __Health_layout__,
-                    ),
-                    expr: FunctionCall(
-                        ExprFunctionCall {
-                            function: ?7::layout,
-                            args: [],
-                            coupon_arg: None,
-                            ty: dojo::database::introspect::Layout,
-                        },
-                    ),
-                },
-            ),
-            Let(
-                StatementLet {
-                    pattern: Variable(
                         __Health,
                     ),
                     expr: FunctionCall(
                         ExprFunctionCall {
-                            function: ?8::entity,
+                            function: ?7::get,
                             args: [
                                 Value(
                                     Var(
@@ -226,11 +211,6 @@ Block(
                                 Value(
                                     Var(
                                         LocalVarId(test::__get_macro_keys__),
-                                    ),
-                                ),
-                                Value(
-                                    Var(
-                                        LocalVarId(test::__Health_layout__),
                                     ),
                                 ),
                             ],

--- a/crates/dojo-lang/src/semantics/test_data/set
+++ b/crates/dojo-lang/src/semantics/test_data/set
@@ -119,95 +119,21 @@ Block(
                 StatementExpr {
                     expr: FunctionCall(
                         ExprFunctionCall {
-                            function: dojo::world::IWorldDispatcherImpl::set_entity,
+                            function: ?6::set,
                             args: [
+                                Value(
+                                    Snapshot(
+                                        ExprSnapshot {
+                                            inner: Var(
+                                                LocalVarId(test::__set_model_instance__),
+                                            ),
+                                            ty: @test::Health,
+                                        },
+                                    ),
+                                ),
                                 Value(
                                     Var(
                                         LocalVarId(test::world),
-                                    ),
-                                ),
-                                Value(
-                                    FunctionCall(
-                                        ExprFunctionCall {
-                                            function: ?7::instance_selector,
-                                            args: [
-                                                Value(
-                                                    Snapshot(
-                                                        ExprSnapshot {
-                                                            inner: Var(
-                                                                LocalVarId(test::__set_model_instance__),
-                                                            ),
-                                                            ty: @test::Health,
-                                                        },
-                                                    ),
-                                                ),
-                                            ],
-                                            coupon_arg: None,
-                                            ty: core::felt252,
-                                        },
-                                    ),
-                                ),
-                                Value(
-                                    FunctionCall(
-                                        ExprFunctionCall {
-                                            function: ?8::keys,
-                                            args: [
-                                                Value(
-                                                    Snapshot(
-                                                        ExprSnapshot {
-                                                            inner: Var(
-                                                                LocalVarId(test::__set_model_instance__),
-                                                            ),
-                                                            ty: @test::Health,
-                                                        },
-                                                    ),
-                                                ),
-                                            ],
-                                            coupon_arg: None,
-                                            ty: core::array::Span::<core::felt252>,
-                                        },
-                                    ),
-                                ),
-                                Value(
-                                    FunctionCall(
-                                        ExprFunctionCall {
-                                            function: ?9::values,
-                                            args: [
-                                                Value(
-                                                    Snapshot(
-                                                        ExprSnapshot {
-                                                            inner: Var(
-                                                                LocalVarId(test::__set_model_instance__),
-                                                            ),
-                                                            ty: @test::Health,
-                                                        },
-                                                    ),
-                                                ),
-                                            ],
-                                            coupon_arg: None,
-                                            ty: core::array::Span::<core::felt252>,
-                                        },
-                                    ),
-                                ),
-                                Value(
-                                    FunctionCall(
-                                        ExprFunctionCall {
-                                            function: ?10::instance_layout,
-                                            args: [
-                                                Value(
-                                                    Snapshot(
-                                                        ExprSnapshot {
-                                                            inner: Var(
-                                                                LocalVarId(test::__set_model_instance__),
-                                                            ),
-                                                            ty: @test::Health,
-                                                        },
-                                                    ),
-                                                ),
-                                            ],
-                                            coupon_arg: None,
-                                            ty: dojo::database::introspect::Layout,
-                                        },
                                     ),
                                 ),
                             ],

--- a/crates/dojo-world/src/contracts/abi/world.rs
+++ b/crates/dojo-world/src/contracts/abi/world.rs
@@ -53,6 +53,24 @@ abigen!(
     ]
   },
   {
+    "type": "enum",
+    "name": "dojo::world::ModelIndex",
+    "variants": [
+      {
+        "name": "Keys",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "Id",
+        "type": "core::felt252"
+      },
+      {
+        "name": "MemberId",
+        "type": "(core::felt252, core::felt252)"
+      }
+    ]
+  },
+  {
     "type": "struct",
     "name": "core::array::Span::<core::integer::u8>",
     "members": [
@@ -304,12 +322,12 @@ abigen!(
         "name": "entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -328,12 +346,12 @@ abigen!(
         "name": "set_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "values",
@@ -352,12 +370,12 @@ abigen!(
         "name": "delete_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -943,6 +961,28 @@ abigen!(
   },
   {
     "type": "event",
+    "name": "dojo::world::world::StoreUpdateRecord",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "table",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "entity_id",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "values",
+        "type": "core::array::Span::<core::felt252>",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
     "name": "dojo::world::world::StoreDelRecord",
     "kind": "struct",
     "members": [
@@ -952,8 +992,8 @@ abigen!(
         "kind": "data"
       },
       {
-        "name": "keys",
-        "type": "core::array::Span::<core::felt252>",
+        "name": "entity_id",
+        "type": "core::felt252",
         "kind": "data"
       }
     ]
@@ -1115,6 +1155,11 @@ abigen!(
       {
         "name": "StoreSetRecord",
         "type": "dojo::world::world::StoreSetRecord",
+        "kind": "nested"
+      },
+      {
+        "name": "StoreUpdateRecord",
+        "type": "dojo::world::world::StoreUpdateRecord",
         "kind": "nested"
       },
       {

--- a/crates/dojo-world/src/contracts/model.rs
+++ b/crates/dojo-world/src/contracts/model.rs
@@ -25,6 +25,9 @@ pub mod abigen {
     pub mod model {
         pub use crate::contracts::abi::model::*;
     }
+    pub mod world {
+        pub use crate::contracts::abi::world::*;
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -126,7 +129,11 @@ where
         let raw_layout = self.model_reader.layout().raw_call().await?;
         let layout = Layout::cairo_deserialize(raw_layout.as_slice(), 0)?;
 
-        Ok(self.world_reader.entity(&self.selector(), &keys.to_vec(), &layout).call().await?)
+        Ok(self
+            .world_reader
+            .entity(&self.selector(), &abigen::world::ModelIndex::Keys(keys.to_vec()), &layout)
+            .call()
+            .await?)
     }
 
     pub async fn entity(&self, keys: &[Felt]) -> Result<Ty, ModelError> {

--- a/crates/dojo-world/src/contracts/naming.rs
+++ b/crates/dojo-world/src/contracts/naming.rs
@@ -68,8 +68,8 @@ pub fn get_filename_from_tag(tag: &str) -> String {
     format!("{tag}{TAG_SEPARATOR}{selector}")
 }
 
-pub fn compute_bytearray_hash(namespace: &str) -> Felt {
-    let ba = ByteArray::from_string(namespace).unwrap();
+pub fn compute_bytearray_hash(value: &str) -> Felt {
+    let ba = ByteArray::from_string(value).unwrap();
     poseidon_hash_many(&ByteArray::cairo_serialize(&ba))
 }
 

--- a/crates/sozo/ops/src/events.rs
+++ b/crates/sozo/ops/src/events.rs
@@ -279,7 +279,7 @@ mod tests {
         let result = extract_events(&manifest, &project_dir, &target_dir).unwrap();
 
         // we are just collecting all events from manifest file so just verifying count should work
-        assert_eq!(result.len(), 16);
+        assert_eq!(result.len(), 17);
     }
 
     #[test]

--- a/crates/torii/core/src/processors/mod.rs
+++ b/crates/torii/core/src/processors/mod.rs
@@ -12,9 +12,11 @@ pub mod register_model;
 pub mod store_del_record;
 pub mod store_set_record;
 pub mod store_transaction;
+pub mod store_update_record;
 
 const MODEL_INDEX: usize = 0;
 const NUM_KEYS_INDEX: usize = 1;
+const ENTITY_ID_INDEX: usize = 1;
 
 #[async_trait]
 pub trait EventProcessor<P>

--- a/crates/torii/core/src/processors/store_del_record.rs
+++ b/crates/torii/core/src/processors/store_del_record.rs
@@ -7,7 +7,7 @@ use starknet::providers::Provider;
 use tracing::info;
 
 use super::EventProcessor;
-use crate::processors::{MODEL_INDEX, NUM_KEYS_INDEX};
+use crate::processors::MODEL_INDEX;
 use crate::sql::Sql;
 
 pub(crate) const LOG_TARGET: &str = "torii_core::processors::store_del_record";
@@ -57,10 +57,11 @@ where
             "Store delete record."
         );
 
-        let keys_start = NUM_KEYS_INDEX + 1;
-        let keys = event.data[keys_start..].to_vec();
+        let entity_id = event.data[MODEL_INDEX + 1];
         let entity = model.schema().await?;
-        db.delete_entity(keys, entity).await?;
+
+        db.delete_entity(entity_id, entity).await?;
+
         Ok(())
     }
 }

--- a/crates/torii/core/src/processors/store_del_record.rs
+++ b/crates/torii/core/src/processors/store_del_record.rs
@@ -7,7 +7,7 @@ use starknet::providers::Provider;
 use tracing::info;
 
 use super::EventProcessor;
-use crate::processors::MODEL_INDEX;
+use crate::processors::{ENTITY_ID_INDEX, MODEL_INDEX};
 use crate::sql::Sql;
 
 pub(crate) const LOG_TARGET: &str = "torii_core::processors::store_del_record";
@@ -57,7 +57,7 @@ where
             "Store delete record."
         );
 
-        let entity_id = event.data[MODEL_INDEX + 1];
+        let entity_id = event.data[ENTITY_ID_INDEX];
         let entity = model.schema().await?;
 
         db.delete_entity(entity_id, entity).await?;

--- a/crates/torii/core/src/processors/store_update_record.rs
+++ b/crates/torii/core/src/processors/store_update_record.rs
@@ -1,0 +1,84 @@
+use anyhow::{Context, Error, Ok, Result};
+use async_trait::async_trait;
+use dojo_world::contracts::model::ModelReader;
+use dojo_world::contracts::naming;
+use dojo_world::contracts::world::WorldContractReader;
+use num_traits::ToPrimitive;
+use starknet::core::types::{Event, TransactionReceiptWithBlockInfo};
+use starknet::providers::Provider;
+use tracing::info;
+
+use super::EventProcessor;
+use crate::processors::{ENTITY_ID_INDEX, MODEL_INDEX};
+use crate::sql::Sql;
+
+pub(crate) const LOG_TARGET: &str = "torii_core::processors::store_update_record";
+
+#[derive(Default, Debug)]
+pub struct StoreUpdateRecordProcessor;
+
+#[async_trait]
+impl<P> EventProcessor<P> for StoreUpdateRecordProcessor
+where
+    P: Provider + Send + Sync + std::fmt::Debug,
+{
+    fn event_key(&self) -> String {
+        "StoreUpdateRecord".to_string()
+    }
+
+    fn validate(&self, event: &Event) -> bool {
+        if event.keys.len() > 1 {
+            info!(
+                target: LOG_TARGET,
+                event_key = %<StoreUpdateRecordProcessor as EventProcessor<P>>::event_key(self),
+                invalid_keys = %<StoreUpdateRecordProcessor as EventProcessor<P>>::event_keys_as_string(self, event),
+                "Invalid event keys."
+            );
+            return false;
+        }
+        true
+    }
+
+    async fn process(
+        &self,
+        _world: &WorldContractReader<P>,
+        db: &mut Sql,
+        _block_number: u64,
+        block_timestamp: u64,
+        _transaction_receipt: &TransactionReceiptWithBlockInfo,
+        event_id: &str,
+        event: &Event,
+    ) -> Result<(), Error> {
+        let selector = event.data[MODEL_INDEX];
+        let entity_id = event.data[ENTITY_ID_INDEX];
+
+        let model = db.model(selector).await?;
+
+        info!(
+            target: LOG_TARGET,
+            name = %model.name(),
+            entity_id = format!("{:#x}", entity_id),
+            "Store update record.",
+        );
+
+        let values_start = ENTITY_ID_INDEX + 1;
+        let values_end: usize =
+            values_start + event.data[values_start].to_usize().context("invalid usize")?;
+
+        // Skip the length to only get the values as they will be deserialized.
+        let values = event.data[values_start + 1..=values_end].to_vec();
+
+        let tag = naming::get_tag(model.namespace(), model.name());
+
+        // Keys are read from the db, since we don't have access to them when only
+        // the entity id is passed.
+        let keys = db.get_entity_keys(entity_id, &tag).await?;
+        let mut keys_and_unpacked = [keys, values].concat();
+
+        let mut entity = model.schema().await?;
+        entity.deserialize(&mut keys_and_unpacked)?;
+
+        db.set_entity(entity, event_id, block_timestamp).await?;
+        Ok(())
+    }
+}

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -271,8 +271,8 @@ impl Sql {
         Ok(())
     }
 
-    pub async fn delete_entity(&mut self, keys: Vec<Felt>, entity: Ty) -> Result<()> {
-        let entity_id = format!("{:#x}", poseidon_hash_many(&keys));
+    pub async fn delete_entity(&mut self, entity_id: Felt, entity: Ty) -> Result<()> {
+        let entity_id = format!("{:#x}", entity_id);
         let path = vec![entity.name()];
         // delete entity models data
         self.build_delete_entity_queries_recursive(path, &entity_id, &entity);

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -9,7 +9,7 @@ use dojo_world::contracts::abi::model::Layout;
 use dojo_world::contracts::naming::compute_selector_from_names;
 use dojo_world::metadata::WorldMetadata;
 use sqlx::pool::PoolConnection;
-use sqlx::{Pool, Sqlite};
+use sqlx::{Pool, Row, Sqlite};
 use starknet::core::types::{Event, Felt, InvokeTransaction, Transaction};
 use starknet_crypto::poseidon_hash_many;
 
@@ -341,6 +341,46 @@ impl Sql {
                 Err(anyhow::anyhow!("Failed to get model from db for selector {selector:#x}: {e}"))
             }
         }
+    }
+
+    /// Retrieves the keys definition for a given model.
+    /// The key definition is currently implemented as (`name`, `type`).
+    pub async fn get_entity_keys_def(&self, model_tag: &str) -> Result<Vec<(String, String)>> {
+        let query = sqlx::query_as::<_, (String, String)>(
+            "SELECT name, type FROM model_members WHERE id = ? AND key = true",
+        )
+        .bind(model_tag);
+
+        let mut conn: PoolConnection<Sqlite> = self.pool.acquire().await?;
+        let rows: Vec<(String, String)> = query.fetch_all(&mut *conn).await?;
+        Ok(rows.iter().map(|(name, ty)| (name.to_string(), ty.to_string())).collect())
+    }
+
+    /// Retrieves the keys for a given entity.
+    /// The keys are returned in the same order as the keys definition.
+    pub async fn get_entity_keys(&self, entity_id: Felt, model_tag: &str) -> Result<Vec<Felt>> {
+        let entity_id = format!("{:#x}", entity_id);
+        let keys_def = self.get_entity_keys_def(model_tag).await?;
+
+        let keys_names =
+            keys_def.iter().map(|(name, _)| format!("external_{}", name)).collect::<Vec<String>>();
+
+        let sql = format!("SELECT {} FROM [{}] WHERE id = ?", keys_names.join(", "), model_tag);
+        let query = sqlx::query(sql.as_str()).bind(entity_id);
+
+        let mut conn: PoolConnection<Sqlite> = self.pool.acquire().await?;
+
+        let mut keys: Vec<Felt> = vec![];
+        let result = query.fetch_all(&mut *conn).await?;
+
+        for row in result {
+            for (i, _) in row.columns().iter().enumerate() {
+                let value: String = row.try_get(i)?;
+                keys.push(Felt::from_hex(&value)?);
+            }
+        }
+
+        Ok(keys)
     }
 
     pub async fn entity(&self, model: String, key: Felt) -> Result<Vec<Felt>> {

--- a/crates/torii/types-test/src/contracts.cairo
+++ b/crates/torii/types-test/src/contracts.cairo
@@ -10,7 +10,7 @@ trait IRecords {
 mod records {
     use starknet::{ContractAddress, get_caller_address};
     use types_test::models::{
-        Record, RecordSibling, Subrecord, Nested, NestedMore, NestedMost, Depth
+        Record, RecordTrait, RecordSibling, RecordSiblingTrait, Subrecord, SubrecordTrait, Nested, NestedMore, NestedMost, Depth
     };
     use types_test::{seed, random};
     use super::IRecords;

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -43,7 +43,7 @@ rpc_url = "http://localhost:5050/"
 # Default account for katana with seed = 0
 account_address = "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03"
 private_key = "0x1800000000300000180000000000030000000000003006001800006600"
-world_address = "0x2f7a4447d78fa066cead76981c04deb1fc9cb3c700bd246b697425e900641a0"
+world_address = "0x5377ecb8b7b6ce3f17daf9064a5f5ee7f6642c3e72579b45478a828007db355"
 
 [profile.release.tool.dojo]
 # for more info on how `merge-strategy` works see:

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -43,7 +43,7 @@ rpc_url = "http://localhost:5050/"
 # Default account for katana with seed = 0
 account_address = "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03"
 private_key = "0x1800000000300000180000000000030000000000003006001800006600"
-world_address = "0x221d9c1ca42fe008cd124d38d5987d5bd3751adf43bec52d1fbb41288203cd5"
+world_address = "0x2f7a4447d78fa066cead76981c04deb1fc9cb3c700bd246b697425e900641a0"
 
 [profile.release.tool.dojo]
 # for more info on how `merge-strategy` works see:

--- a/examples/spawn-and-move/manifests/dev/base/abis/contracts/dojo_examples-actions-40b6994c.json
+++ b/examples/spawn-and-move/manifests/dev/base/abis/contracts/dojo_examples-actions-40b6994c.json
@@ -276,6 +276,30 @@
       },
       {
         "type": "function",
+        "name": "update_player_name",
+        "inputs": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "update_player_name_value",
+        "inputs": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
         "name": "reset_player_config",
         "inputs": [],
         "outputs": [],

--- a/examples/spawn-and-move/manifests/dev/base/abis/dojo-world.json
+++ b/examples/spawn-and-move/manifests/dev/base/abis/dojo-world.json
@@ -47,6 +47,24 @@
     ]
   },
   {
+    "type": "enum",
+    "name": "dojo::world::ModelIndex",
+    "variants": [
+      {
+        "name": "Keys",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "Id",
+        "type": "core::felt252"
+      },
+      {
+        "name": "MemberId",
+        "type": "(core::felt252, core::felt252)"
+      }
+    ]
+  },
+  {
     "type": "struct",
     "name": "core::array::Span::<core::integer::u8>",
     "members": [
@@ -298,12 +316,12 @@
         "name": "entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -322,12 +340,12 @@
         "name": "set_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "values",
@@ -346,12 +364,12 @@
         "name": "delete_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -937,6 +955,28 @@
   },
   {
     "type": "event",
+    "name": "dojo::world::world::StoreUpdateRecord",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "table",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "entity_id",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "values",
+        "type": "core::array::Span::<core::felt252>",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
     "name": "dojo::world::world::StoreDelRecord",
     "kind": "struct",
     "members": [
@@ -946,8 +986,8 @@
         "kind": "data"
       },
       {
-        "name": "keys",
-        "type": "core::array::Span::<core::felt252>",
+        "name": "entity_id",
+        "type": "core::felt252",
         "kind": "data"
       }
     ]
@@ -1109,6 +1149,11 @@
       {
         "name": "StoreSetRecord",
         "type": "dojo::world::world::StoreSetRecord",
+        "kind": "nested"
+      },
+      {
+        "name": "StoreUpdateRecord",
+        "type": "dojo::world::world::StoreUpdateRecord",
         "kind": "nested"
       },
       {

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-actions-40b6994c.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-actions-40b6994c.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d"
-original_class_hash = "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d"
+class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
+original_class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/dojo_examples-actions-40b6994c.json"
 reads = []

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-mock_token-31599eb2.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-mock_token-31599eb2.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef"
-original_class_hash = "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef"
+class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
+original_class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
 base_class_hash = "0x0"
 abi = "manifests/dev/base/abis/contracts/dojo_examples-mock_token-31599eb2.json"
 reads = []

--- a/examples/spawn-and-move/manifests/dev/base/dojo-world.toml
+++ b/examples/spawn-and-move/manifests/dev/base/dojo-world.toml
@@ -1,6 +1,6 @@
 kind = "Class"
-class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
-original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
+original_class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
 abi = "manifests/dev/base/abis/dojo-world.json"
 tag = "dojo-world"
 manifest_name = "dojo-world"

--- a/examples/spawn-and-move/manifests/dev/base/dojo-world.toml
+++ b/examples/spawn-and-move/manifests/dev/base/dojo-world.toml
@@ -1,6 +1,6 @@
 kind = "Class"
-class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
-original_class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
+class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
 abi = "manifests/dev/base/abis/dojo-world.json"
 tag = "dojo-world"
 manifest_name = "dojo-world"

--- a/examples/spawn-and-move/manifests/dev/deployment/abis/contracts/dojo_examples-actions-40b6994c.json
+++ b/examples/spawn-and-move/manifests/dev/deployment/abis/contracts/dojo_examples-actions-40b6994c.json
@@ -276,6 +276,30 @@
       },
       {
         "type": "function",
+        "name": "update_player_name",
+        "inputs": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "update_player_name_value",
+        "inputs": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
         "name": "reset_player_config",
         "inputs": [],
         "outputs": [],

--- a/examples/spawn-and-move/manifests/dev/deployment/abis/dojo-world.json
+++ b/examples/spawn-and-move/manifests/dev/deployment/abis/dojo-world.json
@@ -47,6 +47,24 @@
     ]
   },
   {
+    "type": "enum",
+    "name": "dojo::world::ModelIndex",
+    "variants": [
+      {
+        "name": "Keys",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "Id",
+        "type": "core::felt252"
+      },
+      {
+        "name": "MemberId",
+        "type": "(core::felt252, core::felt252)"
+      }
+    ]
+  },
+  {
     "type": "struct",
     "name": "core::array::Span::<core::integer::u8>",
     "members": [
@@ -298,12 +316,12 @@
         "name": "entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -322,12 +340,12 @@
         "name": "set_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "values",
@@ -346,12 +364,12 @@
         "name": "delete_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -937,6 +955,28 @@
   },
   {
     "type": "event",
+    "name": "dojo::world::world::StoreUpdateRecord",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "table",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "entity_id",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "values",
+        "type": "core::array::Span::<core::felt252>",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
     "name": "dojo::world::world::StoreDelRecord",
     "kind": "struct",
     "members": [
@@ -946,8 +986,8 @@
         "kind": "data"
       },
       {
-        "name": "keys",
-        "type": "core::array::Span::<core::felt252>",
+        "name": "entity_id",
+        "type": "core::felt252",
         "kind": "data"
       }
     ]
@@ -1109,6 +1149,11 @@
       {
         "name": "StoreSetRecord",
         "type": "dojo::world::world::StoreSetRecord",
+        "kind": "nested"
+      },
+      {
+        "name": "StoreUpdateRecord",
+        "type": "dojo::world::world::StoreUpdateRecord",
         "kind": "nested"
       },
       {

--- a/examples/spawn-and-move/manifests/dev/deployment/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/deployment/manifest.json
@@ -1,8 +1,8 @@
 {
   "world": {
     "kind": "WorldContract",
-    "class_hash": "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44",
-    "original_class_hash": "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44",
+    "class_hash": "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557",
+    "original_class_hash": "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557",
     "abi": [
       {
         "type": "impl",
@@ -1189,8 +1189,8 @@
         ]
       }
     ],
-    "address": "0x2f7a4447d78fa066cead76981c04deb1fc9cb3c700bd246b697425e900641a0",
-    "transaction_hash": "0x2587e7362c8ca0f8478bf1256e8fdd40b85f70adfb22d886293c21da653b3e6",
+    "address": "0x5377ecb8b7b6ce3f17daf9064a5f5ee7f6642c3e72579b45478a828007db355",
+    "transaction_hash": "0x59c745b80871acdab7ad1c29703cac9aa949f4326b32037943512adc0a19ab2",
     "block_number": 3,
     "seed": "dojo_examples",
     "metadata": {
@@ -1210,7 +1210,7 @@
   "contracts": [
     {
       "kind": "DojoContract",
-      "address": "0x3f6ef508b9837b327ae5704e719094eae81c1f0086cec8e5b83e25b5e9d071b",
+      "address": "0x5c92c8995272a6ae073392c6878fe80cd71ae0be4931bce75f3dbfe24c208a8",
       "class_hash": "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be",
       "original_class_hash": "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",
@@ -1641,7 +1641,7 @@
     },
     {
       "kind": "DojoContract",
-      "address": "0x26ed07397dc7462adc94b2b070fec2bfa2b0e36aaa6bcafadc8c8cef8e46020",
+      "address": "0x44e1b43ee34f816374612ae2df4a668e76a1aa723de8d7b67166e10a7225112",
       "class_hash": "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674",
       "original_class_hash": "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",
@@ -1878,7 +1878,7 @@
     },
     {
       "kind": "DojoContract",
-      "address": "0x2470881191edf8260e9f6cec7244e117ea2d0f5d48c76ec9e990222c2b7a7a6",
+      "address": "0x6840cf5bebab9c134ddc4d34f6b021684610d7b83d663fc46e2e10d3569ea15",
       "class_hash": "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028",
       "original_class_hash": "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",
@@ -2097,7 +2097,7 @@
     },
     {
       "kind": "DojoContract",
-      "address": "0x7f21ab47087c7fc6e9dae445cf2c7d8e0b8c651cb850d81a7e8eccc636f1b75",
+      "address": "0x512bcb4058b044f689269d8a1c23e653c04baee2029f7e5d3f4ec053e6c5c91",
       "class_hash": "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7",
       "original_class_hash": "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",

--- a/examples/spawn-and-move/manifests/dev/deployment/manifest.json
+++ b/examples/spawn-and-move/manifests/dev/deployment/manifest.json
@@ -1,8 +1,8 @@
 {
   "world": {
     "kind": "WorldContract",
-    "class_hash": "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381",
-    "original_class_hash": "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381",
+    "class_hash": "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44",
+    "original_class_hash": "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44",
     "abi": [
       {
         "type": "impl",
@@ -48,6 +48,24 @@
           {
             "name": "snapshot",
             "type": "@core::array::Array::<core::felt252>"
+          }
+        ]
+      },
+      {
+        "type": "enum",
+        "name": "dojo::world::ModelIndex",
+        "variants": [
+          {
+            "name": "Keys",
+            "type": "core::array::Span::<core::felt252>"
+          },
+          {
+            "name": "Id",
+            "type": "core::felt252"
+          },
+          {
+            "name": "MemberId",
+            "type": "(core::felt252, core::felt252)"
           }
         ]
       },
@@ -303,12 +321,12 @@
             "name": "entity",
             "inputs": [
               {
-                "name": "model",
+                "name": "model_selector",
                 "type": "core::felt252"
               },
               {
-                "name": "keys",
-                "type": "core::array::Span::<core::felt252>"
+                "name": "index",
+                "type": "dojo::world::ModelIndex"
               },
               {
                 "name": "layout",
@@ -327,12 +345,12 @@
             "name": "set_entity",
             "inputs": [
               {
-                "name": "model",
+                "name": "model_selector",
                 "type": "core::felt252"
               },
               {
-                "name": "keys",
-                "type": "core::array::Span::<core::felt252>"
+                "name": "index",
+                "type": "dojo::world::ModelIndex"
               },
               {
                 "name": "values",
@@ -351,12 +369,12 @@
             "name": "delete_entity",
             "inputs": [
               {
-                "name": "model",
+                "name": "model_selector",
                 "type": "core::felt252"
               },
               {
-                "name": "keys",
-                "type": "core::array::Span::<core::felt252>"
+                "name": "index",
+                "type": "dojo::world::ModelIndex"
               },
               {
                 "name": "layout",
@@ -942,6 +960,28 @@
       },
       {
         "type": "event",
+        "name": "dojo::world::world::StoreUpdateRecord",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "table",
+            "type": "core::felt252",
+            "kind": "data"
+          },
+          {
+            "name": "entity_id",
+            "type": "core::felt252",
+            "kind": "data"
+          },
+          {
+            "name": "values",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
         "name": "dojo::world::world::StoreDelRecord",
         "kind": "struct",
         "members": [
@@ -951,8 +991,8 @@
             "kind": "data"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>",
+            "name": "entity_id",
+            "type": "core::felt252",
             "kind": "data"
           }
         ]
@@ -1117,6 +1157,11 @@
             "kind": "nested"
           },
           {
+            "name": "StoreUpdateRecord",
+            "type": "dojo::world::world::StoreUpdateRecord",
+            "kind": "nested"
+          },
+          {
             "name": "StoreDelRecord",
             "type": "dojo::world::world::StoreDelRecord",
             "kind": "nested"
@@ -1144,8 +1189,8 @@
         ]
       }
     ],
-    "address": "0x221d9c1ca42fe008cd124d38d5987d5bd3751adf43bec52d1fbb41288203cd5",
-    "transaction_hash": "0x1de80bae5a65c23715b7ca20ecc775b6bb62a844d8569acf91ff2d3b93f1c9c",
+    "address": "0x2f7a4447d78fa066cead76981c04deb1fc9cb3c700bd246b697425e900641a0",
+    "transaction_hash": "0x2587e7362c8ca0f8478bf1256e8fdd40b85f70adfb22d886293c21da653b3e6",
     "block_number": 3,
     "seed": "dojo_examples",
     "metadata": {
@@ -1165,9 +1210,9 @@
   "contracts": [
     {
       "kind": "DojoContract",
-      "address": "0x64839f1b5e1958354ee257bbd7c07e0403ff6098145a92ddb9b093fc35662c4",
-      "class_hash": "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d",
-      "original_class_hash": "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d",
+      "address": "0x3f6ef508b9837b327ae5704e719094eae81c1f0086cec8e5b83e25b5e9d071b",
+      "class_hash": "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be",
+      "original_class_hash": "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",
       "abi": [
         {
@@ -1447,6 +1492,30 @@
             },
             {
               "type": "function",
+              "name": "update_player_name",
+              "inputs": [
+                {
+                  "name": "name",
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "update_player_name_value",
+              "inputs": [
+                {
+                  "name": "name",
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
               "name": "reset_player_config",
               "inputs": [],
               "outputs": [],
@@ -1572,7 +1641,7 @@
     },
     {
       "kind": "DojoContract",
-      "address": "0x5c4e7bb5f60d58c22c96aba611cb2f53462dcd59f7ade5d1675be5f8c20226b",
+      "address": "0x26ed07397dc7462adc94b2b070fec2bfa2b0e36aaa6bcafadc8c8cef8e46020",
       "class_hash": "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674",
       "original_class_hash": "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",
@@ -1809,9 +1878,9 @@
     },
     {
       "kind": "DojoContract",
-      "address": "0x4b1371f328d8d86f6007f4ee8bd7d8a2f1c9f482531266b2df294dc55044d20",
-      "class_hash": "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef",
-      "original_class_hash": "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef",
+      "address": "0x2470881191edf8260e9f6cec7244e117ea2d0f5d48c76ec9e990222c2b7a7a6",
+      "class_hash": "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028",
+      "original_class_hash": "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",
       "abi": [
         {
@@ -2028,7 +2097,7 @@
     },
     {
       "kind": "DojoContract",
-      "address": "0x3ba8ab3546affa46b8094e7822459537c6e348af82fb3f35a32f42f820f3bfe",
+      "address": "0x7f21ab47087c7fc6e9dae445cf2c7d8e0b8c651cb850d81a7e8eccc636f1b75",
       "class_hash": "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7",
       "original_class_hash": "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7",
       "base_class_hash": "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4",

--- a/examples/spawn-and-move/manifests/dev/deployment/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/deployment/manifest.toml
@@ -1,10 +1,10 @@
 [world]
 kind = "WorldContract"
-class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
-original_class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
+class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
 abi = "manifests/dev/deployment/abis/dojo-world.json"
-address = "0x221d9c1ca42fe008cd124d38d5987d5bd3751adf43bec52d1fbb41288203cd5"
-transaction_hash = "0x1de80bae5a65c23715b7ca20ecc775b6bb62a844d8569acf91ff2d3b93f1c9c"
+address = "0x2f7a4447d78fa066cead76981c04deb1fc9cb3c700bd246b697425e900641a0"
+transaction_hash = "0x2587e7362c8ca0f8478bf1256e8fdd40b85f70adfb22d886293c21da653b3e6"
 block_number = 3
 seed = "dojo_examples"
 manifest_name = "dojo-world"
@@ -23,9 +23,9 @@ manifest_name = "dojo-base"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x64839f1b5e1958354ee257bbd7c07e0403ff6098145a92ddb9b093fc35662c4"
-class_hash = "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d"
-original_class_hash = "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d"
+address = "0x3f6ef508b9837b327ae5704e719094eae81c1f0086cec8e5b83e25b5e9d071b"
+class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
+original_class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"
 abi = "manifests/dev/deployment/abis/contracts/dojo_examples-actions-40b6994c.json"
 reads = []
@@ -40,7 +40,7 @@ manifest_name = "dojo_examples-actions-40b6994c"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x5c4e7bb5f60d58c22c96aba611cb2f53462dcd59f7ade5d1675be5f8c20226b"
+address = "0x26ed07397dc7462adc94b2b070fec2bfa2b0e36aaa6bcafadc8c8cef8e46020"
 class_hash = "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674"
 original_class_hash = "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"
@@ -54,9 +54,9 @@ manifest_name = "dojo_examples-dungeon-6620e0e6"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x4b1371f328d8d86f6007f4ee8bd7d8a2f1c9f482531266b2df294dc55044d20"
-class_hash = "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef"
-original_class_hash = "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef"
+address = "0x2470881191edf8260e9f6cec7244e117ea2d0f5d48c76ec9e990222c2b7a7a6"
+class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
+original_class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"
 abi = "manifests/dev/deployment/abis/contracts/dojo_examples-mock_token-31599eb2.json"
 reads = []
@@ -68,7 +68,7 @@ manifest_name = "dojo_examples-mock_token-31599eb2"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x3ba8ab3546affa46b8094e7822459537c6e348af82fb3f35a32f42f820f3bfe"
+address = "0x7f21ab47087c7fc6e9dae445cf2c7d8e0b8c651cb850d81a7e8eccc636f1b75"
 class_hash = "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7"
 original_class_hash = "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"

--- a/examples/spawn-and-move/manifests/dev/deployment/manifest.toml
+++ b/examples/spawn-and-move/manifests/dev/deployment/manifest.toml
@@ -1,10 +1,10 @@
 [world]
 kind = "WorldContract"
-class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
-original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
+original_class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
 abi = "manifests/dev/deployment/abis/dojo-world.json"
-address = "0x2f7a4447d78fa066cead76981c04deb1fc9cb3c700bd246b697425e900641a0"
-transaction_hash = "0x2587e7362c8ca0f8478bf1256e8fdd40b85f70adfb22d886293c21da653b3e6"
+address = "0x5377ecb8b7b6ce3f17daf9064a5f5ee7f6642c3e72579b45478a828007db355"
+transaction_hash = "0x59c745b80871acdab7ad1c29703cac9aa949f4326b32037943512adc0a19ab2"
 block_number = 3
 seed = "dojo_examples"
 manifest_name = "dojo-world"
@@ -23,7 +23,7 @@ manifest_name = "dojo-base"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x3f6ef508b9837b327ae5704e719094eae81c1f0086cec8e5b83e25b5e9d071b"
+address = "0x5c92c8995272a6ae073392c6878fe80cd71ae0be4931bce75f3dbfe24c208a8"
 class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
 original_class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"
@@ -40,7 +40,7 @@ manifest_name = "dojo_examples-actions-40b6994c"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x26ed07397dc7462adc94b2b070fec2bfa2b0e36aaa6bcafadc8c8cef8e46020"
+address = "0x44e1b43ee34f816374612ae2df4a668e76a1aa723de8d7b67166e10a7225112"
 class_hash = "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674"
 original_class_hash = "0x14b3096b82a761f63dd47277c2b5ac18925dea43586418483939a2f1f57f674"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"
@@ -54,7 +54,7 @@ manifest_name = "dojo_examples-dungeon-6620e0e6"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x2470881191edf8260e9f6cec7244e117ea2d0f5d48c76ec9e990222c2b7a7a6"
+address = "0x6840cf5bebab9c134ddc4d34f6b021684610d7b83d663fc46e2e10d3569ea15"
 class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
 original_class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"
@@ -68,7 +68,7 @@ manifest_name = "dojo_examples-mock_token-31599eb2"
 
 [[contracts]]
 kind = "DojoContract"
-address = "0x7f21ab47087c7fc6e9dae445cf2c7d8e0b8c651cb850d81a7e8eccc636f1b75"
+address = "0x512bcb4058b044f689269d8a1c23e653c04baee2029f7e5d3f4ec053e6c5c91"
 class_hash = "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7"
 original_class_hash = "0x479bfb12dcba5398d77303e7a665fc3fedb16f2d7f9cb1f5d7e2beb3b7e2ba7"
 base_class_hash = "0x26a4f5d2d9638877a2648297339275df5eaab0adb3cdf0010887c2dbf2be4"

--- a/examples/spawn-and-move/manifests/release/base/abis/contracts/dojo_examples-actions-40b6994c.json
+++ b/examples/spawn-and-move/manifests/release/base/abis/contracts/dojo_examples-actions-40b6994c.json
@@ -276,6 +276,30 @@
       },
       {
         "type": "function",
+        "name": "update_player_name",
+        "inputs": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "update_player_name_value",
+        "inputs": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
         "name": "reset_player_config",
         "inputs": [],
         "outputs": [],

--- a/examples/spawn-and-move/manifests/release/base/abis/dojo-world.json
+++ b/examples/spawn-and-move/manifests/release/base/abis/dojo-world.json
@@ -47,6 +47,24 @@
     ]
   },
   {
+    "type": "enum",
+    "name": "dojo::world::ModelIndex",
+    "variants": [
+      {
+        "name": "Keys",
+        "type": "core::array::Span::<core::felt252>"
+      },
+      {
+        "name": "Id",
+        "type": "core::felt252"
+      },
+      {
+        "name": "MemberId",
+        "type": "(core::felt252, core::felt252)"
+      }
+    ]
+  },
+  {
     "type": "struct",
     "name": "core::array::Span::<core::integer::u8>",
     "members": [
@@ -298,12 +316,12 @@
         "name": "entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -322,12 +340,12 @@
         "name": "set_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "values",
@@ -346,12 +364,12 @@
         "name": "delete_entity",
         "inputs": [
           {
-            "name": "model",
+            "name": "model_selector",
             "type": "core::felt252"
           },
           {
-            "name": "keys",
-            "type": "core::array::Span::<core::felt252>"
+            "name": "index",
+            "type": "dojo::world::ModelIndex"
           },
           {
             "name": "layout",
@@ -937,6 +955,28 @@
   },
   {
     "type": "event",
+    "name": "dojo::world::world::StoreUpdateRecord",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "table",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "entity_id",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "values",
+        "type": "core::array::Span::<core::felt252>",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
     "name": "dojo::world::world::StoreDelRecord",
     "kind": "struct",
     "members": [
@@ -946,8 +986,8 @@
         "kind": "data"
       },
       {
-        "name": "keys",
-        "type": "core::array::Span::<core::felt252>",
+        "name": "entity_id",
+        "type": "core::felt252",
         "kind": "data"
       }
     ]
@@ -1109,6 +1149,11 @@
       {
         "name": "StoreSetRecord",
         "type": "dojo::world::world::StoreSetRecord",
+        "kind": "nested"
+      },
+      {
+        "name": "StoreUpdateRecord",
+        "type": "dojo::world::world::StoreUpdateRecord",
         "kind": "nested"
       },
       {

--- a/examples/spawn-and-move/manifests/release/base/contracts/dojo_examples-actions-40b6994c.toml
+++ b/examples/spawn-and-move/manifests/release/base/contracts/dojo_examples-actions-40b6994c.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d"
-original_class_hash = "0x2c975b0d681861edd6caad5fbc0b42dc3e8b034b6c0b0a7628fb3a7bedf1e8d"
+class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
+original_class_hash = "0x19d49d8d67dd2e6f73c93eb886105d445ac6983a49950831a325872f8c662be"
 base_class_hash = "0x0"
 abi = "manifests/release/base/abis/contracts/dojo_examples-actions-40b6994c.json"
 reads = []

--- a/examples/spawn-and-move/manifests/release/base/contracts/dojo_examples-mock_token-31599eb2.toml
+++ b/examples/spawn-and-move/manifests/release/base/contracts/dojo_examples-mock_token-31599eb2.toml
@@ -1,6 +1,6 @@
 kind = "DojoContract"
-class_hash = "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef"
-original_class_hash = "0x97cd4fb3acfe9e6a024589ea34db2fc587586d699ef3732ce627e1771158ef"
+class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
+original_class_hash = "0x761d18a3557d98b3962ebb2c9ddae89ad586ce81de7e86c5fd1e1b4f9d0028"
 base_class_hash = "0x0"
 abi = "manifests/release/base/abis/contracts/dojo_examples-mock_token-31599eb2.json"
 reads = []

--- a/examples/spawn-and-move/manifests/release/base/dojo-world.toml
+++ b/examples/spawn-and-move/manifests/release/base/dojo-world.toml
@@ -1,6 +1,6 @@
 kind = "Class"
-class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
-original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
+original_class_hash = "0x26a8f65e0b0ba2a6d2f9e93d4f72f75eabebb853ea7413e134b3902ea352557"
 abi = "manifests/release/base/abis/dojo-world.json"
 tag = "dojo-world"
 manifest_name = "dojo-world"

--- a/examples/spawn-and-move/manifests/release/base/dojo-world.toml
+++ b/examples/spawn-and-move/manifests/release/base/dojo-world.toml
@@ -1,6 +1,6 @@
 kind = "Class"
-class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
-original_class_hash = "0xa2a68c8a36082692ff56aece7e4e14dfa533b7c565c749ae8045000e1bf381"
+class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
+original_class_hash = "0xcee5f3a6d253f5afc741d10cd0c482767907e473b2cba27a64bdce05934a44"
 abi = "manifests/release/base/abis/dojo-world.json"
 tag = "dojo-world"
 manifest_name = "dojo-world"

--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -6,6 +6,8 @@ trait IActions {
     fn move(ref world: IWorldDispatcher, direction: Direction);
     fn set_player_config(ref world: IWorldDispatcher, name: ByteArray);
     fn get_player_position(world: @IWorldDispatcher) -> Position;
+    fn update_player_name(ref world: IWorldDispatcher, name: ByteArray);
+    fn update_player_name_value(ref world: IWorldDispatcher, name: ByteArray);
     fn reset_player_config(ref world: IWorldDispatcher);
     fn set_player_server_profile(ref world: IWorldDispatcher, server_id: u32, name: ByteArray);
     #[cfg(feature: 'dungeon')]
@@ -25,7 +27,8 @@ mod actions {
 
     use starknet::{ContractAddress, get_caller_address};
     use dojo_examples::models::{
-        Position, Moves, Direction, Vec2, PlayerConfig, PlayerItem, ServerProfile
+        Position, Moves, Direction, Vec2, PlayerConfig, PlayerItem, ServerProfile, PositionTrait,
+        MovesTrait, MovesEntityTrait, PlayerConfigTrait, PlayerConfigEntityTrait
     };
     use dojo_examples::utils::next_position;
 
@@ -84,11 +87,28 @@ mod actions {
 
         fn move(ref world: IWorldDispatcher, direction: Direction) {
             let player = get_caller_address();
-            let (mut position, mut moves) = get!(world, player, (Position, Moves));
+
+            // instead of using the `get!` macro, you can directly use
+            // the <ModelName>Trait::get method
+            let mut position = PositionTrait::get(world, player);
+
+            // you can also get entity values by entity ID with the `<ModelName>EntityTrait` trait.
+            // Note that it returns a `<ModelName>Entity` struct which contains
+            // model values and the entity ID.
+            let move_id = MovesTrait::entity_id_from_keys(player);
+            let mut moves = MovesEntityTrait::get(world, move_id);
+
             moves.remaining -= 1;
             moves.last_direction = direction;
             let next = next_position(position, direction);
-            set!(world, (moves, next));
+
+            // instead of using the `set!` macro, you can directly use
+            // the <ModelName>Trait::set method
+            next.set(world);
+
+            // you can also update entity values by entity ID with the `<ModelName>EntityTrait` trait.
+            moves.update(world);
+
             emit!(world, (Moved { player, direction }));
         }
 
@@ -107,9 +127,11 @@ mod actions {
         fn reset_player_config(ref world: IWorldDispatcher) {
             let player = get_caller_address();
 
-            let (position, moves, config) = get!(world, player, (Position, Moves, PlayerConfig));
+            let (position, moves) = get!(world, player, (Position, Moves));
+            let config = PlayerConfigTrait::get(world, player);
 
-            delete!(world, (position, moves, config));
+            delete!(world, (position, moves));
+            config.delete(world);
 
             let (position, moves, config) = get!(world, player, (Position, Moves, PlayerConfig));
 
@@ -143,6 +165,26 @@ mod actions {
             set!(world, (flatbow, river_skale));
 
             IDungeonDispatcher { contract_address: dungeon_address }.enter();
+        }
+
+        fn update_player_name(ref world: IWorldDispatcher, name: ByteArray) {
+            let player = get_caller_address();
+            let config = PlayerConfigTrait::get(world, player);
+            config.set_name(world, name.clone());
+
+            let new_name = PlayerConfigTrait::get_name(world, player);
+            assert(new_name == name, 'unable to change name');
+        }
+
+        fn update_player_name_value(ref world: IWorldDispatcher, name: ByteArray) {
+            let player = get_caller_address();
+            let config_id = PlayerConfigTrait::entity_id_from_keys(player);
+
+            let config = PlayerConfigEntityTrait::get(world, config_id);
+            config.set_name(world, name.clone());
+
+            let new_name = PlayerConfigEntityTrait::get_name(world, config_id);
+            assert(new_name == name, 'unable to change name');
         }
     }
 
@@ -196,6 +238,12 @@ mod tests {
         // System calls
         actions_system.spawn();
         let initial_moves = get!(world, caller, Moves);
+        let initial_position = get!(world, caller, Position);
+
+        assert(
+            initial_position.vec.x == 10 && initial_position.vec.y == 10, 'wrong initial position'
+        );
+
         actions_system.move(Direction::Right(()));
 
         let moves = get!(world, caller, Moves);
@@ -205,7 +253,7 @@ mod tests {
         assert(moves.last_direction.into() == right_dir_felt, 'last direction is wrong');
 
         let new_position = get!(world, caller, Position);
-        assert(new_position.vec.x == 11, 'position x is wrong');
-        assert(new_position.vec.y == 10, 'position y is wrong');
+        assert(new_position.vec.x == initial_position.vec.x + 1, 'position x is wrong');
+        assert(new_position.vec.y == initial_position.vec.y, 'position y is wrong');
     }
 }

--- a/examples/spawn-and-move/src/mock_token.cairo
+++ b/examples/spawn-and-move/src/mock_token.cairo
@@ -5,7 +5,6 @@ mod mock_token {
 
     fn dojo_init(world: @IWorldDispatcher) {
         let account: ContractAddress = get_caller_address();
-
         set!(world, MockToken { account: account, amount: 1000 });
     }
 }


### PR DESCRIPTION
This PR implements:
- new `get` and `set` methods on models, to be able to get/set model records without using the `get!` and `set!` macro,
- new `get` and `set` methods on models to be able to get/set entities by ID. In these cases, as key values are not known, a new `<ModelName>Entity` struct containing model values and the entity ID is introduced.

Let's take an example with the following `Message` model:

```rust
#[dojo::model]
struct Message {
    #[key]
    identity: ContractAddress,
    #[key]
    channel: felt252,
    message: ByteArray,
}
 ```

A new `MessageEntity` struct will be generated:
```rust
struct MessageEntity {
    __id: felt252,
    message: ByteArray,
}
```

The `dojo::model::Model<T>` and `dojo::model::ModelEntity<T>` are implemented for `Message`.

A new `MessageTrait` impl will be generated to handle model `get`/`set` and `get_[field_name]/set_[field_name]` operations:
```rust
#[generate_trait]
impl MessageImpl of MessageTrait {
     fn entity_id_from_keys(identity: ContractAddress, channel: felt252) -> felt252 {};
     fn get(world: IWorldDispatcher, identity: ContractAddress, channel: felt252) -> Message {}
     
     // field accessors
     fn get_message(world: IWorldDispatcher, identity: ContractAddress, channel: felt252) -> ByteArray {}
     fn set_message(self: @Message world: IWorldDispatcher, value: ByteArray); 
}
```

A new `MessageEntityTrait` impl will be generated to handle model entity `get`/`set` and `get_[field_name]/set_[field_name]` operations:
```rust
#[generate_trait]
impl MessageEntityImpl of MessageEntityTrait {
     fn get(world: IWorldDispatcher, entity_id: felt252) -> MessageEntity {}

     // field accessors
     fn get_message(world: IWorldDispatcher, identity: ContractAddress, channel: felt252) -> ByteArray {}
     fn set_message(self: @Message world: IWorldDispatcher, value: ByteArray); 
}
```

So this `Message` model can be used like this:
```rust
let mut message = MessageTrait::get(world, identity, channel);
message.message = "hello world!";
message.set(world);
message.delete(world);

let id = MessageTrait::entity_id_from_keys(identity, channel);
let mut entity = MessageEntityTrait::get(world, id);
entity.message = "Hi !";
entity.set(world);
entity.delete(world);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Simplified entity deletion and retrieval processes for improved performance and readability.
  - Introduced new functions (`update_player_name`, `update_player_name_value`) in the `dojo_examples-actions` contract.
  - Added new enum `ModelIndex` for better structuring in `dojo-world`.

- **Enhancements**
  - Refactored `SetMacro` for improved code clarity.
  - Updated contract addresses and hashes for better compatibility.

- **Bug Fixes**
  - Adjusted event structures and member names for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->