### PR TITLE
fix(katana): prevent from resending messages to L1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7920,6 +7920,7 @@ dependencies = [
 name = "katana-db"
 version = "1.0.0-alpha.12"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "criterion",
  "dojo-metrics",

--- a/crates/katana/core/src/backend/storage.rs
+++ b/crates/katana/core/src/backend/storage.rs
@@ -7,6 +7,7 @@ use katana_provider::providers::db::DbProvider;
 use katana_provider::traits::block::{BlockProvider, BlockWriter};
 use katana_provider::traits::contract::ContractClassWriter;
 use katana_provider::traits::env::BlockEnvProvider;
+use katana_provider::traits::messaging::MessagingProvider;
 use katana_provider::traits::state::{StateFactoryProvider, StateRootProvider, StateWriter};
 use katana_provider::traits::state_update::StateUpdateProvider;
 use katana_provider::traits::transaction::{
@@ -29,6 +30,7 @@ pub trait Database:
     + ContractClassWriter
     + StateFactoryProvider
     + BlockEnvProvider
+    + MessagingProvider
     + 'static
     + Send
     + Sync
@@ -50,6 +52,7 @@ impl<T> Database for T where
         + ContractClassWriter
         + StateFactoryProvider
         + BlockEnvProvider
+        + MessagingProvider
         + 'static
         + Send
         + Sync

--- a/crates/katana/core/src/backend/storage.rs
+++ b/crates/katana/core/src/backend/storage.rs
@@ -7,7 +7,7 @@ use katana_provider::providers::db::DbProvider;
 use katana_provider::traits::block::{BlockProvider, BlockWriter};
 use katana_provider::traits::contract::ContractClassWriter;
 use katana_provider::traits::env::BlockEnvProvider;
-use katana_provider::traits::messaging::MessagingProvider;
+use katana_provider::traits::messaging::MessagingCheckpointProvider;
 use katana_provider::traits::state::{StateFactoryProvider, StateRootProvider, StateWriter};
 use katana_provider::traits::state_update::StateUpdateProvider;
 use katana_provider::traits::transaction::{
@@ -30,7 +30,7 @@ pub trait Database:
     + ContractClassWriter
     + StateFactoryProvider
     + BlockEnvProvider
-    + MessagingProvider
+    + MessagingCheckpointProvider
     + 'static
     + Send
     + Sync
@@ -52,7 +52,7 @@ impl<T> Database for T where
         + ContractClassWriter
         + StateFactoryProvider
         + BlockEnvProvider
-        + MessagingProvider
+        + MessagingCheckpointProvider
         + 'static
         + Send
         + Sync

--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -16,7 +16,6 @@ use katana_primitives::receipt::Receipt;
 use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{ExecutableTxWithHash, Tx, TxHash, TxWithHash};
 use katana_primitives::version::CURRENT_STARKNET_VERSION;
-use katana_primitives::Felt;
 use katana_provider::error::ProviderError;
 use katana_provider::traits::block::{BlockHashProvider, BlockNumberProvider};
 use katana_provider::traits::env::BlockEnvProvider;
@@ -318,16 +317,7 @@ impl<EF: ExecutorFactory> IntervalBlockProducer<EF> {
                 trace!(target: LOG_TARGET, "Executed transaction: {:?}", tx);
                 let _ = match tx_ref {
                     Tx::L1Handler(l1_tx) => {
-                        // get stored nonce from message hash
-                        let message_hash_bytes = l1_tx.message_hash;
-                        let message_hash_bytes: [u8; 32] = *message_hash_bytes;
-
-                        let message_hash = Felt::from_bytes_be(&message_hash_bytes);
-                        match provider.get_nonce_from_message_hash(message_hash) {
-                            Ok(Some(nonce)) => provider.set_inbound_nonce(nonce),
-                            Ok(None) => Ok(()),
-                            Err(_e) => Ok(()),
-                        }
+                        provider.process_message_nonce(l1_tx)
                     }
                     _ => Ok(()),
                 };

--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -324,7 +324,7 @@ impl<EF: ExecutorFactory> IntervalBlockProducer<EF> {
 
                         let message_hash = Felt::from_bytes_be(&message_hash_bytes);
                         match provider.get_nonce_from_message_hash(message_hash) {
-                            Ok(Some(nonce)) => provider.set_gather_message_nonce(nonce),
+                            Ok(Some(nonce)) => provider.set_inbound_nonce(nonce),
                             Ok(None) => Ok(()),
                             Err(_e) => Ok(()),
                         }

--- a/crates/katana/core/src/service/messaging/mod.rs
+++ b/crates/katana/core/src/service/messaging/mod.rs
@@ -112,6 +112,10 @@ pub struct MessagingConfig {
     pub interval: u64,
     /// The block on settlement chain from where Katana will start fetching messages.
     pub from_block: u64,
+    /// The maximum number of blocks in gather messages
+    pub max_block: u64,
+    /// The size of events returned by get_events call
+    pub chunk_size: u64,
 }
 
 impl MessagingConfig {

--- a/crates/katana/core/src/service/messaging/service.rs
+++ b/crates/katana/core/src/service/messaging/service.rs
@@ -58,16 +58,20 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
             Ok(Some(block)) => block,
             Ok(None) => 0,
             Err(_) => {
-                anyhow::bail!("Messaging could not be initialized.\nVerify that the messaging target node \
-                     (anvil or other katana) is running.\n")
+                anyhow::bail!(
+                    "Messaging could not be initialized.\nVerify that the messaging target node \
+                     (anvil or other katana) is running.\n"
+                )
             }
         };
         let send_from_block = match provider.get_send_from_block() {
             Ok(Some(block)) => block,
             Ok(None) => 0,
             Err(_) => {
-                anyhow::bail!("Messaging could not be initialized.\nVerify that the messaging target node \
-                     (anvil or other katana) is running.\n")
+                anyhow::bail!(
+                    "Messaging could not be initialized.\nVerify that the messaging target node \
+                     (anvil or other katana) is running.\n"
+                )
             }
         };
 
@@ -78,8 +82,10 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
         let messenger = match MessengerMode::from_config(config).await {
             Ok(m) => Arc::new(m),
             Err(_) => {
-                anyhow::bail!("Messaging could not be initialized.\nVerify that the messaging target node \
-                     (anvil or other katana) is running.\n")
+                anyhow::bail!(
+                    "Messaging could not be initialized.\nVerify that the messaging target node \
+                     (anvil or other katana) is running.\n"
+                )
             }
         };
 
@@ -105,7 +111,6 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
         max_block: u64,
         chunk_size: u64,
     ) -> MessengerResult<(u64, usize)> {
-
         match messenger.as_ref() {
             MessengerMode::Ethereum(inner) => {
                 let (block_num, txs) =
@@ -126,8 +131,9 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
 
             #[cfg(feature = "starknet-messaging")]
             MessengerMode::Starknet(inner) => {
-                let (block_num, txs) =
-                    inner.gather_messages(from_block, max_block, chunk_size, backend.chain_id).await?;
+                let (block_num, txs) = inner
+                    .gather_messages(from_block, max_block, chunk_size, backend.chain_id)
+                    .await?;
                 let txs_count = txs.len();
 
                 txs.into_iter().for_each(|tx| {

--- a/crates/katana/core/src/service/messaging/service.rs
+++ b/crates/katana/core/src/service/messaging/service.rs
@@ -213,6 +213,7 @@ impl<EF: ExecutorFactory> Stream for MessagingService<EF> {
                     pin.backend.clone(),
                     pin.gather_from_block,
                     pin.max_block,
+                    pin.chunk_size,
                 )));
             }
 

--- a/crates/katana/core/src/service/messaging/service.rs
+++ b/crates/katana/core/src/service/messaging/service.rs
@@ -10,8 +10,8 @@ use katana_primitives::block::BlockHashOrNumber;
 use katana_primitives::receipt::MessageToL1;
 use katana_primitives::transaction::{ExecutableTxWithHash, L1HandlerTx, TxHash};
 use katana_provider::traits::block::BlockNumberProvider;
-use katana_provider::traits::transaction::ReceiptProvider;
 use katana_provider::traits::messaging::MessagingProvider;
+use katana_provider::traits::transaction::ReceiptProvider;
 use tokio::time::{interval_at, Instant, Interval};
 use tracing::{error, info};
 
@@ -52,9 +52,7 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
         let provider = backend.blockchain.provider();
         let gather_from_block = match provider.get_gather_from_block() {
             Ok(Some(block)) => block,
-            Ok(None) => {
-                0
-            }
+            Ok(None) => 0,
             Err(_) => {
                 panic!(
                     "Messaging could not be initialized.\nVerify that the messaging target node \
@@ -64,9 +62,7 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
         };
         let send_from_block = match provider.get_send_from_block() {
             Ok(Some(block)) => block,
-            Ok(None) => {
-                0
-            }
+            Ok(None) => 0,
             Err(_) => {
                 panic!(
                     "Messaging could not be initialized.\nVerify that the messaging target node \
@@ -235,7 +231,11 @@ impl<EF: ExecutorFactory> Stream for MessagingService<EF> {
             match gather_fut.poll_unpin(cx) {
                 Poll::Ready(Ok((last_block, msg_count))) => {
                     pin.gather_from_block = last_block + 1;
-                    let _ = pin.backend.blockchain.provider().set_gather_from_block(pin.gather_from_block);
+                    let _ = pin
+                        .backend
+                        .blockchain
+                        .provider()
+                        .set_gather_from_block(pin.gather_from_block);
                     return Poll::Ready(Some(MessagingOutcome::Gather {
                         lastest_block: last_block,
                         msg_count,
@@ -261,7 +261,8 @@ impl<EF: ExecutorFactory> Stream for MessagingService<EF> {
                     // +1 to move to the next local block to check messages to be
                     // sent on the settlement chain.
                     pin.send_from_block += 1;
-                    let _ = pin.backend.blockchain.provider().set_send_from_block(pin.send_from_block);
+                    let _ =
+                        pin.backend.blockchain.provider().set_send_from_block(pin.send_from_block);
                     return Poll::Ready(Some(MessagingOutcome::Send { block_num, msg_count }));
                 }
                 Poll::Ready(Err(e)) => {

--- a/crates/katana/core/src/service/messaging/starknet.rs
+++ b/crates/katana/core/src/service/messaging/starknet.rs
@@ -204,10 +204,14 @@ impl Messenger for StarknetMessaging {
                     event = ?e,
                     "Converting event into L1HandlerTx."
                 );
-
-                if let Ok(tx) = l1_handler_tx_from_event(e, chain_id) {
-                    l1_handler_txs.push(tx)
-                }
+                block_events.iter().for_each(|e| {
+                    if let Ok(tx) = l1_handler_tx_from_event(e, chain_id) {
+                        let last_processed_nonce = self.provider.get_gather_message_nonce().unwrap_or(0.into());
+                        if tx.nonce > last_processed_nonce {
+                            l1_handler_txs.push(tx)
+                        }
+                    }
+                })
             });
 
         Ok((to_block, l1_handler_txs))
@@ -236,6 +240,10 @@ impl Messenger for StarknetMessaging {
         }
 
         self.send_hashes(hashes.clone()).await?;
+        for (index, hash) in hashes.iter().enumerate() {
+            self.send_hashes(std::slice::from_ref(hash)).await?;
+            self.provider.set_send_from_index(*hash, index as u64).await?;
+        }
 
         Ok(hashes)
     }

--- a/crates/katana/primitives/src/contract.rs
+++ b/crates/katana/primitives/src/contract.rs
@@ -14,6 +14,9 @@ pub type StorageValue = Felt;
 /// Represents the type for a contract nonce.
 pub type Nonce = Felt;
 
+/// Represents the type for a message hash.
+pub type MessageHash = FieldElement;
+
 /// Represents a contract address.
 #[derive(Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Debug, Deref)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/katana/primitives/src/contract.rs
+++ b/crates/katana/primitives/src/contract.rs
@@ -15,7 +15,7 @@ pub type StorageValue = Felt;
 pub type Nonce = Felt;
 
 /// Represents the type for a message hash.
-pub type MessageHash = FieldElement;
+pub type MessageHash = Felt;
 
 /// Represents a contract address.
 #[derive(Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Debug, Deref)]

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -270,7 +270,7 @@ pub struct GenesisJson {
     pub accounts: HashMap<ContractAddress, GenesisAccountJson>,
     #[serde(default)]
     pub contracts: HashMap<ContractAddress, GenesisContractJson>,
-    pub gather_from_block: BlockNumber,
+    pub settlement_block_number: BlockNumber,
 }
 
 impl GenesisJson {
@@ -612,7 +612,7 @@ impl TryFrom<GenesisJson> for Genesis {
             gas_prices: value.gas_prices,
             state_root: value.state_root,
             parent_hash: value.parent_hash,
-            gather_from_block: value.gather_from_block,
+            settlement_block_number: value.settlement_block_number,
         })
     }
 }

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -1041,6 +1041,7 @@ mod tests {
         let expected_genesis = Genesis {
             classes: expected_classes,
             number: 0,
+            gather_from_block: 0,
             fee_token: expected_fee_token,
             allocations: expected_allocations,
             timestamp: 5123512314u64,
@@ -1181,6 +1182,7 @@ mod tests {
             classes,
             allocations,
             number: 0,
+            gather_from_block: 0,
             timestamp: 5123512314u64,
             state_root: felt!("0x99"),
             parent_hash: felt!("0x999"),

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -612,7 +612,7 @@ impl TryFrom<GenesisJson> for Genesis {
             gas_prices: value.gas_prices,
             state_root: value.state_root,
             parent_hash: value.parent_hash,
-            gather_from_block: value.gather_from_block
+            gather_from_block: value.gather_from_block,
         })
     }
 }

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -270,6 +270,7 @@ pub struct GenesisJson {
     pub accounts: HashMap<ContractAddress, GenesisAccountJson>,
     #[serde(default)]
     pub contracts: HashMap<ContractAddress, GenesisContractJson>,
+    pub gather_from_block: BlockNumber,
 }
 
 impl GenesisJson {
@@ -611,6 +612,7 @@ impl TryFrom<GenesisJson> for Genesis {
             gas_prices: value.gas_prices,
             state_root: value.state_root,
             parent_hash: value.parent_hash,
+            gather_from_block: value.gather_from_block
         })
     }
 }

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -428,6 +428,7 @@ mod tests {
             fee_token: fee_token.clone(),
             allocations: BTreeMap::from(allocations.clone()),
             number: 0,
+            gather_from_block: 0,
             timestamp: 5123512314u64,
             state_root: felt!("0x99"),
             parent_hash: felt!("0x999"),

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -106,7 +106,7 @@ pub struct Genesis {
     /// The genesis contract allocations.
     pub allocations: BTreeMap<ContractAddress, GenesisAllocation>,
     /// The block on settlement chain from where Katana will start fetching messages.
-    pub gather_from_block: BlockNumber,
+    pub settlement_block_number: BlockNumber,
 }
 
 impl Genesis {
@@ -311,7 +311,7 @@ impl Default for Genesis {
             allocations: BTreeMap::new(),
             fee_token,
             universal_deployer: Some(universal_deployer),
-            gather_from_block: 0,
+            settlement_block_number: 0,
         }
     }
 }

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -428,7 +428,7 @@ mod tests {
             fee_token: fee_token.clone(),
             allocations: BTreeMap::from(allocations.clone()),
             number: 0,
-            gather_from_block: 0,
+            settlement_block_number: 0,
             timestamp: 5123512314u64,
             state_root: felt!("0x99"),
             parent_hash: felt!("0x999"),

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -105,6 +105,8 @@ pub struct Genesis {
     pub universal_deployer: Option<UniversalDeployerConfig>,
     /// The genesis contract allocations.
     pub allocations: BTreeMap<ContractAddress, GenesisAllocation>,
+    /// The block on settlement chain from where Katana will start fetching messages.
+    pub gather_from_block: BlockNumber,
 }
 
 impl Genesis {
@@ -309,6 +311,7 @@ impl Default for Genesis {
             allocations: BTreeMap::new(),
             fee_token,
             universal_deployer: Some(universal_deployer),
+            gather_from_block: 0,
         }
     }
 }

--- a/crates/katana/storage/db/Cargo.toml
+++ b/crates/katana/storage/db/Cargo.toml
@@ -21,6 +21,8 @@ tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 
+alloy-primitives.workspace = true
+
 # codecs
 [dependencies.postcard]
 default-features = false

--- a/crates/katana/storage/db/src/models/storage.rs
+++ b/crates/katana/storage/db/src/models/storage.rs
@@ -83,6 +83,43 @@ impl Decompress for ContractStorageEntry {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessagingCheckpointId {
+    SendBlock,
+    SendIndex,
+    GatherBlock,
+    GatherNonce,
+}
+
+
+impl Encode for MessagingCheckpointId {
+    type Encoded = [u8; 1];
+    fn encode(self) -> Self::Encoded {
+        let mut buf = [0u8; 1];
+        buf[0] = match self {
+            MessagingCheckpointId::SendBlock => 1,
+            MessagingCheckpointId::SendIndex => 2,
+            MessagingCheckpointId::GatherBlock => 3,
+            MessagingCheckpointId::GatherNonce => 4,
+        };
+        buf
+    }
+}
+
+impl Decode for MessagingCheckpointId {
+    fn decode<B: AsRef<[u8]>>(bytes: B) -> Result<Self, CodecError> {
+        let bytes = bytes.as_ref();
+        match bytes[0] {
+            1 => Ok(MessagingCheckpointId::SendBlock),
+            2 => Ok(MessagingCheckpointId::SendIndex),
+            3 => Ok(MessagingCheckpointId::GatherBlock),
+            4 => Ok(MessagingCheckpointId::GatherNonce),
+            _ => Err(CodecError::Decode("Invalid MessagingCheckpointId".into())),
+        }
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use starknet::macros::felt;

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -44,7 +44,7 @@ pub enum TableType {
     DupSort,
 }
 
-pub const NUM_TABLES: usize = 23;
+pub const NUM_TABLES: usize = 24;
 
 /// Macro to declare `libmdbx` tables.
 #[macro_export]
@@ -167,7 +167,8 @@ define_tables_enum! {[
     (NonceChangeHistory, TableType::DupSort),
     (ClassChangeHistory, TableType::DupSort),
     (StorageChangeHistory, TableType::DupSort),
-    (StorageChangeSet, TableType::Table)
+    (StorageChangeSet, TableType::Table),
+    (MessagingInfo, TableType::Table)
 ]}
 
 tables! {
@@ -223,8 +224,10 @@ tables! {
     /// storage change set
     StorageChangeSet: (ContractStorageKey) => BlockList,
     /// Account storage change set
-    StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry
+    StorageChangeHistory: (BlockNumber, ContractStorageKey) => ContractStorageEntry,
 
+    /// Stores the block number related to messaging service
+    MessagingInfo: (u64) => BlockNumber
 }
 
 #[cfg(test)]
@@ -258,6 +261,7 @@ mod tests {
         assert_eq!(Tables::ALL[20].name(), ClassChangeHistory::NAME);
         assert_eq!(Tables::ALL[21].name(), StorageChangeHistory::NAME);
         assert_eq!(Tables::ALL[22].name(), StorageChangeSet::NAME);
+        assert_eq!(Tables::ALL[23].name(), MessagingInfo::NAME);
 
         assert_eq!(Tables::Headers.table_type(), TableType::Table);
         assert_eq!(Tables::BlockHashes.table_type(), TableType::Table);
@@ -282,6 +286,7 @@ mod tests {
         assert_eq!(Tables::ClassChangeHistory.table_type(), TableType::DupSort);
         assert_eq!(Tables::StorageChangeHistory.table_type(), TableType::DupSort);
         assert_eq!(Tables::StorageChangeSet.table_type(), TableType::Table);
+        assert_eq!(Tables::MessagingInfo.table_type(), TableType::Table);
     }
 
     use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};

--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -386,28 +386,28 @@ impl<Db> MessagingCheckpointProvider for BlockchainProvider<Db>
 where
     Db: MessagingCheckpointProvider,
 {
-    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-        self.provider.get_send_from_block()
+    fn get_outbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        self.provider.get_outbound_block()
     }
 
-    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
-        self.provider.set_send_from_block(send_from_block)
+    fn set_outbound_block(&self, outbound_block: BlockNumber) -> ProviderResult<()> {
+        self.provider.set_outbound_block(outbound_block)
     }
 
-    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-        self.provider.get_gather_from_block()
+    fn get_inbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        self.provider.get_inbound_block()
     }
 
-    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
-        self.provider.set_gather_from_block(gather_from_block)
+    fn set_inbound_block(&self, inbound_block: BlockNumber) -> ProviderResult<()> {
+        self.provider.set_inbound_block(inbound_block)
     }
 
-    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
-        self.provider.get_gather_message_nonce()
+    fn get_inbound_nonce(&self) -> ProviderResult<Option<Nonce>> {
+        self.provider.get_inbound_nonce()
     }
 
-    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
-        self.provider.set_gather_message_nonce(nonce)
+    fn set_inbound_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
+        self.provider.set_inbound_nonce(nonce)
     }
 
     fn get_nonce_from_message_hash(&self, message_hash: MessageHash) -> ProviderResult<Option<Nonce>> {
@@ -418,11 +418,11 @@ where
         self.provider.set_nonce_from_message_hash(message_hash, nonce)
     }
 
-    fn get_send_from_index(&self) -> ProviderResult<Option<u64>> {
-        self.provider.get_send_from_index()
+    fn get_outbound_index(&self) -> ProviderResult<Option<u64>> {
+        self.provider.get_outbound_index()
     }
 
-    fn set_send_from_index(&self, send_from_index: u64) -> ProviderResult<()> {
-        self.provider.set_send_from_index(send_from_index)
+    fn set_outbound_index(&self, outbound_index: u64) -> ProviderResult<()> {
+        self.provider.set_outbound_index(outbound_index)
     }
 }

--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -16,6 +16,7 @@ use katana_primitives::Felt;
 use traits::block::{BlockIdReader, BlockStatusProvider, BlockWriter};
 use traits::contract::{ContractClassProvider, ContractClassWriter};
 use traits::env::BlockEnvProvider;
+use traits::messaging::MessagingProvider;
 use traits::state::{StateRootProvider, StateWriter};
 use traits::transaction::{TransactionStatusProvider, TransactionTraceProvider};
 
@@ -378,5 +379,26 @@ where
 {
     fn block_env_at(&self, id: BlockHashOrNumber) -> ProviderResult<Option<BlockEnv>> {
         self.provider.block_env_at(id)
+    }
+}
+
+impl<Db> MessagingProvider for BlockchainProvider<Db>
+where
+    Db: MessagingProvider,
+{
+    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+         self.provider.get_send_from_block()
+    }
+
+    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
+         self.provider.set_send_from_block(send_from_block)
+    }
+
+    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+         self.provider.get_gather_from_block()
+    }
+
+    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
+         self.provider.set_gather_from_block(gather_from_block)
     }
 }

--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -16,7 +16,7 @@ use katana_primitives::Felt;
 use traits::block::{BlockIdReader, BlockStatusProvider, BlockWriter};
 use traits::contract::{ContractClassProvider, ContractClassWriter};
 use traits::env::BlockEnvProvider;
-use traits::messaging::MessagingProvider;
+use traits::messaging::MessagingCheckpointProvider;
 use traits::state::{StateRootProvider, StateWriter};
 use traits::transaction::{TransactionStatusProvider, TransactionTraceProvider};
 
@@ -382,9 +382,9 @@ where
     }
 }
 
-impl<Db> MessagingProvider for BlockchainProvider<Db>
+impl<Db> MessagingCheckpointProvider for BlockchainProvider<Db>
 where
-    Db: MessagingProvider,
+    Db: MessagingCheckpointProvider,
 {
     fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
         self.provider.get_send_from_block()
@@ -422,7 +422,7 @@ where
         self.provider.get_send_from_index()
     }
 
-    fn set_send_from_index(&self, _send_from_index: u64) -> ProviderResult<()> {
-        self.provider.get_send_from_index(send_from_index)
+    fn set_send_from_index(&self, send_from_index: u64) -> ProviderResult<()> {
+        self.provider.set_send_from_index(send_from_index)
     }
 }

--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -6,7 +6,7 @@ use katana_primitives::block::{
     SealedBlockWithStatus,
 };
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
-use katana_primitives::contract::{ContractAddress, StorageKey, StorageValue};
+use katana_primitives::contract::{ContractAddress, MessageHash, Nonce, StorageKey, StorageValue};
 use katana_primitives::env::BlockEnv;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
@@ -400,5 +400,29 @@ where
 
     fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
         self.provider.set_gather_from_block(gather_from_block)
+    }
+
+    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
+        self.provider.get_gather_message_nonce()
+    }
+
+    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
+        self.provider.set_gather_message_nonce(nonce)
+    }
+
+    fn get_nonce_from_message_hash(&self, message_hash: MessageHash) -> ProviderResult<Option<Nonce>> {
+        self.provider.get_nonce_from_message_hash(message_hash)
+    }
+
+    fn set_nonce_from_message_hash(&self, message_hash: MessageHash, nonce: Nonce) -> ProviderResult<()> {
+        self.provider.set_nonce_from_message_hash(message_hash, nonce)
+    }
+
+    fn get_send_from_index(&self) -> ProviderResult<Option<u64>> {
+        self.provider.get_send_from_index()
+    }
+
+    fn set_send_from_index(&self, _send_from_index: u64) -> ProviderResult<()> {
+        self.provider.get_send_from_index(send_from_index)
     }
 }

--- a/crates/katana/storage/provider/src/lib.rs
+++ b/crates/katana/storage/provider/src/lib.rs
@@ -387,18 +387,18 @@ where
     Db: MessagingProvider,
 {
     fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-         self.provider.get_send_from_block()
+        self.provider.get_send_from_block()
     }
 
     fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
-         self.provider.set_send_from_block(send_from_block)
+        self.provider.set_send_from_block(send_from_block)
     }
 
     fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-         self.provider.get_gather_from_block()
+        self.provider.get_gather_from_block()
     }
 
     fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
-         self.provider.set_gather_from_block(gather_from_block)
+        self.provider.set_gather_from_block(gather_from_block)
     }
 }

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -764,42 +764,42 @@ impl<Db: Database> BlockWriter for DbProvider<Db> {
 }
 
 impl MessagingCheckpointProvider for DbProvider {
-    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
+    fn set_outbound_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
         self.0.update(|db_tx| {
             db_tx.put::<tables::MessagingCheckpointBlock>(MessagingCheckpointId::SendBlock, send_from_block)?;
             Ok(())
         })?
     }
 
