### PR TITLE
refactor(katana-db): database transaction abstractions

### DIFF
--- a/crates/katana/storage/db/src/abstraction/cursor.rs
+++ b/crates/katana/storage/db/src/abstraction/cursor.rs
@@ -1,0 +1,196 @@
+use crate::error::DatabaseError;
+use crate::tables::{self, DupSort, Table};
+use crate::utils::KeyValue;
+
+/// Cursor trait for navigating the items within a database.
+pub trait DbCursor<T: Table>: Sized {
+    /// Retrieves the first key/value pair, positioning the cursor at the first key/value pair in
+    /// the table.
+    fn first(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Retrieves key/value pair at current cursor position.
+    fn current(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Retrieves the next key/value pair, positioning the cursor at the next key/value pair in
+    /// the table.
+    fn next(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Retrieves the previous key/value pair, positioning the cursor at the previous key/value pair
+    /// in the table.
+    fn prev(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Retrieves the last key/value pair, positioning the cursor at the last key/value pair in
+    /// the table.
+    fn last(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Set the cursor to the specified key, returning and positioning the cursor at the item if
+    /// found.
+    fn set(&mut self, key: T::Key) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Search for a `key` in a table, returning and positioning the cursor at the first item whose
+    /// key is greater than or equal to `key`.
+    fn seek(&mut self, key: T::Key) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Creates a walker to iterate over the table items.
+    ///
+    /// If `start_key` is `None`, the walker will start at the first item of the table. Otherwise,
+    /// it will start at the first item whose key is greater than or equal to `start_key`.
+    fn walk(&mut self, start_key: Option<T::Key>) -> Result<Walker<'_, T, Self>, DatabaseError>;
+}
+
+/// Cursor trait for read-write operations.
+pub trait DbCursorMut<T: Table>: DbCursor<T> {
+    /// Database operation that will update an existing row if a specified value already
+    /// exists in a table, and insert a new row if the specified value doesn't already exist
+    fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+
+    /// Puts a key/value pair into the database. The cursor will be positioned at the new data item,
+    /// or on failure, usually near it.
+    fn insert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+
+    /// Appends the data to the end of the table. Consequently, the append operation
+    /// will fail if the inserted key is less than the last table key
+    fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+
+    /// Deletes the current key/value pair.
+    fn delete_current(&mut self) -> Result<(), DatabaseError>;
+}
+
+/// Cursor trait for DUPSORT tables.
+pub trait DbDupSortCursor<T: DupSort>: DbCursor<T> {
+    /// Positions the cursor at next data item of current key, returning the next `key-value`
+    /// pair of a DUPSORT table.
+    fn next_dup(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Similar to `next_dup()`, but instead of returning a `key-value` pair, it returns
+    /// only the `value`.
+    fn next_dup_val(&mut self) -> Result<Option<T::Value>, DatabaseError>;
+
+    /// Returns the next key/value pair skipping the duplicates.
+    fn next_no_dup(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError>;
+
+    /// Search for a `key` and `subkey` pair in a DUPSORT table. Positioning the cursor at the first
+    /// item whose `subkey` is greater than or equal to the specified `subkey`.
+    fn seek_by_key_subkey(
+        &mut self,
+        key: <T as Table>::Key,
+        subkey: <T as DupSort>::SubKey,
+    ) -> Result<Option<<T as Table>::Value>, DatabaseError>;
+
+    /// Depending on its arguments, returns an iterator starting at:
+    /// - Some(key), Some(subkey): a `key` item whose data is >= than `subkey`
+    /// - Some(key), None: first item of a specified `key`
+    /// - None, Some(subkey): like first case, but in the first key
+    /// - None, None: first item in the table
+    /// of a DUPSORT table.
+    fn walk_dup(
+        &mut self,
+        key: Option<T::Key>,
+        subkey: Option<<T as DupSort>::SubKey>,
+    ) -> Result<Option<DupWalker<'_, T, Self>>, DatabaseError>;
+}
+
+/// Cursor trait for read-write operations on DUPSORT tables.
+pub trait DbDupSortCursorMut<T: tables::DupSort>: DbDupSortCursor<T> + DbCursorMut<T> {
+    /// Deletes all values for the current key.
+    fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError>;
+
+    /// Appends the data as a duplicate for the current key.
+    fn append_dup(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+}
+
+/// A key-value pair coming from an iterator.
+///
+/// The `Result` represents that the operation might fail, while the `Option` represents whether or
+/// not there is an entry.
+pub type IterPairResult<T> = Option<Result<KeyValue<T>, DatabaseError>>;
+
+/// Provides an iterator to a `Cursor` when handling `Table`.
+#[derive(Debug)]
+pub struct Walker<'c, T: Table, C: DbCursor<T>> {
+    /// Cursor to be used to walk through the table.
+    cursor: &'c mut C,
+    /// Initial position of the dup walker. The value (key/value pair)  where to start the walk.
+    start: IterPairResult<T>,
+}
+
+impl<'c, T, C> Walker<'c, T, C>
+where
+    T: Table,
+    C: DbCursor<T>,
+{
+    /// Create a new [`Walker`] from a [`Cursor`] and a [`IterPairResult`].
+    pub fn new(cursor: &'c mut C, start: IterPairResult<T>) -> Self {
+        Self { cursor, start }
+    }
+}
+
+impl<T, C> Walker<'_, T, C>
+where
+    T: Table,
+    C: DbCursorMut<T>,
+{
+    /// Delete the `key/value` pair item at the current position of the walker.
+    pub fn delete_current(&mut self) -> Result<(), DatabaseError> {
+        self.cursor.delete_current()
+    }
+}
+
+impl<T, C> std::iter::Iterator for Walker<'_, T, C>
+where
+    T: Table,
+    C: DbCursor<T>,
+{
+    type Item = Result<KeyValue<T>, DatabaseError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let value @ Some(_) = self.start.take() { value } else { self.cursor.next().transpose() }
+    }
+}
+
+/// A cursor iterator for `DUPSORT` table.
+///
+/// Similar to [`Walker`], but for `DUPSORT` table.
+#[derive(Debug)]
+pub struct DupWalker<'c, T: Table, C: DbCursor<T>> {
+    /// Cursor to be used to walk through the table.
+    cursor: &'c mut C,
+    /// Initial position of the dup walker. The value (key/value pair) where to start the walk.
+    start: IterPairResult<T>,
+}
+
+impl<'c, T, C> DupWalker<'c, T, C>
+where
+    T: DupSort,
+    C: DbCursor<T>,
+{
+    /// Creates a new [`DupWalker`] from a [`Cursor`] and a [`IterPairResult`].
+    pub fn new(cursor: &'c mut C, start: IterPairResult<T>) -> Self {
+        Self { cursor, start }
+    }
+}
+
+impl<T, C> DupWalker<'_, T, C>
+where
+    T: DupSort,
+    C: DbCursorMut<T>,
+{
+    /// Delete the item at the current position of the walker.
+    pub fn delete_current(&mut self) -> Result<(), DatabaseError> {
+        self.cursor.delete_current()
+    }
+}
+
+impl<T, C> std::iter::Iterator for DupWalker<'_, T, C>
+where
+    T: DupSort,
+    C: DbDupSortCursor<T>,
+{
+    type Item = Result<KeyValue<T>, DatabaseError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let value @ Some(_) = self.start.take() {
+            value
+        } else {
+            self.cursor.next_dup().transpose()
+        }
+    }
+}

--- a/crates/katana/storage/db/src/abstraction/mod.rs
+++ b/crates/katana/storage/db/src/abstraction/mod.rs
@@ -1,0 +1,5 @@
+mod cursor;
+mod transaction;
+
+pub use cursor::*;
+pub use transaction::*;

--- a/crates/katana/storage/db/src/abstraction/transaction.rs
+++ b/crates/katana/storage/db/src/abstraction/transaction.rs
@@ -45,7 +45,7 @@ pub trait DbTxMut: DbTx {
     ///
     /// Returns `true` if the key/value pair was present.
     fn delete<T: Table>(&self, key: T::Key, value: Option<T::Value>)
-        -> Result<bool, DatabaseError>;
+    -> Result<bool, DatabaseError>;
 
     /// Clears all entries in the given database. This will empty the database.
     fn clear<T: Table>(&self) -> Result<(), DatabaseError>;

--- a/crates/katana/storage/db/src/abstraction/transaction.rs
+++ b/crates/katana/storage/db/src/abstraction/transaction.rs
@@ -1,0 +1,52 @@
+use super::cursor::{DbCursor, DbCursorMut};
+use crate::error::DatabaseError;
+use crate::tables::Table;
+
+/// Trait for read-only transaction type.
+pub trait DbTx {
+    /// The cursor type.
+    type Cursor<T: Table>: DbCursor<T>;
+
+    /// Creates a cursor to iterate over a table items.
+    fn cursor<T: Table>(&self) -> Result<Self::Cursor<T>, DatabaseError>;
+
+    /// Gets a value from a table using the given key.
+    fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError>;
+
+    /// Returns number of entries in the table.
+    fn entries<T: Table>(&self) -> Result<usize, DatabaseError>;
+
+    /// Commits the transaction.
+    fn commit(self) -> Result<bool, DatabaseError>;
+
+    /// Aborts the transaction.
+    fn abort(self);
+}
+
+/// Trait for read-write transaction type.
+pub trait DbTxMut: DbTx {
+    /// The mutable cursor type.
+    type Cursor<T: Table>: DbCursorMut<T>;
+
+    /// Creates a cursor to mutably iterate over a table items.
+    fn cursor_mut<T: Table>(&self) -> Result<<Self as DbTxMut>::Cursor<T>, DatabaseError>;
+
+    /// Inserts an item into a database.
+    ///
+    /// This function stores key/data pairs in the database. The default behavior is to enter the
+    /// new key/data pair, replacing any previously existing key if duplicates are disallowed, or
+    /// adding a duplicate data item if duplicates are allowed (DatabaseFlags::DUP_SORT).
+    fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError>;
+
+    /// Delete items from a database, removing the key/data pair if it exists.
+    ///
+    /// If the data parameter is [Some] only the matching data item will be deleted. Otherwise, if
+    /// data parameter is [None], any/all value(s) for specified key will be deleted.
+    ///
+    /// Returns `true` if the key/value pair was present.
+    fn delete<T: Table>(&self, key: T::Key, value: Option<T::Value>)
+        -> Result<bool, DatabaseError>;
+
+    /// Clears all entries in the given database. This will empty the database.
+    fn clear<T: Table>(&self) -> Result<(), DatabaseError>;
+}

--- a/crates/katana/storage/db/src/abstraction/transaction.rs
+++ b/crates/katana/storage/db/src/abstraction/transaction.rs
@@ -1,14 +1,23 @@
 use super::cursor::{DbCursor, DbCursorMut};
+use super::{DbDupSortCursor, DbDupSortCursorMut};
 use crate::error::DatabaseError;
-use crate::tables::Table;
+use crate::tables::{DupSort, Table};
 
 /// Trait for read-only transaction type.
 pub trait DbTx {
     /// The cursor type.
     type Cursor<T: Table>: DbCursor<T>;
 
+    /// The cursor type for dupsort table.
+    // TODO: ideally we should only define the cursor type once,
+    // find a way to not have to define both cursor types in both traits
+    type DupCursor<T: DupSort>: DbDupSortCursor<T>;
+
     /// Creates a cursor to iterate over a table items.
     fn cursor<T: Table>(&self) -> Result<Self::Cursor<T>, DatabaseError>;
+
+    /// Creates a cursor to iterate over a dupsort table items.
+    fn cursor_dup<T: DupSort>(&self) -> Result<Self::DupCursor<T>, DatabaseError>;
 
     /// Gets a value from a table using the given key.
     fn get<T: Table>(&self, key: T::Key) -> Result<Option<T::Value>, DatabaseError>;
@@ -28,8 +37,15 @@ pub trait DbTxMut: DbTx {
     /// The mutable cursor type.
     type Cursor<T: Table>: DbCursorMut<T>;
 
+    /// The mutable cursor type for dupsort table.
+    // TODO: find a way to not have to define both cursor types in both traits
+    type DupCursor<T: DupSort>: DbDupSortCursorMut<T>;
+
     /// Creates a cursor to mutably iterate over a table items.
     fn cursor_mut<T: Table>(&self) -> Result<<Self as DbTxMut>::Cursor<T>, DatabaseError>;
+
+    /// Creates a cursor to iterate over a dupsort table items.
+    fn cursor_dup_mut<T: DupSort>(&self) -> Result<<Self as DbTxMut>::DupCursor<T>, DatabaseError>;
 
     /// Inserts an item into a database.
     ///

--- a/crates/katana/storage/db/src/lib.rs
+++ b/crates/katana/storage/db/src/lib.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context};
 
+pub mod abstraction;
 pub mod codecs;
 pub mod error;
 pub mod mdbx;

--- a/crates/katana/storage/db/src/mdbx/cursor.rs
+++ b/crates/katana/storage/db/src/mdbx/cursor.rs
@@ -5,6 +5,9 @@ use std::marker::PhantomData;
 
 use libmdbx::{self, TransactionKind, WriteFlags, RW};
 
+use crate::abstraction::{
+    DbCursor, DbCursorMut, DbDupSortCursor, DbDupSortCursorMut, DupWalker, Walker,
+};
 use crate::codecs::{Compress, Encode};
 use crate::error::DatabaseError;
 use crate::tables::{DupSort, Table};
@@ -32,54 +35,40 @@ impl<K: TransactionKind, T: Table> Cursor<K, T> {
     }
 }
 
-impl<K: TransactionKind, T: Table> Cursor<K, T> {
-    /// Retrieves the first key/value pair, positioning the cursor at the first key/value pair in
-    /// the table.
-    pub fn first(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
+impl<K, T> DbCursor<T> for Cursor<K, T>
+where
+    K: TransactionKind,
+    T: Table,
+{
+    fn first(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::first(&mut self.inner))
     }
 
-    /// Retrieves key/value pair at current cursor position.
-    pub fn current(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
+    fn current(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::get_current(&mut self.inner))
     }
 
-    /// Retrieves the next key/value pair, positioning the cursor at the next key/value pair in
-    /// the table.
-    #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
+    fn next(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::next(&mut self.inner))
     }
 
-    /// Retrieves the previous key/value pair, positioning the cursor at the previous key/value pair
-    /// in the table.
-    pub fn prev(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
+    fn prev(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::prev(&mut self.inner))
     }
 
-    /// Retrieves the last key/value pair, positioning the cursor at the last key/value pair in
-    /// the table.
-    pub fn last(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
+    fn last(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::last(&mut self.inner))
     }
 
-    /// Set the cursor to the specified key, returning and positioning the cursor at the item if
-    /// found.
-    pub fn set(&mut self, key: <T as Table>::Key) -> Result<Option<KeyValue<T>>, DatabaseError> {
+    fn set(&mut self, key: <T as Table>::Key) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::set_key(&mut self.inner, key.encode().as_ref()))
     }
 
-    /// Search for a `key` in a table, returning and positioning the cursor at the first item whose
-    /// key is greater than or equal to `key`.
-    pub fn seek(&mut self, key: <T as Table>::Key) -> Result<Option<KeyValue<T>>, DatabaseError> {
+    fn seek(&mut self, key: <T as Table>::Key) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::set_range(&mut self.inner, key.encode().as_ref()))
     }
 
-    /// Creates a walker to iterate over the table items.
-    ///
-    /// If `start_key` is `None`, the walker will start at the first item of the table. Otherwise,
-    /// it will start at the first item whose key is greater than or equal to `start_key`.
-    pub fn walk(&mut self, start_key: Option<T::Key>) -> Result<Walker<'_, K, T>, DatabaseError> {
+    fn walk(&mut self, start_key: Option<T::Key>) -> Result<Walker<'_, T, Self>, DatabaseError> {
         let start = if let Some(start_key) = start_key {
             self.inner
                 .set_range(start_key.encode().as_ref())
@@ -93,30 +82,27 @@ impl<K: TransactionKind, T: Table> Cursor<K, T> {
     }
 }
 
-impl<K: TransactionKind, T: DupSort> Cursor<K, T> {
-    /// Positions the cursor at next data item of current key, returning the next `key-value`
-    /// pair of a DUPSORT table.
-    pub fn next_dup(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
+impl<K, T> DbDupSortCursor<T> for Cursor<K, T>
+where
+    K: TransactionKind,
+    T: DupSort,
+{
+    fn next_dup(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::next_dup(&mut self.inner))
     }
 
-    /// Similar to [`Self::next_dup()`], but instead of returning a `key-value` pair, it returns
-    /// only the `value`.
-    pub fn next_dup_val(&mut self) -> Result<Option<<T as Table>::Value>, DatabaseError> {
+    fn next_dup_val(&mut self) -> Result<Option<<T as Table>::Value>, DatabaseError> {
         libmdbx::Cursor::next_dup(&mut self.inner)
             .map_err(DatabaseError::Read)?
             .map(decode_value::<T>)
             .transpose()
     }
 
-    /// Returns the next key/value pair skipping the duplicates.
-    pub fn next_no_dup(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
+    fn next_no_dup(&mut self) -> Result<Option<KeyValue<T>>, DatabaseError> {
         decode!(libmdbx::Cursor::next_nodup(&mut self.inner))
     }
 
-    /// Search for a `key` and `subkey` pair in a DUPSORT table. Positioning the cursor at the first
-    /// item whose `subkey` is greater than or equal to the specified `subkey`.
-    pub fn seek_by_key_subkey(
+    fn seek_by_key_subkey(
         &mut self,
         key: <T as Table>::Key,
         subkey: <T as DupSort>::SubKey,
@@ -131,17 +117,11 @@ impl<K: TransactionKind, T: DupSort> Cursor<K, T> {
         .transpose()
     }
 
-    /// Depending on its arguments, returns an iterator starting at:
-    /// - Some(key), Some(subkey): a `key` item whose data is >= than `subkey`
-    /// - Some(key), None: first item of a specified `key`
-    /// - None, Some(subkey): like first case, but in the first key
-    /// - None, None: first item in the table
-    /// of a DUPSORT table.
-    pub fn walk_dup(
+    fn walk_dup(
         &mut self,
         key: Option<T::Key>,
         subkey: Option<T::SubKey>,
-    ) -> Result<Option<DupWalker<'_, K, T>>, DatabaseError> {
+    ) -> Result<Option<DupWalker<'_, T, Self>>, DatabaseError> {
         let start = match (key, subkey) {
             (Some(key), Some(subkey)) => {
                 // encode key and decode it after.
@@ -186,15 +166,11 @@ impl<K: TransactionKind, T: DupSort> Cursor<K, T> {
     }
 }
 
-impl<T: Table> Cursor<RW, T> {
-    /// Database operation that will update an existing row if a specified value already
-    /// exists in a table, and insert a new row if the specified value doesn't already exist
-    ///
-    /// For a `DUPSORT` table, `upsert` will not actually update-or-insert. If the key already
-    /// exists, it will append the value to the subkey, even if the subkeys are the same. So if
-    /// you want to properly upsert, you'll need to `seek_exact` & `delete_current` if the
-    /// key+subkey was found, before calling `upsert`.
-    pub fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+impl<T> DbCursorMut<T> for Cursor<RW, T>
+where
+    T: Table,
+{
+    fn upsert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
         let key = Encode::encode(key);
         let value = Compress::compress(value);
 
@@ -206,9 +182,7 @@ impl<T: Table> Cursor<RW, T> {
             })
     }
 
-    /// Puts a key/value pair into the database. The cursor will be positioned at the new data item,
-    /// or on failure, usually near it.
-    pub fn insert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+    fn insert(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
         let key = Encode::encode(key);
         let value = Compress::compress(value);
 
@@ -225,9 +199,7 @@ impl<T: Table> Cursor<RW, T> {
         })
     }
 
-    /// Appends the data to the end of the table. Consequently, the append operation
-    /// will fail if the inserted key is less than the last table key
-    pub fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+    fn append(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
         let key = Encode::encode(key);
         let value = Compress::compress(value);
 
@@ -239,23 +211,21 @@ impl<T: Table> Cursor<RW, T> {
             })
     }
 
-    /// Deletes the current key/value pair.
-    pub fn delete_current(&mut self) -> Result<(), DatabaseError> {
+    fn delete_current(&mut self) -> Result<(), DatabaseError> {
         libmdbx::Cursor::del(&mut self.inner, WriteFlags::CURRENT).map_err(DatabaseError::Delete)
     }
 }
 
-impl<T: DupSort> Cursor<RW, T> {
-    /// Deletes all values for the current key.
-    ///
-    /// This will delete all values for the current duplicate key of a `DUPSORT` table, including
-    /// the current item.
-    pub fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError> {
+impl<T> DbDupSortCursorMut<T> for Cursor<RW, T>
+where
+    T: DupSort,
+{
+    fn delete_current_duplicates(&mut self) -> Result<(), DatabaseError> {
         libmdbx::Cursor::del(&mut self.inner, WriteFlags::NO_DUP_DATA)
             .map_err(DatabaseError::Delete)
     }
 
-    pub fn append_dup(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+    fn append_dup(&mut self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
         let key = Encode::encode(key);
         let value = Compress::compress(value);
 
@@ -265,85 +235,5 @@ impl<T: DupSort> Cursor<RW, T> {
                 table: T::NAME,
                 key: Box::from(key.as_ref()),
             })
-    }
-}
-
-/// A key-value pair coming from an iterator.
-///
-/// The `Result` represents that the operation might fail, while the `Option` represents whether or
-/// not there is an entry.
-pub type IterPairResult<T> = Option<Result<KeyValue<T>, DatabaseError>>;
-
-/// Provides an iterator to a `Cursor` when handling `Table`.
-#[derive(Debug)]
-pub struct Walker<'c, K: TransactionKind, T: Table> {
-    /// Cursor to be used to walk through the table.
-    cursor: &'c mut Cursor<K, T>,
-    /// Initial position of the dup walker. The value (key/value pair)  where to start the walk.
-    start: IterPairResult<T>,
-}
-
-impl<'c, K, T> Walker<'c, K, T>
-where
-    K: TransactionKind,
-    T: Table,
-{
-    /// Create a new [`Walker`] from a [`Cursor`] and a [`IterPairResult`].
-    pub(super) fn new(cursor: &'c mut Cursor<K, T>, start: IterPairResult<T>) -> Self {
-        Self { cursor, start }
-    }
-}
-
-impl<T: Table> Walker<'_, RW, T> {
-    /// Delete the `key/value` pair item at the current position of the walker.
-    pub fn delete_current(&mut self) -> Result<(), DatabaseError> {
-        self.cursor.delete_current()
-    }
-}
-
-impl<K: TransactionKind, T: Table> std::iter::Iterator for Walker<'_, K, T> {
-    type Item = Result<KeyValue<T>, DatabaseError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if let value @ Some(_) = self.start.take() { value } else { self.cursor.next().transpose() }
-    }
-}
-
-/// A cursor iterator for `DUPSORT` table.
-///
-/// Similar to [`Walker`], but for `DUPSORT` table.
-#[derive(Debug)]
-pub struct DupWalker<'c, K: TransactionKind, T: DupSort> {
-    /// Cursor to be used to walk through the table.
-    cursor: &'c mut Cursor<K, T>,
-    /// Initial position of the dup walker. The value (key/value pair) where to start the walk.
-    start: IterPairResult<T>,
-}
-
-impl<'c, K, T> DupWalker<'c, K, T>
-where
-    K: TransactionKind,
-    T: DupSort,
-{
-    /// Creates a new [`DupWalker`] from a [`Cursor`] and a [`IterPairResult`].
-    pub(super) fn new(cursor: &'c mut Cursor<K, T>, start: IterPairResult<T>) -> Self {
-        Self { cursor, start }
-    }
-}
-
-impl<T: DupSort> DupWalker<'_, RW, T> {
-    /// Delete the item at the current position of the walker.
-    pub fn delete_current(&mut self) -> Result<(), DatabaseError> {
-        self.cursor.delete_current()
-    }
-}
-
-impl<K: TransactionKind, T: DupSort> std::iter::Iterator for DupWalker<'_, K, T> {
-    type Item = Result<KeyValue<T>, DatabaseError>;
-    fn next(&mut self) -> Option<Self::Item> {
-        if let value @ Some(_) = self.start.take() {
-            value
-        } else {
-            self.cursor.next_dup().transpose()
-        }
     }
 }

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -7,9 +7,11 @@ pub mod tx;
 
 use std::path::Path;
 
+pub use libmdbx;
 use libmdbx::{DatabaseFlags, EnvironmentFlags, Geometry, Mode, PageSize, SyncMode, RO, RW};
 
 use self::tx::Tx;
+use crate::abstraction::DbTx;
 use crate::error::DatabaseError;
 use crate::tables::{TableType, Tables};
 use crate::utils;
@@ -142,8 +144,8 @@ mod tests {
     use starknet::macros::felt;
 
     use super::*;
+    use crate::abstraction::{DbCursor, DbCursorMut, DbDupSortCursor, DbTxMut, Walker};
     use crate::codecs::Encode;
-    use crate::mdbx::cursor::Walker;
     use crate::mdbx::test_utils::create_test_db;
     use crate::models::storage::StorageEntry;
     use crate::tables::{BlockHashes, ContractInfo, ContractStorage, Headers, Table};

--- a/crates/katana/storage/db/src/mdbx/tx.rs
+++ b/crates/katana/storage/db/src/mdbx/tx.rs
@@ -7,6 +7,7 @@ use libmdbx::{TransactionKind, WriteFlags, RW};
 use parking_lot::RwLock;
 
 use super::cursor::Cursor;
+use crate::abstraction::{DbTx, DbTxMut};
 use crate::codecs::{Compress, Encode};
 use crate::error::DatabaseError;
 use crate::tables::{Table, Tables, NUM_TABLES};
@@ -34,15 +35,6 @@ impl<K: TransactionKind> Tx<K> {
         Self { inner, db_handles: Default::default() }
     }
 
-    /// Creates a cursor to iterate over a table items.
-    pub fn cursor<T: Table>(&self) -> Result<Cursor<K, T>, DatabaseError> {
-        self.inner
-            .cursor_with_dbi(self.get_dbi::<T>()?)
-            .map(Cursor::new)
-            .map_err(DatabaseError::CreateCursor)
-    }
-
-    /// Gets a table database handle if it exists, otherwise creates it.
     pub fn get_dbi<T: Table>(&self) -> Result<DBI, DatabaseError> {
         let mut handles = self.db_handles.write();
         let table = Tables::from_str(T::NAME).expect("requested table should be part of `Tables`.");
@@ -55,9 +47,19 @@ impl<K: TransactionKind> Tx<K> {
 
         Ok(dbi_handle.expect("is some; qed"))
     }
+}
 
-    /// Gets a value from a table using the given key.
-    pub fn get<T: Table>(&self, key: T::Key) -> Result<Option<<T as Table>::Value>, DatabaseError> {
+impl<K: TransactionKind> DbTx for Tx<K> {
+    type Cursor<T: Table> = Cursor<K, T>;
+
+    fn cursor<T: Table>(&self) -> Result<Cursor<K, T>, DatabaseError> {
+        self.inner
+            .cursor_with_dbi(self.get_dbi::<T>()?)
+            .map(Cursor::new)
+            .map_err(DatabaseError::CreateCursor)
+    }
+
+    fn get<T: Table>(&self, key: T::Key) -> Result<Option<<T as Table>::Value>, DatabaseError> {
         let key = Encode::encode(key);
         self.inner
             .get(self.get_dbi::<T>()?, key.as_ref())
@@ -66,40 +68,37 @@ impl<K: TransactionKind> Tx<K> {
             .transpose()
     }
 
-    /// Returns number of entries in the table using cheap DB stats invocation.
-    pub fn entries<T: Table>(&self) -> Result<usize, DatabaseError> {
+    fn entries<T: Table>(&self) -> Result<usize, DatabaseError> {
         self.inner
             .db_stat_with_dbi(self.get_dbi::<T>()?)
             .map(|stat| stat.entries())
             .map_err(DatabaseError::Stat)
     }
 
-    /// Commits the transaction.
-    pub fn commit(self) -> Result<bool, DatabaseError> {
+    fn commit(self) -> Result<bool, DatabaseError> {
         self.inner.commit().map_err(DatabaseError::Commit)
+    }
+
+    fn abort(self) {
+        drop(self.inner)
     }
 }
 
-impl Tx<RW> {
-    /// Inserts an item into a database.
-    ///
-    /// This function stores key/data pairs in the database. The default behavior is to enter the
-    /// new key/data pair, replacing any previously existing key if duplicates are disallowed, or
-    /// adding a duplicate data item if duplicates are allowed (DatabaseFlags::DUP_SORT).
-    pub fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
+impl DbTxMut for Tx<RW> {
+    type Cursor<T: Table> = Cursor<RW, T>;
+
+    fn cursor_mut<T: Table>(&self) -> Result<<Self as DbTxMut>::Cursor<T>, DatabaseError> {
+        DbTx::cursor(self)
+    }
+
+    fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         let value = value.compress();
         self.inner.put(self.get_dbi::<T>()?, key, value, WriteFlags::UPSERT).unwrap();
         Ok(())
     }
 
-    /// Delete items from a database, removing the key/data pair if it exists.
-    ///
-    /// If the data parameter is [Some] only the matching data item will be deleted. Otherwise, if
-    /// data parameter is [None], any/all value(s) for specified key will be deleted.
-    ///
-    /// Returns `true` if the key/value pair was present.
-    pub fn delete<T: Table>(
+    fn delete<T: Table>(
         &self,
         key: T::Key,
         value: Option<T::Value>,
@@ -109,13 +108,7 @@ impl Tx<RW> {
         self.inner.del(self.get_dbi::<T>()?, key.encode(), value).map_err(DatabaseError::Delete)
     }
 
-    /// Clears all entries in the given database. This will emtpy the database.
-    pub fn clear<T: Table>(&self) -> Result<(), DatabaseError> {
+    fn clear<T: Table>(&self) -> Result<(), DatabaseError> {
         self.inner.clear_db(self.get_dbi::<T>()?).map_err(DatabaseError::Clear)
-    }
-
-    /// Aborts the transaction.
-    pub fn abort(self) {
-        drop(self.inner)
     }
 }

--- a/crates/katana/storage/provider/src/error.rs
+++ b/crates/katana/storage/provider/src/error.rs
@@ -73,7 +73,9 @@ pub enum ProviderError {
 
     /// Error when a contract nonce change entry is not found but the block number of when the
     /// change happen exists in the nonce change list.
-    #[error("Missing contract nonce change entry for contract {contract_address} at block {block}")]
+    #[error(
+        "Missing contract nonce change entry for contract {contract_address} at block {block}"
+    )]
     MissingContractNonceChangeEntry {
         /// The block number of when the change happen.
         block: BlockNumber,

--- a/crates/katana/storage/provider/src/error.rs
+++ b/crates/katana/storage/provider/src/error.rs
@@ -73,9 +73,7 @@ pub enum ProviderError {
 
     /// Error when a contract nonce change entry is not found but the block number of when the
     /// change happen exists in the nonce change list.
-    #[error(
-        "Missing contract nonce change entry for contract {contract_address} at block {block}"
-    )]
+    #[error("Missing contract nonce change entry for contract {contract_address} at block {block}")]
     MissingContractNonceChangeEntry {
         /// The block number of when the change happen.
         block: BlockNumber,

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::ops::{Range, RangeInclusive};
 
+use katana_db::abstraction::{DbCursor, DbCursorMut, DbDupSortCursor, DbTx, DbTxMut};
 use katana_db::error::DatabaseError;
 use katana_db::mdbx::{self, DbEnv};
 use katana_db::models::block::StoredBlockBodyIndices;

--- a/crates/katana/storage/provider/src/providers/db/state.rs
+++ b/crates/katana/storage/provider/src/providers/db/state.rs
@@ -1,3 +1,4 @@
+use katana_db::abstraction::{DbCursorMut, DbDupSortCursor, DbTx, DbTxMut};
 use katana_db::mdbx::{self};
 use katana_db::models::contract::ContractInfoChangeList;
 use katana_db::models::list::BlockList;


### PR DESCRIPTION
# Description

Make the katana database generic over the database tx implementations. Doesnt change any database behaviour.

Right now we only define the traits and implement them on the appropriate structs, replacing the current implementations that are just associated methods.

Later, we will use this trait on the provider level so that we can actually be generic over katana persistent database implementation.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced traits for advanced database cursor operations, enabling navigation, retrieval, insertion, deletion, and iteration over tables.
  - Added traits for read-only and read-write transactions, enhancing database manipulation capabilities.

- **Refactor**
  - Consolidated cursor and transaction implementations using new abstraction traits for improved modularity and reusability.
  
- **Chores**
  - Updated imports in several modules to use the newly introduced database abstraction traits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->