### PR TITLE
feat: dispatcher_from_tag! macro

### DIFF
--- a/crates/dojo-lang/src/inline_macros/dispatcher_from_tag.rs
+++ b/crates/dojo-lang/src/inline_macros/dispatcher_from_tag.rs
@@ -1,0 +1,93 @@
+use cairo_lang_defs::patcher::PatchBuilder;
+use cairo_lang_defs::plugin::{
+    InlineMacroExprPlugin, InlinePluginResult, MacroPluginMetadata, NamedPlugin, PluginDiagnostic,
+    PluginGeneratedFile,
+};
+use cairo_lang_defs::plugin_utils::unsupported_bracket_diagnostic;
+use cairo_lang_diagnostics::Severity;
+use cairo_lang_syntax::node::{ast, TypedStablePtr, TypedSyntaxNode};
+use dojo_world::contracts::naming;
+
+use super::utils::find_interface_path;
+
+#[derive(Debug, Default)]
+pub struct DispatcherFromTagMacro;
+
+impl NamedPlugin for DispatcherFromTagMacro {
+    const NAME: &'static str = "dispatcher_from_tag";
+}
+
+impl InlineMacroExprPlugin for DispatcherFromTagMacro {
+    fn generate_code(
+        &self,
+        db: &dyn cairo_lang_syntax::node::db::SyntaxGroup,
+        syntax: &ast::ExprInlineMacro,
+        metadata: &MacroPluginMetadata<'_>,
+    ) -> InlinePluginResult {
+        let ast::WrappedArgList::ParenthesizedArgList(arg_list) = syntax.arguments(db) else {
+            return unsupported_bracket_diagnostic(db, syntax);
+        };
+
+        let args = arg_list.arguments(db).elements(db);
+
+        if args.len() != 2 {
+            return InlinePluginResult {
+                code: None,
+                diagnostics: vec![PluginDiagnostic {
+                    stable_ptr: syntax.stable_ptr().untyped(),
+                    message: "Invalid arguments. Expected dispatcher_from_tag!(\"tag\", contract_address)"
+                        .to_string(),
+                    severity: Severity::Error,
+                }],
+            };
+        }
+
+        let tag = &args[0].as_syntax_node().get_text(db).replace('\"', "");
+        let contract_address = args[1].as_syntax_node().get_text(db);
+
+        if !naming::is_valid_tag(tag) {
+            return InlinePluginResult {
+                code: None,
+                diagnostics: vec![PluginDiagnostic {
+                    stable_ptr: syntax.stable_ptr().untyped(),
+                    message: "Invalid tag. Tag must be in the format of `namespace-name`."
+                        .to_string(),
+                    severity: Severity::Error,
+                }],
+            };
+        }
+
+        // read the interface path from the manifest and generate a dispatcher:
+        // <interface_path>Dispatcher { contract_address };
+        let interface_path = match find_interface_path(metadata.cfg_set, tag) {
+            Ok(interface_path) => interface_path,
+            Err(_e) => {
+                return InlinePluginResult {
+                    code: None,
+                    diagnostics: vec![PluginDiagnostic {
+                        stable_ptr: syntax.stable_ptr().untyped(),
+                        message: format!("Failed to find the interface path of `{tag}`"),
+                        severity: Severity::Error,
+                    }],
+                };
+            }
+        };
+
+        let mut builder = PatchBuilder::new(db, syntax);
+        builder.add_str(&format!(
+            "{interface_path}Dispatcher {{ contract_address: {contract_address}}}",
+        ));
+
+        let (code, code_mappings) = builder.build();
+
+        InlinePluginResult {
+            code: Some(PluginGeneratedFile {
+                name: "dispatcher_from_tag_macro".into(),
+                content: code,
+                code_mappings,
+                aux_data: None,
+            }),
+            diagnostics: vec![],
+        }
+    }
+}

--- a/crates/dojo-lang/src/inline_macros/mod.rs
+++ b/crates/dojo-lang/src/inline_macros/mod.rs
@@ -5,6 +5,7 @@ use cairo_lang_syntax::node::{ast, Terminal, TypedStablePtr, TypedSyntaxNode};
 use smol_str::SmolStr;
 
 pub mod delete;
+pub mod dispatcher_from_tag;
 pub mod emit;
 pub mod get;
 pub mod get_models_test_class_hashes;

--- a/crates/dojo-lang/src/inline_macros/utils.rs
+++ b/crates/dojo-lang/src/inline_macros/utils.rs
@@ -33,6 +33,22 @@ pub fn parent_of_kind(
     None
 }
 
