### PR TITLE
fix(torii-grpc): world class hash

### DIFF
--- a/crates/dojo-types/src/lib.rs
+++ b/crates/dojo-types/src/lib.rs
@@ -16,7 +16,6 @@ pub mod system;
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct WorldMetadata {
     pub world_address: Felt,
-    pub world_class_hash: Felt,
     pub models: HashMap<Felt, ModelMetadata>,
 }
 

--- a/crates/torii/core/src/lib.rs
+++ b/crates/torii/core/src/lib.rs
@@ -1,8 +1,3 @@
-use serde::Deserialize;
-use sqlx::FromRow;
-
-use crate::types::SQLFelt;
-
 pub mod cache;
 pub mod engine;
 pub mod error;

--- a/crates/torii/core/src/lib.rs
+++ b/crates/torii/core/src/lib.rs
@@ -13,16 +13,3 @@ pub mod simple_broker;
 pub mod sql;
 pub mod types;
 pub mod utils;
-
-#[allow(dead_code)]
-#[derive(FromRow, Deserialize, Debug)]
-pub struct World {
-    #[sqlx(try_from = "String")]
-    world_address: SQLFelt,
-    #[sqlx(try_from = "String")]
-    world_class_hash: SQLFelt,
-    #[sqlx(try_from = "String")]
-    executor_address: SQLFelt,
-    #[sqlx(try_from = "String")]
-    executor_class_hash: SQLFelt,
-}

--- a/crates/torii/core/src/lib.rs
+++ b/crates/torii/core/src/lib.rs
@@ -1,3 +1,8 @@
+use serde::Deserialize;
+use sqlx::FromRow;
+
+use crate::types::SQLFelt;
+
 pub mod cache;
 pub mod engine;
 pub mod error;
@@ -8,3 +13,10 @@ pub mod simple_broker;
 pub mod sql;
 pub mod types;
 pub mod utils;
+
+#[allow(dead_code)]
+#[derive(FromRow, Deserialize, Debug)]
+pub struct World {
+    #[sqlx(try_from = "String")]
+    world_address: SQLFelt,
+}

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -13,7 +13,6 @@ use sqlx::{Pool, Row, Sqlite};
 use starknet::core::types::{Event, Felt, InvokeTransaction, Transaction};
 use starknet_crypto::poseidon_hash_many;
 
-use super::World;
 use crate::model::ModelSQLReader;
 use crate::query_queue::{Argument, QueryQueue};
 use crate::simple_broker::SimpleBroker;
@@ -22,6 +21,7 @@ use crate::types::{
     Model as ModelRegistered,
 };
 use crate::utils::{must_utc_datetime_from_timestamp, utc_dt_string_from_timestamp};
+use crate::World;
 
 type IsEventMessage = bool;
 type IsStoreUpdateMember = bool;

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -6,8 +6,6 @@ import "schema.proto";
 message WorldMetadata {
     // The hex-encoded address of the world.
     string world_address = 1;
-    // The hex-encoded class hash of the world.
-    string world_class_hash = 2;
     // A list of metadata for all registered components in the world. 
     repeated ModelMetadata models = 5;
 }

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -131,8 +131,8 @@ impl DojoWorld {
 
 impl DojoWorld {
     pub async fn metadata(&self) -> Result<proto::types::WorldMetadata, Error> {
-        let (world_address, world_class_hash): (String, String) = sqlx::query_as(&format!(
-            "SELECT world_address, world_class_hash FROM worlds WHERE id = '{:#x}'",
+        let world_address = sqlx::query_scalar(&format!(
+            "SELECT world_address FROM worlds WHERE id = '{:#x}'",
             self.world_address
         ))
         .fetch_one(&self.pool)
@@ -175,7 +175,7 @@ impl DojoWorld {
             });
         }
 
-        Ok(proto::types::WorldMetadata { world_address, world_class_hash, models: models_metadata })
+        Ok(proto::types::WorldMetadata { world_address, models: models_metadata })
     }
 
     async fn entities_all(

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -166,7 +166,6 @@ impl TryFrom<proto::types::WorldMetadata> for dojo_types::WorldMetadata {
         Ok(dojo_types::WorldMetadata {
             models,
             world_address: Felt::from_str(&value.world_address)?,
-            world_class_hash: Felt::from_str(&value.world_class_hash)?,
         })
     }
 }


### PR DESCRIPTION
remove world class hash from grpc proto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified data structures for `WorldMetadata` and `World`, improving readability and maintenance.
  
- **Bug Fixes**
	- Removed unnecessary fields that could lead to potential errors in serialization and database interactions.

- **Documentation**
	- Updated message definitions to reflect changes in data structure, ensuring accurate representation in external communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->