### PR TITLE
feat(sozo): ensure sozo errors with dojo-core version mismatch

### DIFF
--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -11,6 +11,7 @@ use scarb_ui::args::{FeaturesSpec, PackagesFilter};
 use sozo_ops::statistics::{get_contract_statistics_for_dir, ContractStatistics};
 use tracing::trace;
 
+use crate::commands::check_package_dojo_version;
 use crate::commands::clean::CleanArgs;
 
 const BYTECODE_SIZE_LABEL: &str = "Bytecode size [in felts]\n(Sierra, Casm)";
@@ -57,6 +58,10 @@ impl BuildArgs {
         } else {
             ws.members().collect()
         };
+
+        for p in &packages {
+            check_package_dojo_version(&ws, p)?;
+        }
 
         let profile_name =
             ws.current_profile().expect("Scarb profile is expected at this point.").to_string();

--- a/bin/sozo/src/commands/test.rs
+++ b/bin/sozo/src/commands/test.rs
@@ -20,6 +20,8 @@ use scarb::ops::{self, CompileOpts};
 use scarb_ui::args::{FeaturesSpec, PackagesFilter};
 use tracing::trace;
 
+use super::check_package_dojo_version;
+
 pub(crate) const LOG_TARGET: &str = "sozo::cli::commands::test";
 
 #[derive(Debug, Clone, PartialEq, clap::ValueEnum)]
@@ -80,6 +82,10 @@ impl TestArgs {
         } else {
             ws.members().collect()
         };
+
+        for p in &packages {
+            check_package_dojo_version(&ws, p)?;
+        }
 
         let resolve = ops::resolve_workspace(&ws)?;
 

--- a/examples/spawn-and-move/Scarb.lock
+++ b/examples/spawn-and-move/Scarb.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "dojo_examples"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.8"
 dependencies = [
  "armory",
  "bestiary",

--- a/examples/spawn-and-move/Scarb.toml
+++ b/examples/spawn-and-move/Scarb.toml
@@ -1,7 +1,7 @@
 [package]
 cairo-version = "=2.7.0"
 name = "dojo_examples"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.8"
 # Use the prelude with the less imports as possible
 # from corelib.
 edition = "2024_07"


### PR DESCRIPTION
# Description

When the toolchain version changed (`dojoup -v 1.0.0-alpha.8`), the dependency on dojo inside the `Scarb.toml` must also change. To avoid weird error messages, sozo is now throwing an error if the `dojo-core` version mismatches the dependency version set by the user in `Scarb.toml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a version validation check for the "dojo" dependency across packages during build and test processes, enhancing package management robustness.
- **Bug Fixes**
	- Improved error handling for version mismatches, providing clearer feedback on expected versions and paths to package manifests.
- **Chores**
	- Updated the version of the `dojo_examples` package from "1.0.0-alpha.4" to "1.0.0-alpha.8".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->