### PR TITLE
fix(torii): only retrieve metadata for world

### DIFF
--- a/crates/torii/core/src/processors/metadata_update.rs
+++ b/crates/torii/core/src/processors/metadata_update.rs
@@ -69,7 +69,7 @@ where
         let db = db.clone();
         let resource = *resource;
 
-        // Should we only call this when resource is 0, i.e. the World?
+        // Only retrieve metadata for the World contract.
         if resource.is_zero() {
             tokio::spawn(async move {
                 try_retrieve(db, resource, uri_str).await;

--- a/crates/torii/core/src/processors/metadata_update.rs
+++ b/crates/torii/core/src/processors/metadata_update.rs
@@ -4,7 +4,7 @@ use anyhow::{Error, Result};
 use async_trait::async_trait;
 use base64::engine::general_purpose;
 use base64::Engine as _;
-use cainome::cairo_serde::{ByteArray, CairoSerde};
+use cainome::cairo_serde::{ByteArray, CairoSerde, Zeroable};
 use dojo_world::contracts::world::WorldContractReader;
 use dojo_world::metadata::{Uri, WorldMetadata};
 use reqwest::Client;
@@ -68,9 +68,13 @@ where
 
         let db = db.clone();
         let resource = *resource;
-        tokio::spawn(async move {
-            try_retrieve(db, resource, uri_str).await;
-        });
+
+        // Should we only call this when resource is 0, i.e. the World?
+        if resource.is_zero() {
+            tokio::spawn(async move {
+                try_retrieve(db, resource, uri_str).await;
+            });
+        }
 
         Ok(())
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Optimized metadata retrieval process by ensuring it only initiates for relevant resources.
  
- **Bug Fixes**
	- Adjusted control flow to prevent unnecessary metadata retrieval for non-zero resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->