### PR TITLE
feat(katana-db): database stats

### DIFF
--- a/crates/katana/storage/db/src/abstraction/mod.rs
+++ b/crates/katana/storage/db/src/abstraction/mod.rs
@@ -15,6 +15,12 @@ pub trait Database: Send + Sync {
     /// Read-Write transaction
     type TxMut: DbTxMut + Send + Sync + Debug + 'static;
 
+    /// Database statistics
+    ///
+    /// The database implementation is allowed to specify whatever statistics that
+    /// make sense for it, especially from monitoring and debugging perspective.
+    type Stats: Send + Debug + 'static;
+
     /// Create and begin read-only transaction.
     #[track_caller]
     fn tx(&self) -> Result<Self::Tx, DatabaseError>;
@@ -47,4 +53,7 @@ pub trait Database: Send + Sync {
         tx.commit()?;
         Ok(res)
     }
+
+    /// Retrieve the database statistics.
+    fn stats(&self) -> Result<Self::Stats, DatabaseError>;
 }

--- a/crates/katana/storage/db/src/error.rs
+++ b/crates/katana/storage/db/src/error.rs
@@ -38,6 +38,9 @@ pub enum DatabaseError {
 
     #[error("failed to clear db: {0}")]
     Clear(libmdbx::Error),
+
+    #[error("failed to get db stats: {0}")]
+    GetStats(libmdbx::Error),
 }
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -6,6 +6,7 @@ pub mod cursor;
 pub mod stats;
 pub mod tx;
 
+use std::collections::HashMap;
 use std::path::Path;
 
 pub use libmdbx;
