### PR TITLE
refactor(torii): get rid of world class hash

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -20,9 +20,9 @@ use dojo_metrics::{metrics_process, prometheus_exporter};
 use dojo_world::contracts::world::WorldContractReader;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::SqlitePool;
-use starknet::core::types::{BlockId, BlockTag, Felt};
+use starknet::core::types::Felt;
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider};
+use starknet::providers::JsonRpcClient;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::Sender;
 use tokio_stream::StreamExt;
@@ -162,9 +162,7 @@ async fn main() -> anyhow::Result<()> {
     // Get world address
     let world = WorldContractReader::new(args.world_address, &provider);
 
-    let class_hash =
-        provider.get_class_hash_at(BlockId::Tag(BlockTag::Pending), args.world_address).await?;
-    let db = Sql::new(pool.clone(), args.world_address, class_hash).await?;
+    let db = Sql::new(pool.clone(), args.world_address).await?;
     let processors = Processors {
         event: vec![
             Box::new(RegisterModelProcessor),

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -40,11 +40,7 @@ pub struct Sql {
 }
 
 impl Sql {
-    pub async fn new(
-        pool: Pool<Sqlite>,
-        world_address: Felt,
-        world_class_hash: Felt,
-    ) -> Result<Self> {
+    pub async fn new(pool: Pool<Sqlite>, world_address: Felt) -> Result<Self> {
         let mut query_queue = QueryQueue::new(pool.clone());
 
         query_queue.enqueue(
@@ -52,12 +48,8 @@ impl Sql {
             vec![Argument::FieldElement(world_address), Argument::Int(0)],
         );
         query_queue.enqueue(
-            "INSERT OR IGNORE INTO worlds (id, world_address, world_class_hash) VALUES (?, ?, ?)",
-            vec![
-                Argument::FieldElement(world_address),
-                Argument::FieldElement(world_address),
-                Argument::FieldElement(world_class_hash),
-            ],
+            "INSERT OR IGNORE INTO worlds (id, world_address) VALUES (?, ?)",
+            vec![Argument::FieldElement(world_address), Argument::FieldElement(world_address)],
         );
 
         query_queue.execute_all().await?;

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -12,7 +12,7 @@ use katana_runner::{KatanaRunner, KatanaRunnerConfig};
 use scarb::compiler::Profile;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use starknet::accounts::{Account, Call, ConnectedAccount};
-use starknet::core::types::{BlockId, BlockTag, Felt};
+use starknet::core::types::Felt;
 use starknet::core::utils::{get_contract_address, get_selector_from_name};
 use starknet::providers::Provider;
 use starknet_crypto::poseidon_hash_many;
@@ -117,17 +117,7 @@ async fn test_load_from_remote() {
 
     let world_reader = WorldContractReader::new(strat.world_address, account.provider());
 
-    let mut db = Sql::new(
-        pool.clone(),
-        world_reader.address,
-        account
-            .provider()
-            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), world_reader.address)
-            .await
-            .unwrap(),
-    )
-    .await
-    .unwrap();
+    let mut db = Sql::new(pool.clone(), world_reader.address).await.unwrap();
 
     let _ = bootstrap_engine(world_reader, db.clone(), account.provider()).await;
 
@@ -286,17 +276,7 @@ async fn test_load_from_remote_del() {
 
     let world_reader = WorldContractReader::new(strat.world_address, account.provider());
 
-    let mut db = Sql::new(
-        pool.clone(),
-        world_reader.address,
-        account
-            .provider()
-            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), world_reader.address)
-            .await
-            .unwrap(),
-    )
-    .await
-    .unwrap();
+    let mut db = Sql::new(pool.clone(), world_reader.address).await.unwrap();
 
     let _ = bootstrap_engine(world_reader, db.clone(), account.provider()).await;
 
@@ -372,17 +352,7 @@ async fn test_get_entity_keys() {
 
     let world_reader = WorldContractReader::new(strat.world_address, account.provider());
 
-    let mut db = Sql::new(
-        pool.clone(),
-        world_reader.address,
-        account
-            .provider()
-            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), world_reader.address)
-            .await
-            .unwrap(),
-    )
-    .await
-    .unwrap();
+    let mut db = Sql::new(pool.clone(), world_reader.address).await.unwrap();
 
     let _ = bootstrap_engine(world_reader, db.clone(), account.provider()).await;
 

--- a/crates/torii/graphql/src/tests/metadata_test.rs
+++ b/crates/torii/graphql/src/tests/metadata_test.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn test_metadata(pool: SqlitePool) {
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await.unwrap();
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await.unwrap();
         let schema = build_schema(&pool).await.unwrap();
 
         let cover_img = "QWxsIHlvdXIgYmFzZSBiZWxvbmcgdG8gdXM=";
@@ -100,7 +100,7 @@ mod tests {
 
     #[sqlx::test(migrations = "../migrations")]
     async fn test_empty_content(pool: SqlitePool) {
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await.unwrap();
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await.unwrap();
         let schema = build_schema(&pool).await.unwrap();
 
         db.set_metadata(&RESOURCE, URI, BLOCK_TIMESTAMP);

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -344,7 +344,7 @@ pub async fn spinup_types_test() -> Result<SqlitePool> {
 
     let world = WorldContractReader::new(strat.world_address, account.provider());
 
-    let db = Sql::new(pool.clone(), strat.world_address, Felt::ZERO).await.unwrap();
+    let db = Sql::new(pool.clone(), strat.world_address).await.unwrap();
 
     let (shutdown_tx, _) = broadcast::channel(1);
     let mut engine = Engine::new(

--- a/crates/torii/graphql/src/tests/subscription_test.rs
+++ b/crates/torii/graphql/src/tests/subscription_test.rs
@@ -21,7 +21,7 @@ mod tests {
     #[sqlx::test(migrations = "../migrations")]
     #[serial]
     async fn test_entity_subscription(pool: SqlitePool) {
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await.unwrap();
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await.unwrap();
 
         model_fixtures(&mut db).await;
         // 0. Preprocess expected entity value
@@ -147,7 +147,7 @@ mod tests {
     #[sqlx::test(migrations = "../migrations")]
     #[serial]
     async fn test_entity_subscription_with_id(pool: SqlitePool) {
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await.unwrap();
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await.unwrap();
 
         model_fixtures(&mut db).await;
         // 0. Preprocess expected entity value
@@ -252,7 +252,7 @@ mod tests {
     #[sqlx::test(migrations = "../migrations")]
     #[serial]
     async fn test_model_subscription(pool: SqlitePool) {
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await.unwrap();
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await.unwrap();
         // 0. Preprocess model value
         let namespace = "types_test".to_string();
         let model_name = "Subrecord".to_string();
@@ -316,7 +316,7 @@ mod tests {
     #[sqlx::test(migrations = "../migrations")]
     #[serial]
     async fn test_model_subscription_with_id(pool: SqlitePool) {
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await.unwrap();
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await.unwrap();
         // 0. Preprocess model value
         let namespace = "types_test".to_string();
         let model_name = "Subrecord".to_string();
@@ -381,7 +381,7 @@ mod tests {
     #[sqlx::test(migrations = "../migrations")]
     #[serial]
     async fn test_event_emitted(pool: SqlitePool) {
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await.unwrap();
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await.unwrap();
         let block_timestamp: u64 = 1710754478_u64;
         let (tx, mut rx) = mpsc::channel(7);
         tokio::spawn(async move {

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -14,10 +14,9 @@ use scarb::compiler::Profile;
 use scarb::ops;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use starknet::accounts::{Account, Call};
-use starknet::core::types::{BlockId, BlockTag};
 use starknet::core::utils::{get_contract_address, get_selector_from_name};
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider};
+use starknet::providers::JsonRpcClient;
 use starknet_crypto::poseidon_hash_many;
 use tokio::sync::broadcast;
 use torii_core::engine::{Engine, EngineConfig, Processors};
@@ -95,16 +94,7 @@ async fn test_entities_queries() {
 
     TransactionWaiter::new(tx.transaction_hash, &provider).await.unwrap();
 
-    let db = Sql::new(
-        pool.clone(),
-        strat.world_address,
-        provider
-            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), strat.world_address)
-            .await
-            .unwrap(),
-    )
-    .await
-    .unwrap();
+    let db = Sql::new(pool.clone(), strat.world_address).await.unwrap();
 
     let (shutdown_tx, _) = broadcast::channel(1);
     let mut engine = Engine::new(

--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -304,7 +304,7 @@ mod test {
 
         let account = sequencer.account_data(0);
 
-        let mut db = Sql::new(pool.clone(), Felt::ZERO, Felt::ZERO).await?;
+        let mut db = Sql::new(pool.clone(), Felt::ZERO).await?;
 
         // Register the model of our Message
         db.register_model(

--- a/crates/torii/migrations/20240815022036_remove_world_class_hash.sql
+++ b/crates/torii/migrations/20240815022036_remove_world_class_hash.sql
@@ -1,0 +1,25 @@
+-- NOTE: sqlite does not support deleteing columns. Workaround is to create new table, copy, and delete old.
+
+-- Create new table without executor_address and executor_class_hash columns
+CREATE TABLE worlds_new (
+    id TEXT PRIMARY KEY NOT NULL,
+    world_address TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Copy from old worlds
+INSERT INTO worlds_new (id, world_address, created_at)
+SELECT id, world_address, created_at
+FROM worlds;
+
+-- Disable foreign keys constraint so we can delete worlds
+PRAGMA foreign_keys = OFF;
+
+-- Drop old worlds
+DROP TABLE worlds;
+
+-- Rename table and recreate indexes
+ALTER TABLE worlds_new RENAME TO worlds;
+
+-- Renable foreign keys
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
Don't think really think we need to store the world class hash. This removes the dependency of having the world declared before launching torii 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Simplified the instantiation of the SQL object in various functions, enhancing readability and reducing complexity.
  
- **Bug Fixes**
  - Streamlined database interactions by removing unnecessary parameters in the SQL constructor, potentially improving performance and reliability.

- **Chores**
  - Updated SQL migration to restructure the database schema by removing obsolete columns while preserving data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->