-    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+    fn get_outbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
         let db_tx = self.0.tx()?;
         let block_num = db_tx.get::<tables::MessagingCheckpointBlock>(MessagingCheckpointId::SendBlock)?;
         db_tx.commit()?;
         Ok(block_num)
     }
 
-    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
+    fn set_inbound_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
         self.0.update(|db_tx| {
             db_tx.put::<tables::MessagingCheckpointBlock>(MessagingCheckpointId::GatherBlock, gather_from_block)?;
             Ok(())
         })?
     }
 
-    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+    fn get_inbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
         let db_tx = self.0.tx()?;
         let block_num = db_tx.get::<tables::MessagingCheckpointBlock>(MessagingCheckpointId::GatherBlock)?;
         db_tx.commit()?;
         Ok(block_num)
     }
 
-    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
+    fn set_inbound_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
         self.0.update(|db_tx| {
             db_tx.put::<tables::MessagingCheckpointNonce>(MessagingCheckpointId::GatherNonce, nonce)?;
             Ok(())
         })?
     }
 
-    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
+    fn get_inbound_nonce(&self) -> ProviderResult<Option<Nonce>> {
         let db_tx = self.0.tx()?;
         let nonce = db_tx.get::<tables::MessagingCheckpointNonce>(MessagingCheckpointId::GatherNonce)?;
         db_tx.commit()?;
@@ -820,14 +820,14 @@ impl MessagingCheckpointProvider for DbProvider {
         Ok(nonce)
     }
 
-    fn set_send_from_index(&self, send_from_index: u64) -> ProviderResult<()> {
+    fn set_outbound_index(&self, send_from_index: u64) -> ProviderResult<()> {
         self.0.update(|db_tx| {
             db_tx.put::<tables::MessagingCheckpointIndex>(MessagingCheckpointId::SendIndex, send_from_index)?;
             Ok(())
         })?
     }
 
-    fn get_send_from_index(&self) -> ProviderResult<Option<u64>> {
+    fn get_outbound_index(&self) -> ProviderResult<Option<u64>> {
         let db_tx = self.0.tx()?;
         let index = db_tx.get::<tables::MessagingCheckpointIndex>(MessagingCheckpointId::SendIndex)?;
         db_tx.commit()?;

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -36,14 +36,15 @@ use crate::traits::block::{
     HeaderProvider,
 };
 use crate::traits::env::BlockEnvProvider;
+use crate::traits::messaging::MessagingProvider;
 use crate::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
     ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionTraceProvider,
     TransactionsProviderExt,
 };
+use crate::traits::messaging::{SEND_FROM_BLOCK_KEY, GATHER_FROM_BLOCK_KEY};
 use crate::ProviderResult;
-
 /// A provider implementation that uses a persistent database as the backend.
 // TODO: remove the default generic type
 #[derive(Debug)]
@@ -760,6 +761,37 @@ impl<Db: Database> BlockWriter for DbProvider<Db> {
 
             Ok(())
         })?
+    }
+}
+
+impl MessagingProvider for DbProvider {
+
+    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+         let db_tx = self.0.tx()?;
+         let block_num = db_tx.get::<tables::MessagingInfo>(SEND_FROM_BLOCK_KEY)?;
+         db_tx.commit()?;
+         Ok(block_num)
+    }
+
+    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
+         self.0.update(|db_tx| {
+             db_tx.put::<tables::MessagingInfo>(SEND_FROM_BLOCK_KEY, send_from_block)?;
+             Ok(())
+         })?
+    }
+
+    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+         let db_tx = self.0.tx()?;
+         let block_num = db_tx.get::<tables::MessagingInfo>(GATHER_FROM_BLOCK_KEY)?;
+         db_tx.commit()?;
+         Ok(block_num)
+    }
+
+    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
+         self.0.update(|db_tx| {
+             db_tx.put::<tables::MessagingInfo>(GATHER_FROM_BLOCK_KEY, gather_from_block)?;
+             Ok(())
+         })?
     }
 }
 

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -27,7 +27,7 @@ use katana_primitives::env::BlockEnv;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
 use katana_primitives::trace::TxExecInfo;
