### PR TITLE
feat(torii/processor): support integer type column for key

### DIFF
--- a/crates/torii/core/src/processors/store_set_record.rs
+++ b/crates/torii/core/src/processors/store_set_record.rs
@@ -77,6 +77,9 @@ where
         entity.deserialize(&mut keys_and_unpacked)?;
 
         db.set_entity(entity, event_id, block_timestamp, entity_id, model_id, &keys_str).await?;
+        // early flush the queue because this writes entity keys to a table which is required
+        // by other store_* events
+        db.execute().await?;
         Ok(())
     }
 }


### PR DESCRIPTION
If the type of external_* column in the query was not text the try_get would error out because it cannot decode to string, so now we check the column time and decode the value based on it

and also call execute on db before fetching entity keys because the query which inserts these key could be in queue

**Stack**:
- #2426
- #2424 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved error handling for entity key fetching and deserialization, providing clearer error messages.
	- Enhanced database management after setting entity records to ensure proper operation of subsequent events.
	- Added type checking for SQL query results, improving data handling and preventing failures from unexpected data types.
	- Introduced new processors for handling update events for members and records, expanding event processing capabilities.
	- Added a new test case to validate the handling of update operations, ensuring reliability of the new functionality.

- **Bug Fixes**
	- Enhanced robustness in SQL processing logic by raising errors for unsupported column types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->