### PR TITLE
refactor(torii): include model in entity deletion for filter & update member broadcast

### DIFF
--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -246,8 +246,8 @@ impl Sql {
         let keys_str = felts_sql_string(&keys);
         let insert_entities = "INSERT INTO event_messages (id, keys, event_id, executed_at) \
                                VALUES (?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET \
-                               updated_at=CURRENT_TIMESTAMP, event_id=EXCLUDED.event_id RETURNING \
-                               *";
+                               updated_at=CURRENT_TIMESTAMP, executed_at=EXCLUDED.executed_at, \
+                               event_id=EXCLUDED.event_id RETURNING *";
         let mut event_message_updated: EventMessageUpdated = sqlx::query_as(insert_entities)
             .bind(&entity_id)
             .bind(&keys_str)
@@ -300,6 +300,20 @@ impl Sql {
         );
         self.query_queue.execute_all().await?;
 
+        let mut update_entity = sqlx::query_as::<_, EntityUpdated>(
+            "UPDATE entities SET updated_at=CURRENT_TIMESTAMP, executed_at=?, event_id=? WHERE id \
+             = ? RETURNING *",
+        )
+        .bind(utc_dt_string_from_timestamp(block_timestamp))
+        .bind(event_id)
+        .bind(entity_id)
+        .fetch_one(&self.pool)
+        .await?;
+
+        update_entity.updated_model = Some(wrapped_ty);
+
+        SimpleBroker::publish(update_entity);
+
         Ok(())
     }
 
@@ -311,11 +325,14 @@ impl Sql {
         self.query_queue.execute_all().await?;
 
         // delete entity
-        let entity_deleted =
+        let mut entity_deleted =
             sqlx::query_as::<_, EntityUpdated>("DELETE FROM entities WHERE id = ? RETURNING *")
                 .bind(entity_id)
                 .fetch_one(&self.pool)
                 .await?;
+
+        entity_deleted.updated_model = Some(entity.clone());
+        entity_deleted.deleted = true;
 
         SimpleBroker::publish(entity_deleted);
         Ok(())

--- a/crates/torii/core/src/types.rs
+++ b/crates/torii/core/src/types.rs
@@ -38,9 +38,11 @@ pub struct Entity {
     pub executed_at: DateTime<Utc>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-    // if updated_model is None, then the entity has been deleted
+
+    // this should never be None
     #[sqlx(skip)]
     pub updated_model: Option<Ty>,
+    pub deleted: bool,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]
@@ -53,7 +55,7 @@ pub struct EventMessage {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 
-    // this should never be None. as a EventMessage cannot be deleted
+    // this should never be None
     #[sqlx(skip)]
     pub updated_model: Option<Ty>,
 }

--- a/crates/torii/core/src/types.rs
+++ b/crates/torii/core/src/types.rs
@@ -42,6 +42,7 @@ pub struct Entity {
     // this should never be None
     #[sqlx(skip)]
     pub updated_model: Option<Ty>,
+    #[sqlx(skip)]
     pub deleted: bool,
 }
 

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -188,7 +188,7 @@ impl Service {
                 continue;
             }
 
-            if entity.updated_model.is_none() {
+            if entity.deleted {
                 let resp = proto::world::SubscribeEntityResponse {
                     entity: Some(proto::types::Entity {
                         hashed_keys: hashed.to_bytes_be().to_vec(),


### PR DESCRIPTION
We now include the model within the Entity struct to be used with clauses on subscriptions to also receive entity deletions and now broadcast update member to subscriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced enhanced SQL handling for entity updates, managing timestamps for better data integrity.
	- Added a new field to track deletion status in the Entity structure.
	- Improved entity deletion logic to provide more context during event handling.

- **Bug Fixes**
	- Corrected entity processing logic to focus on deletion status rather than the presence of an updated model.

- **Documentation**
	- Clarified comments related to entity state management and event messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->