### PR TITLE
refactor(katana): separate node service task

### DIFF
--- a/crates/katana/core/src/service/metrics.rs
+++ b/crates/katana/core/src/service/metrics.rs
@@ -1,11 +1,6 @@
 use dojo_metrics::Metrics;
 use metrics::Counter;
 
-#[derive(Debug)]
-pub(crate) struct ServiceMetrics {
-    pub(crate) block_producer: BlockProducerMetrics,
-}
-
 #[derive(Metrics)]
 #[metrics(scope = "block_producer")]
 pub(crate) struct BlockProducerMetrics {

--- a/crates/katana/core/src/service/mod.rs
+++ b/crates/katana/core/src/service/mod.rs
@@ -34,6 +34,7 @@ pub struct MessagingTask<EF: ExecutorFactory> {
     messaging: MessagingService<EF>,
 }
 
+#[cfg(feature = "messaging")]
 impl<EF: ExecutorFactory> MessagingTask<EF> {
     pub fn new(messaging: MessagingService<EF>) -> Self {
         Self { messaging }

--- a/crates/katana/core/src/service/mod.rs
+++ b/crates/katana/core/src/service/mod.rs
@@ -22,47 +22,7 @@ pub mod block_producer;
 pub mod messaging;
 mod metrics;
 
-#[cfg(feature = "messaging")]
-use self::messaging::{MessagingOutcome, MessagingService};
-
 pub(crate) const LOG_TARGET: &str = "node";
-
-#[cfg(feature = "messaging")]
-#[allow(missing_debug_implementations)]
-#[must_use = "MessagingTask does nothing unless polled"]
-pub struct MessagingTask<EF: ExecutorFactory> {
-    messaging: MessagingService<EF>,
-}
-
-#[cfg(feature = "messaging")]
-impl<EF: ExecutorFactory> MessagingTask<EF> {
-    pub fn new(messaging: MessagingService<EF>) -> Self {
-        Self { messaging }
-    }
-}
-
-#[cfg(feature = "messaging")]
-impl<EF: ExecutorFactory> Future for MessagingTask<EF> {
-    type Output = ();
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.get_mut();
-
-        while let Poll::Ready(Some(outcome)) = this.messaging.poll_next_unpin(cx) {
-            match outcome {
-                MessagingOutcome::Gather { msg_count, .. } => {
-                    info!(target: LOG_TARGET, %msg_count, "Collected messages from settlement chain.");
-                }
-
-                MessagingOutcome::Send { msg_count, .. } => {
-                    info!(target: LOG_TARGET, %msg_count, "Sent messages to the settlement chain.");
-                }
-            }
-        }
-
-        Poll::Pending
-    }
-}
 
 /// The type that drives the blockchain's state
 ///

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -19,8 +19,8 @@ use katana_core::env::BlockContextGenerator;
 use katana_core::sequencer::SequencerConfig;
 use katana_core::service::block_producer::BlockProducer;
 #[cfg(feature = "messaging")]
-use katana_core::service::messaging::MessagingService;
-use katana_core::service::{BlockProductionTask, MessagingTask, TransactionMiner};
+use katana_core::service::messaging::{MessagingService, MessagingTask};
+use katana_core::service::{BlockProductionTask, TransactionMiner};
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::{ExecutorFactory, SimulationFlag};
 use katana_pool::ordering::FiFo;
@@ -214,7 +214,7 @@ pub async fn start(
 
     let task_manager = TaskManager::current();
 
-    // --- build messaging task
+    // --- build and spawn the messaging task
 
     #[cfg(feature = "messaging")]
     if let Some(config) = sequencer_config.messaging.clone() {

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -20,7 +20,7 @@ use katana_core::sequencer::SequencerConfig;
 use katana_core::service::block_producer::BlockProducer;
 #[cfg(feature = "messaging")]
 use katana_core::service::messaging::MessagingService;
-use katana_core::service::{NodeService, TransactionMiner};
+use katana_core::service::{BlockProductionTask, MessagingTask, TransactionMiner};
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::{ExecutorFactory, SimulationFlag};
 use katana_pool::ordering::FiFo;
@@ -173,7 +173,7 @@ pub async fn start(
         config: starknet_config,
     });
 
-    // --- build block producer service
+    // --- build block producer
 
     let block_producer = if sequencer_config.block_time.is_some() || sequencer_config.no_mining {
         if let Some(interval) = sequencer_config.block_time {
@@ -210,28 +210,25 @@ pub async fn start(
         info!(%addr, "Metrics endpoint started.");
     }
 
-    // --- build messaging service
+    // --- create a TaskManager using the ambient Tokio runtime
+
+    let task_manager = TaskManager::current();
+
+    // --- build messaging task
 
     #[cfg(feature = "messaging")]
-    let messaging = if let Some(config) = sequencer_config.messaging.clone() {
-        MessagingService::new(config, pool.clone(), Arc::clone(&backend)).await.ok()
-    } else {
-        None
-    };
+    if let Some(config) = sequencer_config.messaging.clone() {
+        let messaging = MessagingService::new(config, pool.clone(), Arc::clone(&backend)).await?;
+        let task = MessagingTask::new(messaging);
+        task_manager.build_task().critical().name("Messaging").spawn(task);
+    }
 
     let block_producer = Arc::new(block_producer);
 
-    // Create a TaskManager using the ambient Tokio runtime
-    let task_manager = TaskManager::current();
+    // --- build and spawn the block production task
 
-    // Spawn the NodeService as a critical task
-    task_manager.build_task().critical().name("NodeService").spawn(NodeService::new(
-        pool.clone(),
-        miner,
-        block_producer.clone(),
-        #[cfg(feature = "messaging")]
-        messaging,
-    ));
+    let task = BlockProductionTask::new(pool.clone(), miner, block_producer.clone());
+    task_manager.build_task().critical().name("BlockProduction").spawn(task);
 
     // --- spawn rpc server
 

--- a/crates/katana/tasks/src/manager.rs
+++ b/crates/katana/tasks/src/manager.rs
@@ -47,8 +47,8 @@ impl TaskManager {
         self.on_cancel.cancelled().await;
     }
 
-    /// Shutdowns the manger and wait until all tasks are finished, either due to completion or
-    /// cancellation.
+    /// Shuts down the manager and wait until all currently running tasks are finished, either due
+    /// to completion or cancellation.
     ///
     /// No task can be spawned on the manager after this method is called.
     pub async fn shutdown(self) {

--- a/crates/katana/tasks/src/task.rs
+++ b/crates/katana/tasks/src/task.rs
@@ -131,9 +131,9 @@ impl<'a> CriticalTaskBuilder<'a> {
         let fut = AssertUnwindSafe(fut)
             .catch_unwind()
             .map_err(move |error| {
-                ct.cancel();
                 let error = PanickedTaskError { error };
                 error!(%error, task = task_name, "Critical task failed.");
+                ct.cancel();
                 error
             })
             .map(drop);


### PR DESCRIPTION
small refactor/optimisation separating the `NodeService` task which currently encapsulates both the messaging and block production task. 

this PR separate it into two different tasks. easier to reason about the scope of each task and allowing them to be scheduled by `Tokio` on different worker threads (parallelized)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `MessagingTask` for improved asynchronous messaging handling.
	- Added `BlockProductionTask` to streamline block production processes.
- **Bug Fixes**
	- Enhanced error handling in `CriticalTaskBuilder` to prioritize task cancellation on panic.
- **Documentation**
	- Updated documentation for the `shutdown` method in `TaskManager` for clarity. 
- **Refactor**
	- Simplified the architecture by removing `ServiceMetrics` and focusing on `BlockProducerMetrics`. 
	- Refined task management for both messaging and block production services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->