-use katana_primitives::transaction::{TxHash, TxNumber, TxWithHash};
+use katana_primitives::transaction::{L1HandlerTx, TxHash, TxNumber, TxWithHash};
 use katana_primitives::Felt;
 
 use crate::error::ProviderError;
@@ -832,6 +832,22 @@ impl MessagingCheckpointProvider for DbProvider {
         let index = db_tx.get::<tables::MessagingCheckpointIndex>(MessagingCheckpointId::SendIndex)?;
         db_tx.commit()?;
         Ok(index)
+    }
+
+    fn process_message_nonce(&self, l1_tx: &L1HandlerTx) -> ProviderResult<()>{
+        // Get stored nonce from message hash
+        let message_hash_bytes = l1_tx.message_hash;
+        let message_hash_bytes: [u8; 32] = *message_hash_bytes;
+        let message_hash = Felt::from_bytes_be(&message_hash_bytes);
+
+        // Attempt to get the nonce from the message hash
+        match self.get_nonce_from_message_hash(message_hash) {
+            Ok(Some(nonce)) =>
+            // Set the inbound nonce if a nonce is retrieved
+                self.set_inbound_nonce(nonce),
+            Ok(None) => Ok(()),
+            Err(_e) => Ok(()),
+        }
     }
 }
 

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -36,14 +36,13 @@ use crate::traits::block::{
     HeaderProvider,
 };
 use crate::traits::env::BlockEnvProvider;
