### PR TITLE
refactor(sozo): deploy controller account if not exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12737,7 +12737,6 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "similar-asserts",
  "slot",
  "smol_str",
  "snapbox",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12730,6 +12730,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "prettytable-rs",
+ "reqwest 0.12.5",
  "rpassword",
  "scarb",
  "scarb-ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12737,6 +12737,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
+ "similar-asserts",
  "slot",
  "smol_str",
  "snapbox",

--- a/bin/sozo/Cargo.toml
+++ b/bin/sozo/Cargo.toml
@@ -65,7 +65,6 @@ reqwest = { workspace = true, features = [ "json" ], optional = true }
 assert_fs.workspace = true
 dojo-test-utils = { workspace = true, features = [ "build-examples" ] }
 katana-runner.workspace = true
-similar-asserts.workspace = true
 snapbox = "0.4.6"
 
 [features]

--- a/bin/sozo/Cargo.toml
+++ b/bin/sozo/Cargo.toml
@@ -59,6 +59,7 @@ tracing.workspace = true
 url.workspace = true
 
 cainome.workspace = true
+reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_fs.workspace = true
@@ -67,5 +68,5 @@ katana-runner.workspace = true
 snapbox = "0.4.6"
 
 [features]
-controller = [ "dep:account_sdk", "dep:slot" ]
+controller = [ "dep:account_sdk", "dep:slot", "dep:reqwest" ]
 default = [ "controller" ]

--- a/bin/sozo/Cargo.toml
+++ b/bin/sozo/Cargo.toml
@@ -59,12 +59,13 @@ tracing.workspace = true
 url.workspace = true
 
 cainome.workspace = true
-reqwest = { workspace = true, optional = true }
+reqwest = { workspace = true, features = [ "json" ], optional = true }
 
 [dev-dependencies]
 assert_fs.workspace = true
 dojo-test-utils = { workspace = true, features = [ "build-examples" ] }
 katana-runner.workspace = true
