### PR TITLE
Bump `blockifier` to HEAD of `cairo-2.7` branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,7 @@ dependencies = [
 [[package]]
 name = "blockifier"
 version = "0.8.0-dev.2"
-source = "git+https://github.com/dojoengine/blockifier?branch=cairo-2.7-newer#08ac6f38519f1ca87684665d084a7a62448009cc"
+source = "git+https://github.com/dojoengine/blockifier?branch=cairo-2.7#88a1a8058d59b70429b301f017e0f663f4b06d58"
 dependencies = [
  "anyhow",
  "ark-ec",

--- a/crates/katana/executor/Cargo.toml
+++ b/crates/katana/executor/Cargo.toml
@@ -15,7 +15,7 @@ starknet = { workspace = true, optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 
-blockifier = { git = "https://github.com/dojoengine/blockifier", branch = "cairo-2.7-newer", features = [ "testing" ], optional = true }
+blockifier = { git = "https://github.com/dojoengine/blockifier", branch = "cairo-2.7", features = [ "testing" ], optional = true }
 katana-cairo = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
basically to streamline the blockifier branch for now. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the dependency specification for the `blockifier` package to a more stable version, enhancing overall stability and reliability of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->