-use crate::traits::messaging::MessagingProvider;
+use crate::traits::messaging::{MessagingProvider, GATHER_FROM_BLOCK_KEY, SEND_FROM_BLOCK_KEY};
 use crate::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
     ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionTraceProvider,
     TransactionsProviderExt,
 };
-use crate::traits::messaging::{SEND_FROM_BLOCK_KEY, GATHER_FROM_BLOCK_KEY};
 use crate::ProviderResult;
 /// A provider implementation that uses a persistent database as the backend.
 // TODO: remove the default generic type
@@ -765,33 +764,32 @@ impl<Db: Database> BlockWriter for DbProvider<Db> {
 }
 
 impl MessagingProvider for DbProvider {
-
     fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-         let db_tx = self.0.tx()?;
-         let block_num = db_tx.get::<tables::MessagingInfo>(SEND_FROM_BLOCK_KEY)?;
-         db_tx.commit()?;
-         Ok(block_num)
+        let db_tx = self.0.tx()?;
+        let block_num = db_tx.get::<tables::MessagingInfo>(SEND_FROM_BLOCK_KEY)?;
+        db_tx.commit()?;
+        Ok(block_num)
     }
 
     fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
-         self.0.update(|db_tx| {
-             db_tx.put::<tables::MessagingInfo>(SEND_FROM_BLOCK_KEY, send_from_block)?;
-             Ok(())
-         })?
+        self.0.update(|db_tx| {
+            db_tx.put::<tables::MessagingInfo>(SEND_FROM_BLOCK_KEY, send_from_block)?;
+            Ok(())
+        })?
     }
 
     fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-         let db_tx = self.0.tx()?;
