### PR TITLE
fix(dojo-lang): ensure compiler tests have unique id to not avoid output conflicts

### DIFF
--- a/crates/dojo-lang/src/plugin_test.rs
+++ b/crates/dojo-lang/src/plugin_test.rs
@@ -96,11 +96,12 @@ pub fn test_expand_plugin_inner(
         db.set_cfg_set(Arc::new(cfg_set));
     }
 
+    let test_id = &inputs["test_id"];
     let cairo_code = &inputs["cairo_code"];
 
     // The path as to remain the same, because diagnostics contains the path
     // of the file. Which can cause error when checked without CAIRO_FIX=1.
-    let tmp_dir = PathBuf::from("/tmp/plugin_test");
+    let tmp_dir = PathBuf::from(format!("/tmp/plugin_test/{}", test_id));
     let _ = std::fs::create_dir_all(&tmp_dir);
     let tmp_path = tmp_dir.as_path();
 

--- a/crates/dojo-lang/src/plugin_test_data/introspect
+++ b/crates/dojo-lang/src/plugin_test_data/introspect
@@ -3,6 +3,9 @@
 //! > test_runner_name
 test_expand_plugin
 
+//! > test_id
+introspect
+
 //! > cairo_code
 use core::serde::Serde;
 
@@ -2901,41 +2904,41 @@ impl EnumNotPackable1Introspect<> of dojo::model::introspect::Introspect<EnumNot
 
 //! > expected_diagnostics
 error: Option<T> cannot be used with tuples. Prefer using a struct.
- --> /tmp/plugin_test/src/lib.cairo:171:6
+ --> /tmp/plugin_test/introspect/src/lib.cairo:171:6
     x: Option<(u8, u16)>
      ^*****************^
 
 error: Option<T> cannot be used with tuples. Prefer using a struct.
- --> /tmp/plugin_test/src/lib.cairo:176:10
+ --> /tmp/plugin_test/introspect/src/lib.cairo:176:10
     first: Option<(u8, u16)>,
          ^*****************^
 
 error: Introspect and IntrospectPacked attributes cannot be used at a same time.
- --> /tmp/plugin_test/src/lib.cairo:180:6
+ --> /tmp/plugin_test/introspect/src/lib.cairo:180:6
 enum EnumIncompatibleAttrs {}
      ^*******************^
 
 error: Introspect and IntrospectPacked attributes cannot be used at a same time.
- --> /tmp/plugin_test/src/lib.cairo:183:8
+ --> /tmp/plugin_test/introspect/src/lib.cairo:183:8
 struct StructIncompatibleAttrs {}
        ^*********************^
 
 error: Introspect and IntrospectPacked attributes cannot be used at a same time.
- --> /tmp/plugin_test/src/lib.cairo:187:8
+ --> /tmp/plugin_test/introspect/src/lib.cairo:187:8
 struct StructIncompatibleAttrs2 {}
        ^**********************^
 
 error: Introspect and IntrospectPacked attributes cannot be used at a same time.
- --> /tmp/plugin_test/src/lib.cairo:191:6
+ --> /tmp/plugin_test/introspect/src/lib.cairo:191:6
 enum EnumIncompatibleAttrs2 {}
      ^********************^
 
 error: Array field cannot be packed.
- --> /tmp/plugin_test/src/lib.cairo:213:6
+ --> /tmp/plugin_test/introspect/src/lib.cairo:213:6
     y: Array<u32>
      ^**********^
 
 error: To be packed, all variants must have fixed layout of same size.
