### PR TITLE
refactor(katana-db): main database trait

### DIFF
--- a/crates/katana/storage/db/src/abstraction/mod.rs
+++ b/crates/katana/storage/db/src/abstraction/mod.rs
@@ -1,5 +1,50 @@
 mod cursor;
 mod transaction;
 
+use std::fmt::Debug;
+
 pub use cursor::*;
 pub use transaction::*;
+
+use crate::error::DatabaseError;
+
+/// Main persistent database trait. The database implementation must be transactional.
+pub trait Database: Send + Sync {
+    /// Read-Only transaction
+    type Tx: DbTx + Send + Sync + Debug + 'static;
+    /// Read-Write transaction
+    type TxMut: DbTxMut + Send + Sync + Debug + 'static;
+
+    /// Create and begin read-only transaction.
+    #[track_caller]
+    fn tx(&self) -> Result<Self::Tx, DatabaseError>;
+
+    /// Create and begin read-write transaction, should return error if the database is unable to
+    /// create the transaction e.g, not opened with read-write permission.
+    #[track_caller]
+    fn tx_mut(&self) -> Result<Self::TxMut, DatabaseError>;
+
+    /// Takes a function and passes a read-only transaction into it, making sure it's closed in the
+    /// end of the execution.
+    fn view<T, F>(&self, f: F) -> Result<T, DatabaseError>
+    where
+        F: FnOnce(&Self::Tx) -> T,
+    {
+        let tx = self.tx()?;
+        let res = f(&tx);
+        tx.commit()?;
+        Ok(res)
+    }
+
+    /// Takes a function and passes a write-read transaction into it, making sure it's committed in
+    /// the end of the execution.
+    fn update<T, F>(&self, f: F) -> Result<T, DatabaseError>
+    where
+        F: FnOnce(&Self::TxMut) -> T,
+    {
+        let tx = self.tx_mut()?;
+        let res = f(&tx);
+        tx.commit()?;
+        Ok(res)
+    }
+}

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -11,7 +11,7 @@ pub use libmdbx;
 use libmdbx::{DatabaseFlags, EnvironmentFlags, Geometry, Mode, PageSize, SyncMode, RO, RW};
 
 use self::tx::Tx;
-use crate::abstraction::DbTx;
+use crate::abstraction::{Database, DbTx};
 use crate::error::DatabaseError;
 use crate::tables::{TableType, Tables};
 use crate::utils;
@@ -88,16 +88,6 @@ impl DbEnv {
         Ok(())
     }
 
-    /// Begin a read-only transaction.
-    pub fn tx(&self) -> Result<Tx<RO>, DatabaseError> {
-        Ok(Tx::new(self.0.begin_ro_txn().map_err(DatabaseError::CreateROTx)?))
-    }
-
-    /// Begin a read-write transaction.
-    pub fn tx_mut(&self) -> Result<Tx<RW>, DatabaseError> {
-        Ok(Tx::new(self.0.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?))
-    }
-
     /// Takes a function and passes a read-write transaction into it, making sure it's always
     /// committed in the end of the execution.
     pub fn update<T, F>(&self, f: F) -> Result<T, DatabaseError>
@@ -108,6 +98,19 @@ impl DbEnv {
         let res = f(&tx);
         tx.commit()?;
         Ok(res)
+    }
+}
+
+impl Database for DbEnv {
+    type Tx = Tx<RO>;
+    type TxMut = Tx<RW>;
+
+    fn tx(&self) -> Result<Self::Tx, DatabaseError> {
+        Ok(Tx::new(self.0.begin_ro_txn().map_err(DatabaseError::CreateROTx)?))
+    }
+
+    fn tx_mut(&self) -> Result<Self::TxMut, DatabaseError> {
+        Ok(Tx::new(self.0.begin_rw_txn().map_err(DatabaseError::CreateRWTx)?))
     }
 }
 

--- a/crates/katana/storage/provider/src/providers/db/state.rs
+++ b/crates/katana/storage/provider/src/providers/db/state.rs
@@ -1,5 +1,6 @@
-use katana_db::abstraction::{DbCursorMut, DbDupSortCursor, DbTx, DbTxMut};
-use katana_db::mdbx::{self};
+use core::fmt;
+
+use katana_db::abstraction::{Database, DbCursorMut, DbDupSortCursor, DbTx, DbTxMut};
 use katana_db::models::contract::ContractInfoChangeList;
 use katana_db::models::list::BlockList;
 use katana_db::models::storage::{ContractStorageKey, StorageEntry};
@@ -16,7 +17,7 @@ use crate::traits::contract::{ContractClassProvider, ContractClassWriter};
 use crate::traits::state::{StateProvider, StateWriter};
 use crate::ProviderResult;
 