@@ -106,12 +107,12 @@ impl Database for DbEnv {
 
     fn stats(&self) -> Result<Self::Stats, DatabaseError> {
         self.view(|tx| {
-            let mut table_stats = Vec::with_capacity(NUM_TABLES);
+            let mut table_stats = HashMap::with_capacity(NUM_TABLES);
 
             for table in Tables::ALL.iter() {
                 let dbi = tx.inner.open_db(Some(table.name())).map_err(DatabaseError::OpenDb)?;
                 let stat = tx.inner.db_stat(&dbi).map_err(DatabaseError::GetStats)?;
-                table_stats.push(TableStat::new(table.name(), stat));
+                table_stats.insert(table.name(), TableStat::new(stat));
             }
 
             let info = self.0.info().map_err(DatabaseError::Stat)?;

--- a/crates/katana/storage/db/src/mdbx/stats.rs
+++ b/crates/katana/storage/db/src/mdbx/stats.rs
@@ -16,6 +16,12 @@ impl TableStat {
 
     /// Size of a database page. This is the same for all databases in the environment.
     #[inline]
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Size of a database page. This is the same for all databases in the environment.
+    #[inline]
     pub fn page_size(&self) -> u32 {
         self.stat.page_size()
     }
@@ -65,6 +71,11 @@ impl Stats {
         Self { table_stats, info }
     }
 
+    /// Get statistics for all tables
+    pub fn table_stats(&self) -> &[TableStat] {
+        &self.table_stats
+    }
+
     /// Get statistics for a specific table
     pub fn table_stat(&self, table_name: &str) -> Option<&TableStat> {
         self.table_stats.iter().find(|s| s.name == table_name)
@@ -83,7 +94,7 @@ impl Stats {
             .sum()
     }
 
-    /// Get the size of the memory map
+    /// Get the size of the mapped memory region
     pub fn map_size(&self) -> usize {
         self.info.map_size()
     }

--- a/crates/katana/storage/db/src/mdbx/stats.rs
+++ b/crates/katana/storage/db/src/mdbx/stats.rs
@@ -1,59 +1,52 @@
+use std::collections::HashMap;
+
 use libmdbx::Info;
 
 /// Statistics for an individual table in the database.
 ///
 /// A wrapper over MDBX's environment [Stat](libmdbx::Stat).
-pub struct TableStat {
-    name: &'static str,
-    stat: libmdbx::Stat,
-}
+pub struct TableStat(libmdbx::Stat);
 
 impl TableStat {
     /// Creates a new TableStat instance
-    pub(super) fn new(name: &'static str, stat: libmdbx::Stat) -> Self {
-        Self { name, stat }
-    }
-
-    /// Size of a database page. This is the same for all databases in the environment.
-    #[inline]
-    pub fn name(&self) -> &'static str {
-        self.name
+    pub(super) fn new(stat: libmdbx::Stat) -> Self {
+        Self(stat)
     }
 
     /// Size of a database page. This is the same for all databases in the environment.
     #[inline]
     pub fn page_size(&self) -> u32 {
-        self.stat.page_size()
+        self.0.page_size()
     }
 
     /// Depth (height) of the B-tree.
     #[inline]
     pub fn depth(&self) -> u32 {
-        self.stat.depth()
+        self.0.depth()
     }
 
     /// Number of internal (non-leaf) pages.
     #[inline]
     pub fn branch_pages(&self) -> usize {
-        self.stat.branch_pages()
+        self.0.branch_pages()
     }
 
     /// Number of leaf pages.
     #[inline]
     pub fn leaf_pages(&self) -> usize {
-        self.stat.leaf_pages()
+        self.0.leaf_pages()
     }
 
     /// Number of overflow pages.
     #[inline]
     pub fn overflow_pages(&self) -> usize {
-        self.stat.overflow_pages()
+        self.0.overflow_pages()
     }
 
     /// Number of data items.
     #[inline]
     pub fn entries(&self) -> usize {
-        self.stat.entries()
+        self.0.entries()
     }
 
     /// The total size (in bytes) of the table.
@@ -67,36 +60,36 @@ impl TableStat {
 /// Statistics for the entire MDBX environment.
 pub struct Stats {
     /// Statistics for individual tables in the environment
-    table_stats: Vec<TableStat>,
+    table_stats: HashMap<&'static str, TableStat>,
     /// Overall environment information
     info: Info,
 }
 
 impl Stats {
     /// Creates a new Stats instance
-    pub(super) fn new(table_stats: Vec<TableStat>, info: libmdbx::Info) -> Self {
+    pub(super) fn new(table_stats: HashMap<&'static str, TableStat>, info: libmdbx::Info) -> Self {
         Self { table_stats, info }
     }
 
     /// Get statistics for all tables
-    pub fn table_stats(&self) -> &[TableStat] {
+    pub fn table_stats(&self) -> &HashMap<&'static str, TableStat> {
         &self.table_stats
     }
 
     /// Get statistics for a specific table
     pub fn table_stat(&self, table_name: &str) -> Option<&TableStat> {
-        self.table_stats.iter().find(|s| s.name == table_name)
+        self.table_stats.get(table_name)
     }
 
     /// Get the total number of entries across all tables
     pub fn total_entries(&self) -> usize {
-        self.table_stats.iter().map(|stat| stat.entries()).sum()
+        self.table_stats.values().map(|stat| stat.entries()).sum()
     }
 
     /// Get the total number of pages used across all tables
     pub fn total_pages(&self) -> usize {
         self.table_stats
-            .iter()
+            .values()
             .map(|stat| stat.branch_pages() + stat.leaf_pages() + stat.overflow_pages())
             .sum()
     }
@@ -130,7 +123,6 @@ impl Stats {
 impl std::fmt::Debug for TableStat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TableStat")
-            .field("name", &self.name)
             .field("page_size", &self.page_size())
             .field("depth", &self.depth())
             .field("branch_pages", &self.branch_pages())

--- a/crates/katana/storage/db/src/mdbx/stats.rs
+++ b/crates/katana/storage/db/src/mdbx/stats.rs
@@ -55,6 +55,13 @@ impl TableStat {
     pub fn entries(&self) -> usize {
         self.stat.entries()
     }
+
+    /// The total size (in bytes) of the table.
+    #[inline]
+    pub fn total_size(&self) -> usize {
+        let total_pages = self.leaf_pages() + self.branch_pages() + self.overflow_pages();
+        self.page_size() as usize * total_pages
+    }
 }
 
 /// Statistics for the entire MDBX environment.

--- a/crates/katana/storage/db/src/mdbx/stats.rs
+++ b/crates/katana/storage/db/src/mdbx/stats.rs
@@ -1,0 +1,137 @@
+use libmdbx::Info;
+
+/// Statistics for an individual table in the database.
+///
+/// A wrapper over MDBX's environment [Stat](libmdbx::Stat).
+pub struct TableStat {
+    name: &'static str,
+    stat: libmdbx::Stat,
+}
+
+impl TableStat {
+    /// Creates a new TableStat instance
+    pub(super) fn new(name: &'static str, stat: libmdbx::Stat) -> Self {
+        Self { name, stat }
+    }
+
+    /// Size of a database page. This is the same for all databases in the environment.
+    #[inline]
+    pub fn page_size(&self) -> u32 {
+        self.stat.page_size()
+    }
+
+    /// Depth (height) of the B-tree.
+    #[inline]
+    pub fn depth(&self) -> u32 {
+        self.stat.depth()
+    }
+
+    /// Number of internal (non-leaf) pages.
+    #[inline]
+    pub fn branch_pages(&self) -> usize {
+        self.stat.branch_pages()
+    }
+
+    /// Number of leaf pages.
+    #[inline]
+    pub fn leaf_pages(&self) -> usize {
+        self.stat.leaf_pages()
+    }
+
+    /// Number of overflow pages.
+    #[inline]
+    pub fn overflow_pages(&self) -> usize {
+        self.stat.overflow_pages()
+    }
+
+    /// Number of data items.
+    #[inline]
+    pub fn entries(&self) -> usize {
+        self.stat.entries()
+    }
+}
+
+/// Statistics for the entire MDBX environment.
+pub struct Stats {
+    /// Statistics for individual tables in the environment
+    table_stats: Vec<TableStat>,
+    /// Overall environment information
+    info: Info,
+}
+
+impl Stats {
+    /// Creates a new Stats instance
+    pub(super) fn new(table_stats: Vec<TableStat>, info: libmdbx::Info) -> Self {
+        Self { table_stats, info }
+    }
+
+    /// Get statistics for a specific table
+    pub fn table_stat(&self, table_name: &str) -> Option<&TableStat> {
+        self.table_stats.iter().find(|s| s.name == table_name)
+    }
+
+    /// Get the total number of entries across all tables
+    pub fn total_entries(&self) -> usize {
+        self.table_stats.iter().map(|stat| stat.entries()).sum()
+    }
+
+    /// Get the total number of pages used across all tables
+    pub fn total_pages(&self) -> usize {
+        self.table_stats
+            .iter()
+            .map(|stat| stat.branch_pages() + stat.leaf_pages() + stat.overflow_pages())
+            .sum()
+    }
+
+    /// Get the size of the memory map
+    pub fn map_size(&self) -> usize {
+        self.info.map_size()
+    }
+
+    /// Get the last used page number
+    pub fn last_page_number(&self) -> usize {
+        self.info.last_pgno()
+    }
+
+    /// Get the last transaction ID
+    pub fn last_transaction_id(&self) -> usize {
+        self.info.last_txnid()
+    }
+
+    /// Get the maximum number of reader slots
+    pub fn max_readers(&self) -> usize {
+        self.info.max_readers()
+    }
+
+    /// Get the number of reader slots currently in use
+    pub fn current_readers(&self) -> usize {
+        self.info.num_readers()
+    }
+}
+
+impl std::fmt::Debug for TableStat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TableStat")
+            .field("name", &self.name)
+            .field("page_size", &self.page_size())
+            .field("depth", &self.depth())
+            .field("branch_pages", &self.branch_pages())
+            .field("leaf_pages", &self.leaf_pages())
+            .field("overflow_pages", &self.overflow_pages())
+            .field("entries", &self.entries())
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for Stats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Stats")
+            .field("table_stats", &self.table_stats)
+            .field("map_size", &self.info.map_size())
+            .field("last_page_number", &self.info.last_pgno())
+            .field("last_transaction_id", &self.info.last_txnid())
+            .field("max_readers", &self.info.max_readers())
+            .field("current_readers", &self.info.num_readers())
+            .finish()
+    }
+}

--- a/crates/katana/storage/db/src/mdbx/tx.rs
+++ b/crates/katana/storage/db/src/mdbx/tx.rs
@@ -53,7 +53,7 @@ impl<K: TransactionKind> Tx<K> {
     pub fn stat<T: Table>(&self) -> Result<TableStat, DatabaseError> {
         let dbi = self.get_dbi::<T>()?;
         let stat = self.inner.db_stat_with_dbi(dbi).map_err(DatabaseError::Stat)?;
-        Ok(TableStat::new(T::NAME, stat))
+        Ok(TableStat::new(stat))
     }
 }
 


### PR DESCRIPTION
- add an associated type and getter function for the stats in the main `Database` trait.
- retrieve the stats from mdbx environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a mechanism for database statistics retrieval, allowing users to access detailed performance metrics.
  - Added a method to the `Database` trait for retrieving statistics, enhancing monitoring capabilities.
  - New structures for encapsulating table statistics and overall database statistics, improving data organization.
  
- **Bug Fixes**
  - Improved error handling with the addition of a new error variant for statistics retrieval.

- **Tests**
  - Added test cases to validate the functionality of the new statistics retrieval methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->