### PR TITLE
refactor(katana-pool): enable ordering using `BTreeSet`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ katana-codecs = { path = "crates/katana/storage/codecs" }
 katana-codecs-derive = { path = "crates/katana/storage/codecs/derive" }
 katana-core = { path = "crates/katana/core", default-features = false }
 katana-db = { path = "crates/katana/storage/db" }
-katana-executor = { path = "crates/katana/executor", default-features = false }
+katana-executor = { path = "crates/katana/executor" }
 katana-node = { path = "crates/katana/node", default-features = false }
 katana-pool = { path = "crates/katana/pool" }
 katana-primitives = { path = "crates/katana/primitives" }

--- a/crates/katana/pool/src/ordering.rs
+++ b/crates/katana/pool/src/ordering.rs
@@ -76,15 +76,15 @@ impl PartialEq for TxSubmissionNonce {
 /// This ordering implementation uses the transaction's tip as the priority value. We don't have a
 /// use case for this ordering implementation yet, but it's mostly used for testing.
 #[derive(Debug)]
-pub struct Tip<T>(PhantomData<T>);
+pub struct TipOrdering<T>(PhantomData<T>);
 
-impl<T> Tip<T> {
+impl<T> TipOrdering<T> {
     pub fn new() -> Self {
         Self(PhantomData)
     }
 }
 
-impl<T: PoolTransaction> PoolOrd for Tip<T> {
+impl<T: PoolTransaction> PoolOrd for TipOrdering<T> {
     type Transaction = T;
     type PriorityValue = u64;
 
@@ -93,8 +93,74 @@ impl<T: PoolTransaction> PoolOrd for Tip<T> {
     }
 }
 
-impl<T> Default for Tip<T> {
+impl<T> Default for TipOrdering<T> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::ordering::{self, FiFo};
+    use crate::pool::test_utils::*;
+    use crate::tx::PoolTransaction;
+    use crate::validation::NoopValidator;
+    use crate::{Pool, TransactionPool};
+
+    #[test]
+    fn fifo_ordering() {
+        // Create mock transactions
+        let txs = [PoolTx::new(), PoolTx::new(), PoolTx::new(), PoolTx::new(), PoolTx::new()];
+
+        // Create a pool with FiFo ordering
+        let pool = Pool::new(NoopValidator::new(), FiFo::new());
+
+        // Add transactions to the pool
+        txs.iter().for_each(|tx| {
+            let _ = pool.add_transaction(tx.clone());
+        });
+
+        // Get pending transactions
+        let pendings = pool.take_transactions().collect::<Vec<_>>();
+
+        // Assert that the transactions are in the order they were added (first to last)
+        pendings.iter().zip(txs).for_each(|(pending, tx)| {
+            assert_eq!(pending.tx.as_ref(), &tx);
+        });
+    }
+
+    #[test]
+    fn tip_based_ordering() {
+        // Create mock transactions with different tips and in random order
+        let txs = [
+            PoolTx::new().with_tip(1),
+            PoolTx::new().with_tip(6),
+            PoolTx::new().with_tip(3),
+            PoolTx::new().with_tip(2),
+            PoolTx::new().with_tip(5),
+            PoolTx::new().with_tip(4),
+            PoolTx::new().with_tip(7),
+        ];
+
+        // Create a pool with tip-based ordering
+        let pool = Pool::new(NoopValidator::new(), ordering::TipOrdering::new());
+
+        // Add transactions to the pool
+        txs.iter().for_each(|tx| {
+            let _ = pool.add_transaction(tx.clone());
+        });
+
+        // Get pending transactions
+        let pending = pool.take_transactions().collect::<Vec<_>>();
+
+        // Assert that the transactions are ordered by tip (highest to lowest)
+        assert_eq!(pending[0].tx.tip(), 7);
+        assert_eq!(pending[1].tx.tip(), 6);
+        assert_eq!(pending[2].tx.tip(), 5);
+        assert_eq!(pending[3].tx.tip(), 4);
+        assert_eq!(pending[4].tx.tip(), 3);
+        assert_eq!(pending[5].tx.tip(), 2);
+        assert_eq!(pending[6].tx.tip(), 1);
     }
 }

--- a/crates/katana/pool/src/ordering.rs
+++ b/crates/katana/pool/src/ordering.rs
@@ -157,6 +157,7 @@ mod tests {
     fn tip_based_ordering() {
         // Create mock transactions with different tips and in random order
         let txs = [
+            PoolTx::new().with_tip(2),
             PoolTx::new().with_tip(1),
             PoolTx::new().with_tip(6),
             PoolTx::new().with_tip(3),
@@ -181,12 +182,30 @@ mod tests {
 
         // Assert that the transactions are ordered by tip (highest to lowest)
         assert_eq!(pending[0].tx.tip(), 7);
+        assert_eq!(pending[0].tx.hash(), txs[8].hash());
+
         assert_eq!(pending[1].tx.tip(), 6);
+        assert_eq!(pending[1].tx.hash(), txs[2].hash());
+
         assert_eq!(pending[2].tx.tip(), 5);
+        assert_eq!(pending[2].tx.hash(), txs[6].hash());
+
         assert_eq!(pending[3].tx.tip(), 4);
+        assert_eq!(pending[3].tx.hash(), txs[7].hash());
+
         assert_eq!(pending[4].tx.tip(), 3);
+        assert_eq!(pending[4].tx.hash(), txs[3].hash());
+
         assert_eq!(pending[5].tx.tip(), 2);
+        assert_eq!(pending[5].tx.hash(), txs[0].hash());
+
         assert_eq!(pending[6].tx.tip(), 2);
-        assert_eq!(pending[7].tx.tip(), 1);
+        assert_eq!(pending[6].tx.hash(), txs[4].hash());
+
+        assert_eq!(pending[7].tx.tip(), 2);
+        assert_eq!(pending[7].tx.hash(), txs[5].hash());
+
+        assert_eq!(pending[8].tx.tip(), 1);
+        assert_eq!(pending[8].tx.hash(), txs[1].hash());
     }
 }

--- a/crates/katana/pool/src/pool.rs
+++ b/crates/katana/pool/src/pool.rs
@@ -1,5 +1,6 @@
 use core::fmt;
-use std::collections::{btree_set::IntoIter, BTreeSet};
+use std::collections::btree_set::IntoIter;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use futures::channel::mpsc::{channel, Receiver, Sender};
@@ -215,7 +216,6 @@ pub(crate) mod test_utils {
 
     use super::*;
     use crate::tx::PoolTransaction;
-    use crate::validation::{ValidationOutcome, ValidationResult, Validator};
 
     fn random_bytes<const SIZE: usize>() -> [u8; SIZE] {
         let mut bytes = [0u8; SIZE];
@@ -282,36 +282,6 @@ pub(crate) mod test_utils {
 
         fn tip(&self) -> u64 {
             self.tip
-        }
-    }
-
-    /// A tip-based validator that flags transactions as invalid if they have less than 10 tip.
-    pub struct TipValidator<T> {
-        threshold: u64,
-        t: std::marker::PhantomData<T>,
-    }
-
-    impl<T> TipValidator<T> {
-        pub fn new(threshold: u64) -> Self {
-            Self { threshold, t: std::marker::PhantomData }
-        }
-    }
-
-    impl<T: PoolTransaction> Validator for TipValidator<T> {
-        type Transaction = T;
-
-        fn validate(&self, tx: Self::Transaction) -> ValidationResult<Self::Transaction> {
-            if tx.tip() < self.threshold {
-                return ValidationResult::Ok(ValidationOutcome::Invalid {
-                    error: InvalidTransactionError::InsufficientFunds {
-                        balance: FieldElement::ONE,
-                        max_fee: tx.max_fee(),
-                    },
-                    tx,
-                });
-            }
-
-            ValidationResult::Ok(ValidationOutcome::Valid(tx))
         }
     }
 }

--- a/crates/katana/pool/src/tx.rs
+++ b/crates/katana/pool/src/tx.rs
@@ -94,10 +94,15 @@ impl<T, O: PoolOrd> PartialOrd for PendingTx<T, O> {
     }
 }
 
+/// When two transactions have the same priority, we want to prioritize the one that was added
+/// first. So, when an incoming transaction with similar priority value is added to the
+/// [BTreeSet](std::collections::BTreeSet), the transaction is assigned a 'greater'
+/// [Ordering](std::cmp::Ordering) so that it will be placed after the existing ones. This is
+/// because items in a BTree is ordered from lowest to highest.
 impl<T, O: PoolOrd> Ord for PendingTx<T, O> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match self.priority.cmp(&other.priority) {
-            std::cmp::Ordering::Equal => std::cmp::Ordering::Less,
+            std::cmp::Ordering::Equal => std::cmp::Ordering::Greater,
             other => other,
         }
     }

--- a/crates/katana/pool/src/tx.rs
+++ b/crates/katana/pool/src/tx.rs
@@ -96,7 +96,10 @@ impl<T, O: PoolOrd> PartialOrd for PendingTx<T, O> {
 
 impl<T, O: PoolOrd> Ord for PendingTx<T, O> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.priority.cmp(&other.priority)
+        match self.priority.cmp(&other.priority) {
+            std::cmp::Ordering::Equal => std::cmp::Ordering::Less,
+            other => other,
+        }
     }
 }
 

--- a/crates/katana/pool/src/tx.rs
+++ b/crates/katana/pool/src/tx.rs
@@ -94,11 +94,11 @@ impl<T, O: PoolOrd> PartialOrd for PendingTx<T, O> {
     }
 }
 
-/// When two transactions have the same priority, we want to prioritize the one that was added
-/// first. So, when an incoming transaction with similar priority value is added to the
-/// [BTreeSet](std::collections::BTreeSet), the transaction is assigned a 'greater'
-/// [Ordering](std::cmp::Ordering) so that it will be placed after the existing ones. This is
-/// because items in a BTree is ordered from lowest to highest.
+// When two transactions have the same priority, we want to prioritize the one that was added
+// first. So, when an incoming transaction with similar priority value is added to the
+// [BTreeSet](std::collections::BTreeSet), the transaction is assigned a 'greater'
+// [Ordering](std::cmp::Ordering) so that it will be placed after the existing ones. This is
+// because items in a BTree is ordered from lowest to highest.
 impl<T, O: PoolOrd> Ord for PendingTx<T, O> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match self.priority.cmp(&other.priority) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced transaction ordering mechanism for improved prioritization based on tip values.
	- Introduced new data structures for more efficient transaction management within the pool.

- **Bug Fixes**
	- Adjusted comparison logic for transaction priorities to ensure consistent ordering.

- **Documentation**
	- Updated unit tests for both FIFO and tip-based ordering to validate new functionality.

- **Chores**
	- Removed obsolete test functions reflecting a shift in testing strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->