- --> /tmp/plugin_test/src/lib.cairo:250:6
+ --> /tmp/plugin_test/introspect/src/lib.cairo:250:6
 enum EnumNotPackable1 {
      ^**************^

--- a/crates/dojo-lang/src/plugin_test_data/model
+++ b/crates/dojo-lang/src/plugin_test_data/model
@@ -3,6 +3,9 @@
 //! > test_runner_name
 test_expand_plugin
 
+//! > test_id
+model
+
 //! > cairo_code
 #[dojo::model(version: 0)]
 #[dojo::model(version: 0)]
@@ -26115,56 +26118,56 @@ impl MutableImodel_with_tuple_no_primitivesSafeDispatcherSubPointersCopy of core
 
 //! > expected_diagnostics
 error: A Dojo model must have zero or one dojo::model attribute.
- --> /tmp/plugin_test/src/lib.cairo:1:1
+ --> /tmp/plugin_test/model/src/lib.cairo:1:1
 #[dojo::model(version: 0)]
 ^************************^
 
 error: Too many 'version' attributes for dojo::model
- --> /tmp/plugin_test/src/lib.cairo:9:1
+ --> /tmp/plugin_test/model/src/lib.cairo:9:1
 #[dojo::model(version: 0, version: 0)]
 ^************************************^
 
 error: The argument 'version' of dojo::model must be an integer
- --> /tmp/plugin_test/src/lib.cairo:16:24
+ --> /tmp/plugin_test/model/src/lib.cairo:16:24
 #[dojo::model(version: hello)]
                        ^***^
 
 error: Unexpected argument 'version' for dojo::model
- --> /tmp/plugin_test/src/lib.cairo:23:15
+ --> /tmp/plugin_test/model/src/lib.cairo:23:15
 #[dojo::model(version)]
               ^*****^
 
 error: Unexpected argument 'my_arg' for dojo::model
- --> /tmp/plugin_test/src/lib.cairo:30:15
+ --> /tmp/plugin_test/model/src/lib.cairo:30:15
 #[dojo::model(my_arg: 1)]
               ^*******^
 
 error: Unexpected argument 'my_arg' for dojo::model
- --> /tmp/plugin_test/src/lib.cairo:37:15
+ --> /tmp/plugin_test/model/src/lib.cairo:37:15
 #[dojo::model(my_arg)]
               ^****^
 
 error: dojo::model version 2 not supported
- --> /tmp/plugin_test/src/lib.cairo:44:24
+ --> /tmp/plugin_test/model/src/lib.cairo:44:24
 #[dojo::model(version: 2)]
                        ^
 
 error: Model must define at least one #[key] attribute
- --> /tmp/plugin_test/src/lib.cairo:87:8
+ --> /tmp/plugin_test/model/src/lib.cairo:87:8
 struct Roles {
        ^***^
 
 error: Model must define at least one member that is not a key
- --> /tmp/plugin_test/src/lib.cairo:92:8
+ --> /tmp/plugin_test/model/src/lib.cairo:92:8
 struct OnlyKeyModel {
        ^**********^
 
 error: Key is only supported for core types that are 1 felt long once serialized. `u256` is a struct of 2 u128, hence not supported.
- --> /tmp/plugin_test/src/lib.cairo:100:5
+ --> /tmp/plugin_test/model/src/lib.cairo:100:5
     id: u256
     ^^
 
 error: Model must define at least one member that is not a key
- --> /tmp/plugin_test/src/lib.cairo:98:8
+ --> /tmp/plugin_test/model/src/lib.cairo:98:8
 struct U256KeyModel {
        ^**********^

--- a/crates/dojo-lang/src/plugin_test_data/print
+++ b/crates/dojo-lang/src/plugin_test_data/print
@@ -3,6 +3,9 @@
 //! > test_runner_name
 test_expand_plugin
 
+//! > test_id
+print
+
 //! > cfg
 ["test"]
 
@@ -113,21 +116,21 @@ Enemy::OtherPlayer(v) => { core::debug::PrintTrait::print('OtherPlayer'); core::
 
 //! > expected_diagnostics
 error: Unknown derive `Print` - a plugin might be missing.
- --> /tmp/plugin_test/src/lib.cairo:4:10
+ --> /tmp/plugin_test/print/src/lib.cairo:4:10
 #[derive(Print)]
          ^***^
 
 error: Unknown derive `Print` - a plugin might be missing.
- --> /tmp/plugin_test/src/lib.cairo:12:10
+ --> /tmp/plugin_test/print/src/lib.cairo:12:10
 #[derive(Print)]
          ^***^
 
 error: Unknown derive `Print` - a plugin might be missing.
- --> /tmp/plugin_test/src/lib.cairo:19:10
+ --> /tmp/plugin_test/print/src/lib.cairo:19:10
 #[derive(Print)]
          ^***^
 
 error: Unknown derive `Print` - a plugin might be missing.
- --> /tmp/plugin_test/src/lib.cairo:28:10
+ --> /tmp/plugin_test/print/src/lib.cairo:28:10
 #[derive(Print)]
          ^***^

--- a/crates/dojo-lang/src/plugin_test_data/system
+++ b/crates/dojo-lang/src/plugin_test_data/system
@@ -3,6 +3,9 @@
 //! > test_runner_name
 test_expand_plugin
 
+//! > test_id
+system
+
 //! > cairo_code
 #[dojo::contract(namespace: "My@Namespace")]
 mod bad_namespace_format {
@@ -356,112 +359,112 @@ mod ctxnamed {
 
 //! > expected_diagnostics
 error: Anything other than functions is not supported in a dojo::interface
- --> /tmp/plugin_test/src/lib.cairo:90:5
+ --> /tmp/plugin_test/system/src/lib.cairo:90:5
     const ONE: u8;
     ^************^
 
 error: World parameter must be the first parameter.
- --> /tmp/plugin_test/src/lib.cairo:111:5
+ --> /tmp/plugin_test/system/src/lib.cairo:111:5
     fn do_with_self_and_world(self: @ContractState, world: @IWorldDispatcher) -> felt252;
     ^***********************************************************************************^
 
 error: World parameter must be the first parameter.
- --> /tmp/plugin_test/src/lib.cairo:112:5
+ --> /tmp/plugin_test/system/src/lib.cairo:112:5
     fn do_with_ref_self_and_world(ref self: ContractState, ref world: IWorldDispatcher) -> felt252;
     ^*********************************************************************************************^
 
 error: You cannot use `self` and `world` parameters together.
- --> /tmp/plugin_test/src/lib.cairo:113:5
+ --> /tmp/plugin_test/system/src/lib.cairo:113:5
     fn do_with_self_and_world_inv(world: @IWorldDispatcher, self: @ContractState) -> felt252;
     ^***************************************************************************************^
 
 error: You cannot use `self` and `world` parameters together.
- --> /tmp/plugin_test/src/lib.cairo:114:5
+ --> /tmp/plugin_test/system/src/lib.cairo:114:5
     fn do_with_ref_self_and_world_inv(
     ^********************************^
 
 error: World parameter must be the first parameter.
- --> /tmp/plugin_test/src/lib.cairo:121:5
+ --> /tmp/plugin_test/system/src/lib.cairo:121:5
     fn do_with_world_not_first(vec: Vec2, ref world: IWorldDispatcher) -> felt252;
     ^****************************************************************************^
 
 error: World parameter must be the first parameter.
- --> /tmp/plugin_test/src/lib.cairo:128:9
+ --> /tmp/plugin_test/system/src/lib.cairo:128:9
         fn do_with_self_and_world(self: @ContractState, world: @IWorldDispatcher) -> felt252 {
         ^************************************************************************************^
 
 error: World parameter must be the first parameter.
- --> /tmp/plugin_test/src/lib.cairo:132:9
+ --> /tmp/plugin_test/system/src/lib.cairo:132:9
         fn do_with_ref_self_and_world(
         ^****************************^
 
 error: You cannot use `self` and `world` parameters together.
- --> /tmp/plugin_test/src/lib.cairo:138:9
+ --> /tmp/plugin_test/system/src/lib.cairo:138:9
         fn do_with_self_and_world_inv(world: @IWorldDispatcher, self: @ContractState) -> felt252 {
         ^****************************************************************************************^
 
 error: You cannot use `self` and `world` parameters together.
- --> /tmp/plugin_test/src/lib.cairo:142:9
+ --> /tmp/plugin_test/system/src/lib.cairo:142:9
         fn do_with_ref_self_and_world_inv(
         ^********************************^
 
 error: World parameter must be the first parameter.
- --> /tmp/plugin_test/src/lib.cairo:158:9
+ --> /tmp/plugin_test/system/src/lib.cairo:158:9
         fn do_with_world_not_first(vec: Vec2, ref world: IWorldDispatcher) -> felt252 {
         ^*****************************************************************************^
 
 error: You cannot use `world` and `#[generate_trait]` together. Use `self` instead.
- --> /tmp/plugin_test/src/lib.cairo:165:9
+ --> /tmp/plugin_test/system/src/lib.cairo:165:9
         fn bad_func_using_generate(world: @IWorldDispatcher) -> felt252 {
         ^***************************************************************^
 
 error: World parameter must be a snapshot if `ref` is not used.
- --> /tmp/plugin_test/src/lib.cairo:224:5
+ --> /tmp/plugin_test/system/src/lib.cairo:224:5
     fn dojo_init(
     ^***********^
 
 error: `starknet::interface` function first parameter must be a reference to the trait's generic parameter or a snapshot of it.
- --> /tmp/plugin_test/src/lib.cairo:105:5
+ --> /tmp/plugin_test/system/src/lib.cairo:105:5
     fn do_with_self(self: @ContractState) -> felt252;
     ^**********************************************^
 
 error: `starknet::interface` function first parameter must be a reference to the trait's generic parameter or a snapshot of it.
- --> /tmp/plugin_test/src/lib.cairo:106:5
+ --> /tmp/plugin_test/system/src/lib.cairo:106:5
     fn do_with_ref_self(ref self: ContractState) -> felt252;
     ^*****************************************************^
 
 error: `starknet::interface` function first parameter must be a reference to the trait's generic parameter or a snapshot of it.
- --> /tmp/plugin_test/src/lib.cairo:111:5
+ --> /tmp/plugin_test/system/src/lib.cairo:111:5
     fn do_with_self_and_world(self: @ContractState, world: @IWorldDispatcher) -> felt252;
     ^**********************************************************************************^
 
 error: `starknet::interface` function first parameter must be a reference to the trait's generic parameter or a snapshot of it.
- --> /tmp/plugin_test/src/lib.cairo:112:5
+ --> /tmp/plugin_test/system/src/lib.cairo:112:5
     fn do_with_ref_self_and_world(ref self: ContractState, ref world: IWorldDispatcher) -> felt252;
     ^********************************************************************************************^
 
 error: `starknet::interface` functions don't support `ref` parameters other than the first one.
- --> /tmp/plugin_test/src/lib.cairo:112:5
+ --> /tmp/plugin_test/system/src/lib.cairo:112:5
     fn do_with_ref_self_and_world(ref self: ContractState, ref world: IWorldDispatcher) -> felt252;
     ^********************************************************************************************^
 
 error: `starknet::interface` functions don't support `ref` parameters other than the first one.
- --> /tmp/plugin_test/src/lib.cairo:114:5
+ --> /tmp/plugin_test/system/src/lib.cairo:114:5
     fn do_with_ref_self_and_world_inv(
     ^********************************^
 
 error: `starknet::interface` functions don't support `ref` parameters other than the first one.
- --> /tmp/plugin_test/src/lib.cairo:117:5
+ --> /tmp/plugin_test/system/src/lib.cairo:117:5
     fn do_with_several_world_dispatchers(
     ^***********************************^
 
 error: `starknet::interface` functions don't support `ref` parameters other than the first one.
- --> /tmp/plugin_test/src/lib.cairo:121:5
+ --> /tmp/plugin_test/system/src/lib.cairo:121:5
     fn do_with_world_not_first(vec: Vec2, ref world: IWorldDispatcher) -> felt252;
     ^***************************************************************************^
 
 error: Generated trait must have generic args matching the impl's generic params.
- --> /tmp/plugin_test/src/lib.cairo:163:5
+ --> /tmp/plugin_test/system/src/lib.cairo:163:5
     #[generate_trait]
     ^***************^
 


### PR DESCRIPTION
Add a unique id for each compiler test to ensure reproducibility and avoid output conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error diagnostics with clearer paths for the `introspect`, `model`, `print`, and `system` modules.
  - Added unique test identifiers to improve organization and clarity in test results.

- **Bug Fixes**
  - Updated error messages to ensure they reflect the correct file locations, improving debugging accuracy across multiple modules.
  - Strengthened enforcement of function signature rules within the `system` module to ensure compliance with interface guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->