-         let block_num = db_tx.get::<tables::MessagingInfo>(GATHER_FROM_BLOCK_KEY)?;
-         db_tx.commit()?;
-         Ok(block_num)
+        let db_tx = self.0.tx()?;
+        let block_num = db_tx.get::<tables::MessagingInfo>(GATHER_FROM_BLOCK_KEY)?;
+        db_tx.commit()?;
+        Ok(block_num)
     }
 
     fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
-         self.0.update(|db_tx| {
-             db_tx.put::<tables::MessagingInfo>(GATHER_FROM_BLOCK_KEY, gather_from_block)?;
-             Ok(())
-         })?
+        self.0.update(|db_tx| {
+            db_tx.put::<tables::MessagingInfo>(GATHER_FROM_BLOCK_KEY, gather_from_block)?;
+            Ok(())
+        })?
     }
 }
 

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -30,7 +30,7 @@ use crate::traits::block::{
 };
 use crate::traits::contract::ContractClassWriter;
 use crate::traits::env::BlockEnvProvider;
-use crate::traits::messaging::MessagingProvider;
+use crate::traits::messaging::MessagingCheckpointProvider;
 use crate::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider, StateWriter};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
@@ -583,45 +583,50 @@ impl BlockEnvProvider for ForkedProvider {
     }
 }
 
-impl MessagingProvider for ForkedProvider {
-    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-        Ok(None)
+impl MessagingCheckpointProvider for ForkedProvider {
+    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.send_block = Some(send_from_block);
+        Ok(())
     }
 
-    fn set_send_from_block(&self, _send_from_block: BlockNumber) -> ProviderResult<()> {
+    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        Ok(self.storage.read().messaging_info.send_block)
+    }
+
+    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.send_block = Some(gather_from_block);
         Ok(())
     }
 
     fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
-        Ok(None)
+        Ok(self.storage.read().messaging_info.gather_block)
     }
 
-    fn set_gather_from_block(&self, _gather_from_block: BlockNumber) -> ProviderResult<()> {
+    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
+        self.storage.write().messaging_info.gather_nonce = Some(nonce);
         Ok(())
     }
 
     fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
-        Ok(None)
+        Ok(self.storage.read().messaging_info.gather_nonce)
     }
 
-    fn set_gather_message_nonce(&self, _nonce: Nonce) -> ProviderResult<()> {
+    fn set_nonce_from_message_hash(&self, message_hash: MessageHash, nonce: Nonce) -> ProviderResult<()> {
+        self.storage.write().messaging_message_nonce_mapping.insert(message_hash, nonce);
         Ok(())
     }
 
-    fn get_nonce_from_message_hash(&self, _message_hash: MessageHash) -> ProviderResult<Option<Nonce>> {
-        Ok(None)
+    fn get_nonce_from_message_hash(&self, message_hash: MessageHash) -> ProviderResult<Option<Nonce>> {
+        Ok(self.storage.read().messaging_message_nonce_mapping.get(&message_hash).cloned())
     }
 
-    fn set_nonce_from_message_hash(&self, _message_hash: MessageHash, _nonce: Nonce) -> ProviderResult<()> {
+    fn set_send_from_index(&self, index: u64) -> ProviderResult<()> {
+        self.storage.write().messaging_info.send_index = Some(index);
         Ok(())
     }
 
     fn get_send_from_index(&self) -> ProviderResult<Option<u64>> {
-        Ok(None)
-    }
-
-    fn set_send_from_index(&self, _send_from_index: u64) -> ProviderResult<()> {
-        Ok(())
+        Ok(self.storage.read().messaging_info.send_index)
     }
 
 }

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -10,7 +10,7 @@ use katana_primitives::block::{
     SealedBlockWithStatus,
 };
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
-use katana_primitives::contract::ContractAddress;
+use katana_primitives::contract::{ContractAddress, MessageHash, Nonce};
 use katana_primitives::env::BlockEnv;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
@@ -599,4 +599,29 @@ impl MessagingProvider for ForkedProvider {
     fn set_gather_from_block(&self, _gather_from_block: BlockNumber) -> ProviderResult<()> {
         Ok(())
     }
+
+    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
+        Ok(None)
+    }
+
+    fn set_gather_message_nonce(&self, _nonce: Nonce) -> ProviderResult<()> {
+        Ok(())
+    }
+
+    fn get_nonce_from_message_hash(&self, _message_hash: MessageHash) -> ProviderResult<Option<Nonce>> {
+        Ok(None)
+    }
+
+    fn set_nonce_from_message_hash(&self, _message_hash: MessageHash, _nonce: Nonce) -> ProviderResult<()> {
+        Ok(())
+    }
+
+    fn get_send_from_index(&self) -> ProviderResult<Option<u64>> {
+        Ok(None)
+    }
+
+    fn set_send_from_index(&self, _send_from_index: u64) -> ProviderResult<()> {
+        Ok(())
+    }
+
 }

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -460,7 +460,6 @@ impl StateFactoryProvider for ForkedProvider {
     }
 }
 
-
 impl BlockWriter for ForkedProvider {
     fn insert_block_with_states_and_receipts(
         &self,
@@ -585,7 +584,6 @@ impl BlockEnvProvider for ForkedProvider {
 }
 
 impl MessagingProvider for ForkedProvider {
-
     fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
         Ok(None)
     }

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -584,30 +584,30 @@ impl BlockEnvProvider for ForkedProvider {
 }
 
 impl MessagingCheckpointProvider for ForkedProvider {
-    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
-        self.storage.write().messaging_info.send_block = Some(send_from_block);
+    fn set_outbound_block(&self, outbound_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.send_block = Some(outbound_block);
         Ok(())
     }
 
-    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+    fn get_outbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.storage.read().messaging_info.send_block)
     }
 
-    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
-        self.storage.write().messaging_info.send_block = Some(gather_from_block);
+    fn set_inbound_block(&self, inbound_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.gather_block = Some(inbound_block);
         Ok(())
     }
 
-    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+    fn get_inbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.storage.read().messaging_info.gather_block)
     }
 
