### PR TITLE
katana: include freelist in stats

### DIFF
--- a/bin/katana/src/cli/db.rs
+++ b/bin/katana/src/cli/db.rs
@@ -9,13 +9,13 @@ use katana_db::abstraction::Database;
 use katana_db::mdbx::{DbEnv, DbEnvKind};
 use katana_db::tables::NUM_TABLES;
 
-/// Create a human-readable byte unit string (eg. 1.23 MB)
+/// Create a human-readable byte unit string (eg. 16.00 KiB)
 macro_rules! byte_unit {
     ($size:expr) => {
         format!(
             "{:.2}",
             byte_unit::Byte::from_u64($size as u64)
-                .get_appropriate_unit(byte_unit::UnitType::Decimal)
+                .get_appropriate_unit(byte_unit::UnitType::Binary)
         )
     };
 }
@@ -45,11 +45,12 @@ impl DbArgs {
                 let db = open_db_ro(&self.path)?;
                 let stats = db.stats()?;
 
-                let mut table = Table::new();
+                let mut table = table();
                 let mut rows = Vec::with_capacity(NUM_TABLES);
+                // total size of all tables (incl. freelist)
                 let mut total_size = 0;
 
-                table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS).set_header(vec![
+                table.set_header(vec![
                     "Table",
                     "Entries",
                     "Depth",
@@ -58,6 +59,10 @@ impl DbArgs {
                     "Overflow Pages",
                     "Size",
                 ]);
+
+                // page size is equal across all tables, so we can just get it from the first table
+                // and use it to calculate for the freelist table.
+                let mut pagesize: usize = 0;
 
                 for (name, stat) in stats.table_stats().iter() {
                     let entries = stat.entries();
@@ -79,20 +84,38 @@ impl DbArgs {
 
                     // increment the size of all tables
                     total_size += size;
+
+                    if pagesize == 0 {
+                        pagesize = stat.page_size() as usize;
+                    }
                 }
 
                 // sort the rows by the table name
                 rows.sort_by(|a, b| a[0].cmp(&b[0]));
                 table.add_rows(rows);
 
+                // add special row for the freelist table
+                let freelist_size = stats.freelist() * pagesize;
+                total_size += freelist_size;
+
+                table.add_row(vec![
+                    "Freelist".to_string(),
+                    stats.freelist().to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                    byte_unit!(freelist_size),
+                ]);
+
                 // add the last row for the total size
                 table.add_row(vec![
                     "Total Size".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
                     byte_unit!(total_size),
                 ]);
 
@@ -113,4 +136,11 @@ fn open_db_ro(path: &str) -> Result<DbEnv> {
     DbEnv::open(&path, DbEnvKind::RO).with_context(|| {
         format!("Opening database file in read-only mode at path {}", path.display())
     })
+}
+
+/// Create a table with the default UTF-8 full border and rounded corners.
+fn table() -> Table {
+    let mut table = Table::new();
+    table.load_preset(UTF8_FULL).apply_modifier(UTF8_ROUND_CORNERS);
+    table
 }

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -116,7 +116,8 @@ impl Database for DbEnv {
             }
 
             let info = self.0.info().map_err(DatabaseError::Stat)?;
-            Ok(Stats::new(table_stats, info))
+            let freelist = self.0.freelist().map_err(DatabaseError::Stat)?;
+            Ok(Stats { table_stats, info, freelist })
         })?
     }
 }

--- a/crates/katana/storage/db/src/mdbx/stats.rs
+++ b/crates/katana/storage/db/src/mdbx/stats.rs
@@ -60,17 +60,24 @@ impl TableStat {
 /// Statistics for the entire MDBX environment.
 pub struct Stats {
     /// Statistics for individual tables in the environment
-    table_stats: HashMap<&'static str, TableStat>,
+    pub(super) table_stats: HashMap<&'static str, TableStat>,
     /// Overall environment information
-    info: Info,
+    pub(super) info: Info,
+    /// Number of pages in the MDBX's freelist database.
+    ///
+    /// In MDBX, the freelist is a [special table] that keeps track of a list of potentially
+    /// recyclable pages due to deletions/modifications.
+    ///
+    /// For further reference, see Erigon's writing on [LMBD Freelist] or Reth's discussion on the
+    /// [freelist issue].
+    ///
+    /// [special table]: https://github.com/paradigmxyz/reth/blob/d16ec0de5109098b5d19bf4ca9c33b16aa3e34eb/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c#L2768
+    /// [LMDB Freelist]: https://github.com/erigontech/erigon/wiki/LMDB-freelist
+    /// [freelist issue]: https://github.com/paradigmxyz/reth/issues/5228
+    pub(super) freelist: usize,
 }
 
 impl Stats {
-    /// Creates a new Stats instance
-    pub(super) fn new(table_stats: HashMap<&'static str, TableStat>, info: libmdbx::Info) -> Self {
-        Self { table_stats, info }
-    }
-
     /// Get statistics for all tables
     pub fn table_stats(&self) -> &HashMap<&'static str, TableStat> {
         &self.table_stats
@@ -117,6 +124,11 @@ impl Stats {
     /// Get the number of reader slots currently in use
     pub fn current_readers(&self) -> usize {
         self.info.num_readers()
+    }
+
+    /// Get the number of pages in the freelist
+    pub fn freelist(&self) -> usize {
+        self.freelist
     }
 }
 


### PR DESCRIPTION
freelist is special table in MDBX that stores pages that are free in the database file and can potentially be recycled for later use. 

refer to the rustdoc below for further references:

```rust
    /// Number of pages in the MDBX's freelist database.
    ///
    /// In MDBX, the freelist is a [special table] that keeps track of a list of potentially
    /// recyclable pages due to deletions/modifications.
    ///
    /// For further reference, see Erigon's writing on [LMBD Freelist] or Reth's discussion on the
    /// [freelist issue].
    ///
    /// [special table]: https://github.com/paradigmxyz/reth/blob/d16ec0de5109098b5d19bf4ca9c33b16aa3e34eb/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.c#L2768
    /// [LMDB Freelist]: https://github.com/erigontech/erigon/wiki/LMDB-freelist
    /// [freelist issue]: https://github.com/paradigmxyz/reth/issues/5228
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced database command-line interface for improved byte size representation using binary units.
  - Added a new row for freelist size in the database statistics output, providing a more comprehensive view of database size.
  - Introduced a public method to access the freelist size directly.

- **Bug Fixes**
  - Improved accuracy of total size calculations by including freelist size in the statistics.

- **Documentation**
  - Added detailed documentation for the new freelist feature to aid user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->