### PR TITLE
opt(torii): indexing model schema retrieval

### DIFF
--- a/crates/torii/core/src/cache.rs
+++ b/crates/torii/core/src/cache.rs
@@ -100,7 +100,7 @@ impl ModelCache {
         let model = Model {
             namespace,
             name,
-            selector: selector.clone(),
+            selector: *selector,
             class_hash,
             contract_address,
             packed_size,

--- a/crates/torii/core/src/processors/event_message.rs
+++ b/crates/torii/core/src/processors/event_message.rs
@@ -54,7 +54,7 @@ where
 
         info!(
             target: LOG_TARGET,
-            model = %model.name(),
+            model = %model.name,
             "Store event message."
         );
 
@@ -63,7 +63,7 @@ where
         let mut keys_and_unpacked =
             [event.keys[1..event.keys.len() - 1].to_vec(), event.data.clone()].concat();
 
-        let mut entity = model.schema().await?;
+        let mut entity = model.schema.clone();
         entity.deserialize(&mut keys_and_unpacked)?;
 
         db.set_event_message(entity, event_id, block_timestamp).await?;

--- a/crates/torii/core/src/processors/event_message.rs
+++ b/crates/torii/core/src/processors/event_message.rs
@@ -1,6 +1,5 @@
 use anyhow::{Error, Result};
 use async_trait::async_trait;
-use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{Event, TransactionReceiptWithBlockInfo};
 use starknet::providers::Provider;

--- a/crates/torii/core/src/processors/store_del_record.rs
+++ b/crates/torii/core/src/processors/store_del_record.rs
@@ -1,6 +1,5 @@
 use anyhow::{Error, Ok, Result};
 use async_trait::async_trait;
-use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{Event, TransactionReceiptWithBlockInfo};
 use starknet::providers::Provider;

--- a/crates/torii/core/src/processors/store_del_record.rs
+++ b/crates/torii/core/src/processors/store_del_record.rs
@@ -53,12 +53,12 @@ where
 
         info!(
             target: LOG_TARGET,
-            name = %model.name(),
+            name = %model.name,
             "Store delete record."
         );
 
         let entity_id = event.data[ENTITY_ID_INDEX];
-        let entity = model.schema().await?;
+        let entity = model.schema;
 
         db.delete_entity(entity_id, entity, event_id, block_timestamp).await?;
 

--- a/crates/torii/core/src/processors/store_set_record.rs
+++ b/crates/torii/core/src/processors/store_set_record.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Error, Ok, Result};
 use async_trait::async_trait;
-use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::world::WorldContractReader;
 use num_traits::ToPrimitive;
 use starknet::core::types::{Event, TransactionReceiptWithBlockInfo};

--- a/crates/torii/core/src/processors/store_set_record.rs
+++ b/crates/torii/core/src/processors/store_set_record.rs
@@ -54,7 +54,7 @@ where
 
         info!(
             target: LOG_TARGET,
-            name = %model.name(),
+            name = %model.name,
             "Store set record.",
         );
 
@@ -72,7 +72,7 @@ where
         let values = event.data[values_start..values_end].to_vec();
         let mut keys_and_unpacked = [keys, values].concat();
 
-        let mut entity = model.schema().await?;
+        let mut entity = model.schema;
         entity.deserialize(&mut keys_and_unpacked)?;
 
         db.set_entity(entity, event_id, block_timestamp).await?;

--- a/crates/torii/core/src/processors/store_update_member.rs
+++ b/crates/torii/core/src/processors/store_update_member.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Error, Result};
 use async_trait::async_trait;
-use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::naming;
 use dojo_world::contracts::world::WorldContractReader;
 use num_traits::ToPrimitive;
@@ -57,7 +56,7 @@ where
         let member_selector = event.data[MEMBER_INDEX];
 
         let model = db.model(selector).await?;
-        let schema = model.schema().await?;
+        let schema = model.schema;
 
         let mut member = schema
             .as_struct()