-    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
+    fn set_inbound_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
         self.storage.write().messaging_info.gather_nonce = Some(nonce);
         Ok(())
     }
 
-    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
+    fn get_inbound_nonce(&self) -> ProviderResult<Option<Nonce>> {
         Ok(self.storage.read().messaging_info.gather_nonce)
     }
 
@@ -620,13 +620,12 @@ impl MessagingCheckpointProvider for ForkedProvider {
         Ok(self.storage.read().messaging_message_nonce_mapping.get(&message_hash).cloned())
     }
 
-    fn set_send_from_index(&self, index: u64) -> ProviderResult<()> {
-        self.storage.write().messaging_info.send_index = Some(index);
+    fn set_outbound_index(&self, outbound_index: u64) -> ProviderResult<()> {
+        self.storage.write().messaging_info.send_index = Some(outbound_index);
         Ok(())
     }
 
-    fn get_send_from_index(&self) -> ProviderResult<Option<u64>> {
+    fn get_outbound_index(&self) -> ProviderResult<Option<u64>> {
         Ok(self.storage.read().messaging_info.send_index)
     }
-
 }

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -30,6 +30,7 @@ use crate::traits::block::{
 };
 use crate::traits::contract::ContractClassWriter;
 use crate::traits::env::BlockEnvProvider;
+use crate::traits::messaging::MessagingProvider;
 use crate::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider, StateWriter};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
@@ -459,6 +460,7 @@ impl StateFactoryProvider for ForkedProvider {
     }
 }
 
+
 impl BlockWriter for ForkedProvider {
     fn insert_block_with_states_and_receipts(
         &self,
@@ -579,5 +581,24 @@ impl BlockEnvProvider for ForkedProvider {
             l1_gas_prices: header.gas_prices,
             sequencer_address: header.sequencer_address,
         }))
+    }
+}
+
+impl MessagingProvider for ForkedProvider {
+
+    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        Ok(None)
+    }
+
+    fn set_send_from_block(&self, _send_from_block: BlockNumber) -> ProviderResult<()> {
+        Ok(())
+    }
+
+    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        Ok(None)
+    }
+
+    fn set_gather_from_block(&self, _gather_from_block: BlockNumber) -> ProviderResult<()> {
+        Ok(())
     }
 }

--- a/crates/katana/storage/provider/src/providers/fork/mod.rs
+++ b/crates/katana/storage/provider/src/providers/fork/mod.rs
@@ -15,11 +15,11 @@ use katana_primitives::env::BlockEnv;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
 use katana_primitives::trace::TxExecInfo;
-use katana_primitives::transaction::{Tx, TxHash, TxNumber, TxWithHash};
+use katana_primitives::transaction::{L1HandlerTx, Tx, TxHash, TxNumber, TxWithHash};
 use parking_lot::RwLock;
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
-
+use katana_primitives::Felt;
 use self::backend::{Backend, BackendError, SharedStateProvider};
 use self::state::ForkedStateDb;
 use super::in_memory::cache::{CacheDb, CacheStateDb};
@@ -627,5 +627,21 @@ impl MessagingCheckpointProvider for ForkedProvider {
 
     fn get_outbound_index(&self) -> ProviderResult<Option<u64>> {
         Ok(self.storage.read().messaging_info.send_index)
+    }
+
+    fn process_message_nonce(&self, l1_tx: &L1HandlerTx) -> ProviderResult<()>{
+        // Get stored nonce from message hash
+        let message_hash_bytes = l1_tx.message_hash;
+        let message_hash_bytes: [u8; 32] = *message_hash_bytes;
+        let message_hash = Felt::from_bytes_be(&message_hash_bytes);
+
+        // Attempt to get the nonce from the message hash
+        match self.get_nonce_from_message_hash(message_hash) {
+            Ok(Some(nonce)) =>
+            // Set the inbound nonce if a nonce is retrieved
+                self.set_inbound_nonce(nonce),
+            Ok(None) => Ok(()),
+            Err(_e) => Ok(()),
+        }
     }
 }

--- a/crates/katana/storage/provider/src/providers/in_memory/cache.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/cache.rs
@@ -42,6 +42,14 @@ pub struct CacheStateDb<Db> {
     pub(crate) compiled_class_hashes: RwLock<CompiledClassHashesMap>,
 }
 
+#[derive(Default, Debug)]
+pub struct MessagingCheckpointId {
+    pub(crate) send_block: Option<BlockNumber>,
+    pub(crate) send_index: Option<u64>,
+    pub(crate) gather_block: Option<BlockNumber>,
+    pub(crate) gather_nonce: Option<Nonce>,
+}
+
 impl<Db> CacheStateDb<Db> {
     /// Applies the given state updates to the cache.
     pub fn insert_updates(&self, updates: StateUpdatesWithDeclaredClasses) {
@@ -89,10 +97,8 @@ pub struct CacheDb<Db> {
     pub(crate) transaction_hashes: HashMap<TxNumber, TxHash>,
     pub(crate) transaction_numbers: HashMap<TxHash, TxNumber>,
     pub(crate) transaction_block: HashMap<TxNumber, BlockNumber>,
-    pub(crate) messaging_info: HashMap<u64, BlockNumber>,
-    pub(crate) messaging_nonce_info: HashMap<u64, Nonce>,
+    pub(crate) messaging_info: MessagingCheckpointId,
     pub(crate) messaging_message_nonce_mapping: HashMap<Nonce, Nonce>,
-    pub(crate) messaging_index_info: HashMap<u64, u64>,
 }
 
 impl<Db> CacheStateDb<Db> {
@@ -126,9 +132,7 @@ impl<Db> CacheDb<Db> {
             latest_block_hash: Default::default(),
             latest_block_number: Default::default(),
             messaging_info: Default::default(),
-            messaging_nonce_info: Default::default(),
             messaging_message_nonce_mapping: Default::default(),
-            messaging_index_info: Default::default(),
         }
     }
 }

--- a/crates/katana/storage/provider/src/providers/in_memory/cache.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/cache.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use katana_db::models::block::StoredBlockBodyIndices;
 use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
+use katana_primitives::contract::Nonce;
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
 use katana_primitives::contract::{ContractAddress, GenericContractInfo, StorageKey, StorageValue};
 use katana_primitives::receipt::Receipt;
@@ -89,6 +90,9 @@ pub struct CacheDb<Db> {
     pub(crate) transaction_numbers: HashMap<TxHash, TxNumber>,
     pub(crate) transaction_block: HashMap<TxNumber, BlockNumber>,
     pub(crate) messaging_info: HashMap<u64, BlockNumber>,
+    pub(crate) messaging_nonce_info: HashMap<u64, Nonce>,
+    pub(crate) messaging_message_nonce_mapping: HashMap<Nonce, Nonce>,
+    pub(crate) messaging_index_info: HashMap<u64, u64>,
 }
 
 impl<Db> CacheStateDb<Db> {
@@ -122,6 +126,9 @@ impl<Db> CacheDb<Db> {
             latest_block_hash: Default::default(),
             latest_block_number: Default::default(),
             messaging_info: Default::default(),
+            messaging_nonce_info: Default::default(),
+            messaging_message_nonce_mapping: Default::default(),
+            messaging_index_info: Default::default(),
         }
     }
 }

