### PR TITLE
chore(walnut): put under `walnut` feature flag

### DIFF
--- a/bin/sozo/Cargo.toml
+++ b/bin/sozo/Cargo.toml
@@ -51,7 +51,7 @@ serde.workspace = true
 serde_json.workspace = true
 smol_str.workspace = true
 sozo-ops.workspace = true
-sozo-walnut.workspace = true
+sozo-walnut = { workspace = true, optional = true }
 starknet.workspace = true
 starknet-crypto.workspace = true
 thiserror.workspace = true
@@ -71,5 +71,7 @@ katana-runner.workspace = true
 snapbox = "0.4.6"
 
 [features]
+default = [ "controller", "walnut" ]
+
 controller = [ "dep:account_sdk", "dep:reqwest", "dep:slot" ]
-default = [ "controller" ]
+walnut = [ "dep:sozo-walnut" ]

--- a/bin/sozo/Cargo.toml
+++ b/bin/sozo/Cargo.toml
@@ -74,4 +74,4 @@ snapbox = "0.4.6"
 default = [ "controller", "walnut" ]
 
 controller = [ "dep:account_sdk", "dep:reqwest", "dep:slot" ]
-walnut = [ "dep:sozo-walnut" ]
+walnut = [ "dep:sozo-walnut", "sozo-ops/walnut" ]

--- a/bin/sozo/src/commands/auth.rs
+++ b/bin/sozo/src/commands/auth.rs
@@ -5,6 +5,7 @@ use dojo_world::metadata::get_default_namespace_from_ws;
 use scarb::core::Config;
 use scarb_ui::Ui;
 use sozo_ops::auth;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use tracing::trace;
 
