### PR TITLE
fix(sozo): use `Provider` trait and avoid manifest read when possible

### DIFF
--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use dojo_world::contracts::naming::{ensure_namespace, is_valid_tag};
 use scarb::core::Config;
 use sozo_ops::model;
 use starknet::core::types::Felt;

--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::{Args, Subcommand};
-use dojo_world::contracts::naming::ensure_namespace;
-use dojo_world::metadata::get_default_namespace_from_ws;
+use dojo_world::contracts::naming::{ensure_namespace, is_valid_tag};
 use scarb::core::Config;
 use sozo_ops::model;
 use starknet::core::types::Felt;
@@ -113,44 +112,48 @@ impl ModelArgs {
         trace!(args = ?self);
         let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
         let env_metadata = utils::load_metadata_from_config(config)?;
-        let default_namespace = get_default_namespace_from_ws(&ws)?;
 
         config.tokio_handle().block_on(async {
             match self.command {
                 ModelCommand::ClassHash { tag_or_name, starknet, world } => {
-                    let tag = ensure_namespace(&tag_or_name, &default_namespace);
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
-                    model::model_class_hash(tag, world_address, provider).await
+                    model::model_class_hash(tag, world_address, &provider).await?;
+                    Ok(())
                 }
                 ModelCommand::ContractAddress { tag_or_name, starknet, world } => {
-                    let tag = ensure_namespace(&tag_or_name, &default_namespace);
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
-                    model::model_contract_address(tag, world_address, provider).await
+                    model::model_contract_address(tag, world_address, &provider).await?;
+                    Ok(())
                 }
                 ModelCommand::Layout { tag_or_name, starknet, world } => {
-                    let tag = ensure_namespace(&tag_or_name, &default_namespace);
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
-                    model::model_layout(tag, world_address, provider).await
+                    model::model_layout(tag, world_address, provider).await?;
+                    Ok(())
                 }
                 ModelCommand::Schema { tag_or_name, to_json, starknet, world } => {
-                    let tag = ensure_namespace(&tag_or_name, &default_namespace);
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
-                    model::model_schema(tag, world_address, provider, to_json).await
+                    model::model_schema(tag, world_address, provider, to_json).await?;
+                    Ok(())
                 }
                 ModelCommand::Get { tag_or_name, keys, starknet, world } => {
-                    let tag = ensure_namespace(&tag_or_name, &default_namespace);
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
-                    model::model_get(tag, keys, world_address, provider).await
+                    model::model_get(tag, keys, world_address, provider).await?;
+                    Ok(())
                 }
             }
         })

--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -109,13 +109,12 @@ hashes, called 'hash' in the following documentation.
 impl ModelArgs {
     pub fn run(self, config: &Config) -> Result<()> {
         trace!(args = ?self);
-        let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
         let env_metadata = utils::load_metadata_from_config(config)?;
 
         config.tokio_handle().block_on(async {
             match self.command {
                 ModelCommand::ClassHash { tag_or_name, starknet, world } => {
-                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, config)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
@@ -123,7 +122,7 @@ impl ModelArgs {
                     Ok(())
                 }
                 ModelCommand::ContractAddress { tag_or_name, starknet, world } => {
-                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, config)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
@@ -131,7 +130,7 @@ impl ModelArgs {
                     Ok(())
                 }
                 ModelCommand::Layout { tag_or_name, starknet, world } => {
-                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, config)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
@@ -139,7 +138,7 @@ impl ModelArgs {
                     Ok(())
                 }
                 ModelCommand::Schema { tag_or_name, to_json, starknet, world } => {
-                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, config)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();
@@ -147,7 +146,7 @@ impl ModelArgs {
                     Ok(())
                 }
                 ModelCommand::Get { tag_or_name, keys, starknet, world } => {
-                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, &ws)?;
+                    let tag = model::check_tag_or_read_default_namespace(&tag_or_name, config)?;
 
                     let world_address = world.address(env_metadata.as_ref()).unwrap();
                     let provider = starknet.provider(env_metadata.as_ref()).unwrap();

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -10,7 +10,6 @@ use num_traits::ToPrimitive;
 use scarb::core::Workspace;
 use starknet::core::types::{BlockId, BlockTag, Felt};
 use starknet::core::utils::get_selector_from_name;
-use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::Provider;
 
 const INDENT: &str = "    ";
@@ -673,7 +672,10 @@ pub fn deep_print_ty(root: &Ty) {
 /// sozo model commands to be run even without a Scarb.toml file in the current directory
 /// if a valid tag is provided.
 /// TODO: This may be removed in the future once SDKs are updated to use the new bindgen.
-pub fn check_tag_or_read_default_namespace(tag_or_name: &str, ws: &Workspace) -> Result<String> {
+pub fn check_tag_or_read_default_namespace(
+    tag_or_name: &str,
+    ws: &Workspace<'_>,
+) -> Result<String> {
     if naming::is_valid_tag(tag_or_name) {
         Ok(tag_or_name.to_string())
     } else {

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -7,7 +7,7 @@ use dojo_world::contracts::naming;
 use dojo_world::contracts::world::WorldContractReader;
 use dojo_world::metadata::get_default_namespace_from_ws;
 use num_traits::ToPrimitive;
-use scarb::core::Workspace;
+use scarb::core::Config;
 use starknet::core::types::{BlockId, BlockTag, Felt};
 use starknet::core::utils::get_selector_from_name;
 use starknet::providers::Provider;
@@ -672,14 +672,12 @@ pub fn deep_print_ty(root: &Ty) {
 /// sozo model commands to be run even without a Scarb.toml file in the current directory
 /// if a valid tag is provided.
 /// TODO: This may be removed in the future once SDKs are updated to use the new bindgen.
-pub fn check_tag_or_read_default_namespace(
-    tag_or_name: &str,
-    ws: &Workspace<'_>,
-) -> Result<String> {
+pub fn check_tag_or_read_default_namespace(tag_or_name: &str, config: &Config) -> Result<String> {
     if naming::is_valid_tag(tag_or_name) {
         Ok(tag_or_name.to_string())
     } else {
-        let default_namespace = get_default_namespace_from_ws(ws)?;
+        let ws = scarb::ops::read_workspace(config.manifest_path(), config)?;
+        let default_namespace = get_default_namespace_from_ws(&ws)?;
         let tag = naming::ensure_namespace(tag_or_name, &default_namespace);
         Ok(tag)
     }

--- a/crates/sozo/ops/src/tests/mod.rs
+++ b/crates/sozo/ops/src/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod call;
 pub mod migration;
+pub mod model;
 pub mod setup;
 pub mod utils;

--- a/crates/sozo/ops/src/tests/model.rs
+++ b/crates/sozo/ops/src/tests/model.rs
@@ -134,7 +134,7 @@ async fn test_model_ops() {
 
     let (_, values) = model::model_get(
         "dojo_examples-Moves".to_string(),
-        vec![Felt::from(sequencer.account(0).address())],
+        vec![sequencer.account(0).address()],
         world.address,
         sequencer.provider(),
     )
@@ -159,7 +159,7 @@ async fn test_model_ops() {
 
     let (_, values) = model::model_get(
         "dojo_examples-Moves".to_string(),
-        vec![Felt::from(sequencer.account(0).address())],
+        vec![sequencer.account(0).address()],
         world.address,
         sequencer.provider(),
     )

--- a/crates/sozo/ops/src/tests/model.rs
+++ b/crates/sozo/ops/src/tests/model.rs
@@ -1,0 +1,182 @@
+use dojo_world::contracts::abi::model::{FieldLayout, Layout};
+use dojo_world::contracts::world::WorldContract;
+use dojo_world::migration::TxnConfig;
+use katana_runner::KatanaRunner;
+use scarb_ui::{OutputFormat, Ui, Verbosity};
+use starknet::accounts::Account;
+use starknet::core::types::Felt;
+
+use super::setup;
+use crate::{execute, model};
+
+// Test model ops in the same to avoid spinning up several katana with full
+// migration for now. Should be replaced by individual tests once Katana spinning up is enhanced.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_model_ops() {
+    let sequencer = KatanaRunner::new().expect("Failed to start runner.");
+
+    let world = setup::setup(&sequencer).await.unwrap();
+
+    assert_eq!(
+        model::model_class_hash(
+            "dojo_examples-Moves".to_string(),
+            world.address,
+            sequencer.provider()
+        )
+        .await
+        .unwrap(),
+        Felt::from_hex("0x47f77d27573e12c1441dd65b1a88f4432c1c4ec446241830ff4c33f3f58a44e")
+            .unwrap()
+    );
+
+    assert_eq!(
+        model::model_contract_address(
+            "dojo_examples-Moves".to_string(),
+            world.address,
+            sequencer.provider()
+        )
+        .await
+        .unwrap(),
+        Felt::from_hex("0x413aab3045f0a59103449d05974e30aaf91985113b0ae5d97a43b1141c3e1cb")
+            .unwrap()
+    );
+
+    let layout =
+        model::model_layout("dojo_examples-Moves".to_string(), world.address, sequencer.provider())
+            .await
+            .unwrap();
+
+    let expected_layout = Layout::Struct(vec![
+        FieldLayout {
+            selector: Felt::from_hex(
+                "0x2d09b71759c924026f2006fa173772a54e6cd329e2f4083e6b5742463843116",
+            )
+            .unwrap(),
+            layout: Layout::Fixed(vec![8]),
+        },
+        FieldLayout {
+            selector: Felt::from_hex(
+                "0x38717e79a678d35c1e9a8af2ea98a46dbfd566b6dd257bb4cdabea227c469a2",
+            )
+            .unwrap(),
+            layout: Layout::Enum(vec![
+                FieldLayout { selector: Felt::from(0x0), layout: Layout::Fixed(vec![]) },
+                FieldLayout { selector: Felt::from(0x1), layout: Layout::Fixed(vec![]) },
+                FieldLayout { selector: Felt::from(0x2), layout: Layout::Fixed(vec![]) },
+                FieldLayout { selector: Felt::from(0x3), layout: Layout::Fixed(vec![]) },
+                FieldLayout { selector: Felt::from(0x4), layout: Layout::Fixed(vec![]) },
+            ]),
+        },
+    ]);
+
+    assert_eq!(layout, expected_layout);
+
+    let schema = model::model_schema(
+        "dojo_examples-Moves".to_string(),
+        world.address,
+        sequencer.provider(),
+        true,
+    )
+    .await
+    .unwrap();
+
+    let expected_schema = dojo_types::schema::Ty::Struct(dojo_types::schema::Struct {
+        name: "Moves".to_string(),
+        children: vec![
+            dojo_types::schema::Member {
+                name: "player".to_string(),
+                ty: dojo_types::schema::Ty::Primitive(
+                    dojo_types::primitive::Primitive::ContractAddress(None),
+                ),
+                key: true,
+            },
+            dojo_types::schema::Member {
+                name: "remaining".to_string(),
+                ty: dojo_types::schema::Ty::Primitive(dojo_types::primitive::Primitive::U8(None)),
+                key: false,
+            },
+            dojo_types::schema::Member {
+                name: "last_direction".to_string(),
+                ty: dojo_types::schema::Ty::Enum(dojo_types::schema::Enum {
+                    name: "Direction".to_string(),
+                    option: None,
+                    options: vec![
+                        dojo_types::schema::EnumOption {
+                            name: "None".to_string(),
+                            ty: dojo_types::schema::Ty::Tuple(vec![]),
+                        },
+                        dojo_types::schema::EnumOption {
+                            name: "Left".to_string(),
+                            ty: dojo_types::schema::Ty::Tuple(vec![]),
+                        },
+                        dojo_types::schema::EnumOption {
+                            name: "Right".to_string(),
+                            ty: dojo_types::schema::Ty::Tuple(vec![]),
+                        },
+                        dojo_types::schema::EnumOption {
+                            name: "Up".to_string(),
+                            ty: dojo_types::schema::Ty::Tuple(vec![]),
+                        },
+                        dojo_types::schema::EnumOption {
+                            name: "Down".to_string(),
+                            ty: dojo_types::schema::Ty::Tuple(vec![]),
+                        },
+                    ],
+                }),
+                key: false,
+            },
+        ],
+    });
+
+    assert_eq!(schema, expected_schema);
+
+    let expected_values = vec![Felt::from(0x0), Felt::from(0x0)];
+
+    let (_, values) = model::model_get(
+        "dojo_examples-Moves".to_string(),
+        vec![Felt::from(sequencer.account(0).address())],
+        world.address,
+        sequencer.provider(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(values, expected_values);
+
+    let _r = execute::execute(
+        &Ui::new(Verbosity::Normal, OutputFormat::Text),
+        "dojo_examples-actions".to_string(),
+        "spawn".to_string(),
+        vec![],
+        &WorldContract::new(world.address, sequencer.account(0)),
+        &TxnConfig::init_wait(),
+    )
+    .await;
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+    let expected_values = vec![Felt::from(99), Felt::from(0x0)];
+
+    let (_, values) = model::model_get(
+        "dojo_examples-Moves".to_string(),
+        vec![Felt::from(sequencer.account(0).address())],
+        world.address,
+        sequencer.provider(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(values, expected_values);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_check_tag_or_read_default() {
+    let config = setup::load_config();
+    let ws = setup::setup_ws(&config);
+
+    let tag = model::check_tag_or_read_default_namespace("Moves", &ws).unwrap();
+    assert_eq!(tag, "dojo_examples-Moves");
+
+    let tag = model::check_tag_or_read_default_namespace("dojo_examples-Moves", &ws).unwrap();
+    assert_eq!(tag, "dojo_examples-Moves");
+}

--- a/crates/sozo/ops/src/tests/model.rs
+++ b/crates/sozo/ops/src/tests/model.rs
@@ -172,11 +172,10 @@ async fn test_model_ops() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_tag_or_read_default() {
     let config = setup::load_config();
-    let ws = setup::setup_ws(&config);
 
-    let tag = model::check_tag_or_read_default_namespace("Moves", &ws).unwrap();
+    let tag = model::check_tag_or_read_default_namespace("Moves", &config).unwrap();
     assert_eq!(tag, "dojo_examples-Moves");
 
-    let tag = model::check_tag_or_read_default_namespace("dojo_examples-Moves", &ws).unwrap();
+    let tag = model::check_tag_or_read_default_namespace("dojo_examples-Moves", &config).unwrap();
     assert_eq!(tag, "dojo_examples-Moves");
 }


### PR DESCRIPTION
# Description

`sozo model` commands are useful to be used outside of Dojo project for `dojo.js` at the moment. This PR removes the need to read the `Scarb.toml` when a valid tag is already given to the command.

This may change in the future as @lambda-0x mentioned to keep all the commands synced and homogeneous on their behavior.

Also, this PR changes the model commands to use `Provider` trait instead of hard coded `JsonRpcProvider` for more flexibility if in the future a new provider is available. 

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [x] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [x] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved tag handling and namespace validation for model commands.
	- Added a new function for checking tags and reading default namespaces.
	- Enhanced flexibility for model operations with generic provider types.

- **Bug Fixes**
	- Improved error handling and performance for model operations.

- **Tests**
	- Introduced new unit tests for validating model operations and tag handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->