### PR TITLE
fix(sozo): block can contain multiple event of same type for same address

### DIFF
--- a/crates/dojo-world/src/manifest/mod.rs
+++ b/crates/dojo-world/src/manifest/mod.rs
@@ -587,7 +587,7 @@ fn parse_contracts_events(
                 grants
                     .entry(contract)
                     .and_modify(|(current_block, current_resource)| {
-                        if *current_block < num {
+                        if *current_block <= num {
                             *current_block = num;
                             current_resource.insert(resource, value);
                         }
@@ -629,7 +629,7 @@ fn parse_contracts_events(
                 upgrades
                     .entry(address)
                     .and_modify(|(current_block, current_class_hash)| {
-                        if *current_block < num {
+                        if *current_block <= num {
                             *current_block = num;
                             *current_class_hash = class_hash;
                         }


### PR DESCRIPTION
A block can contain multiple events for the same address. But currently we only read the first event of specific kind in a block.

And although the RPC spec doesn't require it but most RPC implementation return the events in the order that they occur in the particular block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved event parsing logic to ensure accurate resource management by updating the `current_block` even when it equals the specified `num` parameter, enhancing the integrity of state handling.

- **Bug Fixes**
	- Resolved issues related to event processing at the same block number, ensuring consistent updates to resources and class hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->