### PR TITLE
fix(katana): ensure messages are ordered

### DIFF
--- a/crates/katana/core/src/service/messaging/ethereum.rs
+++ b/crates/katana/core/src/service/messaging/ethereum.rs
@@ -145,7 +145,7 @@ impl Messenger for EthereumMessaging {
             .for_each(|l| {
                 debug!(
                     target: LOG_TARGET,
-                    logs: ?l,
+                    logs = ?l,
                     "Converting logs into L1HandlerTx.",
                 );
 

--- a/crates/katana/core/src/service/messaging/ethereum.rs
+++ b/crates/katana/core/src/service/messaging/ethereum.rs
@@ -76,10 +76,10 @@ impl EthereumMessaging {
         &self,
         from_block: u64,
         to_block: u64,
-    ) -> MessengerResult<HashMap<u64, Vec<Log>>> {
+    ) -> MessengerResult<Vec<Log>> {
         trace!(target: LOG_TARGET, from_block = ?from_block, to_block = ?to_block, "Fetching logs.");
 
-        let mut block_to_logs: HashMap<u64, Vec<Log>> = HashMap::new();
+        let mut logs: Vec<Log> = Vec::new();
 
         let filters = Filter {
             block_option: FilterBlockOption::Range {
@@ -107,15 +107,11 @@ impl EthereumMessaging {
             .await?
             .into_iter()
             .filter(|log| log.block_number.is_some())
-            .map(|log| (log.block_number.unwrap(), log))
-            .for_each(|(block_num, log)| {
-                block_to_logs
-                    .entry(block_num)
-                    .and_modify(|v| v.push(log.clone()))
-                    .or_insert(vec![log]);
+            .for_each(|log| {
+                logs.push(log);
             });
 
-        Ok(block_to_logs)
+        Ok(logs)
     }
 }
 
@@ -143,20 +139,19 @@ impl Messenger for EthereumMessaging {
         let mut l1_handler_txs = vec![];
 
         trace!(target: LOG_TARGET, from_block, to_block, "Fetching logs from {from_block} to {to_block}.");
-        self.fetch_logs(from_block, to_block).await?.into_iter().for_each(
-            |(block_number, block_logs)| {
+        self.fetch_logs(from_block, to_block)
+            .await?
+            .iter()
+            .for_each(|l| {
                 debug!(
                     target: LOG_TARGET,
-                    block_number = %block_number,
-                    logs_found = %block_logs.len(),
+                    logs: ?l,
                     "Converting logs into L1HandlerTx.",
                 );
 
-                block_logs.into_iter().for_each(|log| {
-                    if let Ok(tx) = l1_handler_tx_from_log(log, chain_id) {
-                        l1_handler_txs.push(tx)
-                    }
-                })
+                if let Ok(tx) = l1_handler_tx_from_log(l, chain_id) {
+                    l1_handler_txs.push(tx)
+                }
             },
         );
 

--- a/crates/katana/core/src/service/messaging/ethereum.rs
+++ b/crates/katana/core/src/service/messaging/ethereum.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -72,14 +71,10 @@ impl EthereumMessaging {
     ///
     /// * `from_block` - The first block of which logs must be fetched.
     /// * `to_block` - The last block of which logs must be fetched.
-    pub async fn fetch_logs(
-        &self,
-        from_block: u64,
-        to_block: u64,
-    ) -> MessengerResult<Vec<Log>> {
+    pub async fn fetch_logs(&self, from_block: u64, to_block: u64) -> MessengerResult<Vec<Log>> {
         trace!(target: LOG_TARGET, from_block = ?from_block, to_block = ?to_block, "Fetching logs.");
 
-        let mut logs: Vec<Log> = Vec::new();
+        let mut logs = vec![];
 
         let filters = Filter {
             block_option: FilterBlockOption::Range {
@@ -139,21 +134,17 @@ impl Messenger for EthereumMessaging {
         let mut l1_handler_txs = vec![];
 
         trace!(target: LOG_TARGET, from_block, to_block, "Fetching logs from {from_block} to {to_block}.");
-        self.fetch_logs(from_block, to_block)
-            .await?
-            .iter()
-            .for_each(|l| {
-                debug!(
-                    target: LOG_TARGET,
-                    logs = ?l,
-                    "Converting logs into L1HandlerTx.",
-                );
+        self.fetch_logs(from_block, to_block).await?.iter().for_each(|l| {
+            debug!(
+                target: LOG_TARGET,
+                log = ?l,
+                "Converting log into L1HandlerTx.",
+            );
 
-                if let Ok(tx) = l1_handler_tx_from_log(l, chain_id) {
-                    l1_handler_txs.push(tx)
-                }
-            },
-        );
+            if let Ok(tx) = l1_handler_tx_from_log(l.clone(), chain_id) {
+                l1_handler_txs.push(tx)
+            }
+        });
 
         Ok((to_block, l1_handler_txs))
     }

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -104,7 +104,8 @@ impl StarknetMessaging {
         }
 
         // Convert Hashmap into Vec
-        let mut sorted_block_events: Vec<(u64, Vec<EmittedEvent>)> = block_to_events.into_iter().collect();
+        let mut sorted_block_events: Vec<(u64, Vec<EmittedEvent>)> =
+            block_to_events.into_iter().collect();
         sorted_block_events.sort_by_key(|&(block_number, _)| block_number);
 
         Ok(sorted_block_events)

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -89,6 +89,8 @@ impl StarknetMessaging {
             event_page.events.into_iter().for_each(|event| {
                 // We ignore events without the block number
                 if event.block_number.is_some() {
+                    // Blocks are processed in order as retrieved by `get_events`.
+                    // This way we keep the order and ensure the messages are executed in order
                     events.push(event);
                 }
             });
@@ -99,9 +101,6 @@ impl StarknetMessaging {
                 break;
             }
         }
-    
-        // Ordering the events to process them in the correct order
-        events.sort_by_key(|e| e.block_number);
     
         Ok(events)
     }
@@ -203,7 +202,7 @@ impl Messenger for StarknetMessaging {
             .for_each(|e| {
                 debug!(
                     target: LOG_TARGET,
-                    event: %e,
+                    event: ?e,
                     "Converting events of block into L1HandlerTx."
                 );
 

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -103,7 +103,7 @@ impl StarknetMessaging {
             }
         }
 
-        // Converti Hashmap into Vec
+        // Convert Hashmap into Vec
         let mut sorted_block_events: Vec<(u64, Vec<EmittedEvent>)> = block_to_events.into_iter().collect();
         sorted_block_events.sort_by_key(|&(block_number, _)| block_number);
 

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -202,7 +202,7 @@ impl Messenger for StarknetMessaging {
             .for_each(|e| {
                 debug!(
                     target: LOG_TARGET,
-                    event: ?e,
+                    event = ?e,
                     "Converting events of block into L1HandlerTx."
                 );
 

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -68,7 +67,7 @@ impl StarknetMessaging {
     ) -> Result<Vec<EmittedEvent>> {
         trace!(target: LOG_TARGET, from_block = ?from_block, to_block = ?to_block, "Fetching logs.");
 
-        let mut events: Vec<EmittedEvent> = Vec::new();
+        let mut events = vec![];
 
         let filter = EventFilter {
             from_block: Some(from_block),
@@ -101,7 +100,7 @@ impl StarknetMessaging {
                 break;
             }
         }
-    
+
         Ok(events)
     }
 
@@ -203,7 +202,7 @@ impl Messenger for StarknetMessaging {
                 debug!(
                     target: LOG_TARGET,
                     event = ?e,
-                    "Converting events of block into L1HandlerTx."
+                    "Converting event into L1HandlerTx."
                 );
 
                 if let Ok(tx) = l1_handler_tx_from_event(e, chain_id) {

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -89,7 +89,7 @@ impl StarknetMessaging {
                 // We ignore events without the block number
                 if event.block_number.is_some() {
                     // Blocks are processed in order as retrieved by `get_events`.
-                    // This way we keep the order and ensure the messages are executed in order
+                    // This way we keep the order and ensure the messages are executed in order.
                     events.push(event);
                 }
             });


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->
This PR will close issue #2321 converting the hash map in ``` fetch_events ``` to an ordered Vec

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #2321 

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [x] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [x] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `fetch_logs` method to return a simplified flat list of logs instead of a mapping by block number, improving usability and performance.
	- Updated the `fetch_events` method to provide a flat list of emitted events rather than a block-numbered structure, streamlining event handling and processing.
  
- **Bug Fixes**
	- Simplified log and event processing to reduce complexity and enhance clarity in data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->