### PR TITLE
fix(sozo): events subcommand

### DIFF
--- a/bin/sozo/src/commands/events.rs
+++ b/bin/sozo/src/commands/events.rs
@@ -55,11 +55,12 @@ impl EventsArgs {
         let provider = self.starknet.provider(env_metadata.as_ref())?;
         trace!(?provider, "Starknet RPC client provider.");
 
+        let world_address = self.world.address(env_metadata.as_ref())?;
         let event_filter = events::get_event_filter(
             self.from_block,
             self.to_block,
             self.events,
-            self.world.world_address,
+            Some(world_address),
         );
         trace!(
             from_block = self.from_block,

--- a/crates/sozo/ops/src/events.rs
+++ b/crates/sozo/ops/src/events.rs
@@ -270,7 +270,7 @@ fn process_inners(
 mod tests {
     use cainome::parser::tokens::{Array, Composite, CompositeInner, CompositeType};
     use camino::Utf8Path;
-    use dojo_world::manifest::{BaseManifest, BASE_DIR, WORLD_QUALIFIED_PATH};
+    use dojo_world::manifest::WORLD_QUALIFIED_PATH;
     use starknet::core::types::EmittedEvent;
 
     use super::*;
@@ -283,7 +283,10 @@ mod tests {
         println!("manifest_dir {:?}", manifest_dir);
         let target_dir = project_dir.join(TARGET_DIR).join(profile_name);
         println!("target dir {:?}", target_dir);
-        let manifest = BaseManifest::load_from_path(&manifest_dir.join(BASE_DIR)).unwrap().into();
+        let manifest = DeploymentManifest::load_from_path(
+            &manifest_dir.join(DEPLOYMENT_DIR).join("manifest").with_extension("toml"),
+        )
+        .unwrap();
 
         let result = extract_events(&manifest, &project_dir, &target_dir).unwrap();
 

--- a/crates/sozo/ops/src/events.rs
+++ b/crates/sozo/ops/src/events.rs
@@ -89,6 +89,7 @@ fn extract_events(
         let abi_str = fs::read_to_string(full_abi_path)
             .with_context(|| format!("Failed to read ABI file at path: {}", full_abi_path))?;
 
+        // TODO: add support for events emitted by world once its present in ABI
         match AbiParser::tokens_from_abi_string(&abi_str, &HashMap::new()) {
             Ok(tokens) => {
                 for token in tokens.structs {

--- a/crates/sozo/ops/src/events.rs
+++ b/crates/sozo/ops/src/events.rs
@@ -99,7 +99,7 @@ fn extract_events(
                     }
                 }
             }
-            Err(e) => return Err(anyhow!("Error parsing ABI: {}", e)),
+            Err(e) => return Err(anyhow!("Error parsing events from ABI: {}", e)),
         }
 
         Ok(())

--- a/crates/sozo/ops/src/events.rs
+++ b/crates/sozo/ops/src/events.rs
@@ -53,7 +53,7 @@ pub async fn parse(
 
         Some(extract_events(
             &DeploymentManifest::load_from_path(&deployed_manifest)?,
-            &project_dir,
+            project_dir,
             &target_dir,
         )?)
     } else {
@@ -203,7 +203,7 @@ fn parse_event(
         }
     }
 
-    Err(anyhow!("No matching event found for {:?}", event))
+    Err(anyhow!("No matching event found in tokens {:?}", event))
 }
 
 fn process_inners(
@@ -407,12 +407,8 @@ mod tests {
              0x54657374\ncontract_address: 0x54657374\n"
         );
 
-        let actual_output_option = parse_event(event, &events_map).expect("Failed to parse event");
-
-        match actual_output_option {
-            Some(actual_output) => assert_eq!(actual_output, expected_output),
-            None => panic!("Expected event was not found."),
-        }
+        let actual_output = parse_event(event, &events_map).expect("Failed to parse event");
+        assert_eq!(actual_output, expected_output);
     }
 
     #[test]
@@ -472,12 +468,8 @@ mod tests {
              \"Test\"\nkeys: [0x5465737431, 0x5465737432, 0x5465737433]\n"
         );
 
-        let actual_output_option = parse_event(event, &events_map).expect("Failed to parse event");
-
-        match actual_output_option {
-            Some(actual_output) => assert_eq!(actual_output, expected_output),
-            None => panic!("Expected event was not found."),
-        }
+        let actual_output = parse_event(event, &events_map).expect("Failed to parse event");
+        assert_eq!(actual_output, expected_output);
     }
 
     #[test]
@@ -547,12 +539,8 @@ mod tests {
              \"Test1\"\ndata_1: 1\ndata_2: 2\n"
         );
 
-        let actual_output_option = parse_event(event, &events_map).expect("Failed to parse event");
-
-        match actual_output_option {
-            Some(actual_output) => assert_eq!(actual_output, expected_output),
-            None => panic!("Expected event was not found."),
-        }
+        let actual_output = parse_event(event, &events_map).expect("Failed to parse event");
+        assert_eq!(actual_output, expected_output);
     }
 
     #[test]
@@ -612,11 +600,7 @@ mod tests {
              0x2]\n"
         );
 
-        let actual_output_option = parse_event(event, &events_map).expect("Failed to parse event");
-
-        match actual_output_option {
-            Some(actual_output) => assert_eq!(actual_output, expected_output),
-            None => panic!("Expected event was not found."),
-        }
+        let actual_output = parse_event(event, &events_map).expect("Failed to parse event");
+        assert_eq!(actual_output, expected_output);
     }
 }


### PR DESCRIPTION
- Use correct deployment manifest path to extract abis from
- Read world address both from cli and manifest file
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for improved clarity when reading ABI files.
	- Streamlined event parsing logic to ensure valid results or clear error messages.
  
- **Bug Fixes**
	- Adjusted path for accessing the deployed manifest to ensure correct file retrieval.
  
- **Refactor**
	- Cleaned up code to enhance readability and maintainability, including removing unnecessary calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->