### PR TITLE
dev: pin exact rust nightly version 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ ENV TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 # To allow independent workflow of the container, the rust-toolchain is explicitely given.
 RUN echo "1.80.0" > rust_toolchain_version
 # Make sure to sync the nightly version with the scripts in ./scripts
-RUN echo "nightly-2024-08-24" > nightly_rust_toolchain_version
+RUN echo "nightly-2024-08-28" > nightly_rust_toolchain_version
 
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ ENV TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 # To allow independent workflow of the container, the rust-toolchain is explicitely given.
 RUN echo "1.80.0" > rust_toolchain_version
 # Make sure to sync the nightly version with the scripts in ./scripts
-RUN echo "nightly-2024-08-25" > nightly_rust_toolchain_version
+RUN echo "nightly-2024-08-24" > nightly_rust_toolchain_version
 
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ ENV TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 # To allow independent workflow of the container, the rust-toolchain is explicitely given.
 RUN echo "1.80.0" > rust_toolchain_version
 # Make sure to sync the nightly version with the scripts in ./scripts
-RUN echo "nightly-2024-08-27" > nightly_rust_toolchain_version
+RUN echo "nightly-2024-08-26" > nightly_rust_toolchain_version
 
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ ENV TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 # To allow independent workflow of the container, the rust-toolchain is explicitely given.
 RUN echo "1.80.0" > rust_toolchain_version
 # Make sure to sync the nightly version with the scripts in ./scripts
-RUN echo "nightly-2024-08-26" > nightly_rust_toolchain_version
+RUN echo "nightly-2024-08-25" > nightly_rust_toolchain_version
 
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
     rm -r hurl-4.1.0-x86_64-unknown-linux-gnu && \
     rm hurl.tar.gz && \
     rustup component add llvm-tools-preview --toolchain $(cat rust_toolchain_version)-x86_64-unknown-linux-gnu && \
-    rustup target add x86_64-fortanix-unknown-sgx --toolchain nightly; \
+    rustup target add x86_64-fortanix-unknown-sgx --toolchain $(cat nightly_rust_toolchain_version); \
     fi
 
 ARG DOJO_VERSION=stable

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -27,6 +27,8 @@ ENV TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 
 # To allow independent workflow of the container, the rust-toolchain is explicitely given.
 RUN echo "1.80.0" > rust_toolchain_version
+# Make sure to sync the nightly version with the scripts in ./scripts
+RUN echo "nightly-2024-08-29" > nightly_rust_toolchain_version
 
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
@@ -36,8 +38,8 @@ RUN rustup toolchain install $(cat rust_toolchain_version) && \
     rustup component add clippy && \
     rustup component add rustfmt
 
-RUN rustup toolchain install nightly && \
-    rustup component add rustfmt clippy --toolchain nightly
+RUN rustup toolchain install $(cat nightly_rust_toolchain_version) && \
+	rustup component add rustfmt clippy --toolchain $(cat nightly_rust_toolchain_version)
 
 RUN rustup target add x86_64-pc-windows-msvc && \
     rustup target add wasm32-unknown-unknown

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ ENV TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 # To allow independent workflow of the container, the rust-toolchain is explicitely given.
 RUN echo "1.80.0" > rust_toolchain_version
 # Make sure to sync the nightly version with the scripts in ./scripts
-RUN echo "nightly-2024-08-29" > nightly_rust_toolchain_version
+RUN echo "nightly-2024-08-28" > nightly_rust_toolchain_version
 
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ ENV TABLEGEN_170_PREFIX=/usr/lib/llvm-17
 # To allow independent workflow of the container, the rust-toolchain is explicitely given.
 RUN echo "1.80.0" > rust_toolchain_version
 # Make sure to sync the nightly version with the scripts in ./scripts
-RUN echo "nightly-2024-08-28" > nightly_rust_toolchain_version
+RUN echo "nightly-2024-08-27" > nightly_rust_toolchain_version
 
 # Install cargo-binstall
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -8,7 +8,7 @@ set -x
 set -o pipefail
 
 run_clippy() {
-  cargo +nightly-2024-08-25 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
+  cargo +nightly-2024-08-24 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
 }
 
 run_clippy --all-features --workspace

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -8,7 +8,7 @@ set -x
 set -o pipefail
 
 run_clippy() {
-  cargo +nightly clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
+  cargo +nightly-2024-08-29 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
 }
 
 run_clippy --all-features --workspace

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -8,7 +8,7 @@ set -x
 set -o pipefail
 
 run_clippy() {
-  cargo +nightly-2024-08-26 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
+  cargo +nightly-2024-08-25 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
 }
 
 run_clippy --all-features --workspace

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -8,7 +8,7 @@ set -x
 set -o pipefail
 
 run_clippy() {
-  cargo +nightly-2024-08-28 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
+  cargo +nightly-2024-08-27 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
 }
 
 run_clippy --all-features --workspace

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -8,7 +8,7 @@ set -x
 set -o pipefail
 
 run_clippy() {
-  cargo +nightly-2024-08-29 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
+  cargo +nightly-2024-08-28 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
 }
 
 run_clippy --all-features --workspace

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -8,7 +8,7 @@ set -x
 set -o pipefail
 
 run_clippy() {
-  cargo +nightly-2024-08-24 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
+  cargo +nightly-2024-08-28 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
 }
 
 run_clippy --all-features --workspace

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -8,7 +8,7 @@ set -x
 set -o pipefail
 
 run_clippy() {
-  cargo +nightly-2024-08-27 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
+  cargo +nightly-2024-08-26 clippy --all-targets "$@" -- -D warnings -D future-incompatible -D nonstandard-style -D rust-2018-idioms -D unused -D missing-debug-implementations
 }
 
 run_clippy --all-features --workspace

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2024-08-28 fmt --check --all -- "$@"
+cargo +nightly-2024-08-27 fmt --check --all -- "$@"

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2024-08-26 fmt --check --all -- "$@"
+cargo +nightly-2024-08-25 fmt --check --all -- "$@"

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2024-08-27 fmt --check --all -- "$@"
+cargo +nightly-2024-08-26 fmt --check --all -- "$@"

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly fmt --check --all -- "$@"
+cargo +nightly-2024-08-29 fmt --check --all -- "$@"

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2024-08-29 fmt --check --all -- "$@"
+cargo +nightly-2024-08-28 fmt --check --all -- "$@"

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2024-08-24 fmt --check --all -- "$@"
+cargo +nightly-2024-08-28 fmt --check --all -- "$@"

--- a/scripts/rust_fmt.sh
+++ b/scripts/rust_fmt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo +nightly-2024-08-25 fmt --check --all -- "$@"
+cargo +nightly-2024-08-24 fmt --check --all -- "$@"


### PR DESCRIPTION
pin rust nightly version used in devcontainer for ci and in the scripts (ie `./scripts`) to `nightly-2024-08-28` version. 

the version is chosen to match the version that the latest devcontainer was built with


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated to utilize a specific nightly Rust toolchain version for improved stability and feature access.

- **Bug Fixes**
	- Adjusted linting and formatting scripts to ensure compatibility with the specified nightly Rust version, potentially improving code analysis and formatting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->