### PR TITLE
fix(torii-core): change event loop and having global sync method and few other changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6424,6 +6424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13037,7 +13046,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashlink",
+ "hashlink 0.8.4",
  "hex",
  "indexmap 2.2.6",
  "log",
@@ -14545,6 +14554,7 @@ dependencies = [
  "dojo-world",
  "futures-channel",
  "futures-util",
+ "hashlink 0.9.1",
  "hex",
  "katana-runner",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 	"bin/scheduler",
 	"bin/sozo",
 	"bin/torii",
-#	"crates/benches",
+	#	"crates/benches",
 	"crates/common",
 	"crates/dojo-bindgen",
 	"crates/dojo-core",
@@ -172,7 +172,7 @@ pretty_assertions = "1.2.1"
 rand = "0.8.5"
 rayon = "1.8.0"
 regex = "1.10.3"
-reqwest = { version = "0.12", features = [ "blocking", "rustls-tls", "json" ], default-features = false }
+reqwest = { version = "0.12", features = [ "blocking", "json", "rustls-tls" ], default-features = false }
 rpassword = "7.2.0"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
@@ -192,6 +192,7 @@ starknet-crypto = "0.7.0"
 # we need this <https://github.com/starknet-io/types-rs/pull/75>. So we put strict
 # requirement here to prevent from being downgraded.
 # We can remove this requirement once `starknet-rs` is using >=0.1.4
+hashlink = "0.9.1"
 starknet-types-core = "~0.1.4"
 starknet_api = "0.11.0"
 strum = "0.25"

--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -134,7 +134,7 @@ struct Args {
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    let mut start_block = args.start_block;
+    let start_block = args.start_block;
 
     let mut config = if let Some(path) = args.config {
         ToriiConfig::load_from_path(&path)?
@@ -146,11 +146,11 @@ async fn main() -> anyhow::Result<()> {
         config.erc_contracts = erc_contracts;
     }
 
-    for address in &config.erc_contracts {
-        if address.start_block < start_block {
-            start_block = address.start_block;
-        }
-    }
+    // for address in &config.erc_contracts {
+    //     if address.start_block < start_block {
+    //         start_block = address.start_block;
+    //     }
+    // }
 
     let filter_layer = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::new("info,hyper_reverse_proxy=off"));
@@ -199,6 +199,7 @@ async fn main() -> anyhow::Result<()> {
         .iter()
         .map(|contract| (contract.contract_address, contract.clone()))
         .collect();
+
     let db = Sql::new(pool.clone(), args.world_address, &erc_contracts).await?;
     let processors = Processors {
         event: vec![

--- a/crates/torii/core/Cargo.toml
+++ b/crates/torii/core/Cargo.toml
@@ -19,6 +19,7 @@ dojo-types = { path = "../../dojo-types" }
 dojo-world = { path = "../../dojo-world", features = [ "contracts", "manifest" ] }
 futures-channel = "0.3.0"
 futures-util.workspace = true
+hashlink.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
 log.workspace = true

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -98,6 +98,8 @@ impl<P: Provider + Sync> Engine<P> {
         }
     }
 
+    // switch to using BlockTag::Pending instead of sync_range and sync_pending logic
+    // run tasks for world and erc tokens concurrently
     pub async fn start(&mut self) -> Result<()> {
         let (mut head, mut pending_block_tx) = self.db.head().await?;
         if head == 0 {

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -1,10 +1,11 @@
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::time::Duration;
 
 use anyhow::Result;
 use dojo_world::contracts::world::WorldContractReader;
+use hashlink::LinkedHashSet;
 use starknet::core::types::{
     BlockId, BlockTag, EmittedEvent, Event, EventFilter, EventsPage, Felt,
     MaybePendingBlockWithTxHashes, Transaction, TransactionReceipt,
@@ -158,7 +159,7 @@ impl<P: Provider + Sync> Engine<P> {
 
         // Transactions & blocks to process
         let mut blocks = BTreeMap::new();
-        let mut transactions = HashSet::new();
+        let mut transactions = LinkedHashSet::new();
 
         for event in &events {
             let block_number = match event.block_number {
@@ -178,7 +179,9 @@ impl<P: Provider + Sync> Engine<P> {
                 e.insert(block_timestamp);
             }
 
-            transactions.insert((block_number, event.transaction_hash));
+            if !transactions.contains(&(block_number, event.transaction_hash)) {
+                transactions.insert((block_number, event.transaction_hash));
+            }
         }
 
         // Process all transactions

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -56,6 +56,7 @@ impl Default for EngineConfig {
     }
 }
 
+#[derive(Debug)]
 pub struct FetchResult {
     blocks: BTreeMap<u64, u64>,
     transactions: LinkedHashSet<(u64, Felt)>,
@@ -193,7 +194,7 @@ impl<P: Provider + Sync> Engine<P> {
         Ok(FetchResult { blocks, transactions, latest_for_contract })
     }
 
-    async fn process_fetch_result(&mut self, fetch_result: FetchResult) -> Result<()> {
+    pub async fn process_fetch_result(&mut self, fetch_result: FetchResult) -> Result<()> {
         // Process all transactions
         for (block_number, transaction_hash) in fetch_result.transactions {
             // Process transaction

--- a/crates/torii/core/src/lib.rs
+++ b/crates/torii/core/src/lib.rs
@@ -1,8 +1,3 @@
-use serde::Deserialize;
-use sqlx::FromRow;
-
-use crate::types::SQLFelt;
-
 pub mod cache;
 pub mod engine;
 pub mod error;
@@ -13,10 +8,3 @@ pub mod simple_broker;
 pub mod sql;
 pub mod types;
 pub mod utils;
-
-#[allow(dead_code)]
-#[derive(FromRow, Deserialize, Debug)]
-pub struct World {
-    #[sqlx(try_from = "String")]
-    world_address: SQLFelt,
-}

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -1203,55 +1203,6 @@ impl Sql {
         Ok(())
     }
 
-    // Registers a new ERC20 contract in erc20_contracts table
-    pub fn register_erc20(
-        &mut self,
-        address: Felt,
-        decimals: u8,
-        name: String,
-        symbol: String,
-        total_supply: U256,
-    ) -> Result<()> {
-        let insert_query = "INSERT INTO erc20_contracts (token_address, name, symbol, decimals \
-                            total_supply) VALUES (?, ?, ?, ?, ?)";
-
-        self.query_queue.enqueue(
-            insert_query,
-            vec![
-                Argument::FieldElement(address),
-                Argument::String(name),
-                Argument::String(symbol),
-                Argument::Int(decimals.into()),
-                Argument::String(u256_to_sql_string(&total_supply)),
-            ],
-        );
-
-        Ok(())
-    }
-
-    pub fn register_erc721(
-        &mut self,
-        token_address: Felt,
-        name: String,
-        symbol: String,
-        total_supply: U256,
-    ) -> Result<()> {
-        let insert_query = "INSERT INTO erc721_contracts (token_address, name, symbol, \
-                            total_supply) VALUES (?, ?, ?, ?)";
-
-        self.query_queue.enqueue(
-            insert_query,
-            vec![
-                Argument::FieldElement(token_address),
-                Argument::String(name),
-                Argument::String(symbol),
-                Argument::String(u256_to_sql_string(&total_supply)),
-            ],
-        );
-
-        Ok(())
-    }
-
     pub async fn handle_erc20_transfer<P: Provider + Sync>(
         &mut self,
         contract_address: Felt,

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -54,7 +54,8 @@ impl Sql {
         let mut query_queue = QueryQueue::new(pool.clone());
 
         query_queue.enqueue(
-            "INSERT OR IGNORE INTO contracts (id, contract_address, contract_type) VALUES (?, ?, ?)",
+            "INSERT OR IGNORE INTO contracts (id, contract_address, contract_type) VALUES (?, ?, \
+             ?)",
             vec![
                 Argument::FieldElement(world_address),
                 Argument::FieldElement(world_address),
@@ -64,7 +65,8 @@ impl Sql {
 
         for erc_contract in erc_contracts.values() {
             query_queue.enqueue(
-                "INSERT OR IGNORE INTO contracts (id, contract_address, contract_type) VALUES (?, ?, ?)",
+                "INSERT OR IGNORE INTO contracts (id, contract_address, contract_type) VALUES (?, \
+                 ?, ?)",
                 vec![
                     Argument::FieldElement(erc_contract.contract_address),
                     Argument::FieldElement(erc_contract.contract_address),
@@ -78,34 +80,47 @@ impl Sql {
         Ok(Self { pool, query_queue })
     }
 
-    pub async fn head(&self, address: Felt) -> Result<(u64, Option<Felt>, String)> {
+    pub async fn head(&self, address: Felt) -> Result<(Option<u64>, Option<Felt>, String)> {
         let mut conn: PoolConnection<Sqlite> = self.pool.acquire().await?;
-        let indexer_query = sqlx::query_as::<_, (i64, Option<String>, String)>(
-            "SELECT head, pending_block_tx, contract_type FROM contracts WHERE id = ?",
+        let indexer_query = sqlx::query_as::<_, (Option<i64>, Option<String>, String)>(
+            "SELECT head, latest_block_tx, contract_type FROM contracts WHERE id = ?",
         )
         .bind(format!("{:#x}", address));
 
-        let indexer: (i64, Option<String>, String) = indexer_query.fetch_one(&mut *conn).await?;
+        let indexer: (Option<i64>, Option<String>, String) =
+            indexer_query.fetch_one(&mut *conn).await?;
         Ok((
-            indexer.0.try_into().expect("doesn't fit in u64"),
+            indexer.0.map(|h| h.try_into().expect("doesn't fit in u64")),
             indexer.1.map(|f| Felt::from_str(&f)).transpose()?,
             indexer.2,
         ))
     }
 
-    pub fn set_head(&mut self, head: u64, pending_block_tx: Option<Felt>, contract: Felt) {
+    pub fn set_head_and_latest_block_tx(
+        &mut self,
+        head: u64,
+        latest_block_tx: Option<Felt>,
+        contract: Felt,
+    ) {
         let head = Argument::Int(head.try_into().expect("doesn't fit in u64"));
         let id = Argument::FieldElement(contract);
-        let pending_block_tx = if let Some(f) = pending_block_tx {
+        let latest_block_tx = if let Some(f) = latest_block_tx {
             Argument::String(format!("{:#x}", f))
         } else {
             Argument::Null
         };
 
         self.query_queue.enqueue(
-            "UPDATE contracts SET head = ?, pending_block_tx = ? WHERE id = ?",
-            vec![head, pending_block_tx, id],
+            "UPDATE contracts SET head = ?, latest_block_tx = ? WHERE id = ?",
+            vec![head, latest_block_tx, id],
         );
+    }
+
+    pub fn set_head(&mut self, head: u64, contract: Felt) {
+        let head = Argument::Int(head.try_into().expect("doesn't fit in u64"));
+        let id = Argument::FieldElement(contract);
+
+        self.query_queue.enqueue("UPDATE contracts SET head = ? WHERE id = ?", vec![head, id]);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -767,11 +782,7 @@ impl Sql {
             Ty::Enum(e) => {
                 if e.options.iter().all(
                     |o| {
-                        if let Ty::Tuple(t) = &o.ty {
-                            t.is_empty()
-                        } else {
-                            false
-                        }
+                        if let Ty::Tuple(t) = &o.ty { t.is_empty() } else { false }
                     },
                 ) {
                     return;

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -1290,8 +1290,7 @@ impl Sql {
             );
         }
 
-        // Now proceed with the transfer handling
-        // Insert transfer event to erc20_transfers table
+        // Insert transfer event to erc_transfers table
         {
             let insert_query = "INSERT INTO erc_transfers (contract_address, from_address, \
                                 to_address, amount, token_id, executed_at) VALUES (?, ?, ?, ?, ?, \
@@ -1310,14 +1309,14 @@ impl Sql {
             );
         }
 
-        // Update balances in erc20_balance table
+        // Update balance in balances table
         {
             // NOTE: formatting here should match the format we use for Argument type in QueryQueue
             // TODO: abstract this so they cannot mismatch
 
             // Since balance are stored as TEXT in db, we cannot directly use INSERT OR UPDATE
-            // statements.
-            // Fetch balances for both `from` and `to` addresses, update them and write back to db
+            // statements. Fetch balances for both `from` and `to` addresses, update them and
+            // write back to db
             let query = sqlx::query_as::<_, (String, String)>(
                 "SELECT account_address, balance FROM balances WHERE contract_address = ? AND \
                  account_address IN (?, ?)",
@@ -1463,10 +1462,11 @@ impl Sql {
             );
         }
 
-        // Insert transfer event to erc721_transfers table
+        // Insert transfer event to erc_transfers table
         {
-            let insert_query = "INSERT INTO erc721_transfers (contract_address, from_address, \
-                                to_address, token_id, executed_at) VALUES (?, ?, ?, ?, ?)";
+            let insert_query = "INSERT INTO erc_transfers (contract_address, from_address, \
+                                to_address, amount, token_id, executed_at) VALUES (?, ?, ?, ?, ?, \
+                                ?)";
 
             self.query_queue.enqueue(
                 insert_query,
@@ -1474,13 +1474,14 @@ impl Sql {
                     Argument::FieldElement(contract_address),
                     Argument::FieldElement(from),
                     Argument::FieldElement(to),
+                    Argument::String(u256_to_sql_string(&U256::from(1u8))),
                     Argument::String(token_id.clone()),
                     Argument::String(utc_dt_string_from_timestamp(block_timestamp)),
                 ],
             );
         }
 
-        // Update balances in erc721_balances table
+        // Update balance in balances table
         {
             let update_query = "
             INSERT INTO balances (id, balance, account_address, contract_address, token_id)

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -1336,7 +1336,7 @@ impl Sql {
                 .iter()
                 .find(|(address, _)| address == &format!("{:#x}", from))
                 .map(|(_, balance)| balance.clone())
-                .unwrap_or_else(|| format!("{:#63x}", crypto_bigint::U256::ZERO));
+                .unwrap_or_else(|| format!("{:#64x}", crypto_bigint::U256::ZERO));
 
             let to_balance = balances
                 .iter()

--- a/crates/torii/core/src/sql_test.rs
+++ b/crates/torii/core/src/sql_test.rs
@@ -52,7 +52,8 @@ where
         HashMap::default(),
     );
 
-    let _ = engine.sync_to_head(0, None).await?;
+    let res = engine.fetch_events().await?;
+    engine.process_fetch_result(res).await?;
 
     Ok(engine)
 }

--- a/crates/torii/graphql/src/query/data.rs
+++ b/crates/torii/graphql/src/query/data.rs
@@ -25,8 +25,8 @@ pub async fn count_rows(
 }
 
 pub async fn fetch_world_address(conn: &mut SqliteConnection) -> Result<String> {
-    let query = "SELECT world_address FROM worlds".to_string();
-    let res: (String,) = sqlx::query_as(&query).fetch_one(conn).await?;
+    let query = "SELECT contract_address FROM contracts where contract_type = ?".to_string();
+    let res: (String,) = sqlx::query_as(&query).bind("WORLD").fetch_one(conn).await?;
     Ok(res.0)
 }
 

--- a/crates/torii/graphql/src/tests/mod.rs
+++ b/crates/torii/graphql/src/tests/mod.rs
@@ -366,7 +366,8 @@ pub async fn spinup_types_test() -> Result<SqlitePool> {
         HashMap::default(),
     );
 
-    let _ = engine.sync_to_head(0, None).await?;
+    let res = engine.fetch_events().await.unwrap();
+    engine.process_fetch_result(res).await.unwrap();
 
     Ok(pool)
 }

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -132,7 +132,7 @@ impl DojoWorld {
 impl DojoWorld {
     pub async fn metadata(&self) -> Result<proto::types::WorldMetadata, Error> {
         let world_address = sqlx::query_scalar(&format!(
-            "SELECT world_address FROM worlds WHERE id = '{:#x}'",
+            "SELECT contract_address FROM contracts WHERE id = '{:#x}'",
             self.world_address
         ))
         .fetch_one(&self.pool)

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -112,7 +112,8 @@ async fn test_entities_queries() {
         HashMap::default(),
     );
 
-    let _ = engine.sync_to_head(0, None).await.unwrap();
+    let res = engine.fetch_events().await.unwrap();
+    engine.process_fetch_result(res).await.unwrap();
 
     let (_, receiver) = tokio::sync::mpsc::channel(1);
     let grpc = DojoWorld::new(db.pool, receiver, strat.world_address, provider.clone());

--- a/crates/torii/migrations/20240803102207_add_erc.sql
+++ b/crates/torii/migrations/20240803102207_add_erc.sql
@@ -3,8 +3,8 @@ CREATE TABLE contracts (
     id TEXT NOT NULL PRIMARY KEY,
     contract_address TEXT NOT NULL,
     contract_type TEXT NOT NULL,
-    head BIGINT NOT NULL DEFAULT 0,
-    pending_block_tx TEXT NULL DEFAULT NULL
+    head INTEGER,
+    latest_block_tx TEXT NULL DEFAULT NULL
 );
 
 CREATE TABLE balances (

--- a/crates/torii/migrations/20240820102556_worlds_entry_to_contracts.sql
+++ b/crates/torii/migrations/20240820102556_worlds_entry_to_contracts.sql
@@ -1,3 +1,4 @@
 -- remove unused tables
+-- TODO: move old data to contracts table
 DROP TABLE worlds;
 DROP TABLE indexers;

--- a/crates/torii/migrations/20240820102556_worlds_entry_to_contracts.sql
+++ b/crates/torii/migrations/20240820102556_worlds_entry_to_contracts.sql
@@ -1,0 +1,3 @@
+-- remove unused tables
+DROP TABLE worlds;
+DROP TABLE indexers;


### PR DESCRIPTION
# Description

fix: #2263 
- use get_events with BlockTag::Pending instead of handling range and pending block separately
- combine worlds and indexer table to generic `contracts` table (which also contains erc token addresses)
- erc tokens now have there own head/latest_pending_tx
- make future in select branch cancel safe