### PR TITLE
fix(schema): empty array name

### DIFF
--- a/crates/dojo-types/src/schema.rs
+++ b/crates/dojo-types/src/schema.rs
@@ -56,7 +56,13 @@ impl Ty {
             Ty::Struct(s) => s.name.clone(),
             Ty::Enum(e) => e.name.clone(),
             Ty::Tuple(tys) => format!("({})", tys.iter().map(|ty| ty.name()).join(", ")),
-            Ty::Array(ty) => format!("Array<{}>", ty[0].name()),
+            Ty::Array(ty) => {
+                if let Some(inner) = ty.first() {
+                    format!("Array<{}>", inner.name())
+                } else {
+                    "Array".to_string()
+                }
+            }
             Ty::ByteArray(_) => "ByteArray".to_string(),
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of array types for better clarity in type representation: empty arrays are now displayed as "Array," while non-empty arrays show the type of the first element. 

These changes enhance the user experience by providing more meaningful and accurate type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->