@@ -152,6 +153,7 @@ pub async fn grant(
     let world =
         utils::world_from_env_metadata(world, account, &starknet, &env_metadata, config).await?;
 
+    #[cfg(feature = "walnut")]
     let walnut_debugger =
         WalnutDebugger::new_from_flag(transaction.walnut, starknet.url(env_metadata.as_ref())?);
 
@@ -167,6 +169,7 @@ pub async fn grant(
                 &models_contracts,
                 &transaction.into(),
                 default_namespace,
+                #[cfg(feature = "walnut")]
                 &walnut_debugger,
             )
             .await
@@ -182,6 +185,7 @@ pub async fn grant(
                 &owners_resources,
                 &transaction.into(),
                 default_namespace,
+                #[cfg(feature = "walnut")]
                 &walnut_debugger,
             )
             .await
@@ -205,6 +209,7 @@ pub async fn revoke(
     let world =
         utils::world_from_env_metadata(world, account, &starknet, &env_metadata, config).await?;
 
+    #[cfg(feature = "walnut")]
     let walnut_debugger =
         WalnutDebugger::new_from_flag(transaction.walnut, starknet.url(env_metadata.as_ref())?);
 
@@ -220,6 +225,7 @@ pub async fn revoke(
                 &models_contracts,
                 &transaction.into(),
                 default_namespace,
+                #[cfg(feature = "walnut")]
                 &walnut_debugger,
             )
             .await
@@ -235,6 +241,7 @@ pub async fn revoke(
                 &owners_resources,
                 &transaction.into(),
                 default_namespace,
+                #[cfg(feature = "walnut")]
                 &walnut_debugger,
             )
             .await

--- a/bin/sozo/src/commands/execute.rs
+++ b/bin/sozo/src/commands/execute.rs
@@ -4,6 +4,7 @@ use dojo_world::contracts::naming::ensure_namespace;
 use dojo_world::metadata::get_default_namespace_from_ws;
 use scarb::core::Config;
 use sozo_ops::execute;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use tracing::trace;
 
@@ -62,6 +63,7 @@ impl ExecuteArgs {
             ensure_namespace(&self.tag_or_address, &default_namespace)
         };
 
+        #[cfg(feature = "walnut")]
         let walnut_debugger = WalnutDebugger::new_from_flag(
             self.transaction.walnut,
             self.starknet.url(env_metadata.as_ref())?,
@@ -99,6 +101,7 @@ impl ExecuteArgs {
                 calldata,
                 &world,
                 &tx_config,
+                #[cfg(feature = "walnut")]
                 &walnut_debugger,
             )
             .await

--- a/bin/sozo/src/commands/register.rs
+++ b/bin/sozo/src/commands/register.rs
@@ -3,6 +3,7 @@ use clap::{Args, Subcommand};
 use dojo_world::contracts::WorldContractReader;
 use scarb::core::Config;
 use sozo_ops::register;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, BlockTag, Felt};
@@ -59,6 +60,7 @@ impl RegisterArgs {
         let world_address = world.world_address.unwrap_or_default();
         trace!(?world_address, "Using world address.");
 
+        #[cfg(feature = "walnut")]
         let walnut_debugger =
             WalnutDebugger::new_from_flag(transaction.walnut, starknet.url(env_metadata.as_ref())?);
 
@@ -77,6 +79,7 @@ impl RegisterArgs {
                 world_reader,
                 world_address,
                 config,
+                #[cfg(feature = "walnut")]
                 &walnut_debugger,
             )
             .await

--- a/crates/sozo/ops/Cargo.toml
+++ b/crates/sozo/ops/Cargo.toml
@@ -43,6 +43,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 smol_str.workspace = true
+sozo-walnut = { workspace = true, optional = true }
 starknet.workspace = true
 starknet-crypto.workspace = true
 thiserror.workspace = true
@@ -50,7 +51,6 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 url.workspace = true
-sozo-walnut.workspace = true
 
 dojo-test-utils = { workspace = true, features = [ "build-examples" ], optional = true }
 katana-runner = { workspace = true, optional = true }
@@ -64,3 +64,4 @@ tee = "0.1.0"
 
 [features]
 test-utils = [ "dep:dojo-test-utils", "dep:katana-runner" ]
+walnut = [ "dep:sozo-walnut" ]

--- a/crates/sozo/ops/src/auth.rs
+++ b/crates/sozo/ops/src/auth.rs
@@ -9,6 +9,7 @@ use dojo_world::contracts::naming::{
 use dojo_world::contracts::world::WorldContract;
 use dojo_world::contracts::WorldContractReader;
 use scarb_ui::Ui;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use starknet::accounts::{Account, ConnectedAccount};
 use starknet::core::types::{BlockId, BlockTag, Felt};
@@ -111,7 +112,7 @@ pub async fn grant_writer<'a, A>(
     new_writers: &[ResourceWriter],
     txn_config: &TxnConfig,
     default_namespace: &str,
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send,
@@ -143,6 +144,7 @@ where
             res,
             txn_config.wait,
             txn_config.receipt,
+            #[cfg(feature = "walnut")]
             walnut_debugger,
         )
         .await?;
@@ -157,7 +159,7 @@ pub async fn grant_owner<A>(
     new_owners: &[ResourceOwner],
     txn_config: &TxnConfig,
     default_namespace: &str,
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -185,6 +187,7 @@ where
         res,
         txn_config.wait,
         txn_config.receipt,
+        #[cfg(feature = "walnut")]
         walnut_debugger,
     )
     .await?;
@@ -198,7 +201,7 @@ pub async fn revoke_writer<A>(
     new_writers: &[ResourceWriter],
     txn_config: &TxnConfig,
     default_namespace: &str,
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -229,6 +232,7 @@ where
             res,
             txn_config.wait,
             txn_config.receipt,
+            #[cfg(feature = "walnut")]
             walnut_debugger,
         )
         .await?;
@@ -243,7 +247,7 @@ pub async fn revoke_owner<A>(
     new_owners: &[ResourceOwner],
     txn_config: &TxnConfig,
     default_namespace: &str,
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -269,6 +273,7 @@ where
         res,
         txn_config.wait,
         txn_config.receipt,
+        #[cfg(feature = "walnut")]
         walnut_debugger,
     )
     .await?;

--- a/crates/sozo/ops/src/execute.rs
+++ b/crates/sozo/ops/src/execute.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use dojo_utils::{TransactionExt, TxnConfig};
 use dojo_world::contracts::world::WorldContract;
 use scarb_ui::Ui;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use starknet::accounts::{Call, ConnectedAccount};
 use starknet::core::types::Felt;
@@ -16,7 +17,7 @@ pub async fn execute<A>(
     calldata: Vec<Felt>,
     world: &WorldContract<A>,
     txn_config: &TxnConfig,
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -39,6 +40,7 @@ where
         res,
         txn_config.wait,
         txn_config.receipt,
+        #[cfg(feature = "walnut")]
         walnut_debugger,
     )
     .await

--- a/crates/sozo/ops/src/migration/auto_auth.rs
+++ b/crates/sozo/ops/src/migration/auto_auth.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use dojo_utils::TxnConfig;
 use dojo_world::contracts::WorldContract;
 use scarb::core::Workspace;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use starknet::accounts::ConnectedAccount;
 
@@ -14,7 +15,7 @@ pub async fn auto_authorize<A>(
     default_namespace: &str,
     grant: &[ResourceWriter],
     revoke: &[ResourceWriter],
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -22,8 +23,26 @@ where
 {
     let ui = ws.config().ui();
 
-    grant_writer(&ui, world, grant, txn_config, default_namespace, walnut_debugger).await?;
-    revoke_writer(&ui, world, revoke, txn_config, default_namespace, walnut_debugger).await?;
+    grant_writer(
+        &ui,
+        world,
+        grant,
+        txn_config,
+        default_namespace,
+        #[cfg(feature = "walnut")]
+        walnut_debugger,
+    )
+    .await?;
+    revoke_writer(
+        &ui,
+        world,
+        revoke,
+        txn_config,
+        default_namespace,
+        #[cfg(feature = "walnut")]
+        walnut_debugger,
+    )
+    .await?;
 
     Ok(())
 }

--- a/crates/sozo/ops/src/migration/mod.rs
+++ b/crates/sozo/ops/src/migration/mod.rs
@@ -10,6 +10,7 @@ use dojo_world::metadata::get_default_namespace_from_ws;
 use dojo_world::migration::world::WorldDiff;
 use dojo_world::migration::{DeployOutput, UpgradeOutput};
 use scarb::core::Workspace;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use starknet::accounts::{Call, ConnectedAccount, ExecutionEncoding, SingleOwnerAccount};
 use starknet::core::types::{BlockId, BlockTag, Felt, InvokeTransactionResult};
@@ -135,6 +136,8 @@ where
     A::SignError: 'static,
 {
     let ui = ws.config().ui();
+
+    #[cfg(feature = "walnut")]
     let walnut_debugger =
         WalnutDebugger::new_from_flag(txn_config.walnut, Url::parse(&rpc_url).unwrap());
 
@@ -219,6 +222,7 @@ where
 
         Ok(None)
     } else {
+        #[cfg(feature = "walnut")]
         if txn_config.walnut {
             WalnutDebugger::check_api_key()?;
         }
@@ -283,6 +287,7 @@ where
             &default_namespace,
             &grant,
             &revoke,
+            #[cfg(feature = "walnut")]
             &walnut_debugger,
         )
         .await
@@ -373,6 +378,7 @@ where
             }
         }
 
+        #[cfg(feature = "walnut")]
         if let Some(walnut_debugger) = &walnut_debugger {
             walnut_debugger.verify_migration_strategy(ws, &strategy).await?;
         }

--- a/crates/sozo/ops/src/register.rs
+++ b/crates/sozo/ops/src/register.rs
@@ -6,6 +6,7 @@ use dojo_world::contracts::model::ModelReader;
 use dojo_world::contracts::{WorldContract, WorldContractReader};
 use dojo_world::manifest::DeploymentManifest;
 use scarb::core::Config;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::Felt;
@@ -20,7 +21,7 @@ pub async fn model_register<A, P>(
     world_reader: WorldContractReader<P>,
     world_address: Felt,
     config: &Config,
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     A: ConnectedAccount + Sync + Send + 'static,
@@ -78,6 +79,7 @@ where
         res,
         txn_config.wait,
         txn_config.receipt,
+        #[cfg(feature = "walnut")]
         walnut_debugger,
     )
     .await?;

--- a/crates/sozo/ops/src/test_utils/setup.rs
+++ b/crates/sozo/ops/src/test_utils/setup.rs
@@ -155,6 +155,7 @@ pub async fn setup(
         &default_namespace,
         &grant,
         &revoke,
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await?;

--- a/crates/sozo/ops/src/tests/auth.rs
+++ b/crates/sozo/ops/src/tests/auth.rs
@@ -65,6 +65,7 @@ async fn auth_grant_writer_ok() {
         &get_resource_writers(),
         &TxnConfig { wait: true, ..Default::default() },
         DEFAULT_NAMESPACE,
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await
@@ -90,6 +91,7 @@ async fn auth_revoke_writer_ok() {
         &get_resource_writers(),
         &TxnConfig { wait: true, ..Default::default() },
         DEFAULT_NAMESPACE,
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await
@@ -103,6 +105,7 @@ async fn auth_revoke_writer_ok() {
         &get_resource_writers(),
         &TxnConfig { wait: true, ..Default::default() },
         DEFAULT_NAMESPACE,
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await
@@ -141,6 +144,7 @@ async fn auth_grant_owner_ok() {
         &get_resource_owners(other_account),
         &TxnConfig { wait: true, ..Default::default() },
         DEFAULT_NAMESPACE,
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await
@@ -175,6 +179,7 @@ async fn auth_revoke_owner_ok() {
         &get_resource_owners(default_account),
         &TxnConfig { wait: true, ..Default::default() },
         DEFAULT_NAMESPACE,
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await
@@ -204,6 +209,7 @@ async fn execute_spawn<A: ConnectedAccount + Sync + Send + 'static>(
         vec![],
         world,
         &TxnConfig::init_wait(),
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await;

--- a/crates/sozo/ops/src/tests/migration.rs
+++ b/crates/sozo/ops/src/tests/migration.rs
@@ -387,8 +387,17 @@ async fn migrate_with_auto_authorize() {
             .await
             .unwrap();
 
-    let res =
-        auto_authorize(&ws, &world, &txn_config, &default_namespace, &grant, &revoke, &None).await;
+    let res = auto_authorize(
+        &ws,
+        &world,
+        &txn_config,
+        &default_namespace,
+        &grant,
+        &revoke,
+        #[cfg(feature = "walnut")]
+        &None,
+    )
+    .await;
     assert!(res.is_ok());
 
     let provider = sequencer.provider();

--- a/crates/sozo/ops/src/tests/model.rs
+++ b/crates/sozo/ops/src/tests/model.rs
@@ -171,6 +171,7 @@ async fn test_model_ops() {
         vec![],
         &WorldContract::new(world.address, sequencer.account(0)),
         &TxnConfig::init_wait(),
+        #[cfg(feature = "walnut")]
         &None,
     )
     .await;

--- a/crates/sozo/ops/src/utils.rs
+++ b/crates/sozo/ops/src/utils.rs
@@ -5,6 +5,7 @@ use dojo_world::contracts::naming::get_name_from_tag;
 use dojo_world::contracts::world::{WorldContract, WorldContractReader};
 use dojo_world::migration::strategy::generate_salt;
 use scarb_ui::Ui;
+#[cfg(feature = "walnut")]
 use sozo_walnut::WalnutDebugger;
 use starknet::accounts::ConnectedAccount;
 use starknet::core::types::{BlockId, BlockTag, ExecutionResult, Felt, InvokeTransactionResult};
@@ -86,7 +87,7 @@ pub async fn handle_transaction_result<P>(
     transaction_result: InvokeTransactionResult,
     wait_for_tx: bool,
     show_receipt: bool,
-    walnut_debugger: &Option<WalnutDebugger>,
+    #[cfg(feature = "walnut")] walnut_debugger: &Option<WalnutDebugger>,
 ) -> Result<()>
 where
     P: Provider + Send,
@@ -110,6 +111,7 @@ where
                 }
             };
 
+            #[cfg(feature = "walnut")]
             if let Some(walnut_debugger) = walnut_debugger {
                 walnut_debugger.debug_transaction(ui, &transaction_result.transaction_hash)?;
             }


### PR DESCRIPTION
put all walnut code in Sozo under the `walnut` feature flag which will be enabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new optional feature, "walnut," allowing users to enhance functionality with the `sozo-walnut` dependency.
	- Added conditional debugging capabilities through the `WalnutDebugger`, enabling modular debugging options based on feature activation.

- **Bug Fixes**
	- Improved flexibility in function signatures by conditionally including parameters related to the `WalnutDebugger`.

- **Documentation**
	- Enhanced clarity in code structure and readability for functions affected by the new feature.

- **Tests**
	- Updated tests to accommodate the new "walnut" feature, ensuring compatibility and functionality under conditional compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->