### PR TITLE
refactor(dojo-lang): output debug info conditionally

### DIFF
--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -47,6 +47,10 @@ pub struct BuildArgs {
     /// Specify packages to build.
     #[command(flatten)]
     pub packages: Option<PackagesFilter>,
+
+    #[arg(long)]
+    #[arg(help = "Output the Sierra debug information for the compiled contracts.")]
+    pub output_debug_info: bool,
 }
 
 impl BuildArgs {
@@ -167,6 +171,7 @@ impl Default for BuildArgs {
             bindings_output: "bindings".to_string(),
             stats: false,
             packages: None,
+            output_debug_info: false,
         }
     }
 }

--- a/bin/sozo/src/main.rs
+++ b/bin/sozo/src/main.rs
@@ -33,10 +33,16 @@ fn cli_main(args: SozoArgs) -> Result<()> {
     let cairo_plugins = CairoPluginRepository::default();
 
     match &args.command {
-        Commands::Build(_) | Commands::Dev(_) | Commands::Migrate(_) => {
+        Commands::Build(args) => {
             trace!("Adding DojoCompiler to compiler repository.");
-            compilers.add(Box::new(DojoCompiler)).unwrap()
+            compilers.add(Box::new(DojoCompiler::new(args.output_debug_info))).unwrap()
         }
+
+        Commands::Dev(_) | Commands::Migrate(_) => {
+            trace!("Adding DojoCompiler to compiler repository.");
+            compilers.add(Box::new(DojoCompiler::default())).unwrap()
+        }
+
         _ => {}
     }
 

--- a/crates/dojo-lang/src/compiler.rs
+++ b/crates/dojo-lang/src/compiler.rs
@@ -63,8 +63,21 @@ pub(crate) const LOG_TARGET: &str = "dojo_lang::compiler";
 #[path = "compiler_test.rs"]
 mod test;
 
-#[derive(Debug)]
-pub struct DojoCompiler;
+#[derive(Debug, Default)]
+pub struct DojoCompiler {
+    /// Output the debug information of the compiled Sierra contracts.
+    ///
+    /// Mainly used for the Walnut debugger integration. It is used
+    /// internally by Walnut to build the Dojo project with the Sierra
+    /// debug information. This flag has no use outside of that.
+    output_debug_info: bool,
+}
+
+impl DojoCompiler {
+    pub fn new(output_debug_info: bool) -> Self {
+        Self { output_debug_info }
+    }
+}
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -143,9 +156,7 @@ impl Compiler for DojoCompiler {
             compile_prepared_db(db, &contracts, compiler_config)?
         };
 
-        // TODO: get the debug flag from the `dojo_<profile>.toml` file.
-        let with_debug_info = true;
-        let debug_info_classes: Vec<Option<SierraToCairoDebugInfo>> = if with_debug_info {
+        let debug_info_classes: Vec<Option<SierraToCairoDebugInfo>> = if self.output_debug_info {
             let debug_classes =
                 crate::scarb_internal::debug::compile_prepared_db_to_debug_info(db, &contracts)?;
 

--- a/crates/dojo-test-utils/src/compiler.rs
+++ b/crates/dojo-test-utils/src/compiler.rs
@@ -271,7 +271,7 @@ pub fn copy_project_temp(
 /// * `profile` - The profile to use for the config.
 pub fn build_test_config(path: &str, profile: Profile) -> anyhow::Result<Config> {
     let mut compilers = CompilerRepository::empty();
-    compilers.add(Box::new(DojoCompiler)).unwrap();
+    compilers.add(Box::new(DojoCompiler::default())).unwrap();
 
     let cairo_plugins = CairoPluginRepository::default();
 


### PR DESCRIPTION
related #2333 

this PR adds a flag in the `sozo` cli and dojo compiler to determine whether to output the Sierra program debug information or not. 

the debug artifacts have no use outside of the Walnut debugger integration, which they (the walnut team) are only using it internally. currently we're outputting it every time, which takes a huge chunk of the build time.

Imo, this is not something that we should maintain on our end but this is the path of least resistance for us.
