### PR TITLE
fix(sozo): upgrade_contract use selector instead of contract_address

### DIFF
--- a/bin/sozo/tests/test_migrate.rs
+++ b/bin/sozo/tests/test_migrate.rs
@@ -1,4 +1,4 @@
-mod utils;
+use std::fs;
 
 use dojo_test_utils::compiler::CompilerTestSetup;
 use katana_runner::KatanaRunner;
@@ -6,6 +6,8 @@ use scarb::compiler::Profile;
 use starknet::accounts::Account;
 use starknet::core::types::{BlockId, BlockTag};
 use utils::snapbox::get_snapbox;
+
+mod utils;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn migrate_dry_run() {
@@ -45,4 +47,53 @@ async fn migrate_dry_run() {
     assert!(output.contains("# Models (10)"));
     assert!(output.contains("# World"));
     assert!(output.contains("# Contracts (4)"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_migrate_then_upgrade() {
+    let setup = CompilerTestSetup::from_examples("../../crates/dojo-core", "../../examples/");
+    let config = setup.build_test_config("spawn-and-move", Profile::DEV);
+    let tmp_dir = config.manifest_path().parent().unwrap();
+
+    let sequencer = KatanaRunner::new().expect("Failed to start runner.");
+
+    let mut account = sequencer.account(0);
+    account.set_block_id(BlockId::Tag(BlockTag::Pending));
+
+    let account_address = &format!("0x{:x}", account.address());
+    let private_key =
+        &format!("0x{:x}", sequencer.account_data(0).private_key.as_ref().unwrap().secret_scalar());
+    let rpc_url = &sequencer.url().to_string();
+
+    let args_vec = [
+        "migrate",
+        "apply",
+        "--account-address",
+        account_address,
+        "--rpc-url",
+        rpc_url,
+        "--private-key",
+        private_key,
+        "--manifest-path",
+        config.manifest_path().as_ref(),
+    ];
+
+    get_snapbox().args(args_vec.iter()).assert().success();
+
+    println!("tmp_dir: {:?}", tmp_dir);
+
+    // Modify the actions contracts to have a new class hash.
+    let actions_path = tmp_dir.join("src/actions.cairo");
+    let mut actions_content = fs::read_to_string(&actions_path).unwrap();
+    actions_content = actions_content.replace("quantity: 100", "quantity: 200");
+    fs::write(&actions_path, actions_content).unwrap();
+
+    let build_vec = ["build", "--manifest-path", config.manifest_path().as_ref()];
+
+    get_snapbox().args(build_vec.iter()).assert().success();
+
+    let assert = get_snapbox().args(args_vec.iter()).assert().success();
+    let output = format!("{:#?}", assert.get_output());
+
+    assert!(output.contains("Contracts (1)"));
 }

--- a/crates/dojo-world/src/contracts/world_test.rs
+++ b/crates/dojo-world/src/contracts/world_test.rs
@@ -143,6 +143,7 @@ pub async fn deploy_world(
                 &account,
                 &TxnConfig::init_wait(),
                 &contract.diff.init_calldata,
+                None,
             )
             .await
             .unwrap();

--- a/crates/dojo-world/src/contracts/world_test.rs
+++ b/crates/dojo-world/src/contracts/world_test.rs
@@ -143,7 +143,7 @@ pub async fn deploy_world(
                 &account,
                 &TxnConfig::init_wait(),
                 &contract.diff.init_calldata,
-                None,
+                &contract.diff.tag,
             )
             .await
             .unwrap();

--- a/crates/dojo-world/src/migration/mod.rs
+++ b/crates/dojo-world/src/migration/mod.rs
@@ -177,7 +177,7 @@ pub trait Deployable: Declarable + Sync {
         account: A,
         txn_config: &TxnConfig,
         calldata: &[String],
-        tag: Option<&String>,
+        tag: &str,
     ) -> Result<DeployOutput, MigrationError<<A as Account>::SignError>>
     where
         A: ConnectedAccount + Send + Sync,
@@ -202,7 +202,8 @@ pub trait Deployable: Declarable + Sync {
             Ok(current_class_hash) if current_class_hash != class_hash => {
                 was_upgraded = true;
 
-                let contract_selector = compute_selector_from_tag(tag.expect("expected tag!").as_ref());
+                let contract_selector = compute_selector_from_tag(tag);
+
                 Call {
                     calldata: vec![contract_selector, class_hash],
                     selector: selector!("upgrade_contract"),

--- a/crates/sozo/ops/src/migration/migrate.rs
+++ b/crates/sozo/ops/src/migration/migrate.rs
@@ -541,6 +541,7 @@ where
                 &migrator,
                 txn_config,
                 &contract.diff.init_calldata,
+                Some(tag),
             )
             .await
         {

--- a/crates/sozo/ops/src/migration/migrate.rs
+++ b/crates/sozo/ops/src/migration/migrate.rs
@@ -541,7 +541,7 @@ where
                 &migrator,
                 txn_config,
                 &contract.diff.init_calldata,
-                Some(tag),
+                tag,
             )
             .await
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced contract deployment capabilities by allowing optional parameters to improve flexibility and control in the deployment process.
	- Added functionality for migration processes to accept additional context metadata for improved traceability.
	- Introduced a new test case to validate the migration process followed by an upgrade, ensuring the integrity of the workflow.

- **Bug Fixes**
	- Improved handling of contract upgrades by incorporating a selector derived from a newly introduced tag parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->