### PR TITLE
refactor(torii-grpc): subscribe to all for empty clauses

### DIFF
--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -124,64 +124,66 @@ impl Service {
 
             // If we have a clause of keys, then check that the key pattern of the entity
             // matches the key pattern of the subscriber.
-            if !sub.clauses.is_empty() && !sub.clauses.iter().any(|clause| match clause {
-                EntityKeysClause::HashedKeys(hashed_keys) => {
-                    hashed_keys.is_empty() || hashed_keys.contains(&hashed)
-                }
-                EntityKeysClause::Keys(clause) => {
-                    // if we have a model clause, then we need to check that the entity
-                    // has an updated model and that the model name matches the clause
-                    if let Some(updated_model) = &entity.updated_model {
-                        let name = updated_model.name();
-                        let (namespace, name) = name.split_once('-').unwrap();
+            if !sub.clauses.is_empty()
+                && !sub.clauses.iter().any(|clause| match clause {
+                    EntityKeysClause::HashedKeys(hashed_keys) => {
+                        hashed_keys.is_empty() || hashed_keys.contains(&hashed)
+                    }
+                    EntityKeysClause::Keys(clause) => {
+                        // if we have a model clause, then we need to check that the entity
+                        // has an updated model and that the model name matches the clause
+                        if let Some(updated_model) = &entity.updated_model {
+                            let name = updated_model.name();
+                            let (namespace, name) = name.split_once('-').unwrap();
 
-                        if !clause.models.is_empty()
-                            && !clause.models.iter().any(|clause_model| {
-                                let (clause_namespace, clause_model) =
-                                    clause_model.split_once('-').unwrap();
-                                // if both namespace and model are empty, we should match all.
-                                // if namespace is specified and model is empty or * we should match
-                                // all models in the namespace
-                                // if namespace and model are specified, we should match the
-                                // specific model
-                                (clause_namespace.is_empty()
-                                    || clause_namespace == namespace
-                                    || clause_namespace == "*")
-                                    && (clause_model.is_empty()
-                                        || clause_model == name
-                                        || clause_model == "*")
-                            })
+                            if !clause.models.is_empty()
+                                && !clause.models.iter().any(|clause_model| {
+                                    let (clause_namespace, clause_model) =
+                                        clause_model.split_once('-').unwrap();
+                                    // if both namespace and model are empty, we should match all.
+                                    // if namespace is specified and model is empty or * we should
+                                    // match all models in the
+                                    // namespace if namespace
+                                    // and model are specified, we should match the
+                                    // specific model
+                                    (clause_namespace.is_empty()
+                                        || clause_namespace == namespace
+                                        || clause_namespace == "*")
+                                        && (clause_model.is_empty()
+                                            || clause_model == name
+                                            || clause_model == "*")
+                                })
+                            {
+                                return false;
+                            }
+                        }
+
+                        // if the key pattern doesnt match our subscribers key pattern, skip
+                        // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
+                        if clause.pattern_matching == PatternMatching::FixedLen
+                            && keys.len() != clause.keys.len()
                         {
                             return false;
                         }
+
+                        return keys.iter().enumerate().all(|(idx, key)| {
+                            // this is going to be None if our key pattern overflows the subscriber
+                            // key pattern in this case we should skip
+                            let sub_key = clause.keys.get(idx);
+
+                            match sub_key {
+                                // the key in the subscriber must match the key of the entity
+                                // athis index
+                                Some(Some(sub_key)) => key == sub_key,
+                                // otherwise, if we have no key we should automatically match.
+                                // or.. we overflowed the subscriber key pattern
+                                // but we're in VariableLen pattern matching
+                                // so we should match all next keys
+                                _ => true,
+                            }
+                        });
                     }
-
-                    // if the key pattern doesnt match our subscribers key pattern, skip
-                    // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
-                    if clause.pattern_matching == PatternMatching::FixedLen
-                        && keys.len() != clause.keys.len()
-                    {
-                        return false;
-                    }
-
-                    return keys.iter().enumerate().all(|(idx, key)| {
-                        // this is going to be None if our key pattern overflows the subscriber
-                        // key pattern in this case we should skip
-                        let sub_key = clause.keys.get(idx);
-
-                        match sub_key {
-                            // the key in the subscriber must match the key of the entity
-                            // athis index
-                            Some(Some(sub_key)) => key == sub_key,
-                            // otherwise, if we have no key we should automatically match.
-                            // or.. we overflowed the subscriber key pattern
-                            // but we're in VariableLen pattern matching
-                            // so we should match all next keys
-                            _ => true,
-                        }
-                    });
-                }
-            })
+                })
             {
                 continue;
             }

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -124,7 +124,7 @@ impl Service {
 
             // If we have a clause of keys, then check that the key pattern of the entity
             // matches the key pattern of the subscriber.
-            if !sub.clauses.iter().any(|clause| match clause {
+            if !sub.clauses.is_empty() && !sub.clauses.iter().any(|clause| match clause {
                 EntityKeysClause::HashedKeys(hashed_keys) => {
                     hashed_keys.is_empty() || hashed_keys.contains(&hashed)
                 }
@@ -181,7 +181,8 @@ impl Service {
                         }
                     });
                 }
-            }) {
+            })
+            {
                 continue;
             }
 

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -118,64 +118,67 @@ impl Service {
 
             // If we have a clause of keys, then check that the key pattern of the entity
             // matches the key pattern of the subscriber.
-            if !sub.clauses.is_empty() && !sub.clauses.iter().any(|clause| match clause {
-                EntityKeysClause::HashedKeys(hashed_keys) => {
-                    hashed_keys.is_empty() || hashed_keys.contains(&hashed)
-                }
-                EntityKeysClause::Keys(clause) => {
-                    // if we have a model clause, then we need to check that the entity
-                    // has an updated model and that the model name matches the clause
-                    if let Some(updated_model) = &entity.updated_model {
-                        let name = updated_model.name();
-                        let (namespace, name) = name.split_once('-').unwrap();
+            if !sub.clauses.is_empty()
+                && !sub.clauses.iter().any(|clause| match clause {
+                    EntityKeysClause::HashedKeys(hashed_keys) => {
+                        hashed_keys.is_empty() || hashed_keys.contains(&hashed)
+                    }
+                    EntityKeysClause::Keys(clause) => {
+                        // if we have a model clause, then we need to check that the entity
+                        // has an updated model and that the model name matches the clause
+                        if let Some(updated_model) = &entity.updated_model {
+                            let name = updated_model.name();
+                            let (namespace, name) = name.split_once('-').unwrap();
 
-                        if !clause.models.is_empty()
-                            && !clause.models.iter().any(|clause_model| {
-                                let (clause_namespace, clause_model) =
-                                    clause_model.split_once('-').unwrap();
-                                // if both namespace and model are empty, we should match all.
-                                // if namespace is specified and model is empty or * we should match
-                                // all models in the namespace
-                                // if namespace and model are specified, we should match the
-                                // specific model
-                                (clause_namespace.is_empty()
-                                    || clause_namespace == namespace
-                                    || clause_namespace == "*")
-                                    && (clause_model.is_empty()
-                                        || clause_model == name
-                                        || clause_model == "*")
-                            })
+                            if !clause.models.is_empty()
+                                && !clause.models.iter().any(|clause_model| {
+                                    let (clause_namespace, clause_model) =
+                                        clause_model.split_once('-').unwrap();
+                                    // if both namespace and model are empty, we should match all.
+                                    // if namespace is specified and model is empty or * we should
+                                    // match all models in the
+                                    // namespace if namespace
+                                    // and model are specified, we should match the
+                                    // specific model
+                                    (clause_namespace.is_empty()
+                                        || clause_namespace == namespace
+                                        || clause_namespace == "*")
+                                        && (clause_model.is_empty()
+                                            || clause_model == name
+                                            || clause_model == "*")
+                                })
+                            {
+                                return false;
+                            }
+                        }
+
+                        // if the key pattern doesnt match our subscribers key pattern, skip
+                        // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
+                        if clause.pattern_matching == PatternMatching::FixedLen
+                            && keys.len() != clause.keys.len()
                         {
                             return false;
                         }
+
+                        return keys.iter().enumerate().all(|(idx, key)| {
+                            // this is going to be None if our key pattern overflows the subscriber
+                            // key pattern in this case we should skip
+                            let sub_key = clause.keys.get(idx);
+
+                            match sub_key {
+                                // the key in the subscriber must match the key of the entity
+                                // athis index
+                                Some(Some(sub_key)) => key == sub_key,
+                                // otherwise, if we have no key we should automatically match.
+                                // or.. we overflowed the subscriber key pattern
+                                // but we're in VariableLen pattern matching
+                                // so we should match all next keys
+                                _ => true,
+                            }
+                        });
                     }
-
-                    // if the key pattern doesnt match our subscribers key pattern, skip
-                    // ["", "0x0"] would match with keys ["0x...", "0x0", ...]
-                    if clause.pattern_matching == PatternMatching::FixedLen
-                        && keys.len() != clause.keys.len()
-                    {
-                        return false;
-                    }
-
-                    return keys.iter().enumerate().all(|(idx, key)| {
-                        // this is going to be None if our key pattern overflows the subscriber
-                        // key pattern in this case we should skip
-                        let sub_key = clause.keys.get(idx);
-
-                        match sub_key {
-                            // the key in the subscriber must match the key of the entity
-                            // athis index
-                            Some(Some(sub_key)) => key == sub_key,
-                            // otherwise, if we have no key we should automatically match.
-                            // or.. we overflowed the subscriber key pattern
-                            // but we're in VariableLen pattern matching
-                            // so we should match all next keys
-                            _ => true,
-                        }
-                    });
-                }
-            }) {
+                })
+            {
                 continue;
             }
 

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -118,7 +118,7 @@ impl Service {
 
             // If we have a clause of keys, then check that the key pattern of the entity
             // matches the key pattern of the subscriber.
-            if !sub.clauses.iter().any(|clause| match clause {
+            if !sub.clauses.is_empty() && !sub.clauses.iter().any(|clause| match clause {
                 EntityKeysClause::HashedKeys(hashed_keys) => {
                     hashed_keys.is_empty() || hashed_keys.contains(&hashed)
                 }


### PR DESCRIPTION
subscirbe to all entities when emtpy clauses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Improvements**
	- Enhanced conditional logic to check for empty collections before evaluating clauses, improving performance and efficiency.
	- Refined control flow to avoid unnecessary iterations when no clauses are present, leading to more predictable service behavior.

- **Code Quality**
	- Improved readability by restructuring conditional statements for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->