### PR TITLE
refactor(katana): update execution error message 

### DIFF
--- a/crates/katana/executor/src/abstraction/error.rs
+++ b/crates/katana/executor/src/abstraction/error.rs
@@ -9,52 +9,64 @@ pub enum ExecutorError {}
 /// Errors that can occur during the transaction execution.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ExecutionError {
-    #[error("contract constructor execution error: {reason}")]
+    #[error("Contract constructor execution error: {reason}")]
     ConstructorExecutionFailed { reason: String },
 
-    #[error("class with hash {0:#x} is already declared")]
+    #[error("Class with hash {0:#x} is already declared")]
     ClassAlreadyDeclared(ClassHash),
 
-    #[error("entry point {0:#x} not found in contract")]
+    #[error("Entry point {0:#x} not found in contract")]
     EntryPointNotFound(FieldElement),
 
-    #[error("invalid input: {input_descriptor}; {info}")]
+    #[error("Invalid input: {input_descriptor}; {info}")]
     InvalidInput { input_descriptor: String, info: String },
 
-    #[error("execution failed due to recursion depth exceeded")]
+    #[error("Execution failed due to recursion depth exceeded")]
     RecursionDepthExceeded,
 
-    #[error("contract with address {0} is not deployed")]
+    #[error("Contract with address {0} is not deployed")]
     ContractNotDeployed(ContractAddress),
 
-    #[error("invalid transaction nonce: expected {expected} got {actual}")]
-    InvalidNonce { actual: Nonce, expected: Nonce },
+    // The error message is the exact copy of the one defined by blockifier but without using
+    // Debug formatting for the struct fields.
+    #[error(
+        "Invalid transaction nonce of contract at address {address}. Account nonce: \
+         {current_nonce:#x}; got: {tx_nonce:#x}."
+    )]
+    InvalidNonce {
+        /// The address of the account contract.
+        address: ContractAddress,
+        /// The current nonce of the account.
+        current_nonce: Nonce,
+        /// The nonce of the incoming transaction.
+        tx_nonce: Nonce,
+    },
 
     #[error(
-        "insufficient balance: max fee {max_fee} exceeds account balance u256({balance_low}, \
+        "Insufficient balance: max fee {max_fee} exceeds account balance u256({balance_low}, \
          {balance_high})"
     )]
     InsufficientBalance { max_fee: u128, balance_low: FieldElement, balance_high: FieldElement },
 
-    #[error("actual fee {max_fee} exceeded transaction max fee {actual_fee}")]
+    #[error("Actual fee ({actual_fee}) exceeded max fee ({max_fee})")]
     ActualFeeExceedsMaxFee { max_fee: u128, actual_fee: u128 },
 
-    #[error("transaction max fee ({max_fee:#x}) is too low; min max fee is {min:#x}")]
+    #[error("Transaction max fee ({max_fee:#x}) is too low; min max fee is {min:#x}")]
     MaxFeeTooLow { min: u128, max_fee: u128 },
 
-    #[error("class with hash {0:#x} is not declared")]
+    #[error("Class with hash {0:#x} is not declared")]
     UndeclaredClass(ClassHash),
 
-    #[error("fee transfer error: {0}")]
+    #[error("Fee transfer error: {0}")]
     FeeTransferError(String),
 
-    #[error("entry point execution error: {reason}")]
+    #[error("Entry point execution error: {reason}")]
     ExecutionFailed { reason: String },
 
-    #[error("transaction validation error: {reason}")]
+    #[error("Transaction validation error: {reason}")]
     TransactionValidationFailed { reason: String },
 
-    #[error("transaction reverted: {revert_error}")]
+    #[error("Transaction reverted: {revert_error}")]
     TransactionReverted { revert_error: String },
 
     #[error("{0}")]

--- a/crates/katana/executor/src/implementation/blockifier/error.rs
+++ b/crates/katana/executor/src/implementation/blockifier/error.rs
@@ -63,10 +63,14 @@ impl From<TransactionPreValidationError> for ExecutionError {
     fn from(error: TransactionPreValidationError) -> Self {
         match error {
             TransactionPreValidationError::InvalidNonce {
+                address,
                 account_nonce,
                 incoming_tx_nonce,
-                ..
-            } => Self::InvalidNonce { actual: incoming_tx_nonce.0, expected: account_nonce.0 },
+            } => Self::InvalidNonce {
+                address: to_address(address),
+                tx_nonce: incoming_tx_nonce.0,
+                current_nonce: account_nonce.0,
+            },
             TransactionPreValidationError::TransactionFeeError(e) => Self::from(e),
             TransactionPreValidationError::StateError(e) => Self::from(e),
         }


### PR DESCRIPTION
Initially, i defined custom execution error messages for two main reasons:-

1. Removing any `Debug`s formatting in the error messages returned by executor (ie blockifier)
2. To standardize the messages across different executor implementations (when we were supporting both starknet-in-rust 🪦 and blockifier)

But reason no.1 is more intrusive as the errors are returned to user-space. Blockifier used to use `Debug` formatting in their error messages (they have since slowly removing the `Debug`s but there are still some left). For example [ref](https://github.com/dojoengine/blockifier/blob/5e6e47ea47eeca12316d4a0e3394f38aa4870c71/crates/blockifier/src/transaction/errors.rs#L62-L63):

```rust
#[error("Class with hash {class_hash:?} is already declared.")]
DeclareTransactionError { class_hash: ClassHash }
```

and IMO this would output the error message string with debug info which results in not so appealing/readable message. This message is also used as a response data in the JSON-RPC server through the Starknet API. The Katana messages are more or less similar to its original counterpart but with slight variations in the wordings. 

So the main idea of the redundancy was to provide user with more human readable and 'easier' to understand messages, but due to the string itself being different, if you wanna extract the individual atomic values (eg nonce, fee) from the string, you have to do it differently for katana vs other nodes (or gateway).

Important thing to note, however, the error message is not strictly defined in the JSON-RPC [specs](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_api_openrpc.json#L3948-L3987
) so Katana returning different error messages than blockifier is not technically wrong.

but @tarrencev needed them to be similar with the ones returned by Pathfinder, for some of Cartridge's internal operations. At least for these two errors:

1. Invalid transaction nonce:

**Katana**:
```
invalid transaction nonce: expected 2 got 1
```

**Pathfinder**:
```
Invalid transaction nonce of contract at address 0x07ee88d7b4da7b83bf2eeb0c530a126e3b586d5da2b44e39c4fa54e74a0d4cce. Account nonce: 0x0000000000000000000000000000000000000000000000000000000000000194; got: 0x000000000000000000000000000000000000000000000000000000000000012f.
```

5. Insufficient balance:

This is from older version of Katana, latest version outputs the same one as Pathfinder.

**Katana**:
```
Max fee (Fee(24129000)) exceeds balance (Uint256(StarkFelt(\"0x0000000000000000000000000000000000000000000000000000000000000000\"), StarkFelt(\"0x0000000000000000000000000000000000000000000000000000000000000000\"
```

**Pathfinder**:
```
Max fee (193191155591958) exceeds balance (124008699329154).
```

Eventually, we'd probably remove this redundant error enum and use directly from blockifier. But for now, we just copy the exact string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages for improved clarity and consistency across various error types.
	- Detailed multi-line error message for the `InvalidNonce` error, including specific fields for better debugging.

- **Bug Fixes**
	- Improved handling of the `InvalidNonce` variant in the transaction pre-validation error conversion, adding context for better error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->