### PR TITLE
refactor(katana): remove unneccessary level of abstraction due to `KatanaSequencer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7539,7 +7539,6 @@ dependencies = [
  "console",
  "dojo-metrics",
  "katana-core",
- "katana-executor",
  "katana-primitives",
  "katana-rpc",
  "katana-rpc-api",

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -15,7 +15,6 @@ common.workspace = true
 console.workspace = true
 dojo-metrics.workspace = true
 katana-core.workspace = true
-katana-executor = { workspace = true, features = [ "blockifier" ] }
 katana-primitives.workspace = true
 katana-rpc.workspace = true
 katana-rpc-api.workspace = true

--- a/bin/katana/src/args.rs
+++ b/bin/katana/src/args.rs
@@ -23,6 +23,7 @@ use katana_core::constants::{
     DEFAULT_ETH_L1_GAS_PRICE, DEFAULT_INVOKE_MAX_STEPS, DEFAULT_SEQUENCER_ADDRESS,
     DEFAULT_STRK_L1_GAS_PRICE, DEFAULT_VALIDATE_MAX_STEPS,
 };
+#[allow(deprecated)]
 use katana_core::sequencer::SequencerConfig;
 use katana_primitives::block::GasPrices;
 use katana_primitives::chain::ChainId;
@@ -234,6 +235,7 @@ impl KatanaArgs {
         Ok(tracing::subscriber::set_global_default(subscriber)?)
     }
 
+    #[allow(deprecated)]
     pub fn sequencer_config(&self) -> SequencerConfig {
         SequencerConfig {
             block_time: self.block_time,

--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -2,13 +2,11 @@ use std::sync::Arc;
 
 use jsonrpsee::core::Error;
 pub use katana_core::backend::config::{Environment, StarknetConfig};
-use katana_core::constants::MAX_RECURSION_DEPTH;
-use katana_core::sequencer::KatanaSequencer;
+use katana_core::backend::Backend;
+#[allow(deprecated)]
 pub use katana_core::sequencer::SequencerConfig;
 use katana_executor::implementation::blockifier::BlockifierFactory;
-use katana_executor::SimulationFlag;
 use katana_primitives::chain::ChainId;
-use katana_primitives::env::{CfgEnv, FeeTokenAddressses};
 use katana_rpc::config::ServerConfig;
 use katana_rpc::{spawn, NodeHandle};
 use katana_rpc_api::ApiKind;
@@ -32,38 +30,21 @@ pub struct TestSequencer {
     url: Url,
     handle: NodeHandle,
     account: TestAccount,
-    pub sequencer: Arc<KatanaSequencer<BlockifierFactory>>,
+    backend: Arc<Backend<BlockifierFactory>>,
 }
 
 impl TestSequencer {
+    #[allow(deprecated)]
     pub async fn start(config: SequencerConfig, starknet_config: StarknetConfig) -> Self {
-        let cfg_env = CfgEnv {
-            chain_id: starknet_config.env.chain_id,
-            invoke_tx_max_n_steps: starknet_config.env.invoke_max_steps,
-            validate_max_n_steps: starknet_config.env.validate_max_steps,
-            max_recursion_depth: MAX_RECURSION_DEPTH,
-            fee_token_addresses: FeeTokenAddressses {
-                eth: starknet_config.genesis.fee_token.address,
-                strk: Default::default(),
-            },
-        };
+        let components = katana_core::build_node_components(config, starknet_config)
+            .await
+            .expect("Failed to build node components");
 
-        let simulation_flags = SimulationFlag {
-            skip_validate: starknet_config.disable_validate,
-            skip_fee_transfer: starknet_config.disable_fee,
-            ..Default::default()
-        };
-
-        let executor_factory = BlockifierFactory::new(cfg_env, simulation_flags);
-
-        let sequencer = Arc::new(
-            KatanaSequencer::new(executor_factory, config, starknet_config)
-                .await
-                .expect("Failed to create sequencer"),
-        );
+        // get a reference to the backend struct
+        let backend = components.1.clone();
 
         let handle = spawn(
-            Arc::clone(&sequencer),
+            components,
             ServerConfig {
                 port: 0,
                 host: "127.0.0.1".into(),
@@ -83,13 +64,13 @@ impl TestSequencer {
 
         let url = Url::parse(&format!("http://{}", handle.addr)).expect("Failed to parse URL");
 
-        let account = sequencer.backend().config.genesis.accounts().next().unwrap();
+        let account = backend.config.genesis.accounts().next().unwrap();
         let account = TestAccount {
             private_key: Felt::from_bytes_be(&account.1.private_key().unwrap().to_bytes_be()),
             account_address: Felt::from_bytes_be(&account.0.to_bytes_be()),
         };
 
-        TestSequencer { sequencer, account, handle, url }
+        TestSequencer { backend, account, handle, url }
     }
 
     pub fn account(&self) -> SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet> {
@@ -114,7 +95,7 @@ impl TestSequencer {
         &self,
         index: usize,
     ) -> SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet> {
-        let accounts: Vec<_> = self.sequencer.backend().config.genesis.accounts().collect::<_>();
+        let accounts: Vec<_> = self.backend.config.genesis.accounts().collect::<_>();
 
         let account = accounts[index];
         let private_key = Felt::from_bytes_be(&account.1.private_key().unwrap().to_bytes_be());

--- a/crates/dojo-world/src/utils.rs
+++ b/crates/dojo-world/src/utils.rs
@@ -390,6 +390,7 @@ where
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
+    #[allow(deprecated)]
     use dojo_test_utils::sequencer::{
         get_default_test_starknet_config, SequencerConfig, TestSequencer,
     };
@@ -403,6 +404,7 @@ mod tests {
 
     use super::{Duration, TransactionWaiter};
 
+    #[allow(deprecated)]
     async fn create_test_sequencer() -> (TestSequencer, JsonRpcClient<HttpTransport>) {
         let sequencer =
             TestSequencer::start(SequencerConfig::default(), get_default_test_starknet_config())

--- a/crates/katana/core/Cargo.toml
+++ b/crates/katana/core/Cargo.toml
@@ -8,7 +8,7 @@ version.workspace = true
 
 [dependencies]
 katana-db.workspace = true
-katana-executor.workspace = true
+katana-executor = { workspace = true, features = [ "blockifier" ] }
 katana-primitives.workspace = true
 katana-provider.workspace = true
 katana-tasks.workspace = true
@@ -37,8 +37,8 @@ alloy-sol-types = { workspace = true, default-features = false, features = [ "js
 alloy-contract = { workspace = true, default-features = false, optional = true }
 alloy-network = { workspace = true, default-features = false, optional = true }
 alloy-provider = { workspace = true, default-features = false, optional = true, features = [ "reqwest" ] }
-alloy-transport = { workspace = true, default-features = false, optional = true }
 alloy-rpc-types-eth = { workspace = true, default-features = false, optional = true }
+alloy-transport = { workspace = true, default-features = false, optional = true }
 
 [dev-dependencies]
 assert_matches.workspace = true
@@ -47,15 +47,15 @@ tempfile.workspace = true
 
 [features]
 messaging = [
-    "alloy-contract",
-    "alloy-network",
-    "alloy-provider",
-    "alloy-rpc-types-eth",
-    "alloy-sol-types",
-    "alloy-transport",
-    "async-trait",
-    "reqwest",
-    "serde",
-    "serde_json",
+	"alloy-contract",
+	"alloy-network",
+	"alloy-provider",
+	"alloy-rpc-types-eth",
+	"alloy-sol-types",
+	"alloy-transport",
+	"async-trait",
+	"reqwest",
+	"serde",
+	"serde_json",
 ]
 starknet-messaging = [  ]

--- a/crates/katana/core/src/lib.rs
+++ b/crates/katana/core/src/lib.rs
@@ -1,5 +1,20 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
+use std::sync::Arc;
+
+use constants::MAX_RECURSION_DEPTH;
+use katana_executor::implementation::blockifier::BlockifierFactory;
+use katana_executor::SimulationFlag;
+use katana_primitives::env::{CfgEnv, FeeTokenAddressses};
+
+use crate::backend::config::StarknetConfig;
+use crate::backend::Backend;
+use crate::pool::TransactionPool;
+use crate::service::block_producer::BlockProducer;
+#[cfg(feature = "messaging")]
+use crate::service::messaging::MessagingService;
+use crate::service::{NodeService, TransactionMiner};
+
 pub mod backend;
 pub mod constants;
 pub mod env;
@@ -7,3 +22,73 @@ pub mod pool;
 pub mod sequencer;
 pub mod service;
 pub mod utils;
+
+#[allow(deprecated)]
+use sequencer::SequencerConfig;
+
+/// Build the core Katana components from the given configurations.
+// TODO: placeholder until we implement a dedicated class that encapsulate building the node
+// components
+#[allow(deprecated)]
+pub async fn build_node_components(
+    config: SequencerConfig,
+    starknet_config: StarknetConfig,
+) -> anyhow::Result<(
+    Arc<TransactionPool>,
+    Arc<Backend<BlockifierFactory>>,
+    Arc<BlockProducer<BlockifierFactory>>,
+)> {
+    // build executor factory
+    let cfg_env = CfgEnv {
+        chain_id: starknet_config.env.chain_id,
+        invoke_tx_max_n_steps: starknet_config.env.invoke_max_steps,
+        validate_max_n_steps: starknet_config.env.validate_max_steps,
+        max_recursion_depth: MAX_RECURSION_DEPTH,
+        fee_token_addresses: FeeTokenAddressses {
+            eth: starknet_config.genesis.fee_token.address,
+            strk: Default::default(),
+        },
+    };
+
+    let simulation_flags = SimulationFlag {
+        skip_validate: starknet_config.disable_validate,
+        skip_fee_transfer: starknet_config.disable_fee,
+        ..Default::default()
+    };
+
+    let executor_factory = Arc::new(BlockifierFactory::new(cfg_env, simulation_flags));
+    let backend = Arc::new(Backend::new(executor_factory.clone(), starknet_config).await);
+
+    let pool = Arc::new(TransactionPool::new());
+    let miner = TransactionMiner::new(pool.add_listener());
+
+    let block_producer = if config.block_time.is_some() || config.no_mining {
+        if let Some(interval) = config.block_time {
+            BlockProducer::interval(Arc::clone(&backend), interval)
+        } else {
+            BlockProducer::on_demand(Arc::clone(&backend))
+        }
+    } else {
+        BlockProducer::instant(Arc::clone(&backend))
+    };
+
+    #[cfg(feature = "messaging")]
+    let messaging = if let Some(config) = config.messaging.clone() {
+        MessagingService::new(config, Arc::clone(&pool), Arc::clone(&backend)).await.ok()
+    } else {
+        None
+    };
+
+    let block_producer = Arc::new(block_producer);
+
+    // TODO: avoid dangling task, or at least store the handle to the NodeService
+    tokio::spawn(NodeService::new(
+        Arc::clone(&pool),
+        miner,
+        block_producer.clone(),
+        #[cfg(feature = "messaging")]
+        messaging,
+    ));
+
+    Ok((pool, backend, block_producer))
+}

--- a/crates/katana/core/src/lib.rs
+++ b/crates/katana/core/src/lib.rs
@@ -29,6 +29,9 @@ use sequencer::SequencerConfig;
 /// Build the core Katana components from the given configurations.
 // TODO: placeholder until we implement a dedicated class that encapsulate building the node
 // components
+//
+// Most of the logic are taken out of the `main.rs` file in `/bin/katana` directory, and combined
+// with the exact copy of the setup logic for `NodeService` from `KatanaSequencer::new`.
 #[allow(deprecated)]
 pub async fn build_node_components(
     config: SequencerConfig,

--- a/crates/katana/core/src/sequencer.rs
+++ b/crates/katana/core/src/sequencer.rs
@@ -14,6 +14,9 @@ use crate::service::messaging::MessagingConfig;
 use crate::service::messaging::MessagingService;
 use crate::service::{NodeService, TransactionMiner};
 
+// TODO: just a placeholder for now, remove until we have a dedicated class for building node
+// components
+#[deprecated = "In the process of removal"]
 #[derive(Debug, Default)]
 pub struct SequencerConfig {
     pub block_time: Option<u64>,
@@ -22,7 +25,8 @@ pub struct SequencerConfig {
     pub messaging: Option<MessagingConfig>,
 }
 
-#[allow(missing_debug_implementations)]
+#[deprecated = "In the process of removal"]
+#[allow(missing_debug_implementations, deprecated)]
 pub struct KatanaSequencer<EF: ExecutorFactory> {
     config: SequencerConfig,
     pool: Arc<TransactionPool>,
@@ -30,6 +34,7 @@ pub struct KatanaSequencer<EF: ExecutorFactory> {
     block_producer: Arc<BlockProducer<EF>>,
 }
 
+#[allow(deprecated)]
 impl<EF: ExecutorFactory> KatanaSequencer<EF> {
     pub async fn new(
         executor_factory: EF,
@@ -112,9 +117,11 @@ impl<EF: ExecutorFactory> KatanaSequencer<EF> {
 
 #[cfg(test)]
 mod tests {
+
     use katana_executor::implementation::noop::NoopExecutorFactory;
     use katana_provider::traits::block::BlockNumberProvider;
 
+    #[allow(deprecated)]
     use super::{KatanaSequencer, SequencerConfig};
     use crate::backend::config::StarknetConfig;
 
@@ -122,6 +129,7 @@ mod tests {
     async fn init_interval_block_producer_with_correct_block_env() {
         let executor_factory = NoopExecutorFactory::default();
 
+        #[allow(deprecated)]
         let sequencer = KatanaSequencer::new(
             executor_factory,
             SequencerConfig { no_mining: true, ..Default::default() },
@@ -130,7 +138,7 @@ mod tests {
         .await
         .unwrap();
 
-        let provider = sequencer.backend.blockchain.provider();
+        let provider = sequencer.provider();
 
         let latest_num = provider.latest_number().unwrap();
         let producer_block_env = sequencer.pending_executor().unwrap().read().block_env();

--- a/crates/katana/executor/Cargo.toml
+++ b/crates/katana/executor/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 katana-primitives.workspace = true
 katana-provider.workspace = true
 
-parking_lot.workspace = true
+parking_lot = { workspace = true, optional = true }
 starknet = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing.workspace = true
@@ -36,7 +36,12 @@ pprof = { version = "0.13.0", features = [ "criterion", "flamegraph" ] }
 rayon.workspace = true
 
 [features]
-blockifier = [ "dep:blockifier", "dep:katana-cairo", "dep:starknet" ]
+blockifier = [
+	"dep:blockifier",
+	"dep:katana-cairo",
+	"dep:parking_lot",
+	"dep:starknet",
+]
 default = [ "blockifier" ]
 
 [[bench]]

--- a/crates/katana/rpc/rpc/src/katana.rs
+++ b/crates/katana/rpc/rpc/src/katana.rs
@@ -1,32 +1,25 @@
 use std::sync::Arc;
 
 use jsonrpsee::core::{async_trait, Error};
-use katana_core::sequencer::KatanaSequencer;
+use katana_core::backend::Backend;
 use katana_executor::ExecutorFactory;
 use katana_rpc_api::katana::KatanaApiServer;
 use katana_rpc_types::account::Account;
 
 #[allow(missing_debug_implementations)]
 pub struct KatanaApi<EF: ExecutorFactory> {
-    sequencer: Arc<KatanaSequencer<EF>>,
+    backend: Arc<Backend<EF>>,
 }
 
 impl<EF: ExecutorFactory> KatanaApi<EF> {
-    pub fn new(sequencer: Arc<KatanaSequencer<EF>>) -> Self {
-        Self { sequencer }
+    pub fn new(backend: Arc<Backend<EF>>) -> Self {
+        Self { backend }
     }
 }
 
 #[async_trait]
 impl<EF: ExecutorFactory> KatanaApiServer for KatanaApi<EF> {
     async fn predeployed_accounts(&self) -> Result<Vec<Account>, Error> {
-        Ok(self
-            .sequencer
-            .backend()
-            .config
-            .genesis
-            .accounts()
-            .map(|e| Account::new(*e.0, e.1))
-            .collect())
+        Ok(self.backend.config.genesis.accounts().map(|e| Account::new(*e.0, e.1)).collect())
     }
 }

--- a/crates/katana/rpc/rpc/src/lib.rs
+++ b/crates/katana/rpc/rpc/src/lib.rs
@@ -19,7 +19,9 @@ use hyper::{Method, Uri};
 use jsonrpsee::server::middleware::proxy_get_request::ProxyGetRequestLayer;
 use jsonrpsee::server::{AllowHosts, ServerBuilder, ServerHandle};
 use jsonrpsee::RpcModule;
-use katana_core::sequencer::KatanaSequencer;
+use katana_core::backend::Backend;
+use katana_core::pool::TransactionPool;
+use katana_core::service::block_producer::BlockProducer;
 use katana_executor::ExecutorFactory;
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::katana::KatanaApiServer;
@@ -37,9 +39,11 @@ use crate::starknet::StarknetApi;
 use crate::torii::ToriiApi;
 
 pub async fn spawn<EF: ExecutorFactory>(
-    sequencer: Arc<KatanaSequencer<EF>>,
+    node_components: (Arc<TransactionPool>, Arc<Backend<EF>>, Arc<BlockProducer<EF>>),
     config: ServerConfig,
 ) -> Result<NodeHandle> {
+    let (pool, backend, block_producer) = node_components;
+
     let mut methods = RpcModule::new(());
     methods.register_method("health", |_, _| Ok(serde_json::json!({ "health": true })))?;
 
@@ -47,22 +51,25 @@ pub async fn spawn<EF: ExecutorFactory>(
         match api {
             ApiKind::Starknet => {
                 // TODO: merge these into a single logic.
-                let server = StarknetApi::new(sequencer.clone());
+                let server =
+                    StarknetApi::new(backend.clone(), pool.clone(), block_producer.clone());
                 methods.merge(StarknetApiServer::into_rpc(server.clone()))?;
                 methods.merge(StarknetWriteApiServer::into_rpc(server.clone()))?;
                 methods.merge(StarknetTraceApiServer::into_rpc(server))?;
             }
             ApiKind::Katana => {
-                methods.merge(KatanaApi::new(sequencer.clone()).into_rpc())?;
+                methods.merge(KatanaApi::new(backend.clone()).into_rpc())?;
             }
             ApiKind::Dev => {
-                methods.merge(DevApi::new(sequencer.clone()).into_rpc())?;
+                methods.merge(DevApi::new(backend.clone(), block_producer.clone()).into_rpc())?;
             }
             ApiKind::Torii => {
-                methods.merge(ToriiApi::new(sequencer.clone()).into_rpc())?;
+                methods.merge(
+                    ToriiApi::new(backend.clone(), pool.clone(), block_producer.clone()).into_rpc(),
+                )?;
             }
             ApiKind::Saya => {
-                methods.merge(SayaApi::new(sequencer.clone()).into_rpc())?;
+                methods.merge(SayaApi::new(backend.clone(), block_producer.clone()).into_rpc())?;
             }
         }
     }

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -29,7 +29,7 @@ use super::StarknetApi;
 #[async_trait]
 impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
     async fn chain_id(&self) -> RpcResult<FeltAsHex> {
-        Ok(self.inner.sequencer.backend().chain_id.id().into())
+        Ok(self.inner.backend.chain_id.id().into())
     }
 
     async fn get_nonce(
@@ -73,10 +73,10 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithTxHashes> {
         self.on_io_blocking_task(move |this| {
-            let provider = this.inner.sequencer.backend().blockchain.provider();
+            let provider = this.inner.backend.blockchain.provider();
 
             if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                if let Some(executor) = this.inner.sequencer.pending_executor() {
+                if let Some(executor) = this.pending_executor() {
                     let block_env = executor.read().block_env();
                     let latest_hash = provider.latest_hash().map_err(StarknetApiError::from)?;
 
@@ -132,7 +132,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         self.on_io_blocking_task(move |this| {
             // TEMP: have to handle pending tag independently for now
             let tx = if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                let Some(executor) = this.inner.sequencer.pending_executor() else {
+                let Some(executor) = this.pending_executor() else {
                     return Err(StarknetApiError::BlockNotFound.into());
                 };
 
@@ -140,7 +140,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                 let pending_txs = executor.transactions();
                 pending_txs.get(index as usize).map(|(tx, _)| tx.clone())
             } else {
-                let provider = &this.inner.sequencer.backend().blockchain.provider();
+                let provider = &this.inner.backend.blockchain.provider();
 
                 let block_num = BlockIdReader::convert_block_id(provider, block_id)
                     .map_err(StarknetApiError::from)?
@@ -161,10 +161,10 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithTxs> {
         self.on_io_blocking_task(move |this| {
-            let provider = this.inner.sequencer.backend().blockchain.provider();
+            let provider = this.inner.backend.blockchain.provider();
 
             if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                if let Some(executor) = this.inner.sequencer.pending_executor() {
+                if let Some(executor) = this.pending_executor() {
                     let block_env = executor.read().block_env();
                     let latest_hash = provider.latest_hash().map_err(StarknetApiError::from)?;
 
@@ -218,10 +218,10 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithReceipts> {
         self.on_io_blocking_task(move |this| {
-            let provider = this.inner.sequencer.backend().blockchain.provider();
+            let provider = this.inner.backend.blockchain.provider();
 
             if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                if let Some(executor) = this.inner.sequencer.pending_executor() {
+                if let Some(executor) = this.pending_executor() {
                     let block_env = executor.read().block_env();
                     let latest_hash = provider.latest_hash().map_err(StarknetApiError::from)?;
 
@@ -271,7 +271,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
 
     async fn get_state_update(&self, block_id: BlockIdOrTag) -> RpcResult<StateUpdate> {
         self.on_io_blocking_task(move |this| {
-            let provider = this.inner.sequencer.backend().blockchain.provider();
+            let provider = this.inner.backend.blockchain.provider();
 
             let block_id = match block_id {
                 BlockIdOrTag::Number(num) => BlockHashOrNumber::Num(num),
@@ -299,7 +299,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         transaction_hash: FieldElement,
     ) -> RpcResult<TxReceiptWithBlockInfo> {
         self.on_io_blocking_task(move |this| {
-            let provider = this.inner.sequencer.backend().blockchain.provider();
+            let provider = this.inner.backend.blockchain.provider();
             let receipt = ReceiptBuilder::new(transaction_hash, provider)
                 .build()
                 .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
@@ -308,7 +308,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                 Some(receipt) => Ok(receipt),
 
                 None => {
-                    let executor = this.inner.sequencer.pending_executor();
+                    let executor = this.pending_executor();
                     let pending_receipt = executor
                         .and_then(|executor| {
                             executor.read().transactions().iter().find_map(|(tx, res)| {
@@ -392,12 +392,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
             // get the state and block env at the specified block for function call execution
             let state = this.state(&block_id)?;
             let env = this.block_env_at(&block_id)?;
-            let executor = this
-                .inner
-                .sequencer
-                .backend()
-                .executor_factory
-                .with_state_and_block_env(state, env);
+            let executor = this.inner.backend.executor_factory.with_state_and_block_env(state, env);
 
             match executor.call(request) {
                 Ok(retdata) => Ok(retdata.into_iter().map(|v| v.into()).collect()),
@@ -429,7 +424,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         block_id: BlockIdOrTag,
     ) -> RpcResult<Vec<FeeEstimate>> {
         self.on_cpu_blocking_task(move |this| {
-            let chain_id = this.inner.sequencer.backend().chain_id;
+            let chain_id = this.inner.backend.chain_id;
 
             let transactions = request
                 .into_iter()
@@ -468,8 +463,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
 
             // If the node is run with transaction validation disabled, then we should not validate
             // transactions when estimating the fee even if the `SKIP_VALIDATE` flag is not set.
-            let should_validate =
-                !(skip_validate || this.inner.sequencer.backend().config.disable_validate);
+            let should_validate = !(skip_validate || this.inner.backend.config.disable_validate);
             let flags = katana_executor::SimulationFlag {
                 skip_validate: !should_validate,
                 ..Default::default()
@@ -487,7 +481,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         block_id: BlockIdOrTag,
     ) -> RpcResult<FeeEstimate> {
         self.on_cpu_blocking_task(move |this| {
-            let chain_id = this.inner.sequencer.backend().chain_id;
+            let chain_id = this.inner.backend.chain_id;
 
             let tx = message.into_tx_with_chain_id(chain_id);
             let hash = tx.calculate_hash();

--- a/crates/katana/rpc/rpc/src/starknet/write.rs
+++ b/crates/katana/rpc/rpc/src/starknet/write.rs
@@ -20,11 +20,11 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
                 return Err(StarknetApiError::UnsupportedTransactionVersion);
             }
 
-            let tx = tx.into_tx_with_chain_id(this.inner.sequencer.backend().chain_id);
+            let tx = tx.into_tx_with_chain_id(this.inner.backend.chain_id);
             let tx = ExecutableTxWithHash::new(ExecutableTx::Invoke(tx));
             let tx_hash = tx.hash;
 
-            this.inner.sequencer.pool().add_transaction(tx);
+            this.inner.pool.add_transaction(tx);
             Ok(tx_hash.into())
         })
         .await
@@ -40,14 +40,14 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
             }
 
             let tx = tx
-                .try_into_tx_with_chain_id(this.inner.sequencer.backend().chain_id)
+                .try_into_tx_with_chain_id(this.inner.backend.chain_id)
                 .map_err(|_| StarknetApiError::InvalidContractClass)?;
 
             let class_hash = tx.class_hash();
             let tx = ExecutableTxWithHash::new(ExecutableTx::Declare(tx));
             let tx_hash = tx.hash;
 
-            this.inner.sequencer.pool().add_transaction(tx);
+            this.inner.pool.add_transaction(tx);
             Ok((tx_hash, class_hash).into())
         })
         .await
@@ -62,13 +62,13 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
                 return Err(StarknetApiError::UnsupportedTransactionVersion);
             }
 
-            let tx = tx.into_tx_with_chain_id(this.inner.sequencer.backend().chain_id);
+            let tx = tx.into_tx_with_chain_id(this.inner.backend.chain_id);
             let contract_address = tx.contract_address();
 
             let tx = ExecutableTxWithHash::new(ExecutableTx::DeployAccount(tx));
             let tx_hash = tx.hash;
 
-            this.inner.sequencer.pool().add_transaction(tx);
+            this.inner.pool.add_transaction(tx);
             Ok((tx_hash, contract_address).into())
         })
         .await

--- a/crates/katana/rpc/rpc/src/torii.rs
+++ b/crates/katana/rpc/rpc/src/torii.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use jsonrpsee::core::{async_trait, RpcResult};
-use katana_core::sequencer::KatanaSequencer;
-use katana_core::service::block_producer::BlockProducerMode;
+use katana_core::backend::Backend;
+use katana_core::pool::TransactionPool;
+use katana_core::service::block_producer::{BlockProducer, BlockProducerMode, PendingExecutor};
 use katana_executor::ExecutorFactory;
 use katana_primitives::block::{BlockHashOrNumber, FinalityStatus};
 use katana_provider::traits::block::BlockNumberProvider;
@@ -19,18 +20,28 @@ const MAX_PAGE_SIZE: usize = 100;
 
 #[allow(missing_debug_implementations)]
 pub struct ToriiApi<EF: ExecutorFactory> {
-    sequencer: Arc<KatanaSequencer<EF>>,
+    backend: Arc<Backend<EF>>,
+    pool: Arc<TransactionPool>,
+    block_producer: Arc<BlockProducer<EF>>,
 }
 
 impl<EF: ExecutorFactory> Clone for ToriiApi<EF> {
     fn clone(&self) -> Self {
-        Self { sequencer: self.sequencer.clone() }
+        Self {
+            pool: Arc::clone(&self.pool),
+            backend: Arc::clone(&self.backend),
+            block_producer: Arc::clone(&self.block_producer),
+        }
     }
 }
 
 impl<EF: ExecutorFactory> ToriiApi<EF> {
-    pub fn new(sequencer: Arc<KatanaSequencer<EF>>) -> Self {
-        Self { sequencer }
+    pub fn new(
+        backend: Arc<Backend<EF>>,
+        pool: Arc<TransactionPool>,
+        block_producer: Arc<BlockProducer<EF>>,
+    ) -> Self {
+        Self { pool, backend, block_producer }
     }
 
     async fn on_io_blocking_task<F, T>(&self, func: F) -> T
@@ -40,6 +51,14 @@ impl<EF: ExecutorFactory> ToriiApi<EF> {
     {
         let this = self.clone();
         TokioTaskSpawner::new().unwrap().spawn_blocking(move || func(this)).await.unwrap()
+    }
+
+    /// Returns the pending state if the sequencer is running in _interval_ mode. Otherwise `None`.
+    fn pending_executor(&self) -> Option<PendingExecutor> {
+        match &*self.block_producer.inner.read() {
+            BlockProducerMode::Instant(_) => None,
+            BlockProducerMode::Interval(producer) => Some(producer.executor()),
+        }
     }
 }
 
@@ -54,9 +73,8 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
                 let mut transactions = Vec::new();
                 let mut next_cursor = cursor;
 
-                let provider = this.sequencer.backend().blockchain.provider();
-                let latest_block_number =
-                    this.sequencer.provider().latest_number().map_err(ToriiApiError::from)?;
+                let provider = this.backend.blockchain.provider();
+                let latest_block_number = provider.latest_number().map_err(ToriiApiError::from)?;
 
                 if cursor.block_number > latest_block_number + 1 {
                     return Err(ToriiApiError::BlockNotFound);
@@ -101,7 +119,7 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
                     }
                 }
 
-                if let Some(pending_executor) = this.sequencer.pending_executor() {
+                if let Some(pending_executor) = this.pending_executor() {
                     let remaining = MAX_PAGE_SIZE - transactions.len();
 
                     // If cursor is in the pending block
@@ -130,7 +148,7 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
                         // If there are no transactions after the index in the pending block
                         if pending_transactions.is_empty() {
                             // Wait for a new transaction to be executed
-                            let inner = this.sequencer.block_producer().inner.read();
+                            let inner = this.block_producer.inner.read();
                             let block_producer = match &*inner {
                                 BlockProducerMode::Interval(block_producer) => block_producer,
                                 _ => panic!(
@@ -177,7 +195,7 @@ impl<EF: ExecutorFactory> ToriiApiServer for ToriiApi<EF> {
 
                     if transactions.is_empty() {
                         // Wait for a new transaction to be executed
-                        let inner = this.sequencer.block_producer().inner.read();
+                        let inner = this.block_producer.inner.read();
                         let block_producer = match &*inner {
                             BlockProducerMode::Instant(block_producer) => block_producer,
                             _ => {

--- a/crates/katana/rpc/rpc/tests/saya.rs
+++ b/crates/katana/rpc/rpc/tests/saya.rs
@@ -1,9 +1,12 @@
+#![allow(deprecated)]
+
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use dojo_test_utils::sequencer::{get_default_test_starknet_config, TestSequencer};
 use dojo_world::utils::TransactionWaiter;
 use jsonrpsee::http_client::HttpClientBuilder;
+#[allow(deprecated)]
 use katana_core::sequencer::SequencerConfig;
 use katana_primitives::block::{BlockIdOrTag, BlockTag};
 use katana_rpc_api::dev::DevApiClient;

--- a/crates/katana/rpc/rpc/tests/starknet.rs
+++ b/crates/katana/rpc/rpc/tests/starknet.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::fs::{self};
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/katana/rpc/rpc/tests/torii.rs
+++ b/crates/katana/rpc/rpc/tests/torii.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;


### PR DESCRIPTION

cleaning up some of the tech debts that was added when Katana was initially being built. 

`KatanaSequencer` used to be a central point where most the RPC api implementations are placed, but as Katana becomes more complex and we started introducing more features/endpoints, the implementations started to become more messy as things were being placed in either the RPC server struct itself (eg `StarknetApi`) or the `KatanaSequencer` struct, without any real considerations. some methods are only used by a single module , but because it is put under the shared struct, understanding the scope of the methods are becoming a bit more difficult. placing these methods only in the module/struct that exclusively use them is much more manageable.

other than that, bundling together all the fields doesn't seem that necessary, as it makes more sense to only pass around the specific components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function to build node components, enhancing modularity and flexibility in configuration.
  - Updated several APIs to utilize backend services, improving transaction handling and processing.

- **Bug Fixes**
  - Added annotations to suppress warnings for deprecated items, ensuring smoother compilation and backward compatibility.

- **Refactor**
  - Restructured various components to replace sequencer dependencies with backend and block producer fields, streamlining the architecture and improving clarity.
  - Adjusted dependency configuration for `katana-executor` to specify features explicitly, enhancing clarity in dependency management.
  - Updated dependency declarations in the executor configuration to clarify optional dependencies and reorganize feature specifications.

- **Tests**
  - Enhanced test suite by updating the method for creating test sequencers, allowing for better encapsulation and flexibility in testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->