### PR TITLE
fix(katana-rpc): include events from pending block in `getEvents` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8021,6 +8021,7 @@ dependencies = [
  "serde_json",
  "starknet 0.11.0",
  "tempfile",
+ "thiserror",
  "tokio",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7941,6 +7941,7 @@ version = "1.0.0-alpha.9"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "assert_matches",
  "base64 0.21.7",
  "derive_more",
  "flate2",

--- a/crates/katana/primitives/Cargo.toml
+++ b/crates/katana/primitives/Cargo.toml
@@ -25,6 +25,7 @@ flate2 = { workspace = true, optional = true }
 katana-cairo.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 num-traits.workspace = true
 similar-asserts.workspace = true
 

--- a/crates/katana/primitives/src/event.rs
+++ b/crates/katana/primitives/src/event.rs
@@ -11,38 +11,58 @@ pub struct OrderedEvent {
     pub data: Vec<FieldElement>,
 }
 
+/// Represents a continuation token for implementing paging in event queries.
+///
+/// This struct stores the necessary information to resume fetching events
+/// from a specific point relative to the given filter passed as parameter to the
+/// `starknet_getEvents` API, [EventFilter][starknet::core::types::EventFilter].
+///
+/// There JSON-RPC specification does not specify the format of the continuation token,
+/// so how the node should handle it is implementation specific.
 #[derive(PartialEq, Eq, Debug, Default)]
 pub struct ContinuationToken {
+    /// The block number to continue from.
     pub block_n: u64,
+    /// The transaction number within the block to continue from.
     pub txn_n: u64,
+    /// The event number within the transaction to continue from.
     pub event_n: u64,
 }
 
 #[derive(PartialEq, Eq, Debug, thiserror::Error)]
 pub enum ContinuationTokenError {
+    #[error("Missing block number")]
+    MissingBlock,
+    #[error("Missing transaction number")]
+    MissingTxn,
+    #[error("Missing event number")]
+    MissingEvent,
     #[error("Invalid data")]
     InvalidToken,
-    #[error("Invalid format: {0}")]
-    ParseFailed(ParseIntError),
+    #[error("Invalid format: {0}. Expected format: block_n,txn_n,event_n")]
+    ParseFailed(#[from] ParseIntError),
 }
 
 impl ContinuationToken {
-    pub fn parse(token: String) -> Result<Self, ContinuationTokenError> {
-        let arr: Vec<&str> = token.split(',').collect();
-        if arr.len() != 3 {
+    pub fn parse(token: &str) -> Result<Self, ContinuationTokenError> {
+        let mut parts = token.split(',');
+
+        if parts.clone().count() > 3 {
             return Err(ContinuationTokenError::InvalidToken);
         }
-        let block_n =
-            u64::from_str_radix(arr[0], 16).map_err(ContinuationTokenError::ParseFailed)?;
-        let receipt_n =
-            u64::from_str_radix(arr[1], 16).map_err(ContinuationTokenError::ParseFailed)?;
-        let event_n =
-            u64::from_str_radix(arr[2], 16).map_err(ContinuationTokenError::ParseFailed)?;
 
-        Ok(ContinuationToken { block_n, txn_n: receipt_n, event_n })
+        let block = parts.next().ok_or(ContinuationTokenError::MissingBlock)?;
+        let block_n = u64::from_str_radix(block, 16)?;
+
+        let txn = parts.next().ok_or(ContinuationTokenError::MissingTxn)?;
+        let txn_n = u64::from_str_radix(txn, 16)?;
+
+        let event = parts.next().ok_or(ContinuationTokenError::MissingEvent)?;
+        let event_n = u64::from_str_radix(event, 16)?;
+
+        Ok(ContinuationToken { block_n, txn_n, event_n })
     }
 }
-
 impl fmt::Display for ContinuationToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:x},{:x},{:x}", self.block_n, self.txn_n, self.event_n)
@@ -66,7 +86,7 @@ mod test {
     #[test]
     fn parse_works() {
         fn helper(token: &str) -> ContinuationToken {
-            ContinuationToken::parse(token.to_owned()).unwrap()
+            ContinuationToken::parse(token).unwrap()
         }
         assert_eq!(helper("0,0,0"), ContinuationToken { block_n: 0, txn_n: 0, event_n: 0 });
         assert_eq!(helper("1e,ff,4"), ContinuationToken { block_n: 30, txn_n: 255, event_n: 4 });
@@ -75,15 +95,15 @@ mod test {
     #[test]
     fn parse_should_fail() {
         assert_eq!(
-            ContinuationToken::parse("100".to_owned()).unwrap_err(),
+            ContinuationToken::parse("100").unwrap_err(),
             ContinuationTokenError::InvalidToken
         );
         assert_eq!(
-            ContinuationToken::parse("0,".to_owned()).unwrap_err(),
+            ContinuationToken::parse("0,").unwrap_err(),
             ContinuationTokenError::InvalidToken
         );
         assert_eq!(
-            ContinuationToken::parse("0,0".to_owned()).unwrap_err(),
+            ContinuationToken::parse("0,0").unwrap_err(),
             ContinuationTokenError::InvalidToken
         );
     }
@@ -91,15 +111,15 @@ mod test {
     #[test]
     fn parse_u64_should_fail() {
         matches!(
-            ContinuationToken::parse("2y,100,4".to_owned()).unwrap_err(),
+            ContinuationToken::parse("2y,100,4").unwrap_err(),
             ContinuationTokenError::ParseFailed(_)
         );
         matches!(
-            ContinuationToken::parse("30,255g,4".to_owned()).unwrap_err(),
+            ContinuationToken::parse("30,255g,4").unwrap_err(),
             ContinuationTokenError::ParseFailed(_)
         );
         matches!(
-            ContinuationToken::parse("244,1,fv".to_owned()).unwrap_err(),
+            ContinuationToken::parse("244,1,fv").unwrap_err(),
             ContinuationTokenError::ParseFailed(_)
         );
     }

--- a/crates/katana/primitives/src/event.rs
+++ b/crates/katana/primitives/src/event.rs
@@ -77,7 +77,7 @@ mod test {
     #[test]
     fn parse_works() {
         fn helper(token: &str) -> ContinuationToken {
-            ContinuationToken::parse(&token).unwrap()
+            ContinuationToken::parse(token).unwrap()
         }
         assert_eq!(helper("0,0,0"), ContinuationToken { block_n: 0, txn_n: 0, event_n: 0 });
         assert_eq!(helper("1e,ff,4"), ContinuationToken { block_n: 30, txn_n: 255, event_n: 4 });

--- a/crates/katana/rpc/rpc-types/src/error/starknet.rs
+++ b/crates/katana/rpc/rpc-types/src/error/starknet.rs
@@ -151,8 +151,13 @@ impl From<ProviderError> for StarknetApiError {
 }
 
 impl From<ContinuationTokenError> for StarknetApiError {
-    fn from(_: ContinuationTokenError) -> Self {
-        StarknetApiError::InvalidContinuationToken
+    fn from(value: ContinuationTokenError) -> Self {
+        match value {
+            ContinuationTokenError::InvalidToken => StarknetApiError::InvalidContinuationToken,
+            ContinuationTokenError::ParseFailed(e) => {
+                StarknetApiError::UnexpectedError { reason: e.to_string() }
+            }
+        }
     }
 }
 

--- a/crates/katana/rpc/rpc-types/src/error/starknet.rs
+++ b/crates/katana/rpc/rpc-types/src/error/starknet.rs
@@ -151,13 +151,8 @@ impl From<ProviderError> for StarknetApiError {
 }
 
 impl From<ContinuationTokenError> for StarknetApiError {
-    fn from(value: ContinuationTokenError) -> Self {
-        match value {
-            ContinuationTokenError::InvalidToken => StarknetApiError::InvalidContinuationToken,
-            ContinuationTokenError::ParseFailed(e) => {
-                StarknetApiError::UnexpectedError { reason: e.to_string() }
-            }
-        }
+    fn from(_: ContinuationTokenError) -> Self {
+        StarknetApiError::InvalidContinuationToken
     }
 }
 

--- a/crates/katana/rpc/rpc/Cargo.toml
+++ b/crates/katana/rpc/rpc/Cargo.toml
@@ -22,6 +22,7 @@ katana-rpc-types-builder.workspace = true
 katana-tasks.workspace = true
 metrics.workspace = true
 starknet.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/katana/rpc/rpc/src/lib.rs
+++ b/crates/katana/rpc/rpc/src/lib.rs
@@ -10,3 +10,5 @@ pub mod metrics;
 pub mod saya;
 pub mod starknet;
 pub mod torii;
+
+mod utils;

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -406,7 +406,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
                         &mut buffer,
                     )?;
 
-                    if end {
+                    if end && buffer.len() as u64 == chunk_size {
                         return Ok(EventsPage {
                             events: buffer,
                             continuation_token: Some(cursor.to_string()),

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -370,17 +370,17 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
             let block_range = (from + continuation_token.block_n)..=to;
 
             for current in block_range {
-                let block_hash = provider
-                    .block_hash_by_num(current)?
-                    .ok_or(StarknetApiError::UnexpectedError { reason: "Missing".into() })?;
+                let block_hash = provider.block_hash_by_num(current)?.ok_or(
+                    StarknetApiError::UnexpectedError { reason: "Missing block hash".into() },
+                )?;
 
-                let receipts = provider
-                    .receipts_by_block(current.into())?
-                    .ok_or(StarknetApiError::UnexpectedError { reason: "Missing".into() })?;
+                let receipts = provider.receipts_by_block(current.into())?.ok_or(
+                    StarknetApiError::UnexpectedError { reason: "Missing receipts".into() },
+                )?;
 
-                let tx_range = provider
-                    .block_body_indices(current.into())?
-                    .ok_or(StarknetApiError::UnexpectedError { reason: "Missing".into() })?;
+                let tx_range = provider.block_body_indices(current.into())?.ok_or(
+                    StarknetApiError::UnexpectedError { reason: "Missing block body index".into() },
+                )?;
 
                 let tx_hashes = provider.transaction_hashes_in_range(tx_range.into())?;
                 let txn_n = receipts.len();

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -432,7 +432,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
                         .collect::<Vec<_>>();
 
                     // the next time we have to fetch the events, we will start from this index.
-                    let new_event_n = continuation_token.event_n as usize + filtered_events.len();
+                    let new_event_n = continuation_token.event_n as usize + remaining_capacity;
                     all_events.extend(filtered_events);
 
                     if all_events.len() >= chunk_size as usize {
@@ -518,8 +518,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
                             .collect::<Vec<_>>();
 
                         // the next time we have to fetch the events, we will start from this index.
-                        let new_event_n =
-                            continuation_token.event_n as usize + filtered_events.len();
+                        let new_event_n = continuation_token.event_n as usize + remaining_capacity;
 
                         all_events.extend(filtered_events);
 

--- a/crates/katana/rpc/rpc/src/utils/events.rs
+++ b/crates/katana/rpc/rpc/src/utils/events.rs
@@ -1,0 +1,347 @@
+use std::cmp::Ordering;
+use std::ops::RangeInclusive;
+
+use anyhow::Context;
+use katana_core::service::block_producer::PendingExecutor;
+use katana_primitives::block::{BlockHash, BlockNumber};
+use katana_primitives::contract::ContractAddress;
+use katana_primitives::event::ContinuationToken;
+use katana_primitives::receipt::Event;
+use katana_primitives::transaction::TxHash;
+use katana_primitives::FieldElement;
+use katana_provider::error::ProviderError;
+use katana_provider::traits::block::BlockProvider;
+use katana_provider::traits::transaction::ReceiptProvider;
+use katana_rpc_types::error::starknet::StarknetApiError;
+use starknet::core::types::EmittedEvent;
+
+pub type EventQueryResult<T> = Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Invalid cursor")]
+    InvalidCursor,
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+#[derive(Debug)]
+pub enum EventBlockId {
+    Pending,
+    Num(BlockNumber),
+}
+
+/// An object to specify how events should be filtered.
+#[derive(Debug, Default, Clone)]
+pub struct Filter {
+    /// The contract address to filter by.
+    ///
+    /// If `None`, all events are considered. If `Some`, only events emitted by the specified
+    /// contract are considered.
+    pub address: Option<ContractAddress>,
+    /// The keys to filter by.
+    pub keys: Option<Vec<Vec<FieldElement>>>,
+}
+
+/// Internal cursor
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cursor {
+    block: u64,
+    txn: PartialCursor,
+}
+
+impl Cursor {
+    pub fn new(block: u64, txn: usize, event: usize) -> Self {
+        Self { block, txn: PartialCursor { idx: txn, event } }
+    }
+
+    pub fn new_block(block: u64) -> Self {
+        Self { block, txn: PartialCursor::default() }
+    }
+
+    pub fn into_rpc_cursor(self) -> ContinuationToken {
+        ContinuationToken {
+            block_n: self.block,
+            txn_n: self.txn.idx as u64,
+            event_n: self.txn.event as u64,
+        }
+    }
+}
+
+/// A partial cursor that points to a specific event within a transaction.
+#[derive(Debug, Clone, PartialEq, Default)]
+struct PartialCursor {
+    /// The transaction index within a block.
+    idx: usize,
+    /// The event index within a transaction.
+    event: usize,
+}
+
+impl PartialCursor {
+    fn into_full(self, block: BlockNumber) -> Cursor {
+        Cursor { block, txn: self }
+    }
+}
+
+pub fn fetch_pending_events(
+    pending_executor: &PendingExecutor,
+    filter: &Filter,
+    chunk_size: u64,
+    cursor: Option<Cursor>,
+    buffer: &mut Vec<EmittedEvent>,
+) -> EventQueryResult<Cursor> {
+    let pending_block = pending_executor.read();
+
+    let block_env = pending_block.block_env();
+    let txs = pending_block.transactions();
+    let cursor = cursor.unwrap_or(Cursor::new_block(block_env.number));
+
+    // process individual transactions in the block.
+    // the iterator will start with txn index == cursor.txn.idx
+    for (tx_idx, (tx_hash, events)) in txs
+        .iter()
+        .filter_map(|(tx, res)| res.receipt().map(|receipt| (tx.hash, receipt.events())))
+        .enumerate()
+        .skip(cursor.txn.idx)
+    {
+        if tx_idx == cursor.txn.idx {
+            match events.len().cmp(&cursor.txn.event) {
+                Ordering::Equal | Ordering::Greater => {}
+                Ordering::Less => continue,
+            }
+        }
+
+        // we should only skip for the last txn pointed by the cursor.
+        let next_event = if tx_idx == cursor.txn.idx { cursor.txn.event } else { 0 };
+        let partial_cursor = fetch_tx_events(
+            next_event,
+            None,
+            None,
+            tx_idx,
+            tx_hash,
+            events,
+            filter,
+            chunk_size as usize,
+            buffer,
+        )?;
+
+        if let Some(c) = partial_cursor {
+            return Ok(c.into_full(block_env.number));
+        }
+    }
+
+    // if we reach here, it means we have processed all the transactions in the pending block.
+    // we return a cursor that points to the next tx in the pending block.
+    let next_pending_tx_idx = txs.len();
+    Ok(Cursor::new(block_env.number, next_pending_tx_idx, 0))
+}
+
+/// Returns `true` if reach the end of the block range.
+pub fn fetch_events_at_blocks(
+    provider: impl BlockProvider + ReceiptProvider,
+    block_range: RangeInclusive<BlockNumber>,
+    filter: &Filter,
+    chunk_size: u64,
+    cursor: Option<Cursor>,
+    buffer: &mut Vec<EmittedEvent>,
+) -> EventQueryResult<Option<Cursor>> {
+    let cursor = cursor.unwrap_or(Cursor::new_block(*block_range.start()));
+
+    // update the block range to start from the block pointed by the cursor.
+    let block_range = cursor.block..=*block_range.end();
+
+    for block_num in block_range {
+        let block_hash = provider.block_hash_by_num(block_num)?.context("Missing block hash")?;
+        let receipts = provider.receipts_by_block(block_num.into())?.context("Missing receipts")?;
+
+        let body_index =
+            provider.block_body_indices(block_num.into())?.context("Missing block body index")?;
+
+        let tx_hashes = provider.transaction_hashes_in_range(body_index.into())?;
+
+        if block_num == cursor.block {
+            match receipts.len().cmp(&cursor.txn.idx) {
+                Ordering::Equal | Ordering::Greater => {}
+                Ordering::Less => continue,
+            }
+        }
+
+        // we should only skip for the last block pointed by the cursor.
+        let total_tx_to_skip = if block_num == cursor.block { cursor.txn.idx } else { 0 };
+
+        // skip number of transactions as specified in the continuation token
+        for (tx_idx, (tx_hash, events)) in tx_hashes
+            .into_iter()
+            .zip(receipts.iter().map(|r| r.events()))
+            .enumerate()
+            .skip(total_tx_to_skip)
+        {
+            // we should only skip for the last txn pointed by the cursor.
+            if block_num == cursor.block && tx_idx == cursor.txn.idx {
+                match events.len().cmp(&cursor.txn.event) {
+                    Ordering::Greater => {}
+                    Ordering::Less | Ordering::Equal => continue,
+                }
+            }
+
+            // we should only skip for the last txn pointed by the cursor.
+            let next_event = if tx_idx == cursor.txn.idx { cursor.txn.event } else { 0 };
+            let partial_cursor = fetch_tx_events(
+                next_event,
+                Some(block_num),
+                Some(block_hash),
+                tx_idx,
+                tx_hash,
+                events,
+                filter,
+                chunk_size as usize,
+                buffer,
+            )?;
+
+            if let Some(c) = partial_cursor {
+                return Ok(Some(c.into_full(block_num)));
+            }
+        }
+    }
+
+    // if we reach here, it means we have processed all the blocks in the range.
+    // therefore we don't need to return a cursor.
+    Ok(None)
+}
+
+/// An iterator that yields events that match the given filters.
+#[derive(Debug)]
+struct FilteredEvents<'a, I: Iterator<Item = &'a Event>> {
+    iter: I,
+    filter: &'a Filter,
+}
+
+impl<'a, I: Iterator<Item = &'a Event>> FilteredEvents<'a, I> {
+    fn new(iter: I, filter: &'a Filter) -> Self {
+        Self { iter, filter }
+    }
+}
+
+impl<'a, I: Iterator<Item = &'a Event>> Iterator for FilteredEvents<'a, I> {
+    type Item = &'a Event;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for event in self.iter.by_ref() {
+            // Check if the event matches the address filter
+            if !self.filter.address.map_or(true, |addr| addr == event.from_address) {
+                continue;
+            }
+
+            // Check if the event matches the keys filter
+            let is_matched = match &self.filter.keys {
+                None => true,
+                // From starknet-api spec:
+                // Per key (by position), designate the possible values to be matched for events to
+                // be returned. Empty array designates 'any' value"
+                Some(filters) => filters.iter().enumerate().all(|(i, keys)| {
+                    // Lets say we want to filter events which are either named `Event1` or `Event2`
+                    // and custom key `0x1` or `0x2` Filter:
+                    // [[sn_keccak("Event1"), sn_keccak("Event2")], ["0x1", "0x2"]]
+
+                    // This checks: number of keys in event >= number of keys in filter (we check >
+                    // i and not >= i because i is zero indexed) because
+                    // otherwise this event doesn't contain all the keys we
+                    // requested
+                    event.keys.len() > i &&
+                         // This checks: Empty array desginates 'any' value
+                         (keys.is_empty()
+                         ||
+                         // This checks: If this events i'th value is one of the requested value in filter_keys[i]
+                         keys.contains(&event.keys[i]))
+                }),
+            };
+
+            if is_matched {
+                return Some(event);
+            }
+        }
+
+        None
+    }
+}
+
+// returns a cursor if it couldn't include all the events of the current transaction because
+// the buffer is already full. otherwise none.
+#[allow(clippy::too_many_arguments)]
+fn fetch_tx_events(
+    next_event_idx: usize,
+    block_number: Option<BlockNumber>,
+    block_hash: Option<BlockHash>,
+    tx_idx: usize,
+    tx_hash: TxHash,
+    events: &[Event],
+    filter: &Filter,
+    chunk_size: usize,
+    buffer: &mut Vec<EmittedEvent>,
+) -> EventQueryResult<Option<PartialCursor>> {
+    // calculate the remaining capacity based on the chunk size and the current
+    // number of events we have taken.
+    let total_can_take = chunk_size.saturating_sub(buffer.len());
+
+    // skip events according to the continuation token.
+    let filtered = FilteredEvents::new(events.iter(), filter)
+        .map(|e| EmittedEvent {
+            block_hash,
+            block_number,
+            keys: e.keys.clone(),
+            data: e.data.clone(),
+            transaction_hash: tx_hash,
+            from_address: e.from_address.into(),
+        })
+        .enumerate()
+        .skip(next_event_idx)
+        .take(total_can_take)
+        .collect::<Vec<_>>();
+
+    // remaining possible events that we haven't seen due to the chunk size limit.
+    let total_events_traversed = next_event_idx + total_can_take;
+
+    // get the index of the last matching event that we have reached. if there is not
+    // matching events (ie `filtered` is empty) we point the end of the chunk
+    // we've covered thus far using the iterator..
+    let last_event_idx = filtered.last().map(|(idx, _)| *idx).unwrap_or(total_events_traversed);
+
+    buffer.extend(filtered.into_iter().map(|(_, event)| event));
+
+    if buffer.len() >= chunk_size {
+        // the next time we have to fetch the events, we will start from this index.
+        let new_last_event = if total_can_take == 0 {
+            // start from the the same event pointed by the
+            // current cursor..
+            last_event_idx
+        } else {
+            // start at the next event of the last event we've filtered out.
+            last_event_idx + 1
+        };
+
+        // if there are still more events that we haven't fetched yet for this tx.
+        if new_last_event < events.len() {
+            return Ok(Some(PartialCursor { idx: tx_idx, event: new_last_event }));
+        }
+    }
+
+    Ok(None)
+}
+
+impl From<Error> for StarknetApiError {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::InvalidCursor => Self::InvalidContinuationToken,
+            Error::Provider(e) => e.into(),
+            Error::Other(e) => e.into(),
+        }
+    }
+}
+
+impl From<ContinuationToken> for Cursor {
+    fn from(token: ContinuationToken) -> Self {
+        Cursor::new(token.block_n, token.txn_n as usize, token.event_n as usize)
+    }
+}

--- a/crates/katana/rpc/rpc/src/utils/mod.rs
+++ b/crates/katana/rpc/rpc/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod events;

--- a/crates/katana/rpc/rpc/tests/starknet.rs
+++ b/crates/katana/rpc/rpc/tests/starknet.rs
@@ -10,19 +10,23 @@ use cainome::rs::abigen_legacy;
 use common::split_felt;
 use dojo_test_utils::sequencer::{get_default_test_starknet_config, TestSequencer};
 use indexmap::IndexSet;
+use jsonrpsee::http_client::HttpClientBuilder;
 use katana_core::sequencer::SequencerConfig;
+use katana_primitives::event::ContinuationToken;
 use katana_primitives::genesis::constant::{
     DEFAULT_FEE_TOKEN_ADDRESS, DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH,
     DEFAULT_PREFUNDED_ACCOUNT_BALANCE, DEFAULT_UDC_ADDRESS,
 };
+use katana_rpc_api::dev::DevApiClient;
 use starknet::accounts::{
     Account, AccountError, AccountFactory, Call, ConnectedAccount, ExecutionEncoding,
     OpenZeppelinAccountFactory, SingleOwnerAccount,
 };
 use starknet::core::types::contract::legacy::LegacyContractClass;
 use starknet::core::types::{
-    BlockId, BlockTag, DeclareTransactionReceipt, DeployAccountTransactionReceipt, ExecutionResult,
-    Felt, StarknetError, TransactionFinalityStatus, TransactionReceipt,
+    BlockId, BlockTag, DeclareTransactionReceipt, DeployAccountTransactionReceipt, EventFilter,
+    EventsPage, ExecutionResult, Felt, StarknetError, TransactionFinalityStatus,
+    TransactionReceipt,
 };
 use starknet::core::utils::get_contract_address;
 use starknet::macros::{felt, selector};
@@ -198,6 +202,8 @@ async fn deploy_account(
     Ok(())
 }
 
+abigen_legacy!(Erc20Contract, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
+
 #[tokio::test]
 async fn estimate_fee() -> Result<()> {
     let sequencer =
@@ -207,8 +213,7 @@ async fn estimate_fee() -> Result<()> {
     let account = sequencer.account();
 
     // setup contract to interact with (can be any existing contract that can be interacted with)
-    abigen_legacy!(Erc20Token, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
-    let contract = Erc20Token::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
+    let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
 
     // setup contract function params
     let recipient = felt!("0x1");
@@ -253,9 +258,6 @@ async fn concurrent_transactions_submissions(
     let provider = sequencer.provider();
     let account = Arc::new(sequencer.account());
 
-    // setup test contract to interact with.
-    abigen_legacy!(Contract, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
-
     // function call params
     let recipient = Felt::ONE;
     let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
@@ -277,7 +279,7 @@ async fn concurrent_transactions_submissions(
 
         let handle = tokio::spawn(async move {
             let mut nonce = nonce.lock().await;
-            let contract = Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), account);
+            let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), account);
             let res = contract.transfer(&recipient, &amount).nonce(*nonce).send().await.unwrap();
             txs.lock().await.insert(res.transaction_hash);
             *nonce += Felt::ONE;
@@ -332,8 +334,7 @@ async fn ensure_validator_have_valid_state(
     let account = sequencer.account();
 
     // setup test contract to interact with.
-    abigen_legacy!(Contract, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
-    let contract = Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
+    let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
 
     // reduce account balance
     let recipient = felt!("0x1337");
@@ -366,8 +367,7 @@ async fn send_txs_with_insufficient_fee(
     let sequencer = TestSequencer::start(sequencer_config, starknet_config).await;
 
     // setup test contract to interact with.
-    abigen_legacy!(Contract, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
-    let contract = Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), sequencer.account());
+    let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), sequencer.account());
 
     // function call params
     let recipient = Felt::ONE;
@@ -444,8 +444,7 @@ async fn send_txs_with_invalid_signature(
     );
 
     // setup test contract to interact with.
-    abigen_legacy!(Contract, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
-    let contract = Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
+    let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
 
     // function call params
     let recipient = Felt::ONE;
@@ -492,8 +491,7 @@ async fn send_txs_with_invalid_nonces(
     let account = sequencer.account();
 
     // setup test contract to interact with.
-    abigen_legacy!(Contract, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
-    let contract = Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
+    let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
 
     // function call params
     let recipient = Felt::ONE;
@@ -545,6 +543,170 @@ async fn send_txs_with_invalid_nonces(
 
     let nonce = account.get_nonce().await?;
     assert_eq!(nonce, Felt::TWO, "Nonce shouldn't change bcs the tx is still invalid.");
+
+    Ok(())
+}
+
+// TODO: write more elaborate tests for get events.
+#[tokio::test]
+async fn get_events_no_pending() -> Result<()> {
+    // setup test sequencer with the given configuration
+    let starknet_config = get_default_test_starknet_config();
+    let sequencer_config = SequencerConfig { no_mining: true, ..Default::default() };
+    let sequencer = TestSequencer::start(sequencer_config, starknet_config).await;
+
+    // create a json rpc client to interact with the dev api.
+    let client = HttpClientBuilder::default().build(sequencer.url()).unwrap();
+
+    let provider = sequencer.provider();
+    let account = sequencer.account();
+
+    // setup test contract to interact with.
+    let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
+    // tx that emits 1 event
+    let tx = || contract.transfer(&Felt::ONE, &Uint256 { low: Felt::ONE, high: Felt::ZERO });
+
+    for _ in 0..5 {
+        let res = tx().send().await?;
+        dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider).await?;
+    }
+
+    // generate a block to mine pending transactions.
+    client.generate_block().await?;
+
+    let filter = EventFilter {
+        keys: None,
+        address: None,
+        to_block: Some(BlockId::Number(1)),
+        from_block: Some(BlockId::Number(0)),
+    };
+
+    // -----------------------------------------------------------------------
+    //  case 1
+
+    let chunk_size = 0;
+    let EventsPage { events, continuation_token } =
+        provider.get_events(filter.clone(), None, chunk_size).await?;
+
+    assert_eq!(events.len(), 0);
+    assert_matches!(continuation_token, Some(token ) => {
+        let token = ContinuationToken::parse(&token)?;
+        assert_eq!(token.block_n, 1);
+        assert_eq!(token.txn_n, 0);
+        assert_eq!(token.event_n, 0);
+    });
+
+    // -----------------------------------------------------------------------
+    //  case 2
+
+    let chunk_size = 3;
+    let EventsPage { events, continuation_token } =
+        provider.get_events(filter.clone(), None, chunk_size).await?;
+
+    assert_eq!(events.len(), 3, "Total events should be limited by chunk size ({chunk_size})");
+    assert_matches!(continuation_token, Some(ref token) => {
+        let token = ContinuationToken::parse(token)?;
+        assert_eq!(token.block_n, 1);
+        assert_eq!(token.txn_n, 3);
+        assert_eq!(token.event_n, 0);
+    });
+
+    let EventsPage { events, continuation_token } =
+        provider.get_events(filter, continuation_token, chunk_size).await?;
+
+    assert_eq!(events.len(), 2, "Remaining should be 2");
+    assert_matches!(continuation_token, None);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_events_with_pending() -> Result<()> {
+    // setup test sequencer with the given configuration
+    let starknet_config = get_default_test_starknet_config();
+    let sequencer_config = SequencerConfig { no_mining: true, ..Default::default() };
+    let sequencer = TestSequencer::start(sequencer_config, starknet_config).await;
+
+    // create a json rpc client to interact with the dev api.
+    let client = HttpClientBuilder::default().build(sequencer.url()).unwrap();
+
+    let provider = sequencer.provider();
+    let account = sequencer.account();
+
+    // setup test contract to interact with.
+    let contract = Erc20Contract::new(DEFAULT_FEE_TOKEN_ADDRESS.into(), &account);
+    // tx that emits 1 event
+    let tx = || contract.transfer(&Felt::ONE, &Uint256 { low: Felt::ONE, high: Felt::ZERO });
+
+    const BLOCK_1_TX_COUNT: usize = 5;
+    const PENDING_BLOCK_TX_COUNT: usize = 5;
+
+    for _ in 0..BLOCK_1_TX_COUNT {
+        let res = tx().send().await?;
+        dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider).await?;
+    }
+
+    // generate block 1
+    client.generate_block().await?;
+
+    // events in pending block (2)
+    for _ in 0..PENDING_BLOCK_TX_COUNT {
+        let res = tx().send().await?;
+        dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider).await?;
+    }
+
+    // because we didnt specifically set the `from` and `to` block, it will implicitly
+    // get events starting from the initial (0) block to the pending block (2)
+    let filter = EventFilter { keys: None, address: None, to_block: None, from_block: None };
+
+    let chunk_size = BLOCK_1_TX_COUNT;
+    let EventsPage { events, continuation_token } =
+        provider.get_events(filter.clone(), None, chunk_size as u64).await?;
+
+    assert_eq!(events.len(), chunk_size);
+    assert_matches!(continuation_token, Some(ref token) => {
+        // the continuation token should now point to block 2 (pending block) because:-
+        // (1) the filter doesn't specify the exact 'to' block, so it will keep moving the cursor to point to the next block.
+        // (2) events in block 1 has been exhausted by the first two queries.
+        let token = ContinuationToken::parse(token)?;
+        assert_eq!(token.block_n, 2);
+        assert_eq!(token.txn_n, 0);
+        assert_eq!(token.event_n, 0);
+    });
+
+    // we split the pending events into two chunks to cover different cases.
+
+    let chunk_size = 3;
+    let EventsPage { events, continuation_token } =
+        provider.get_events(filter.clone(), continuation_token, chunk_size).await?;
+
+    assert_eq!(events.len() as u64, chunk_size);
+    assert_matches!(continuation_token, Some(ref token) => {
+        let token = ContinuationToken::parse(token)?;
+        assert_eq!(token.block_n, 2);
+        assert_eq!(token.txn_n, 3);
+        assert_eq!(token.event_n, 0);
+    });
+
+    // get the rest of events in the pending block
+    let EventsPage { events, continuation_token } =
+        provider.get_events(filter.clone(), continuation_token, chunk_size).await?;
+
+    assert_eq!(events.len(), PENDING_BLOCK_TX_COUNT - chunk_size as usize);
+    assert_matches!(continuation_token, Some(ref token) => {
+        let token = ContinuationToken::parse(token)?;
+        assert_eq!(token.block_n, 2);
+        assert_eq!(token.txn_n, 5);
+        assert_eq!(token.event_n, 0);
+    });
+
+    // fetching events with the continuation token should return an empty list and the
+    // token shouldn't change.
+    let EventsPage { events, continuation_token: new_token } =
+        provider.get_events(filter, continuation_token.clone(), chunk_size).await?;
+
+    assert_eq!(events.len(), 0);
+    assert_eq!(new_token, continuation_token);
 
     Ok(())
 }


### PR DESCRIPTION
resolves #2328 

the `starknet_getEvents` method will now return pending events. though you can explicitly specify the pending block, there is also a case where pending block will be implicitly used, that is when either the `from` or `to` is set to `None` in the json rpc request params.

the events extracting logic could probably be better tho. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `ContinuationToken` for improved event query paging.
	- Enhanced event retrieval logic with refined checks and filtering capabilities.
	- Added a new `utils` module for better organization of event handling functions.

- **Bug Fixes**
	- Improved error handling for continuation tokens, providing more descriptive error messages.

- **Documentation**
	- Added comments to clarify the intent behind new conditions in event retrieval.

- **Refactor**
	- Streamlined event filtering process and improved code readability in the `StarknetApi` implementation.
	- Optimized control flow in event retrieval to prevent unnecessary operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->