@@ -73,7 +72,7 @@ where
 
         info!(
             target: LOG_TARGET,
-            name = %model.name(),
+            name = %model.name,
             entity_id = format!("{:#x}", entity_id),
             member = %member.name,
             "Store update member.",
@@ -86,7 +85,7 @@ where
         // Skip the length to only get the values as they will be deserialized.
         let mut values = event.data[values_start + 1..=values_end].to_vec();
 
-        let tag = naming::get_tag(model.namespace(), model.name());
+        let tag = naming::get_tag(&model.namespace, &model.name);
 
         if !db.does_entity_exist(tag.clone(), entity_id).await? {
             warn!(

--- a/crates/torii/core/src/processors/store_update_record.rs
+++ b/crates/torii/core/src/processors/store_update_record.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Error, Ok, Result};
 use async_trait::async_trait;
-use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::naming;
 use dojo_world::contracts::world::WorldContractReader;
 use num_traits::ToPrimitive;
@@ -56,7 +55,7 @@ where
 
         info!(
             target: LOG_TARGET,
-            name = %model.name(),
+            name = %model.name,
             entity_id = format!("{:#x}", entity_id),
             "Store update record.",
         );
@@ -68,14 +67,14 @@ where
         // Skip the length to only get the values as they will be deserialized.
         let values = event.data[values_start + 1..=values_end].to_vec();
 
-        let tag = naming::get_tag(model.namespace(), model.name());
+        let tag = naming::get_tag(&model.namespace, &model.name);
 
         // Keys are read from the db, since we don't have access to them when only
         // the entity id is passed.
         let keys = db.get_entity_keys(entity_id, &tag).await?;
         let mut keys_and_unpacked = [keys, values].concat();
 
-        let mut entity = model.schema().await?;
+        let mut entity = model.schema;
         entity.deserialize(&mut keys_and_unpacked)?;
 
         db.set_entity(entity, event_id, block_timestamp).await?;

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -15,7 +15,6 @@ use starknet::core::types::{Event, Felt, InvokeTransaction, Transaction};
 use starknet_crypto::poseidon_hash_many;
 
 use crate::cache::{Model, ModelCache};
-use crate::model::ModelSQLReader;
 use crate::query_queue::{Argument, QueryQueue};
 use crate::simple_broker::SimpleBroker;
 use crate::types::{
@@ -758,11 +757,7 @@ impl Sql {
             Ty::Enum(e) => {
                 if e.options.iter().all(
                     |o| {
-                        if let Ty::Tuple(t) = &o.ty {
-                            t.is_empty()
-                        } else {
-                            false
-                        }
+                        if let Ty::Tuple(t) = &o.ty { t.is_empty() } else { false }
                     },
                 ) {
                     return;

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use chrono::Utc;
@@ -13,6 +14,7 @@ use sqlx::{Pool, Row, Sqlite};
 use starknet::core::types::{Event, Felt, InvokeTransaction, Transaction};
 use starknet_crypto::poseidon_hash_many;
 
+use crate::cache::{Model, ModelCache};
 use crate::model::ModelSQLReader;
 use crate::query_queue::{Argument, QueryQueue};
 use crate::simple_broker::SimpleBroker;
@@ -37,6 +39,7 @@ pub struct Sql {
     world_address: Felt,
     pub pool: Pool<Sqlite>,
     query_queue: QueryQueue,
+    model_cache: Arc<ModelCache>,
 }
 
 impl Sql {
@@ -54,7 +57,12 @@ impl Sql {
 
         query_queue.execute_all().await?;
 
-        Ok(Self { pool, world_address, query_queue })
+        Ok(Self {
+            pool: pool.clone(),
+            world_address,
+            query_queue,
+            model_cache: Arc::new(ModelCache::new(pool)),
+        })
     }
 
     pub async fn head(&self) -> Result<(u64, Option<Felt>)> {
@@ -411,13 +419,8 @@ impl Sql {
         Ok(())
     }
 
-    pub async fn model(&self, selector: Felt) -> Result<ModelSQLReader> {
-        match ModelSQLReader::new(selector, self.pool.clone()).await {
-            Ok(reader) => Ok(reader),
-            Err(e) => {
-                Err(anyhow::anyhow!("Failed to get model from db for selector {selector:#x}: {e}"))
-            }
-        }
+    pub async fn model(&self, selector: Felt) -> Result<Model> {
+        self.model_cache.model(&selector).await.map_err(|e| e.into())
     }
 
     /// Retrieves the keys definition for a given model.
@@ -755,7 +758,11 @@ impl Sql {
             Ty::Enum(e) => {
                 if e.options.iter().all(
                     |o| {
-                        if let Ty::Tuple(t) = &o.ty { t.is_empty() } else { false }
+                        if let Ty::Tuple(t) = &o.ty {
+                            t.is_empty()
+                        } else {
+                            false
+                        }
                     },
                 ) {
                     return;

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -218,7 +218,7 @@ impl Service {
                 .map(Felt::from_str)
                 .collect::<Result<_, _>>()
                 .map_err(ParseError::FromStr)?;
-            let schemas = cache.schemas(&model_ids).await?;
+            let schemas = cache.models(&model_ids).await?.into_iter().map(|m| m.schema).collect();
 
             let (entity_query, arrays_queries, _) = build_sql_query(
                 &schemas,

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -197,7 +197,7 @@ impl Service {
                 .map(Felt::from_str)
                 .collect::<Result<_, _>>()
                 .map_err(ParseError::FromStr)?;
-            let schemas = cache.schemas(&model_ids).await?;
+            let schemas = cache.models(&model_ids).await?.into_iter().map(|m| m.schema).collect();
 
             let (entity_query, arrays_queries, _) = build_sql_query(
                 &schemas,

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -32,8 +32,6 @@ use crate::errors::Error;
 
 mod events;
 
-use dojo_world::contracts::model::ModelReader;
-
 use crate::server::events::ServerEvent;
 use crate::typed_data::{parse_value_to_ty, PrimitiveType};
 use crate::types::Message;
@@ -455,11 +453,7 @@ async fn validate_message(
         .model(selector)
         .await
         .map_err(|e| Error::InvalidMessageError(format!("Model {} not found: {}", model, e)))?
-        .schema()
-        .await
-        .map_err(|e| {
-            Error::InvalidMessageError(format!("Failed to get schema for model {}: {}", model, e))
-        })?;
+        .schema;
 
     if let Some(object) = message.get(model) {
         parse_value_to_ty(object, &mut ty)?;


### PR DESCRIPTION
we use the model cache to avoid fetching the models scheam & parsing every time we index a model state update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new `Model` struct for improved data representation in the cache.
  - Enhanced model retrieval efficiency by implementing caching mechanisms in the `Sql` struct.

- **Bug Fixes**
  - Improved logging and data access performance by switching from method calls to direct property access.

- **Refactor**
  - Updated several method return types and signatures to align with new structural changes, streamlining the codebase and enhancing clarity.

- **Chores**
  - Simplified error handling in model retrieval methods, contributing to cleaner code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->