### PR TITLE
fix(torii): member clause escaped table name

### DIFF
--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -516,7 +516,7 @@ impl DojoWorld {
             table,
             entity_relation_column,
             Some(&format!(
-                "{table_name}.{column_name} {comparison_operator} ? ORDER BY {table}.event_id \
+                "[{table_name}].{column_name} {comparison_operator} ? ORDER BY {table}.event_id \
                  DESC LIMIT ? OFFSET ?"
             )),
             None,


### PR DESCRIPTION
Escapes the table name (breaks due to namespaces) when querying with member clause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved SQL query formatting to prevent potential issues with reserved words or special characters in table names.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->