+similar-asserts.workspace = true
 snapbox = "0.4.6"
 
 [features]

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -253,7 +253,7 @@ fn get_dojo_world_address(
 ///
 /// `cartridge_deployController` is not a method that Katana itself exposes. It's from a middleware
 /// layer that is deployed on top of the Katana deployment on Slot. This method will deploy the
-/// Contract contract of a user based on the Slot deployment.
+/// contract of a user based on the Slot deployment.
 async fn deploy_account_if_not_exist(
     rpc_url: Url,
     provider: &impl Provider,

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -342,6 +342,7 @@ mod tests {
         let expected_policies: Vec<Policy> = serde_json::from_str(&test_data).unwrap();
 
         // Compare the collected policies with the test data
-        similar_asserts::assert_eq!(policies, expected_policies);
+        assert_eq!(policies.len(), expected_policies.len());
+        expected_policies.iter().for_each(|p| assert!(policies.contains(p)));
     }
 }

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -316,3 +316,27 @@ async fn deploy_account_if_not_exist(
         Err(e) => bail!(e),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use starknet::macros::felt;
+
+    use super::{collect_policies, Policy};
+    use crate::commands::options::account::WorldAddressOrName;
+
+    #[test]
+    fn collect_policies_from_project() {
+        let world_addr = felt!("0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a");
+        let user_addr = felt!("0x2f5fd1892492ca8106f14ff3bb8400f104dd2327068d2572e31d5b21fc5c4cc");
+
+        let policies =
+            collect_policies(WorldAddressOrName::Address(world_addr), user_addr, todo!()).unwrap();
+
+        // Get test data
+        let test_data = include_str!("../../../../tests/test_data/policies.json");
+        let expected_policies: Vec<Policy> = serde_json::from_str(&test_data).unwrap();
+
+        // Compare the collected policies with the test data
+        assert_eq!(policies, expected_policies);
+    }
+}

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -319,6 +319,8 @@ async fn deploy_account_if_not_exist(
 
 #[cfg(test)]
 mod tests {
+    use dojo_test_utils::compiler::CompilerTestSetup;
+    use scarb::compiler::Profile;
     use starknet::macros::felt;
 
     use super::{collect_policies, Policy};
@@ -326,17 +328,20 @@ mod tests {
 
     #[test]
     fn collect_policies_from_project() {
+        let config = CompilerTestSetup::from_examples("../../crates/dojo-core", "../../examples/")
+            .build_test_config("spawn-and-move", Profile::DEV);
+
         let world_addr = felt!("0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a");
-        let user_addr = felt!("0x2f5fd1892492ca8106f14ff3bb8400f104dd2327068d2572e31d5b21fc5c4cc");
+        let user_addr = felt!("0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03");
 
         let policies =
-            collect_policies(WorldAddressOrName::Address(world_addr), user_addr, todo!()).unwrap();
+            collect_policies(WorldAddressOrName::Address(world_addr), user_addr, &config).unwrap();
 
         // Get test data
         let test_data = include_str!("../../../../tests/test_data/policies.json");
         let expected_policies: Vec<Policy> = serde_json::from_str(&test_data).unwrap();
 
         // Compare the collected policies with the test data
-        assert_eq!(policies, expected_policies);
+        similar_asserts::assert_eq!(policies, expected_policies);
     }
 }

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -265,7 +265,7 @@ async fn deploy_account_if_not_exist(
         Ok(_) => Ok(()),
 
         // if account doesn't exist, deploy it by calling `cartridge_deployController` method
-        Err(StarknetError(ContractNotFound)) => {
+        Err(err @ StarknetError(ContractNotFound)) => {
             trace!(
                 %username,
                 chain = format!("{chain_id:#}"),
@@ -275,12 +275,8 @@ async fn deploy_account_if_not_exist(
 
             // Skip deployment if the rpc_url is not a Slot instance
             if !rpc_url.host_str().map_or(false, |host| host.contains("x.cartridge.gg")) {
-                warn!(
-                    %rpc_url,
-                    "Unable to deploy Controller on non-Slot instance. Skipping deployment..."
-                );
-
-                return Ok(());
+                warn!(%rpc_url, "Unable to deploy Controller on non-Slot instance.");
+                bail!("Controller with username '{username}' does not exist: {err}");
             }
 
             let client = Client::new();

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -295,20 +295,20 @@ async fn deploy_account_if_not_exist(
                 bail!("Controller with username '{username}' does not exist: {err}");
             }
 
-            let response = Client::new()
-                .post(rpc_url)
-                .json(&json!({
-                    "id": 1,
-                    "jsonrpc": "2.0",
-                    "method": "cartridge_deployController",
-                    "params": { "id": username },
-                }))
-                .send()
-                .await?;
+            let body = json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "params": { "id": username },
+                "method": "cartridge_deployController",
+            });
 
-            if !response.status().is_success() {
-                bail!("Failed to deploy controller: {}", response.status());
-            }
+            let _ = Client::new()
+                .post(rpc_url)
+                .json(&body)
+                .send()
+                .await?
+                .error_for_status()
+                .with_context(|| "Failed to deploy controller")?;
 
             Ok(())
         }

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -283,8 +283,7 @@ async fn deploy_account_if_not_exist(
                 bail!("Controller with username '{username}' does not exist: {err}");
             }
 
-            let client = Client::new();
-            let response = client
+            let response = Client::new()
                 .post(rpc_url)
                 .json(&json!({
                     "id": 1,

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -339,7 +339,7 @@ mod tests {
 
         // Get test data
         let test_data = include_str!("../../../../tests/test_data/policies.json");
-        let expected_policies: Vec<Policy> = serde_json::from_str(&test_data).unwrap();
+        let expected_policies: Vec<Policy> = serde_json::from_str(test_data).unwrap();
 
         // Compare the collected policies with the test data
         assert_eq!(policies.len(), expected_policies.len());

--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -250,6 +250,10 @@ fn get_dojo_world_address(
 /// This function will call the `cartridge_deployController` method to deploy the account if it
 /// doesn't yet exist on the chain. But this JSON-RPC method is only available on Katana deployed on
 /// Slot. If the `rpc_url` is not a Slot url, it will return an error.
+///
+/// `cartridge_deployController` is not a method that Katana itself exposes. It's from a middleware
+/// layer that is deployed on top of the Katana deployment on Slot. This method will deploy the
+/// Contract contract of a user based on the Slot deployment.
 async fn deploy_account_if_not_exist(
     rpc_url: Url,
     provider: &impl Provider,
@@ -274,7 +278,7 @@ async fn deploy_account_if_not_exist(
             );
 
             // Skip deployment if the rpc_url is not a Slot instance
-            if !rpc_url.host_str().map_or(false, |host| host.contains("x.cartridge.gg")) {
+            if !rpc_url.host_str().map_or(false, |host| host.contains("api.cartridge.gg")) {
                 warn!(%rpc_url, "Unable to deploy Controller on non-Slot instance.");
                 bail!("Controller with username '{username}' does not exist: {err}");
             }

--- a/bin/sozo/tests/test_data/policies.json
+++ b/bin/sozo/tests/test_data/policies.json
@@ -1,0 +1,126 @@
+[
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "spawn"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "move"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "set_player_config"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "update_player_name"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "update_player_name_value"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "reset_player_config"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "set_player_server_profile"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "enter_dungeon"
+  },
+  {
+    "target": "0x2d24481107b55ecd73c4d1b62f6bfe8c42a224447b71db7dcec2eab484d53cd",
+    "method": "upgrade"
+  },
+  {
+    "target": "0x454e4731e29aad869794ce03040f1bd866556132b0e633a376918ee17801f5e",
+    "method": "upgrade"
+  },
+  {
+    "target": "0x57d20e85621372042af6b626884361c1c64c701b0b7db985d10faf92aa0dedc",
+    "method": "upgrade"
+  },
+  {
+    "target": "0x52da0b3df1cb3f0627dbe75960ae5ebad647b6ade1930dc9a499c0475168754",
+    "method": "upgrade"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "set_metadata"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "register_model"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "register_namespace"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "deploy_contract"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "upgrade_contract"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "uuid"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "set_entity"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "delete_entity"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "grant_owner"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "revoke_owner"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "grant_writer"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "revoke_writer"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "upgrade"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "upgrade_state"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "set_differ_program_hash"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "set_merger_program_hash"
+  },
+  {
+    "target": "0x74c73d35df54ddc53bcf34aab5e0dbb09c447e99e01f4d69535441253c9571a",
+    "method": "set_facts_registry"
+  },
+  {
+    "target": "0x6162896d1d7ab204c7ccac6dd5f8e9e7c25ecd5ae4fcb4ad32e57786bb46e03",
+    "method": "__declare_transaction__"
+  },
+  {
+    "target": "0x41a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf",
+    "method": "deployContract"
+  }
+]


### PR DESCRIPTION
resolves #2231 

calls the `cartrige_deployController` upon Controller account creation on Sozo. its the easiest to just call that method at this phase of the account creation as we dont have to call it separately in different Sozo commands (eg `migrate`, `execute` `auth`). i think it's pretty chill to have the deployment logic this early in the Sozo flow as mostly the Sozo account creation will only be done when we need to send actual transactions and there's not much stuff going in between the account creation up to the first tx being sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to deploy accounts automatically if they do not exist on the specified blockchain.
	- Enhanced account management with improved error handling and session management.
	- Added comprehensive logging for better visibility into account deployment processes.

- **Improvements**
	- Integrated a new HTTP library to enhance project capabilities for web interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->