-impl StateWriter for DbProvider {
+impl<Db: Database> StateWriter for DbProvider<Db> {
     fn set_nonce(&self, address: ContractAddress, nonce: Nonce) -> ProviderResult<()> {
         self.0.update(move |db_tx| -> ProviderResult<()> {
             let value = if let Some(info) = db_tx.get::<tables::ContractInfo>(address)? {
@@ -36,7 +37,7 @@ impl StateWriter for DbProvider {
         storage_value: StorageValue,
     ) -> ProviderResult<()> {
         self.0.update(move |db_tx| -> ProviderResult<()> {
-            let mut cursor = db_tx.cursor::<tables::ContractStorage>()?;
+            let mut cursor = db_tx.cursor_dup_mut::<tables::ContractStorage>()?;
             let entry = cursor.seek_by_key_subkey(address, storage_key)?;
 
             match entry {
@@ -101,15 +102,18 @@ impl ContractClassWriter for DbProvider {
 
 /// A state provider that provides the latest states from the database.
 #[derive(Debug)]
-pub(super) struct LatestStateProvider(mdbx::tx::TxRO);
+pub(super) struct LatestStateProvider<Tx: DbTx>(Tx);
 
-impl LatestStateProvider {
-    pub fn new(tx: mdbx::tx::TxRO) -> Self {
+impl<Tx: DbTx> LatestStateProvider<Tx> {
+    pub fn new(tx: Tx) -> Self {
         Self(tx)
     }
 }
 
-impl ContractClassProvider for LatestStateProvider {
+impl<Tx> ContractClassProvider for LatestStateProvider<Tx>
+where
+    Tx: DbTx + Send + Sync,
+{
     fn class(&self, hash: ClassHash) -> ProviderResult<Option<CompiledClass>> {
         let class = self.0.get::<tables::CompiledClasses>(hash)?;
         Ok(class)
@@ -129,7 +133,10 @@ impl ContractClassProvider for LatestStateProvider {
     }
 }
 
-impl StateProvider for LatestStateProvider {
+impl<Tx> StateProvider for LatestStateProvider<Tx>
+where
+    Tx: DbTx + fmt::Debug + Send + Sync,
+{
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
         let info = self.0.get::<tables::ContractInfo>(address)?;
         Ok(info.map(|info| info.nonce))
@@ -148,7 +155,7 @@ impl StateProvider for LatestStateProvider {
         address: ContractAddress,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
-        let mut cursor = self.0.cursor::<tables::ContractStorage>()?;
+        let mut cursor = self.0.cursor_dup::<tables::ContractStorage>()?;
         let entry = cursor.seek_by_key_subkey(address, storage_key)?;
         match entry {
             Some(entry) if entry.key == storage_key => Ok(Some(entry.value)),
@@ -159,20 +166,23 @@ impl StateProvider for LatestStateProvider {
 
 /// A historical state provider.
 #[derive(Debug)]
-pub(super) struct HistoricalStateProvider {
+pub(super) struct HistoricalStateProvider<Tx: DbTx + fmt::Debug> {
     /// The database transaction used to read the database.
-    tx: mdbx::tx::TxRO,
+    tx: Tx,
     /// The block number of the state.
     block_number: u64,
 }
 
-impl HistoricalStateProvider {
-    pub fn new(tx: mdbx::tx::TxRO, block_number: u64) -> Self {
+impl<Tx: DbTx + fmt::Debug> HistoricalStateProvider<Tx> {
+    pub fn new(tx: Tx, block_number: u64) -> Self {
         Self { tx, block_number }
     }
 }
 
-impl ContractClassProvider for HistoricalStateProvider {
+impl<Tx> ContractClassProvider for HistoricalStateProvider<Tx>
+where
+    Tx: DbTx + fmt::Debug + Send + Sync,
+{
     fn compiled_class_hash_of_class_hash(
         &self,
         hash: ClassHash,
@@ -207,14 +217,17 @@ impl ContractClassProvider for HistoricalStateProvider {
     }
 }
 
-impl StateProvider for HistoricalStateProvider {
+impl<Tx> StateProvider for HistoricalStateProvider<Tx>
+where
+    Tx: DbTx + fmt::Debug + Send + Sync,
+{
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
         let change_list = self.tx.get::<tables::ContractInfoChangeSet>(address)?;
 
         if let Some(num) = change_list
             .and_then(|entry| recent_change_from_block(self.block_number, &entry.nonce_change_list))
         {
-            let mut cursor = self.tx.cursor::<tables::NonceChangeHistory>()?;
+            let mut cursor = self.tx.cursor_dup::<tables::NonceChangeHistory>()?;
             let entry = cursor.seek_by_key_subkey(num, address)?.ok_or(
                 ProviderError::MissingContractNonceChangeEntry {
                     block: num,
@@ -240,7 +253,7 @@ impl StateProvider for HistoricalStateProvider {
         if let Some(num) = change_list
             .and_then(|entry| recent_change_from_block(self.block_number, &entry.class_change_list))
         {
-            let mut cursor = self.tx.cursor::<tables::ClassChangeHistory>()?;
+            let mut cursor = self.tx.cursor_dup::<tables::ClassChangeHistory>()?;
             let entry = cursor.seek_by_key_subkey(num, address)?.ok_or(
                 ProviderError::MissingContractClassChangeEntry {
                     block: num,
@@ -267,7 +280,7 @@ impl StateProvider for HistoricalStateProvider {
         if let Some(num) =
             block_list.and_then(|list| recent_change_from_block(self.block_number, &list))
         {
-            let mut cursor = self.tx.cursor::<tables::StorageChangeHistory>()?;
+            let mut cursor = self.tx.cursor_dup::<tables::StorageChangeHistory>()?;
             let entry = cursor.seek_by_key_subkey(num, key)?.ok_or(
                 ProviderError::MissingStorageChangeEntry {
                     block: num,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a generic type parameter for better flexibility in `DbProvider` and its associated implementations.

- **Refactor**
	- Consolidated transaction handling methods into a new `Database` trait.
	- Refactored `DbEnv` to implement the new `Database` trait.
	- Updated `LatestStateProvider` and `HistoricalStateProvider` to accept a generic type parameter, enhancing functionality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->