### PR TITLE
fix(torii-grpc): deser from db for grpc enums

### DIFF
--- a/crates/dojo-types/src/schema.rs
+++ b/crates/dojo-types/src/schema.rs
@@ -55,15 +55,8 @@ impl Ty {
             Ty::Primitive(c) => c.to_string(),
             Ty::Struct(s) => s.name.clone(),
             Ty::Enum(e) => e.name.replace(
-                "<T>",
-                &e.options
-                    .iter()
-                    .map(|o| {
-                        let t = o.ty.name().replace("()", "");
-                        format!("<{}>", t)
-                    })
-                    .unique()
-                    .join(""),
+                "T",
+                &e.options.iter().map(|o| o.ty.name().replace("()", "")).unique().join(""),
             ),
             Ty::Tuple(tys) => format!("({})", tys.iter().map(|ty| ty.name()).join(", ")),
             Ty::Array(ty) => format!("Array<{}>", ty[0].name()),

--- a/crates/dojo-types/src/schema.rs
+++ b/crates/dojo-types/src/schema.rs
@@ -55,8 +55,15 @@ impl Ty {
             Ty::Primitive(c) => c.to_string(),
             Ty::Struct(s) => s.name.clone(),
             Ty::Enum(e) => e.name.replace(
-                "T",
-                &e.options.iter().map(|o| o.ty.name().replace("()", "")).unique().join(""),
+                "<T>",
+                &e.options
+                    .iter()
+                    .map(|o| {
+                        let t = o.ty.name().replace("()", "");
+                        format!("<{}>", t)
+                    })
+                    .unique()
+                    .join(""),
             ),
             Ty::Tuple(tys) => format!("({})", tys.iter().map(|ty| ty.name()).join(", ")),
             Ty::Array(ty) => format!("Array<{}>", ty[0].name()),

--- a/crates/dojo-types/src/schema.rs
+++ b/crates/dojo-types/src/schema.rs
@@ -54,17 +54,7 @@ impl Ty {
         match self {
             Ty::Primitive(c) => c.to_string(),
             Ty::Struct(s) => s.name.clone(),
-            Ty::Enum(e) => e.name.replace(
-                "<T>",
-                &e.options
-                    .iter()
-                    .map(|o| {
-                        let t = o.ty.name().replace("()", "");
-                        format!("<{}>", t)
-                    })
-                    .unique()
-                    .join(""),
-            ),
+            Ty::Enum(e) => e.name.clone(),
             Ty::Tuple(tys) => format!("({})", tys.iter().map(|ty| ty.name()).join(", ")),
             Ty::Array(ty) => format!("Array<{}>", ty[0].name()),
             Ty::ByteArray(_) => "ByteArray".to_string(),

--- a/crates/dojo-world/src/contracts/model.rs
+++ b/crates/dojo-world/src/contracts/model.rs
@@ -227,12 +227,13 @@ fn parse_schema(ty: &abigen::model::Ty) -> Result<Ty, ParseError> {
                 .children
                 .iter()
                 .map(|(name, ty)| {
-                    // strip of the type (T) of the enum variant for now
+                    // strip "(T)" of the type of the enum variant for now
                     // breaks the db queries
+                    // Some(T) => Some
                     let name =
                         parse_cairo_short_string(name)?.split('(').next().unwrap().to_string();
-                    let ty = parse_schema(ty)?;
 
+                    let ty = parse_schema(ty)?;
                     Ok(EnumOption { name, ty })
                 })
                 .collect::<Result<Vec<_>, ParseError>>()?;

--- a/crates/dojo-world/src/contracts/model.rs
+++ b/crates/dojo-world/src/contracts/model.rs
@@ -231,14 +231,14 @@ fn parse_schema(ty: &abigen::model::Ty) -> Result<Ty, ParseError> {
                     // breaks the db queries
                     // Some(T) => Some
                     let mut variant_name = parse_cairo_short_string(variant_name)?;
-                    
+
                     let ty = parse_schema(ty)?;
                     // generalize this for any generic name?
                     if variant_name.ends_with("(T)") {
                         variant_name = variant_name.trim_end_matches("(T)").to_string();
                         name = name.replace("<T>", format!("<{}>", ty.name()).as_str());
                     }
-                    
+
                     Ok(EnumOption { name: variant_name, ty })
                 })
                 .collect::<Result<Vec<_>, ParseError>>()?;

--- a/crates/dojo-world/src/contracts/model.rs
+++ b/crates/dojo-world/src/contracts/model.rs
@@ -221,20 +221,25 @@ fn parse_schema(ty: &abigen::model::Ty) -> Result<Ty, ParseError> {
             Ok(Ty::Struct(Struct { name, children }))
         }
         abigen::model::Ty::Enum(enum_) => {
-            let name = parse_cairo_short_string(&enum_.name)?;
+            let mut name = parse_cairo_short_string(&enum_.name)?;
 
             let options = enum_
                 .children
                 .iter()
-                .map(|(name, ty)| {
+                .map(|(variant_name, ty)| {
                     // strip "(T)" of the type of the enum variant for now
                     // breaks the db queries
                     // Some(T) => Some
-                    let name =
-                        parse_cairo_short_string(name)?.split('(').next().unwrap().to_string();
-
+                    let mut variant_name = parse_cairo_short_string(variant_name)?;
+                    
                     let ty = parse_schema(ty)?;
-                    Ok(EnumOption { name, ty })
+                    // generalize this for any generic name?
+                    if variant_name.ends_with("(T)") {
+                        variant_name = variant_name.trim_end_matches("(T)").to_string();
+                        name = name.replace("<T>", format!("<{}>", ty.name()).as_str());
+                    }
+                    
+                    Ok(EnumOption { name: variant_name, ty })
                 })
                 .collect::<Result<Vec<_>, ParseError>>()?;
 

--- a/crates/torii/grpc/src/types/schema.rs
+++ b/crates/torii/grpc/src/types/schema.rs
@@ -189,36 +189,31 @@ impl From<Primitive> for proto::types::Primitive {
         use proto::types::value::ValueType;
 
         let value_type = match primitive {
-            Primitive::I8(i8) => i8.map(|val| ValueType::IntValue(val as i64)),
-            Primitive::I16(i16) => i16.map(|val| ValueType::IntValue(val as i64)),
-            Primitive::I32(i32) => i32.map(|val| ValueType::IntValue(val as i64)),
-            Primitive::I64(i64) => i64.map(ValueType::IntValue),
+            Primitive::I8(i8) => ValueType::IntValue(i8.unwrap_or_default() as i64),
+            Primitive::I16(i16) => ValueType::IntValue(i16.unwrap_or_default() as i64),
+            Primitive::I32(i32) => ValueType::IntValue(i32.unwrap_or_default() as i64),
+            Primitive::I64(i64) => ValueType::IntValue(i64.unwrap_or_default()),
             Primitive::I128(i128) => {
-                i128.map(|val| ValueType::ByteValue(val.to_be_bytes().to_vec()))
+                ValueType::ByteValue(i128.unwrap_or_default().to_be_bytes().to_vec())
             }
-            Primitive::U8(u8) => u8.map(|val| ValueType::UintValue(val as u64)),
-            Primitive::U16(u16) => u16.map(|val| ValueType::UintValue(val as u64)),
-            Primitive::U32(u32) => u32.map(|val| ValueType::UintValue(val as u64)),
-            Primitive::U64(u64) => u64.map(ValueType::UintValue),
+            Primitive::U8(u8) => ValueType::UintValue(u8.unwrap_or_default() as u64),
+            Primitive::U16(u16) => ValueType::UintValue(u16.unwrap_or_default() as u64),
+            Primitive::U32(u32) => ValueType::UintValue(u32.unwrap_or_default() as u64),
+            Primitive::U64(u64) => ValueType::UintValue(u64.unwrap_or_default()),
             Primitive::U128(u128) => {
-                u128.map(|val| ValueType::ByteValue(val.to_be_bytes().to_vec()))
+                ValueType::ByteValue(u128.unwrap_or_default().to_be_bytes().to_vec())
             }
             Primitive::U256(u256) => {
-                u256.map(|val| ValueType::ByteValue(val.to_be_bytes().to_vec()))
+                ValueType::ByteValue(u256.unwrap_or_default().to_be_bytes().to_vec())
             }
-            Primitive::USize(usize) => usize.map(|val| ValueType::UintValue(val as u64)),
-            Primitive::Bool(bool) => bool.map(ValueType::BoolValue),
-            Primitive::Felt252(felt) => {
-                felt.map(|val| ValueType::ByteValue(val.to_bytes_be().to_vec()))
+            Primitive::USize(usize) => ValueType::UintValue(usize.unwrap_or_default() as u64),
+            Primitive::Bool(bool) => ValueType::BoolValue(bool.unwrap_or_default()),
+            Primitive::Felt252(felt)
+            | Primitive::ClassHash(felt)
+            | Primitive::ContractAddress(felt) => {
+                ValueType::ByteValue(felt.unwrap_or_default().to_bytes_be().to_vec())
             }
-            Primitive::ClassHash(class) => {
-                class.map(|val| ValueType::ByteValue(val.to_bytes_be().to_vec()))
-            }
-            Primitive::ContractAddress(contract) => {
-                contract.map(|val| ValueType::ByteValue(val.to_bytes_be().to_vec()))
-            }
-        }
-        .expect("value expected");
+        };
 
         proto::types::Primitive {
             value: Some(proto::types::Value { value_type: Some(value_type) }),


### PR DESCRIPTION
Fixes an issue with the deserialization of enums and optional primitives that occurred due to the new felt update 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved clarity and logic in data handling with enhanced variable naming and refined control flow.
	- Simplified processing of primitive types, ensuring default values are used when options are empty.
	- Streamlined construction of enum type names, enhancing readability and maintainability through a more concise implementation.
	- Enhanced comments for better understanding of the schema parsing logic.

- **Bug Fixes**
	- Addressed potential issues in type conversion through improved robustness in handling primitive data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->