### PR TITLE
Break on empty events when loading from remote

### DIFF
--- a/crates/dojo-world/src/manifest/mod.rs
+++ b/crates/dojo-world/src/manifest/mod.rs
@@ -551,12 +551,17 @@ async fn get_events<P: Provider + Send + Sync>(
     loop {
         let res =
             provider.get_events(filter.clone(), continuation_token, DEFAULT_CHUNK_SIZE).await?;
-
         continuation_token = res.continuation_token;
-        events.extend(res.events);
 
         if continuation_token.is_none() {
             break;
+        }
+
+        // stop when there are no more events being returned
+        if res.events.is_empty() {
+            break;
+        } else {
+            events.extend(res.events);
         }
     }
 

--- a/crates/dojo-world/src/manifest/mod.rs
+++ b/crates/dojo-world/src/manifest/mod.rs
@@ -553,15 +553,15 @@ async fn get_events<P: Provider + Send + Sync>(
             provider.get_events(filter.clone(), continuation_token, DEFAULT_CHUNK_SIZE).await?;
         continuation_token = res.continuation_token;
 
-        if continuation_token.is_none() {
-            break;
-        }
-
         // stop when there are no more events being returned
         if res.events.is_empty() {
             break;
         } else {
             events.extend(res.events);
+        }
+
+        if continuation_token.is_none() {
+            break;
         }
     }
 


### PR DESCRIPTION
currently we only stop querying for events when the provider no longer returns a continuation token. this pr adds an extra safety net to stop immediately when there are no more events being returned.

though the spec mentions explicitly that the token [`Should not appear if there are no more pages.`](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_api_openrpc.json#L899-L903) but it doesn't mention exactly how the token should behave with pending block as the list of events in the pending block could still grow.

there could be a case where someone calls `getEvents` with the the `to` block sets `to=pending`. if they already reach the end of the pending block during the first call, yet the block could still emit new events. but if the returned continuation token is nil, then if the user wants to continue from the last events in the first call, they couldn't and had to start from the beginning again.

ref: #2375 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved event retrieval efficiency by terminating early when no events are returned, enhancing performance and reducing unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->