--- a/crates/katana/storage/provider/src/providers/in_memory/cache.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/cache.rs
@@ -88,6 +88,7 @@ pub struct CacheDb<Db> {
     pub(crate) transaction_hashes: HashMap<TxNumber, TxHash>,
     pub(crate) transaction_numbers: HashMap<TxHash, TxNumber>,
     pub(crate) transaction_block: HashMap<TxNumber, BlockNumber>,
+    pub(crate) messaging_info: HashMap<u64, BlockNumber>,
 }
 
 impl<Db> CacheStateDb<Db> {
@@ -120,6 +121,7 @@ impl<Db> CacheDb<Db> {
             transactions_executions: Vec::new(),
             latest_block_hash: Default::default(),
             latest_block_number: Default::default(),
+            messaging_info: Default::default(),
         }
     }
 }

--- a/crates/katana/storage/provider/src/providers/in_memory/mod.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/mod.rs
@@ -26,14 +26,13 @@ use crate::traits::block::{
 };
 use crate::traits::contract::ContractClassWriter;
 use crate::traits::env::BlockEnvProvider;
-use crate::traits::messaging::MessagingProvider;
+use crate::traits::messaging::{MessagingProvider, GATHER_FROM_BLOCK_KEY, SEND_FROM_BLOCK_KEY};
 use crate::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider, StateWriter};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
     ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionTraceProvider,
     TransactionsProviderExt,
 };
-use crate::traits::messaging::{SEND_FROM_BLOCK_KEY, GATHER_FROM_BLOCK_KEY};
 use crate::ProviderResult;
 
 #[derive(Debug)]

--- a/crates/katana/storage/provider/src/providers/in_memory/mod.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/mod.rs
@@ -26,12 +26,14 @@ use crate::traits::block::{
 };
 use crate::traits::contract::ContractClassWriter;
 use crate::traits::env::BlockEnvProvider;
+use crate::traits::messaging::MessagingProvider;
 use crate::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider, StateWriter};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
     ReceiptProvider, TransactionProvider, TransactionStatusProvider, TransactionTraceProvider,
     TransactionsProviderExt,
 };
+use crate::traits::messaging::{SEND_FROM_BLOCK_KEY, GATHER_FROM_BLOCK_KEY};
 use crate::ProviderResult;
 
 #[derive(Debug)]
@@ -573,5 +575,25 @@ impl BlockEnvProvider for InMemoryProvider {
             l1_gas_prices: header.gas_prices,
             sequencer_address: header.sequencer_address,
         }))
+    }
+}
+
+impl MessagingProvider for InMemoryProvider {
+    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        Ok(self.storage.read().messaging_info.get(&SEND_FROM_BLOCK_KEY).cloned())
+    }
+
+    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.insert(SEND_FROM_BLOCK_KEY, send_from_block);
+        Ok(())
+    }
+
+    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+        Ok(self.storage.read().messaging_info.get(&GATHER_FROM_BLOCK_KEY).cloned())
+    }
+
+    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.insert(GATHER_FROM_BLOCK_KEY, gather_from_block);
+        Ok(())
     }
 }

--- a/crates/katana/storage/provider/src/providers/in_memory/mod.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/mod.rs
@@ -10,7 +10,7 @@ use katana_primitives::block::{
     SealedBlockWithStatus,
 };
 use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
-use katana_primitives::contract::ContractAddress;
+use katana_primitives::contract::{ContractAddress, MessageHash, Nonce};
 use katana_primitives::env::BlockEnv;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
@@ -26,7 +26,7 @@ use crate::traits::block::{
 };
 use crate::traits::contract::ContractClassWriter;
 use crate::traits::env::BlockEnvProvider;
-use crate::traits::messaging::{MessagingProvider, GATHER_FROM_BLOCK_KEY, SEND_FROM_BLOCK_KEY};
+use crate::traits::messaging::{MessagingProvider, GATHER_FROM_BLOCK_KEY, SEND_FROM_BLOCK_KEY, GATHER_FROM_NONCE_KEY, SEND_FROM_INDEX_KEY};
 use crate::traits::state::{StateFactoryProvider, StateProvider, StateRootProvider, StateWriter};
 use crate::traits::state_update::StateUpdateProvider;
 use crate::traits::transaction::{
@@ -593,6 +593,33 @@ impl MessagingProvider for InMemoryProvider {
 
     fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
         self.storage.write().messaging_info.insert(GATHER_FROM_BLOCK_KEY, gather_from_block);
+        Ok(())
+    }
+
+    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
+        Ok(self.storage.read().messaging_nonce_info.get(&GATHER_FROM_NONCE_KEY).cloned())
+    }
+
+    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
+        self.storage.write().messaging_nonce_info.insert(GATHER_FROM_NONCE_KEY, nonce);
+        Ok(())
+    }
+
+    fn get_nonce_from_message_hash(&self, message_hash: MessageHash) -> ProviderResult<Option<Nonce>> {
+        Ok(self.storage.read().messaging_message_nonce_mapping.get(&message_hash).cloned())
+    }
+
+    fn set_nonce_from_message_hash(&self, message_hash: MessageHash, nonce: Nonce) -> ProviderResult<()> {
+        self.storage.write().messaging_message_nonce_mapping.insert(message_hash, nonce);
+        Ok(())
+    }
+
+    fn get_send_from_index(&self) -> ProviderResult<Option<Nonce>> {
+        Ok(self.storage.read().messaging_index_info.get(&SEND_FROM_INDEX_KEY).cloned())
+    }
+
+    fn set_send_from_index(&self, index: u64) -> ProviderResult<()> {
+        self.storage.write().messaging_index_info.insert(SEND_FROM_INDEX_KEY, index);
         Ok(())
     }
 }

--- a/crates/katana/storage/provider/src/providers/in_memory/mod.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/mod.rs
@@ -578,30 +578,30 @@ impl BlockEnvProvider for InMemoryProvider {
 }
 
 impl MessagingCheckpointProvider for InMemoryProvider {
-    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()> {
-        self.storage.write().messaging_info.send_block = Some(send_from_block);
+    fn set_outbound_block(&self, outbound_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.send_block = Some(outbound_block);
         Ok(())
     }
 
-    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+    fn get_outbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.storage.read().messaging_info.send_block)
     }
 
