### PR TITLE
fix: ensure the snake case is only applied to model name

### DIFF
--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -69,8 +69,18 @@ impl ContractSelector {
         PackageName::new(parts.0)
     }
 
-    fn full_path(&self) -> String {
-        self.0.clone()
+    /// Returns the path with the model name in snake case.
+    /// This is used to match the output of the `compile()` function and Dojo plugin naming for
+    /// models contracts.
+    fn path_with_model_snake_case(&self) -> String {
+        let (path, last_segment) =
+            self.0.rsplit_once(CAIRO_PATH_SEPARATOR).unwrap_or(("", &self.0));
+
+        // We don't want to snake case the whole path because some of names like `erc20`
+        // will be changed to `erc_20`, and leading to invalid paths.
+        // The model name has to be snaked case as it's how the Dojo plugin names the Model's
+        // contract.
+        format!("{}{}{}", path, CAIRO_PATH_SEPARATOR, last_segment.to_case(Case::Snake))
     }
 }
 
@@ -174,11 +184,10 @@ fn find_project_contracts(
         find_contracts(db, crate_ids.as_ref())
             .into_iter()
             .filter(|decl| {
-                external_contracts.iter().any(|selector| {
-                    let contract_path = decl.module_id().full_path(db.upcast());
-                    // Snake case is used to ensure we match the `compile()` output.
-                    contract_path == selector.full_path().to_case(Case::Snake)
-                })
+                let contract_path = decl.module_id().full_path(db.upcast());
+                external_contracts
+                    .iter()
+                    .any(|selector| contract_path == selector.path_with_model_snake_case())
             })
             .collect::<Vec<ContractDeclaration>>()
     } else {
@@ -395,9 +404,10 @@ fn get_dojo_model_artifacts(
         if let Ok(Some(ModuleItemId::Struct(struct_id))) =
             db.module_item_by_name(module_id, model.name.clone().into())
         {
-            // The `struct_id` full_path() method uses the original struct name case while
-            // snake case was used to build `compiled_classes` in `compile()`.
-            let qualified_path = struct_id.full_path(db).to_case(Case::Snake);
+            // Leverages the contract selector function to only snake case the model name and
+            // not the full path.
+            let contract_selector = ContractSelector(struct_id.full_path(db));
+            let qualified_path = contract_selector.path_with_model_snake_case();
             let compiled_class = compiled_classes.get(&qualified_path).cloned();
             let tag = naming::get_tag(&model.namespace, &model.name);
 

--- a/crates/dojo-lang/src/compiler_test.rs
+++ b/crates/dojo-lang/src/compiler_test.rs
@@ -1,8 +1,9 @@
 use dojo_test_utils::compiler::build_test_config;
 use scarb::compiler::Profile;
-use scarb::core::TargetKind;
+use scarb::core::{PackageName, TargetKind};
 use scarb::ops::{CompileOpts, FeaturesOpts, FeaturesSelector};
 
+use crate::compiler::ContractSelector;
 use crate::scarb_internal;
 
 #[test]
@@ -29,4 +30,31 @@ fn test_compiler_cairo_features() {
     .unwrap();
 
     assert_eq!(compile_info.compile_error_units, Vec::<String>::default());
+}
+
+#[test]
+fn test_package() {
+    let selector = ContractSelector("my_package::my_contract".to_string());
+    assert_eq!(selector.package(), PackageName::new("my_package"));
+
+    let selector_no_separator = ContractSelector("my_package".to_string());
+    assert_eq!(selector_no_separator.package(), PackageName::new("my_package"));
+}
+
+#[test]
+fn test_path_with_model_snake_case() {
+    let selector = ContractSelector("my_package::MyContract".to_string());
+    assert_eq!(selector.path_with_model_snake_case(), "my_package::my_contract");
+
+    let selector_multiple_segments =
+        ContractSelector("my_package::sub_package::MyContract".to_string());
+    assert_eq!(
+        selector_multiple_segments.path_with_model_snake_case(),
+        "my_package::sub_package::my_contract"
+    );
+
+    // In snake case, erc20 should be erc_20. This test ensures that the path is converted to snake
+    // case only for the model's name.
+    let selector_erc20 = ContractSelector("my_package::erc20::Token".to_string());
+    assert_eq!(selector_erc20.path_with_model_snake_case(), "my_package::erc20::token");
 }


### PR DESCRIPTION
In Dojo plugin, we snake case the model name for the contract name associated to the model.
However, we were snake casing the whole path when looking for model's contract into artifacts folders.

This PR ensures that only the model's name is snaked case, which ensure correct path matching for paths like `module::erc20` which is `module::erc_20` in snake case. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved contract path matching to ensure naming consistency with Dojo plugin conventions.
	- Enhanced the handling of model names to prevent issues with specific names like `erc20`.

- **Tests**
	- Added tests for new contract path manipulation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->