### PR TITLE
refactor(torii): event messages share logic entities

### DIFF
--- a/crates/torii/core/src/processors/event_message.rs
+++ b/crates/torii/core/src/processors/event_message.rs
@@ -66,7 +66,7 @@ where
         let mut entity = model.schema().await?;
         entity.deserialize(&mut keys_and_unpacked)?;
 
-        db.set_event_message(entity, event_id, block_timestamp).await?;
+        db.set_entity(entity, true, event_id, block_timestamp).await?;
         Ok(())
     }
 }

--- a/crates/torii/core/src/processors/store_set_record.rs
+++ b/crates/torii/core/src/processors/store_set_record.rs
@@ -75,7 +75,7 @@ where
         let mut entity = model.schema().await?;
         entity.deserialize(&mut keys_and_unpacked)?;
 
-        db.set_entity(entity, event_id, block_timestamp).await?;
+        db.set_entity(entity, false, event_id, block_timestamp).await?;
         Ok(())
     }
 }

--- a/crates/torii/core/src/processors/store_update_record.rs
+++ b/crates/torii/core/src/processors/store_update_record.rs
@@ -78,7 +78,7 @@ where
         let mut entity = model.schema().await?;
         entity.deserialize(&mut keys_and_unpacked)?;
 
-        db.set_entity(entity, event_id, block_timestamp).await?;
+        db.set_entity(entity, false, event_id, block_timestamp).await?;
         Ok(())
     }
 }

--- a/crates/torii/core/src/types.rs
+++ b/crates/torii/core/src/types.rs
@@ -45,21 +45,6 @@ pub struct Entity {
 
 #[derive(FromRow, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct EventMessage {
-    pub id: String,
-    pub keys: String,
-    pub event_id: String,
-    pub executed_at: DateTime<Utc>,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-
-    // this should never be None. as a EventMessage cannot be deleted
-    #[sqlx(skip)]
-    pub updated_model: Option<Ty>,
-}
-
-#[derive(FromRow, Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
 pub struct Model {
     pub id: String,
     pub namespace: String,


### PR DESCRIPTION
refactor the event messages to behave just like entities and use the same tables but with a "event:*" prefix