### PR TITLE
fix: use `merge-strategy` instead of copying profile

### DIFF
--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -31,27 +31,10 @@ account_address = "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb4
 private_key = "0x1800000000300000180000000000030000000000003006001800006600"
 world_address = "0x504b804eeac62e68d12dc030e56b8f62cb047950c346e60a974da02795f6aba"
 
-# `release` profile
-#
-# for now configurations in `tool` are not merged recursively so to override
-# `skip_migration` we need to redefine the whole `tool.dojo` table
-[profile.release]
-
-[profile.release.tool.dojo.world]
-description = "example world"
-name = "example"
-seed = "dojo_examples"
-namespace = "dojo_examples"
-
-[profile.release.tool.dojo.env]
-rpc_url = "http://localhost:5050/"
-
-# Default account for katana with seed = 0
-account_address = "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03"
-private_key = "0x1800000000300000180000000000030000000000003006001800006600"
-world_address = "0x07efebb0c2d4cc285d48a97a7174def3be7fdd6b7bd29cca758fa2e17e03ef30"
-
 [profile.release.tool.dojo]
+# for more info on how `merge-strategy` works see:
+# https://docs.swmansion.com/scarb/docs/reference/profiles.html#overriding-tool-metadata
+merge-strategy = "merge"
 skip_migration = [
     "dojo_examples::mock_token::mock_token",
     "dojo_examples::models::mock_token",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration Updates**
  - Added `merge-strategy` field.
  - Removed `description`, `name`, `seed`, and `namespace` fields.
  - Updated `skip_migration` list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->