### PR TITLE
feat(katana): add node handle

### DIFF
--- a/bin/katana/src/cli/node.rs
+++ b/bin/katana/src/cli/node.rs
@@ -226,18 +226,17 @@ impl NodeArgs {
         let starknet_config = self.starknet_config()?;
 
         // build the node and start it
-        let (rpc_handle, backend) =
-            katana_node::start(server_config, sequencer_config, starknet_config).await?;
+        let node = katana_node::start(server_config, sequencer_config, starknet_config).await?;
 
         if !self.silent {
             #[allow(deprecated)]
-            let genesis = &backend.config.genesis;
-            print_intro(&self, genesis, rpc_handle.addr);
+            let genesis = &node.backend.config.genesis;
+            print_intro(&self, genesis, node.rpc.addr);
         }
 
         // Wait until Ctrl + C is pressed, then shutdown
         ctrl_c().await?;
-        rpc_handle.handle.stop()?;
+        node.rpc.handle.stop()?;
 
         Ok(())
     }

--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -7,7 +7,7 @@ use katana_core::constants::DEFAULT_SEQUENCER_ADDRESS;
 #[allow(deprecated)]
 pub use katana_core::sequencer::SequencerConfig;
 use katana_executor::implementation::blockifier::BlockifierFactory;
-use katana_node::Node;
+use katana_node::Handle;
 use katana_primitives::chain::ChainId;
 use katana_rpc::config::ServerConfig;
 use katana_rpc_api::ApiKind;
