### PR TITLE
refactor(torii): entity deletion logic for models

### DIFF
--- a/crates/torii/core/src/processors/store_del_record.rs
+++ b/crates/torii/core/src/processors/store_del_record.rs
@@ -42,9 +42,9 @@ where
         _world: &WorldContractReader<P>,
         db: &mut Sql,
         _block_number: u64,
-        _block_timestamp: u64,
+        block_timestamp: u64,
         _transaction_receipt: &TransactionReceiptWithBlockInfo,
-        _event_id: &str,
+        event_id: &str,
         event: &Event,
     ) -> Result<(), Error> {
         let selector = event.data[MODEL_INDEX];
@@ -60,7 +60,7 @@ where
         let entity_id = event.data[ENTITY_ID_INDEX];
         let entity = model.schema().await?;
 
-        db.delete_entity(entity_id, entity).await?;
+        db.delete_entity(entity_id, entity, event_id, block_timestamp).await?;
 
         Ok(())
     }

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -322,11 +322,17 @@ impl Sql {
         self.build_delete_entity_queries_recursive(path, &entity_id, &entity);
         self.query_queue.execute_all().await?;
 
-        sqlx::query("DELETE FROM entity_model WHERE entity_id = ? AND model_id = ?")
+        let deleted_entity_model = sqlx::query("DELETE FROM entity_model WHERE entity_id = ? AND model_id = ?")
             .bind(&entity_id)
             .bind(format!("{:#x}", compute_selector_from_tag(&entity.name())))
             .execute(&self.pool)
             .await?;
+        if deleted_entity_model.rows_affected() == 0 {
+            // fail silently. we have no entity-model relation to delete.
+            // this can happen if a entity model that doesnt exist 
+            // got deleted 
+            return Ok(());
+        }
 
         let mut update_entity = sqlx::query_as::<_, EntityUpdated>(
             "UPDATE entities SET updated_at=CURRENT_TIMESTAMP, executed_at=?, event_id=? WHERE id \

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -344,7 +344,7 @@ impl Sql {
 
         let models = models.split(',').collect::<Vec<&str>>();
 
-        if models.len() == 0 {
+        if models.is_empty() {
             // delete entity
             sqlx::query("DELETE FROM entities WHERE id = ?")
                 .bind(&entity_id)

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -322,15 +322,16 @@ impl Sql {
         self.build_delete_entity_queries_recursive(path, &entity_id, &entity);
         self.query_queue.execute_all().await?;
 
-        let deleted_entity_model = sqlx::query("DELETE FROM entity_model WHERE entity_id = ? AND model_id = ?")
-            .bind(&entity_id)
-            .bind(format!("{:#x}", compute_selector_from_tag(&entity.name())))
-            .execute(&self.pool)
-            .await?;
+        let deleted_entity_model =
+            sqlx::query("DELETE FROM entity_model WHERE entity_id = ? AND model_id = ?")
+                .bind(&entity_id)
+                .bind(format!("{:#x}", compute_selector_from_tag(&entity.name())))
+                .execute(&self.pool)
+                .await?;
         if deleted_entity_model.rows_affected() == 0 {
             // fail silently. we have no entity-model relation to delete.
-            // this can happen if a entity model that doesnt exist 
-            // got deleted 
+            // this can happen if a entity model that doesnt exist
+            // got deleted
             return Ok(());
         }
 

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -219,7 +219,7 @@ async fn test_load_from_remote_del() {
     .unwrap();
     let actions = strat.contracts.first().unwrap();
     let actions_address = get_contract_address(
-        actions.salt, 
+        actions.salt,
         strat.base.as_ref().unwrap().diff.local_class_hash,
         &[],
         strat.world_address,

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -219,7 +219,7 @@ async fn test_load_from_remote_del() {
     .unwrap();
     let actions = strat.contracts.first().unwrap();
     let actions_address = get_contract_address(
-        actions.salt,
+        actions.salt, 
         strat.base.as_ref().unwrap().diff.local_class_hash,
         &[],
         strat.world_address,


### PR DESCRIPTION
Change the entity deletion processor for deleting unique models instead of the whole entity directly. An additional check is done to see if the entity has no models left - where we'd delete the entity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Enhanced entity deletion functionality with improved parameter handling for better tracking.
    - Introduced event tracking capabilities during entity updates and deletions.

- **Bug Fixes**
    - Resolved issues related to entity deletion logic, ensuring accurate updates to timestamps and event associations.

- **Refactor**
    - Streamlined the method signatures for clarity and improved integration with operational logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->