+///
+pub fn find_interface_path(cfg_set: &CfgSet, contract_tag: &str) -> anyhow::Result<String> {
+    let dojo_manifests_dir = get_dojo_manifests_dir(cfg_set.clone())?;
+
+    let base_dir = dojo_manifests_dir.join("base");
+    let base_manifest = BaseManifest::load_from_path(&base_dir)?;
+
+    for contract in base_manifest.contracts {
+        if contract.inner.tag == contract_tag {
+            return Ok(contract.inner.interface_path);
+        }
+    }
+
+    Err(anyhow::anyhow!("Unable to find the interface path of `{}`", contract_tag))
+}
+
 /// Reads all the models and namespaces from base manifests files.
 pub fn load_manifest_models_and_namespaces(
     cfg_set: &CfgSet,

--- a/crates/dojo-lang/src/interface.rs
+++ b/crates/dojo-lang/src/interface.rs
@@ -1,6 +1,7 @@
 use cairo_lang_defs::patcher::{PatchBuilder, RewriteNode};
 use cairo_lang_defs::plugin::{
-    MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile, PluginResult,
+    DynGeneratedFileAuxData, MacroPluginMetadata, PluginDiagnostic, PluginGeneratedFile,
+    PluginResult,
 };
 use cairo_lang_diagnostics::Severity;
 use cairo_lang_plugins::plugins::HasItemsInCfgEx;
@@ -8,6 +9,7 @@ use cairo_lang_syntax::node::db::SyntaxGroup;
 use cairo_lang_syntax::node::{ast, ids, Terminal, TypedStablePtr, TypedSyntaxNode};
 use cairo_lang_utils::unordered_hash_map::UnorderedHashMap;
 
+use crate::plugin::{DojoAuxData, InterfaceAuxData};
 use crate::syntax::self_param;
 use crate::syntax::world_param::{self, WorldParamInjectionKind};
 
@@ -84,7 +86,12 @@ impl DojoInterface {
             code: Some(PluginGeneratedFile {
                 name: name.clone(),
                 content: code,
-                aux_data: None,
+                aux_data: Some(DynGeneratedFileAuxData::new(DojoAuxData {
+                    models: vec![],
+                    contracts: vec![],
+                    events: vec![],
+                    interfaces: vec![InterfaceAuxData { name: name.to_string() }],
+                })),
                 code_mappings,
             }),
             diagnostics: interface.diagnostics,

--- a/crates/dojo-lang/src/plugin.rs
+++ b/crates/dojo-lang/src/plugin.rs
@@ -28,6 +28,7 @@ use url::Url;
 use crate::contract::DojoContract;
 use crate::event::handle_event_struct;
 use crate::inline_macros::delete::DeleteMacro;
+use crate::inline_macros::dispatcher_from_tag::DispatcherFromTagMacro;
 use crate::inline_macros::emit::EmitMacro;
 use crate::inline_macros::get::GetMacro;
 use crate::inline_macros::get_models_test_class_hashes::GetModelsTestClassHashes;
@@ -54,12 +55,24 @@ pub struct Model {
     pub members: Vec<Member>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Trait {
+    pub name: String,
+    pub path: String,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub struct ContractAuxData {
     pub name: SmolStr,
     pub namespace: String,
     pub dependencies: Vec<Dependency>,
     pub systems: Vec<String>,
+    pub traits: Vec<Trait>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InterfaceAuxData {
+    pub name: String,
 }
 
 /// Dojo related auxiliary data of the Dojo plugin.
@@ -71,6 +84,8 @@ pub struct DojoAuxData {
     pub contracts: Vec<ContractAuxData>,
     /// A list of events that were processed by the plugin.
     pub events: Vec<StarkNetEventAuxData>,
+    /// A list of interfaces that were processed by the plugin.
+    pub interfaces: Vec<InterfaceAuxData>,
 }
 
 impl GeneratedFileAuxData for DojoAuxData {
@@ -78,7 +93,11 @@ impl GeneratedFileAuxData for DojoAuxData {
         self
     }
     fn eq(&self, other: &dyn GeneratedFileAuxData) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<Self>() { self == other } else { false }
+        if let Some(other) = other.as_any().downcast_ref::<Self>() {
+            self == other
+        } else {
+            false
+        }
     }
 }
 
@@ -158,6 +177,7 @@ pub fn dojo_plugin_suite() -> PluginSuite {
         .add_inline_macro_plugin::<SetMacro>()
         .add_inline_macro_plugin::<EmitMacro>()
         .add_inline_macro_plugin::<SelectorFromTagMacro>()
+        .add_inline_macro_plugin::<DispatcherFromTagMacro>()
         .add_inline_macro_plugin::<GetModelsTestClassHashes>()
         .add_inline_macro_plugin::<SpawnTestWorld>();
 

--- a/crates/dojo-lang/src/semantics/test_data/dispatcher_from_tag
+++ b/crates/dojo-lang/src/semantics/test_data/dispatcher_from_tag
@@ -1,0 +1,66 @@
+//! > Test no param
+
+//! > test_runner_name
+test_semantics
+
+//! > expression
+dispatcher_from_tag!()
+
+//! > expected
+Missing(
+    ExprMissing {
+        ty: <missing>,
+    },
+)
+
+//! > semantic_diagnostics
+error: Plugin diagnostic: Invalid arguments. Expected dispatcher_from_tag!("tag", contract_address)
+ --> lib.cairo:2:1
+dispatcher_from_tag!()
+^********************^
+
+//! > ==========================================================================
+
+//! > Test missing address
+
+//! > test_runner_name
+test_semantics
+
+//! > expression
+dispatcher_from_tag!("dojo-foo_setter")
+
+//! > expected
+Missing(
+    ExprMissing {
+        ty: <missing>,
+    },
+)
+
+//! > semantic_diagnostics
+error: Plugin diagnostic: Invalid arguments. Expected dispatcher_from_tag!("tag", contract_address)
+ --> lib.cairo:2:1
+dispatcher_from_tag!("dojo-foo_setter")
+^*************************************^
+
+//! > ==========================================================================
+
+//! > Test ok but expected to fail due to missing dojo_manifests_dir
+
+//! > test_runner_name
+test_semantics
+
+//! > expression
+dispatcher_from_tag!("dojo-foo_setter", 0x1234)
+
+//! > expected
+Missing(
+    ExprMissing {
+        ty: <missing>,
+    },
+)
+
+//! > semantic_diagnostics
+error: Plugin diagnostic: Failed to find the interface path of `dojo-foo_setter`
+ --> lib.cairo:2:1
+dispatcher_from_tag!("dojo-foo_setter", 0x1234)
+^*********************************************^

--- a/crates/dojo-lang/src/semantics/tests.rs
+++ b/crates/dojo-lang/src/semantics/tests.rs
@@ -19,6 +19,8 @@ test_file_test!(
 
         selector_from_tag: "selector_from_tag",
 
+        dispatcher_from_tag: "dispatcher_from_tag",
+
         get_models_test_class_hashes: "get_models_test_class_hashes",
 
         spawn_test_world: "spawn_test_world",

--- a/crates/dojo-world/src/manifest/types.rs
+++ b/crates/dojo-world/src/manifest/types.rs
@@ -107,6 +107,7 @@ pub struct DojoContract {
     pub init_calldata: Vec<String>,
     pub tag: String,
     pub systems: Vec<String>,
+    pub interface_path: String,
 }
 
 /// Represents a declaration of a model.

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-actions-40b6994c.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-actions-40b6994c.toml
@@ -18,4 +18,5 @@ systems = [
     "update_player_name",
     "update_player_items",
 ]
+interface_path = "dojo_examples::actions::IActions"
 manifest_name = "dojo_examples-actions-40b6994c"

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-dungeon-6620e0e6.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-dungeon-6620e0e6.toml
@@ -8,4 +8,5 @@ writes = []
 init_calldata = []
 tag = "dojo_examples-dungeon"
 systems = ["enter"]
+interface_path = "dojo_examples::dungeon::IDungeon"
 manifest_name = "dojo_examples-dungeon-6620e0e6"

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-mock_token-31599eb2.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-mock_token-31599eb2.toml
@@ -8,4 +8,5 @@ writes = []
 init_calldata = []
 tag = "dojo_examples-mock_token"
 systems = []
+interface_path = ""
 manifest_name = "dojo_examples-mock_token-31599eb2"

--- a/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-others-61de2c18.toml
+++ b/examples/spawn-and-move/manifests/dev/base/contracts/dojo_examples-others-61de2c18.toml
@@ -8,4 +8,5 @@ writes = []
 init_calldata = []
 tag = "dojo_examples-others"
 systems = []
+interface_path = ""
 manifest_name = "dojo_examples-others-61de2c18"

--- a/examples/spawn-and-move/src/actions.cairo
+++ b/examples/spawn-and-move/src/actions.cairo
@@ -166,7 +166,8 @@ pub mod actions {
             let river_skale = RiverSkale { id: 1, health: 5, armor: 3, attack: 2 };
 
             set!(world, (flatbow, river_skale));
-            IDungeonDispatcher { contract_address: dungeon_address }.enter();
+            let d = dispatcher_from_tag("dojo_examples-dungeon", dungeon_address);
+            d.enter();
         }
 
         fn update_player_name(ref world: IWorldDispatcher, name: ByteArray) {


### PR DESCRIPTION
The idea of this PR was to provide a `dispatcher_from_tag!` macro, allowing the developper to get a dispatcher from a contract tag and an address, without any `use` clause for the contract dispatcher.

For example:
```rust
fn enter_dungeon(ref world: IWorldDispatcher, dungeon_address: ContractAddress) {
     let d = dispatcher_from_tag!("dojo_examples-dungeon", dungeon_address);
     d.enter();
}
```

Unfortunately, this macro needs to access to the project base manifest which is built at compile time, meaning that it is not accessible by the macro during compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced handling of Dojo interfaces to ensure contracts implement only a single interface.
	- Introduced `get_traits` function for extracting traits from contract modules.
	- Added a macro for generating dispatcher code based on tags and contract addresses.
	- New utility function to find interface paths associated with contract tags.
	- Expanded `DojoContract` and `PluginGeneratedFile` structures to include interface paths and traits.

- **Bug Fixes**
	- Improved error handling for missing or incorrect parameters in dispatcher macros.

- **Tests**
	- Added comprehensive tests for the new dispatcher macro functionality. 

- **Chores**
	- Updated configuration files to include interface paths for various contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->