### PR TITLE
refactor(katana-rpc): rename trait methods to their exact names in the api spec

### DIFF
--- a/crates/katana/rpc/rpc-api/src/starknet.rs
+++ b/crates/katana/rpc/rpc-api/src/starknet.rs
@@ -40,29 +40,32 @@ pub trait StarknetApi {
 
     /// Get block information with transaction hashes given the block id.
     #[method(name = "getBlockWithTxHashes")]
-    async fn block_with_tx_hashes(
+    async fn get_block_with_tx_hashes(
         &self,
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithTxHashes>;
 
     /// Get block information with full transactions given the block id.
     #[method(name = "getBlockWithTxs")]
-    async fn block_with_txs(&self, block_id: BlockIdOrTag) -> RpcResult<MaybePendingBlockWithTxs>;
+    async fn get_block_with_txs(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> RpcResult<MaybePendingBlockWithTxs>;
 
     /// Get block information with full transactions and receipts given the block id.
     #[method(name = "getBlockWithReceipts")]
-    async fn block_with_receipts(
+    async fn get_block_with_receipts(
         &self,
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithReceipts>;
 
     /// Get the information about the result of executing the requested block.
     #[method(name = "getStateUpdate")]
-    async fn state_update(&self, block_id: BlockIdOrTag) -> RpcResult<StateUpdate>;
+    async fn get_state_update(&self, block_id: BlockIdOrTag) -> RpcResult<StateUpdate>;
 
     /// Get the value of the storage at the given address and key
     #[method(name = "getStorageAt")]
-    async fn storage_at(
+    async fn get_storage_at(
         &self,
         contract_address: FieldElement,
         key: FieldElement,
@@ -72,15 +75,18 @@ pub trait StarknetApi {
     /// Gets the transaction status (possibly reflecting that the tx is still in the mempool, or
     /// dropped from it).
     #[method(name = "getTransactionStatus")]
-    async fn transaction_status(&self, transaction_hash: TxHash) -> RpcResult<TransactionStatus>;
+    async fn get_transaction_status(
+        &self,
+        transaction_hash: TxHash,
+    ) -> RpcResult<TransactionStatus>;
 
     /// Get the details and status of a submitted transaction.
     #[method(name = "getTransactionByHash")]
-    async fn transaction_by_hash(&self, transaction_hash: TxHash) -> RpcResult<Tx>;
+    async fn get_transaction_by_hash(&self, transaction_hash: TxHash) -> RpcResult<Tx>;
 
     /// Get the details of a transaction by a given block id and index.
     #[method(name = "getTransactionByBlockIdAndIndex")]
-    async fn transaction_by_block_id_and_index(
+    async fn get_transaction_by_block_id_and_index(
         &self,
         block_id: BlockIdOrTag,
         index: u64,
@@ -88,14 +94,14 @@ pub trait StarknetApi {
 
     /// Get the transaction receipt by the transaction hash.
     #[method(name = "getTransactionReceipt")]
-    async fn transaction_receipt(
+    async fn get_transaction_receipt(
         &self,
         transaction_hash: TxHash,
     ) -> RpcResult<TxReceiptWithBlockInfo>;
 
     /// Get the contract class definition in the given block associated with the given hash.
     #[method(name = "getClass")]
-    async fn class(
+    async fn get_class(
         &self,
         block_id: BlockIdOrTag,
         class_hash: FieldElement,
@@ -104,7 +110,7 @@ pub trait StarknetApi {
     /// Get the contract class hash in the given block for the contract deployed at the given
     /// address.
     #[method(name = "getClassHashAt")]
-    async fn class_hash_at(
+    async fn get_class_hash_at(
         &self,
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
@@ -112,7 +118,7 @@ pub trait StarknetApi {
 
     /// Get the contract class definition in the given block at the given address.
     #[method(name = "getClassAt")]
-    async fn class_at(
+    async fn get_class_at(
         &self,
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
@@ -120,7 +126,7 @@ pub trait StarknetApi {
 
     /// Get the number of transactions in a block given a block id.
     #[method(name = "getBlockTransactionCount")]
-    async fn block_transaction_count(&self, block_id: BlockIdOrTag) -> RpcResult<BlockTxCount>;
+    async fn get_block_transaction_count(&self, block_id: BlockIdOrTag) -> RpcResult<BlockTxCount>;
 
     /// Call a starknet function without creating a StarkNet transaction.
     #[method(name = "call")]
@@ -167,11 +173,11 @@ pub trait StarknetApi {
 
     /// Returns all event objects matching the conditions in the provided filter.
     #[method(name = "getEvents")]
-    async fn events(&self, filter: EventFilterWithPage) -> RpcResult<EventsPage>;
+    async fn get_events(&self, filter: EventFilterWithPage) -> RpcResult<EventsPage>;
 
     /// Get the nonce associated with the given address in the given block.
     #[method(name = "getNonce")]
-    async fn nonce(
+    async fn get_nonce(
         &self,
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
@@ -210,11 +216,11 @@ pub trait StarknetWriteApi {
 pub trait StarknetTraceApi {
     /// Returns the execution trace of the transaction designated by the input hash.
     #[method(name = "traceTransaction")]
-    async fn trace(&self, transaction_hash: TxHash) -> RpcResult<TransactionTrace>;
+    async fn trace_transaction(&self, transaction_hash: TxHash) -> RpcResult<TransactionTrace>;
 
     /// Simulates a list of transactions on the provided block.
     #[method(name = "simulateTransactions")]
-    async fn simulate(
+    async fn simulate_transactions(
         &self,
         block_id: BlockIdOrTag,
         transactions: Vec<BroadcastedTx>,
@@ -223,6 +229,8 @@ pub trait StarknetTraceApi {
 
     /// Returns the execution traces of all transactions included in the given block.
     #[method(name = "traceBlockTransactions")]
-    async fn trace_block(&self, block_id: BlockIdOrTag)
-    -> RpcResult<Vec<TransactionTraceWithHash>>;
+    async fn trace_block_transactions(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> RpcResult<Vec<TransactionTraceWithHash>>;
 }

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -36,7 +36,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         Ok(FieldElement::from(self.inner.sequencer.chain_id()).into())
     }
 
-    async fn nonce(
+    async fn get_nonce(
         &self,
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
@@ -62,7 +62,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn transaction_by_hash(&self, transaction_hash: FieldElement) -> RpcResult<Tx> {
+    async fn get_transaction_by_hash(&self, transaction_hash: FieldElement) -> RpcResult<Tx> {
         self.on_io_blocking_task(move |this| {
             let tx = this
                 .inner
@@ -75,7 +75,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn block_transaction_count(&self, block_id: BlockIdOrTag) -> RpcResult<u64> {
+    async fn get_block_transaction_count(&self, block_id: BlockIdOrTag) -> RpcResult<u64> {
         self.on_io_blocking_task(move |this| {
             let count = this
                 .inner
@@ -88,7 +88,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn class_at(
+    async fn get_class_at(
         &self,
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
@@ -102,7 +102,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                     .ok_or(StarknetApiError::ContractNotFound)
             })
             .await?;
-        self.class(block_id, class_hash).await
+        self.get_class(block_id, class_hash).await
     }
 
     async fn block_hash_and_number(&self) -> RpcResult<BlockHashAndNumber> {
@@ -113,7 +113,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         Ok(hash_and_num_pair.into())
     }
 
-    async fn block_with_tx_hashes(
+    async fn get_block_with_tx_hashes(
         &self,
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithTxHashes> {
@@ -169,7 +169,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn transaction_by_block_id_and_index(
+    async fn get_transaction_by_block_id_and_index(
         &self,
         block_id: BlockIdOrTag,
         index: u64,
@@ -201,7 +201,10 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn block_with_txs(&self, block_id: BlockIdOrTag) -> RpcResult<MaybePendingBlockWithTxs> {
+    async fn get_block_with_txs(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> RpcResult<MaybePendingBlockWithTxs> {
         self.on_io_blocking_task(move |this| {
             let provider = this.inner.sequencer.backend.blockchain.provider();
 
@@ -255,7 +258,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn block_with_receipts(
+    async fn get_block_with_receipts(
         &self,
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithReceipts> {
@@ -311,7 +314,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn state_update(&self, block_id: BlockIdOrTag) -> RpcResult<StateUpdate> {
+    async fn get_state_update(&self, block_id: BlockIdOrTag) -> RpcResult<StateUpdate> {
         self.on_io_blocking_task(move |this| {
             let provider = this.inner.sequencer.backend.blockchain.provider();
 
@@ -336,7 +339,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn transaction_receipt(
+    async fn get_transaction_receipt(
         &self,
         transaction_hash: FieldElement,
     ) -> RpcResult<TxReceiptWithBlockInfo> {
@@ -380,7 +383,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn class_hash_at(
+    async fn get_class_hash_at(
         &self,
         block_id: BlockIdOrTag,
         contract_address: FieldElement,
@@ -397,7 +400,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn class(
+    async fn get_class(
         &self,
         block_id: BlockIdOrTag,
         class_hash: FieldElement,
@@ -419,7 +422,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn events(&self, filter: EventFilterWithPage) -> RpcResult<EventsPage> {
+    async fn get_events(&self, filter: EventFilterWithPage) -> RpcResult<EventsPage> {
         self.on_io_blocking_task(move |this| {
             let from_block = filter.event_filter.from_block.unwrap_or(BlockIdOrTag::Number(0));
             let to_block =
@@ -479,7 +482,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn storage_at(
+    async fn get_storage_at(
         &self,
         contract_address: FieldElement,
         key: FieldElement,
@@ -590,7 +593,10 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn transaction_status(&self, transaction_hash: TxHash) -> RpcResult<TransactionStatus> {
+    async fn get_transaction_status(
+        &self,
+        transaction_hash: TxHash,
+    ) -> RpcResult<TransactionStatus> {
         self.on_io_blocking_task(move |this| {
             let provider = this.inner.sequencer.backend.blockchain.provider();
 

--- a/crates/katana/rpc/rpc/src/starknet/trace.rs
+++ b/crates/katana/rpc/rpc/src/starknet/trace.rs
@@ -21,7 +21,7 @@ use super::StarknetApi;
 
 #[async_trait]
 impl<EF: ExecutorFactory> StarknetTraceApiServer for StarknetApi<EF> {
-    async fn trace(&self, _: TxHash) -> RpcResult<TransactionTrace> {
+    async fn trace_transaction(&self, _: TxHash) -> RpcResult<TransactionTrace> {
         Err(Error::Call(CallError::Custom(ErrorObject::owned(
             METHOD_NOT_FOUND_CODE,
             "Unsupported method - starknet_traceTransaction".to_string(),
@@ -29,7 +29,7 @@ impl<EF: ExecutorFactory> StarknetTraceApiServer for StarknetApi<EF> {
         ))))
     }
 
-    async fn simulate(
+    async fn simulate_transactions(
         &self,
         block_id: BlockIdOrTag,
         transactions: Vec<BroadcastedTx>,
@@ -211,7 +211,10 @@ impl<EF: ExecutorFactory> StarknetTraceApiServer for StarknetApi<EF> {
         .await
     }
 
-    async fn trace_block(&self, _: BlockIdOrTag) -> RpcResult<Vec<TransactionTraceWithHash>> {
+    async fn trace_block_transactions(
+        &self,
+        _: BlockIdOrTag,
+    ) -> RpcResult<Vec<TransactionTraceWithHash>> {
         Err(Error::Call(CallError::Custom(ErrorObject::owned(
             METHOD_NOT_FOUND_CODE,
             "Unsupported method - starknet_traceBlockTransactions".to_string(),

--- a/crates/katana/rpc/rpc/tests/torii.rs
+++ b/crates/katana/rpc/rpc/tests/torii.rs
@@ -134,7 +134,7 @@ async fn test_get_transactions() {
     let max_retry = 10;
     let mut attempt = 0;
     loop {
-        match client.transaction_status(last_tx_hash).await {
+        match client.get_transaction_status(last_tx_hash).await {
             Ok(s) => {
                 if s != TransactionStatus::Received {
                     break;


### PR DESCRIPTION
renaming to their exact names in the json rpc spec so that we can reserve the current names for other stuff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced API method naming for improved clarity and consistency.
	- Explicitly named methods such as `get_block_with_tx_hashes`, `get_transaction_status`, and `trace_transaction` for better understanding of their functions.

- **Bug Fixes**
	- Updated function calls in tests to align with the new method names, ensuring correct functionality.

- **Documentation**
	- Changes reflect improved semantic clarity in API usage, aiding developers in understanding and utilizing the API effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->