### PR TITLE
feat(dojo-core): add selector_from_names for cairo runtime

### DIFF
--- a/crates/dojo-core/src/lib.cairo
+++ b/crates/dojo-core/src/lib.cairo
@@ -45,7 +45,7 @@ pub mod utils {
     pub mod utils;
     pub use utils::{
         bytearray_hash, entity_id_from_keys, find_field_layout, find_model_field_layout, any_none,
-        sum, combine_key
+        sum, combine_key, selector_from_names
     };
 }
 

--- a/crates/dojo-core/src/tests/utils.cairo
+++ b/crates/dojo-core/src/tests/utils.cairo
@@ -1,5 +1,5 @@
 use dojo::model::Model;
-use dojo::utils::bytearray_hash;
+use dojo::utils::{bytearray_hash, selector_from_names};
 
 #[derive(Drop, Copy, Serde)]
 #[dojo::model(namespace: "my_namespace")]
@@ -17,4 +17,12 @@ fn test_hash_computation() {
     let namespace_hash = Model::<MyModel>::namespace_hash();
 
     assert(bytearray_hash(@namespace) == namespace_hash, 'invalid computed hash');
+}
+
+#[test]
+fn test_selector_computation() {
+    let namespace = Model::<MyModel>::namespace();
+    let name = Model::<MyModel>::name();
+    let selector = selector_from_names(@namespace, @name);
+    assert(selector == Model::<MyModel>::selector(), 'invalid computed selector');
 }

--- a/crates/dojo-core/src/utils/utils.cairo
+++ b/crates/dojo-core/src/utils/utils.cairo
@@ -13,6 +13,11 @@ pub fn bytearray_hash(data: @ByteArray) -> felt252 {
     poseidon_hash_span(serialized.span())
 }
 
+/// Computes the selector of a resource from the namespace and the name.
+pub fn selector_from_names(namespace: @ByteArray, name: @ByteArray) -> felt252 {
+    poseidon_hash_span(array![bytearray_hash(namespace), bytearray_hash(name)].span())
+}
+
 /// Computes the entity id from the keys.
 ///
 /// # Arguments


### PR DESCRIPTION
# Description

Dojo compiler plugin proposes a `selector_from_tag!` macro. However, no variables can be used in their.

This PR adds a `selector_from_name` utils function, that can compute a selector of a resource providing it's namespace and name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new utility function, `selector_from_names`, for enhanced resource selector computation.
	- Expanded the public module exports to include the new function alongside existing utilities.

- **Tests**
	- Added a new test function, `test_selector_computation`, to validate the new selector functionality, improving overall testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->