### PR TITLE
refactor(torii-grpc): correct pagination logic for grpc query member

### DIFF
--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -1027,7 +1027,7 @@ mod tests {
              entities.id = [Test-Position$vec].entity_id  JOIN [Test-Position] ON entities.id = \
              [Test-Position].entity_id  JOIN [Test-PlayerConfig$favorite_item] ON entities.id = \
              [Test-PlayerConfig$favorite_item].entity_id  JOIN [Test-PlayerConfig] ON entities.id \
-             = [Test-PlayerConfig].entity_id";
+             = [Test-PlayerConfig].entity_id ORDER BY entities.event_id DESC";
         // todo: completely tests arrays
         assert_eq!(query.0, expected_query);
     }

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -407,7 +407,7 @@ pub fn build_sql_query(
         query += &format!(" WHERE {}", where_clause);
         count_query += &format!(" WHERE {}", where_clause);
     }
-    query += &format!(" ORDER BY {entities_table}.id DESC");
+    query += &format!(" ORDER BY {entities_table}.event_id DESC");
 
     if let Some(limit) = limit {
         query += &format!(" LIMIT {}", limit);

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -400,25 +400,22 @@ pub fn build_sql_query(
         "SELECT {entities_table}.id, {entities_table}.keys, {selections_clause} FROM \
          {entities_table}{join_clause}"
     );
-    let mut count_query = format!(
-        "SELECT COUNT({entities_table}.id) FROM {entities_table}{join_clause}",
-    );
-    
+    let mut count_query =
+        format!("SELECT COUNT({entities_table}.id) FROM {entities_table}{join_clause}",);
 
     if let Some(where_clause) = where_clause {
-        query = format!("{} WHERE {}", query, where_clause);
-        count_query = format!("{} WHERE {}", count_query, where_clause);
+        query += &format!(" WHERE {}", where_clause);
+        count_query += &format!(" WHERE {}", where_clause);
     }
+    query += &format!(" ORDER BY {entities_table}.id DESC");
 
     if let Some(limit) = limit {
-        query = format!("{} LIMIT {}", query, limit);
+        query += &format!(" LIMIT {}", limit);
     }
 
     if let Some(offset) = offset {
-        query = format!("{} OFFSET {}", query, offset);
+        query += &format!(" OFFSET {}", offset);
     }
-
-    query += " ORDER BY {table}.event_id DESC";
 
     if let Some(where_clause_arrays) = where_clause_arrays {
         for (_, formatted_query) in formatted_arrays_queries.iter_mut() {
@@ -1009,9 +1006,16 @@ mod tests {
             ],
         });
 
-        let query =
-            build_sql_query(&vec![position, player_config], "entities", "entity_id", None, None, None, None)
-                .unwrap();
+        let query = build_sql_query(
+            &vec![position, player_config],
+            "entities",
+            "entity_id",
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
         let expected_query =
             "SELECT entities.id, entities.keys, [Test-Position].external_player AS \

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -418,7 +418,7 @@ pub fn build_sql_query(
         query = format!("{} OFFSET {}", query, offset);
     }
 
-    query += "ORDER BY {table}.event_id DESC";
+    query += " ORDER BY {table}.event_id DESC";
 
     if let Some(where_clause_arrays) = where_clause_arrays {
         for (_, formatted_query) in formatted_arrays_queries.iter_mut() {

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -231,7 +231,9 @@ pub fn build_sql_query(
     entity_relation_column: &str,
     where_clause: Option<&str>,
     where_clause_arrays: Option<&str>,
-) -> Result<(String, HashMap<String, String>), Error> {
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> Result<(String, HashMap<String, String>, String), Error> {
     fn parse_ty(
         path: &str,
         name: &str,
@@ -398,10 +400,25 @@ pub fn build_sql_query(
         "SELECT {entities_table}.id, {entities_table}.keys, {selections_clause} FROM \
          {entities_table}{join_clause}"
     );
+    let mut count_query = format!(
+        "SELECT COUNT({entities_table}.id) FROM {entities_table}{join_clause}",
+    );
+    
 
     if let Some(where_clause) = where_clause {
         query = format!("{} WHERE {}", query, where_clause);
+        count_query = format!("{} WHERE {}", count_query, where_clause);
     }
+
+    if let Some(limit) = limit {
+        query = format!("{} LIMIT {}", query, limit);
+    }
+
+    if let Some(offset) = offset {
+        query = format!("{} OFFSET {}", query, offset);
+    }
+
+    query += "ORDER BY {table}.event_id DESC";
 
     if let Some(where_clause_arrays) = where_clause_arrays {
         for (_, formatted_query) in formatted_arrays_queries.iter_mut() {
@@ -409,7 +426,7 @@ pub fn build_sql_query(
         }
     }
 
-    Ok((query, formatted_arrays_queries))
+    Ok((query, formatted_arrays_queries, count_query))
 }
 
 /// Populate the values of a Ty (schema) from SQLite row.
@@ -993,7 +1010,7 @@ mod tests {
         });
 
         let query =
-            build_sql_query(&vec![position, player_config], "entities", "entity_id", None, None)
+            build_sql_query(&vec![position, player_config], "entities", "entity_id", None, None, None, None)
                 .unwrap();
 
         let expected_query =

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -294,12 +294,14 @@ impl DojoWorld {
                 .map_err(ParseError::FromStr)?;
             let schemas = self.model_cache.schemas(&model_ids).await?;
 
-            let (entity_query, arrays_queries) = build_sql_query(
+            let (entity_query, arrays_queries, _) = build_sql_query(
                 &schemas,
                 table,
                 entity_relation_column,
                 Some(&format!("{table}.id = ?")),
                 Some(&format!("{table}.id = ?")),
+                None,
+                None,
             )?;
 
             let row =
@@ -433,12 +435,14 @@ impl DojoWorld {
                 .map_err(ParseError::FromStr)?;
             let schemas = self.model_cache.schemas(&model_ids).await?;
 
-            let (entity_query, arrays_queries) = build_sql_query(
+            let (entity_query, arrays_queries, _) = build_sql_query(
                 &schemas,
                 table,
                 entity_relation_column,
                 Some(&format!("{table}.id = ?")),
                 Some(&format!("{table}.id = ?")),
+                None,
+                None,
             )?;
 
             let row = sqlx::query(&entity_query).bind(entity_id).fetch_one(&self.pool).await?;
@@ -525,16 +529,20 @@ impl DojoWorld {
 
         let table_name = member_clause.model;
         let column_name = format!("external_{}", member_clause.member);
-        let (entity_query, arrays_queries) = build_sql_query(
+        let (entity_query, arrays_queries, count_query) = build_sql_query(
             &schemas,
             table,
             entity_relation_column,
-            Some(&format!(
-                "[{table_name}].{column_name} {comparison_operator} ? ORDER BY {table}.event_id \
-                 DESC LIMIT ? OFFSET ?"
-            )),
+            Some(&format!("[{table_name}].{column_name} {comparison_operator} ?")),
             None,
+            limit,
+            offset,
         )?;
+
+        let total_count = sqlx::query_scalar(&count_query)
+            .bind(comparison_value.clone())
+            .fetch_one(&self.pool)
+            .await?;
 
         let db_entities = sqlx::query(&entity_query)
             .bind(comparison_value.clone())
@@ -553,8 +561,6 @@ impl DojoWorld {
             .iter()
             .map(|row| map_row_to_entity(row, &arrays_rows, schemas.clone()))
             .collect::<Result<Vec<_>, Error>>()?;
-        // Since there is not limit and offset, total_count is same as number of entities
-        let total_count = entities_collection.len() as u32;
         Ok((entities_collection, total_count))
     }
 
@@ -698,12 +704,14 @@ impl DojoWorld {
                 .map_err(ParseError::FromStr)?;
             let schemas = self.model_cache.schemas(&model_ids).await?;
 
-            let (entity_query, arrays_queries) = build_sql_query(
+            let (entity_query, arrays_queries, _) = build_sql_query(
                 &schemas,
                 table,
                 entity_relation_column,
                 Some(&format!("[{table}].id = ?")),
                 Some(&format!("[{table}].id = ?")),
+                None,
+                None
             )?;
 
             let row = sqlx::query(&entity_query).bind(entity_id).fetch_one(&self.pool).await?;

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -711,7 +711,7 @@ impl DojoWorld {
                 Some(&format!("[{table}].id = ?")),
                 Some(&format!("[{table}].id = ?")),
                 None,
-                None
+                None,
             )?;
 
             let row = sqlx::query(&entity_query).bind(entity_id).fetch_one(&self.pool).await?;

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -227,7 +227,7 @@ impl Service {
                 Some("entities.id = ?"),
                 Some("entities.id = ?"),
                 None,
-                None
+                None,
             )?;
 
             let row = sqlx::query(&entity_query).bind(&entity.id).fetch_one(&pool).await?;

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -220,12 +220,14 @@ impl Service {
                 .map_err(ParseError::FromStr)?;
             let schemas = cache.schemas(&model_ids).await?;
 
-            let (entity_query, arrays_queries) = build_sql_query(
+            let (entity_query, arrays_queries, _) = build_sql_query(
                 &schemas,
                 "entities",
                 "entity_id",
                 Some("entities.id = ?"),
                 Some("entities.id = ?"),
+                None,
+                None
             )?;
 
             let row = sqlx::query(&entity_query).bind(&entity.id).fetch_one(&pool).await?;

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -199,12 +199,14 @@ impl Service {
                 .map_err(ParseError::FromStr)?;
             let schemas = cache.schemas(&model_ids).await?;
 
-            let (entity_query, arrays_queries) = build_sql_query(
+            let (entity_query, arrays_queries, _) = build_sql_query(
                 &schemas,
                 "event_messages",
                 "event_message_id",
                 Some("event_messages.id = ?"),
                 Some("event_messages.id = ?"),
+                None,
+                None
             )?;
 
             let row = sqlx::query(&entity_query).bind(&entity.id).fetch_one(&pool).await?;

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -206,7 +206,7 @@ impl Service {
                 Some("event_messages.id = ?"),
                 Some("event_messages.id = ?"),
                 None,
-                None
+                None,
             )?;
 
             let row = sqlx::query(&entity_query).bind(&entity.id).fetch_one(&pool).await?;


### PR DESCRIPTION
Fixes pagination logic for query by member on GRPC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced SQL query generation with added support for pagination through `limit` and `offset` parameters.
  - Introduced a count query feature to retrieve the total number of records alongside the main query results.

- **Improvements**
  - Refinement of existing query construction to better integrate new optional parameters, allowing for more flexible data retrieval options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->