### PR TITLE
fix(katana): handle when database is None

### DIFF
--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -175,13 +175,13 @@ pub async fn start(
     // it to be registered.
     if let Some(addr) = server_config.metrics {
         let prometheus_handle = prometheus_exporter::install_recorder("katana")?;
-        let db = db.unwrap();
+        let reports = db.map(|db| vec![Box::new(db) as Box<dyn Report>]).unwrap_or_default();
 
         prometheus_exporter::serve(
             addr,
             prometheus_handle,
             metrics_process::Collector::default(),
-            vec![Box::new(db) as Box<dyn Report>],
+            reports,
         )
         .await?;
 


### PR DESCRIPTION
forgot to remove the unwrap when passing database to the metrics server in #2258. currently running katana with metrics but WITHOUT persistent db (ie just `katana --metrics 9100`) will result in a panic.

this basically resolve it by passing an empty vec to the `server` function.