### PR TITLE
fix(torii-grpc): member clause should never error out if no entities

### DIFF
--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -521,7 +521,14 @@ impl DojoWorld {
         "#,
             compute_selector_from_names(namespace, model)
         );
-        let (models_str,): (String,) = sqlx::query_as(&models_query).fetch_one(&self.pool).await?;
+        
+        let models_result: Option<(String,)> = sqlx::query_as(&models_query).fetch_optional(&self.pool).await?;
+        // we return an empty array of entities if the table is empty
+        if models_result.is_none() {
+            return Ok((Vec::new(), 0));
+        }
+
+        let (models_str,) = models_result.unwrap();
 
         let model_ids = models_str
             .split(',')

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -257,7 +257,8 @@ impl DojoWorld {
                 "#
         );
         // total count of rows without limit and offset
-        let total_count: u32 = sqlx::query_scalar(&count_query).fetch_optional(&self.pool).await?.unwrap_or(0);
+        let total_count: u32 =
+            sqlx::query_scalar(&count_query).fetch_optional(&self.pool).await?.unwrap_or(0);
 
         if total_count == 0 {
             return Ok((Vec::new(), 0));
@@ -375,8 +376,11 @@ impl DojoWorld {
             }
         );
 
-        let total_count =
-            sqlx::query_scalar(&count_query).bind(&keys_pattern).fetch_optional(&self.pool).await?.unwrap_or(0);
+        let total_count = sqlx::query_scalar(&count_query)
+            .bind(&keys_pattern)
+            .fetch_optional(&self.pool)
+            .await?
+            .unwrap_or(0);
 
         if total_count == 0 {
             return Ok((Vec::new(), 0));
@@ -521,8 +525,9 @@ impl DojoWorld {
         "#,
             compute_selector_from_names(namespace, model)
         );
-        
-        let models_result: Option<(String,)> = sqlx::query_as(&models_query).fetch_optional(&self.pool).await?;
+
+        let models_result: Option<(String,)> =
+            sqlx::query_as(&models_query).fetch_optional(&self.pool).await?;
         // we return an empty array of entities if the table is empty
         if models_result.is_none() {
             return Ok((Vec::new(), 0));

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -257,7 +257,7 @@ impl DojoWorld {
                 "#
         );
         // total count of rows without limit and offset
-        let total_count: u32 = sqlx::query_scalar(&count_query).fetch_one(&self.pool).await?;
+        let total_count: u32 = sqlx::query_scalar(&count_query).fetch_optional(&self.pool).await?.unwrap_or(0);
 
         if total_count == 0 {
             return Ok((Vec::new(), 0));
@@ -376,7 +376,7 @@ impl DojoWorld {
         );
 
         let total_count =
-            sqlx::query_scalar(&count_query).bind(&keys_pattern).fetch_one(&self.pool).await?;
+            sqlx::query_scalar(&count_query).bind(&keys_pattern).fetch_optional(&self.pool).await?.unwrap_or(0);
 
         if total_count == 0 {
             return Ok((Vec::new(), 0));
@@ -552,8 +552,9 @@ impl DojoWorld {
 
         let total_count = sqlx::query_scalar(&count_query)
             .bind(comparison_value.clone())
-            .fetch_one(&self.pool)
-            .await?;
+            .fetch_optional(&self.pool)
+            .await?
+            .unwrap_or(0);
 
         let db_entities = sqlx::query(&entity_query)
             .bind(comparison_value.clone())
@@ -678,7 +679,7 @@ impl DojoWorld {
             count_query = count_query.bind(value);
         }
 
-        let total_count = count_query.fetch_one(&self.pool).await?;
+        let total_count = count_query.fetch_optional(&self.pool).await?.unwrap_or(0);
 
         if total_count == 0 {
             return Ok((Vec::new(), 0));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for model data retrieval, preventing crashes when no results are found.
	- Enhanced application stability by returning an empty vector and count of zero when no data is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->