-    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()> {
-        self.storage.write().messaging_info.send_block = Some(gather_from_block);
+    fn set_inbound_block(&self, inbound_block: BlockNumber) -> ProviderResult<()> {
+        self.storage.write().messaging_info.gather_block = Some(inbound_block);
         Ok(())
     }
 
-    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>> {
+    fn get_inbound_block(&self) -> ProviderResult<Option<BlockNumber>> {
         Ok(self.storage.read().messaging_info.gather_block)
     }
 
-    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
+    fn set_inbound_nonce(&self, nonce: Nonce) -> ProviderResult<()> {
         self.storage.write().messaging_info.gather_nonce = Some(nonce);
         Ok(())
     }
 
-    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>> {
+    fn get_inbound_nonce(&self) -> ProviderResult<Option<Nonce>> {
         Ok(self.storage.read().messaging_info.gather_nonce)
     }
 
@@ -614,12 +614,12 @@ impl MessagingCheckpointProvider for InMemoryProvider {
         Ok(self.storage.read().messaging_message_nonce_mapping.get(&message_hash).cloned())
     }
 
-    fn set_send_from_index(&self, index: u64) -> ProviderResult<()> {
-        self.storage.write().messaging_info.send_index = Some(index);
+    fn set_outbound_index(&self, outbound_index: u64) -> ProviderResult<()> {
+        self.storage.write().messaging_info.send_index = Some(outbound_index);
         Ok(())
     }
 
-    fn get_send_from_index(&self) -> ProviderResult<Option<u64>> {
+    fn get_outbound_index(&self) -> ProviderResult<Option<u64>> {
         Ok(self.storage.read().messaging_info.send_index)
     }
 }

--- a/crates/katana/storage/provider/src/traits/messaging.rs
+++ b/crates/katana/storage/provider/src/traits/messaging.rs
@@ -1,9 +1,12 @@
 use katana_primitives::block::BlockNumber;
+use katana_primitives::contract::{Nonce, MessageHash};
 
 use crate::ProviderResult;
 
 pub const SEND_FROM_BLOCK_KEY: u64 = 1;
 pub const GATHER_FROM_BLOCK_KEY: u64 = 2;
+pub const GATHER_FROM_NONCE_KEY: u64 = 3;
+pub const SEND_FROM_INDEX_KEY: u64 = 4;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait MessagingProvider: Send + Sync {
@@ -15,4 +18,16 @@ pub trait MessagingProvider: Send + Sync {
     fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()>;
     /// Returns the gather from block.
     fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>>;
+    /// Sets the gather from nonce.
+    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()>;
+    /// Returns the gather from nonce.
+    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>>;
+    /// Sets the nonce by message_hash.
+    fn set_nonce_from_message_hash(&self, message_hash: MessageHash, nonce: Nonce) -> ProviderResult<()>;
+    /// Returns the nonce by message_hash.
+    fn get_nonce_from_message_hash(&self, message_hash: MessageHash) -> ProviderResult<Option<Nonce>>;
+    /// Sets the send from index.
+    fn set_send_from_index(&self, index: u64) -> ProviderResult<()>;
+    /// Returns the send from index.
+    fn get_send_from_index(&self) -> ProviderResult<Option<u64>>;
 }

--- a/crates/katana/storage/provider/src/traits/messaging.rs
+++ b/crates/katana/storage/provider/src/traits/messaging.rs
@@ -1,0 +1,18 @@
+use crate::ProviderResult;
+use katana_primitives::block::BlockNumber;
+
+pub const SEND_FROM_BLOCK_KEY: u64 = 1;
+pub const GATHER_FROM_BLOCK_KEY: u64 = 2;
+
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait MessagingProvider: Send + Sync {
+
+    /// Sets the send from block.
+    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()>;
+    /// Returns the send from block.
+    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>>;
+    /// Sets the gather from block.
+    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()>;
+    /// Returns the gather from block.
+    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>>;
+}

--- a/crates/katana/storage/provider/src/traits/messaging.rs
+++ b/crates/katana/storage/provider/src/traits/messaging.rs
@@ -5,24 +5,25 @@ use crate::ProviderResult;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait MessagingCheckpointProvider: Send + Sync {
-    /// Sets the send from block.
-    fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()>;
-    /// Returns the send from block.
-    fn get_send_from_block(&self) -> ProviderResult<Option<BlockNumber>>;
-    /// Sets the gather from block.
-    fn set_gather_from_block(&self, gather_from_block: BlockNumber) -> ProviderResult<()>;
-    /// Returns the gather from block.
-    fn get_gather_from_block(&self) -> ProviderResult<Option<BlockNumber>>;
-    /// Sets the gather from nonce.
-    fn set_gather_message_nonce(&self, nonce: Nonce) -> ProviderResult<()>;
-    /// Returns the gather from nonce.
-    fn get_gather_message_nonce(&self) -> ProviderResult<Option<Nonce>>;
+    /// Sets the outbound block.
+    fn set_outbound_block(&self, outbound_block: BlockNumber) -> ProviderResult<()>;
+    /// Returns the outbound block.
+    fn get_outbound_block(&self) -> ProviderResult<Option<BlockNumber>>;
+
+    /// Sets the inbound block.
+    fn set_inbound_block(&self, inbound_block: BlockNumber) -> ProviderResult<()>;
+    /// Returns the inbound block.
+    fn get_inbound_block(&self) -> ProviderResult<Option<BlockNumber>>;
+    /// Sets the inbound nonce.
+    fn set_inbound_nonce(&self, nonce: Nonce) -> ProviderResult<()>;
+    /// Returns the inbound nonce.
+    fn get_inbound_nonce(&self) -> ProviderResult<Option<Nonce>>;
     /// Sets the nonce by message_hash.
     fn set_nonce_from_message_hash(&self, message_hash: MessageHash, nonce: Nonce) -> ProviderResult<()>;
     /// Returns the nonce by message_hash.
     fn get_nonce_from_message_hash(&self, message_hash: MessageHash) -> ProviderResult<Option<Nonce>>;
-    /// Sets the send from index.
-    fn set_send_from_index(&self, index: u64) -> ProviderResult<()>;
-    /// Returns the send from index.
-    fn get_send_from_index(&self) -> ProviderResult<Option<u64>>;
+    /// Sets the outbound index.
+    fn set_outbound_index(&self, index: u64) -> ProviderResult<()>;
+    /// Returns the outbound index.
+    fn get_outbound_index(&self) -> ProviderResult<Option<u64>>;
 }

--- a/crates/katana/storage/provider/src/traits/messaging.rs
+++ b/crates/katana/storage/provider/src/traits/messaging.rs
@@ -1,6 +1,6 @@
 use katana_primitives::block::BlockNumber;
 use katana_primitives::contract::{Nonce, MessageHash};
-
+use katana_primitives::transaction::L1HandlerTx;
 use crate::ProviderResult;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
@@ -26,4 +26,6 @@ pub trait MessagingCheckpointProvider: Send + Sync {
     fn set_outbound_index(&self, index: u64) -> ProviderResult<()>;
     /// Returns the outbound index.
     fn get_outbound_index(&self) -> ProviderResult<Option<u64>>;
+    /// Processes the nonce in the provided L1HandlerTx and updates the inbound nonce within the provider.
+    fn process_message_nonce(&self, l1_tx: &L1HandlerTx) -> ProviderResult<()>;
 }

--- a/crates/katana/storage/provider/src/traits/messaging.rs
+++ b/crates/katana/storage/provider/src/traits/messaging.rs
@@ -1,12 +1,12 @@
-use crate::ProviderResult;
 use katana_primitives::block::BlockNumber;
+
+use crate::ProviderResult;
 
 pub const SEND_FROM_BLOCK_KEY: u64 = 1;
 pub const GATHER_FROM_BLOCK_KEY: u64 = 2;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait MessagingProvider: Send + Sync {
-
     /// Sets the send from block.
     fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()>;
     /// Returns the send from block.

--- a/crates/katana/storage/provider/src/traits/messaging.rs
+++ b/crates/katana/storage/provider/src/traits/messaging.rs
@@ -3,13 +3,8 @@ use katana_primitives::contract::{Nonce, MessageHash};
 
 use crate::ProviderResult;
 
-pub const SEND_FROM_BLOCK_KEY: u64 = 1;
-pub const GATHER_FROM_BLOCK_KEY: u64 = 2;
-pub const GATHER_FROM_NONCE_KEY: u64 = 3;
-pub const SEND_FROM_INDEX_KEY: u64 = 4;
-
 #[auto_impl::auto_impl(&, Box, Arc)]
-pub trait MessagingProvider: Send + Sync {
+pub trait MessagingCheckpointProvider: Send + Sync {
     /// Sets the send from block.
     fn set_send_from_block(&self, send_from_block: BlockNumber) -> ProviderResult<()>;
     /// Returns the send from block.

--- a/crates/katana/storage/provider/src/traits/mod.rs
+++ b/crates/katana/storage/provider/src/traits/mod.rs
@@ -1,6 +1,7 @@
 pub mod block;
 pub mod contract;
 pub mod env;
+pub mod messaging;
 pub mod state;
 pub mod state_update;
 pub mod transaction;


### PR DESCRIPTION
# Description

1. add gather_from_block to genesis file
2. persist send_from_block & gather_from_block in database
3. service use send_from_block & gather_from_block in messaging service

<!--
A description of what this PR is solving.
-->

## Related issue
Fixes #2033
<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `MessagingProvider` trait to manage messaging operations across various providers.
	- Added `gather_from_block` field to `Genesis` and `GenesisJson` configurations, enabling specific block number tracking.
	- Enhanced `DbProvider` and `ForkedProvider` to manage messaging-related block numbers with new methods.
	- Updated `CacheDb` to include messaging information storage.

- **Bug Fixes**
	- Improved error message formatting for better readability in `ProviderError`.

- **Documentation**
	- Enhanced documentation strings for better clarity and readability in the `Migrate` command description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->