### PR TITLE
refactor(torii-libp2p): use is_valid_signature for different sig impls

### DIFF
--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -431,10 +431,7 @@ mod test {
 
         client
             .command_sender
-            .publish(Message {
-                message: typed_data,
-                signature: vec![signature.r, signature.s],
-            })
+            .publish(Message { message: typed_data, signature: vec![signature.r, signature.s] })
             .await?;
 
         sleep(std::time::Duration::from_secs(2)).await;

--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -433,8 +433,7 @@ mod test {
             .command_sender
             .publish(Message {
                 message: typed_data,
-                signature_r: signature.r,
-                signature_s: signature.s,
+                signature: vec![signature.r, signature.s],
             })
             .await?;
 

--- a/crates/torii/libp2p/src/types.rs
+++ b/crates/torii/libp2p/src/types.rs
@@ -6,6 +6,5 @@ use crate::typed_data::TypedData;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub message: TypedData,
-    pub signature_r: Felt,
-    pub signature_s: Felt,
+    pub signature: Vec<Felt>,
 }


### PR DESCRIPTION
controller signatures are different from signatures from like argent, openzeppelin etc.. so we directly use the account's is_valid_signature function to check the signature validity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Simplified signature validation process by directly checking signatures, enhancing efficiency.
	- Consolidated the representation of signatures in the `Message` structure for improved clarity and flexibility.

- **Bug Fixes**
	- Removed unnecessary error handling related to public key fetching, streamlining control flow during signature validation.

- **Documentation**
	- Updated the documentation to reflect changes in the `Message` struct and its signature handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->