### PR TITLE
chore: use provided namespace on no mapping

### DIFF
--- a/crates/dojo-world/src/config/namespace_config.rs
+++ b/crates/dojo-world/src/config/namespace_config.rs
@@ -75,8 +75,10 @@ impl NamespaceConfig {
                 .and_then(|m| m.get(namespace))
                 .unwrap_or(&self.default)
                 .to_string()
-        } else {
+        } else if self.default.len() > 0 {
             self.default.clone()
+        } else {
+            tag_or_namespace.into()
         }
     }
 


### PR DESCRIPTION
# Description

If there's no mapping use default namespace

## Related issue

None

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [x] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced flexibility in configuration handling by modifying the return logic for namespace settings, allowing for a broader range of inputs.
  
- **Bug Fixes**
	- Improved handling of default values in configuration, ensuring more accurate results based on user-defined parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->