@@ -29,7 +29,7 @@ pub struct TestAccount {
 #[allow(missing_debug_implementations)]
 pub struct TestSequencer {
     url: Url,
-    handle: Node,
+    handle: Handle,
     account: TestAccount,
 }
 

--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -7,7 +7,7 @@ use katana_core::constants::DEFAULT_SEQUENCER_ADDRESS;
 #[allow(deprecated)]
 pub use katana_core::sequencer::SequencerConfig;
 use katana_executor::implementation::blockifier::BlockifierFactory;
-use katana_node::NodeHandle;
+use katana_node::Node;
 use katana_primitives::chain::ChainId;
 use katana_rpc::config::ServerConfig;
 use katana_rpc_api::ApiKind;
@@ -29,9 +29,8 @@ pub struct TestAccount {
 #[allow(missing_debug_implementations)]
 pub struct TestSequencer {
     url: Url,
-    handle: NodeHandle,
+    handle: Node,
     account: TestAccount,
-    backend: Arc<Backend<BlockifierFactory>>,
 }
 
 impl TestSequencer {
@@ -46,19 +45,19 @@ impl TestSequencer {
             apis: vec![ApiKind::Starknet, ApiKind::Dev, ApiKind::Saya, ApiKind::Torii],
         };
 
-        let (handle, backend) = katana_node::start(server_config, config, starknet_config)
+        let node = katana_node::start(server_config, config, starknet_config)
             .await
             .expect("Failed to build node components");
 
-        let url = Url::parse(&format!("http://{}", handle.addr)).expect("Failed to parse URL");
+        let url = Url::parse(&format!("http://{}", node.rpc.addr)).expect("Failed to parse URL");
 
-        let account = backend.config.genesis.accounts().next().unwrap();
+        let account = node.backend.config.genesis.accounts().next().unwrap();
         let account = TestAccount {
             private_key: Felt::from_bytes_be(&account.1.private_key().unwrap().to_bytes_be()),
             account_address: Felt::from_bytes_be(&account.0.to_bytes_be()),
         };
 
-        TestSequencer { backend, account, handle, url }
+        TestSequencer { handle: node, account, url }
     }
 
     pub fn account(&self) -> SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet> {
@@ -80,7 +79,7 @@ impl TestSequencer {
     }
 
     pub fn backend(&self) -> &Arc<Backend<BlockifierFactory>> {
-        &self.backend
+        &self.handle.backend
     }
 
     pub fn account_at_index(
@@ -88,7 +87,7 @@ impl TestSequencer {
         index: usize,
     ) -> SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet> {
         #[allow(deprecated)]
-        let accounts: Vec<_> = self.backend.config.genesis.accounts().collect::<_>();
+        let accounts: Vec<_> = self.handle.backend.config.genesis.accounts().collect::<_>();
 
         let account = accounts[index];
         let private_key = Felt::from_bytes_be(&account.1.private_key().unwrap().to_bytes_be());
@@ -112,7 +111,7 @@ impl TestSequencer {
     }
 
     pub fn stop(self) -> Result<(), Error> {
-        self.handle.handle.stop()
+        self.handle.rpc.handle.stop()
     }
 
     pub fn url(&self) -> Url {

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -49,12 +49,13 @@ use starknet::providers::{JsonRpcClient, Provider};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tracing::{info, trace};
 
+/// A handle to the instantiated Katana node.
 #[allow(missing_debug_implementations)]
-pub struct Node {
-    pub backend: Arc<Backend<BlockifierFactory>>,
-    pub block_producer: Arc<BlockProducer<BlockifierFactory>>,
+pub struct Handle {
     pub pool: TxPool,
     pub rpc: RpcServer,
+    pub backend: Arc<Backend<BlockifierFactory>>,
+    pub block_producer: Arc<BlockProducer<BlockifierFactory>>,
 }
 
 /// Build the core Katana components from the given configurations and start running the node.
@@ -71,7 +72,7 @@ pub async fn start(
     server_config: ServerConfig,
     sequencer_config: SequencerConfig,
     mut starknet_config: StarknetConfig,
-) -> Result<Node> {
+) -> Result<Handle> {
     // --- build executor factory
 
     let cfg_env = CfgEnv {
@@ -222,7 +223,7 @@ pub async fn start(
     let node_components = (pool.clone(), backend.clone(), block_producer.clone(), validator);
     let rpc = spawn(node_components, server_config).await?;
 
-    Ok(Node { backend, block_producer, pool, rpc })
+    Ok(Handle { backend, block_producer, pool, rpc })
 }
 
 // Moved from `katana_rpc` crate

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -54,7 +54,7 @@ pub struct Node {
     pub backend: Arc<Backend<BlockifierFactory>>,
     pub block_producer: Arc<BlockProducer<BlockifierFactory>>,
     pub pool: TxPool,
-    pub rpc: RpcServerHandle,
+    pub rpc: RpcServer,
 }
 
 /// Build the core Katana components from the given configurations and start running the node.
@@ -229,7 +229,7 @@ pub async fn start(
 pub async fn spawn<EF: ExecutorFactory>(
     node_components: (TxPool, Arc<Backend<EF>>, Arc<BlockProducer<EF>>, TxValidator),
     config: ServerConfig,
-) -> Result<RpcServerHandle> {
+) -> Result<RpcServer> {
     let (pool, backend, block_producer, validator) = node_components;
 
     let mut methods = RpcModule::new(());
@@ -299,11 +299,11 @@ pub async fn spawn<EF: ExecutorFactory>(
     let addr = server.local_addr()?;
     let handle = server.start(methods)?;
 
-    Ok(RpcServerHandle { handle, addr })
+    Ok(RpcServer { handle, addr })
 }
 
 #[derive(Debug)]
-pub struct RpcServerHandle {
+pub struct RpcServer {
     pub addr: SocketAddr,
     pub handle: ServerHandle,
 }


### PR DESCRIPTION
a super handle that encapsulates all the node components. renamed the old `NodeHandle` into `RpcServer`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Handle` struct that encapsulates key components for improved organization and maintainability.
	- Updated the `start` function to return a `Handle` instance, enhancing clarity in node state representation.
	- Enhanced the `TestSequencer` functionality by integrating with the new `Handle` type for better access to backend components.

- **Bug Fixes**
	- Streamlined the shutdown process and method calls to improve control flow and reduce potential errors.

- **Refactor**
	- Simplified the code structure by consolidating node initialization and reducing variable usage for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->