### PR TITLE
fix(sozo): ensure overlays can support any resource type

### DIFF
--- a/crates/sozo/ops/src/migration/auto_auth.rs
+++ b/crates/sozo/ops/src/migration/auto_auth.rs
@@ -66,7 +66,7 @@ pub fn compute_writers(
                 format!("m:{}", tag_with_prefix)
             };
 
-            let resource = format!("{},{}", resource_type, migrated_contract.contract_address);
+            let resource = format!("{},{}", resource_type, migrated_contract.tag);
             res.push(ResourceWriter::from_str(&resource)?);
         }
     }

--- a/crates/sozo/ops/src/migration/auto_auth.rs
+++ b/crates/sozo/ops/src/migration/auto_auth.rs
@@ -49,8 +49,6 @@ pub fn compute_writers(
             .find(|c| migrated_contract.tag == c.inner.tag)
             .expect("we know this contract exists");
 
-        // TODO: we may add support for `owns`?
-
         if !contract.inner.writes.is_empty() {
             ui.print_sub(format!(
                 "Authorizing {} for resources: {:?}",


### PR DESCRIPTION
This PR enables the use of any resource type into the overlays, to follow the scheme used by `sozo auth` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved authorization process for better clarity and efficiency.
	- Adjusted UI messages related to resource authorization.

- **Bug Fixes**
	- Ensured proper handling of contracts and resources in the authorization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->