### PR TITLE
Bump `slot` to `0.14.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12841,8 +12841,8 @@ dependencies = [
 
 [[package]]
 name = "slot"
-version = "0.14.0"
-source = "git+https://github.com/cartridge-gg/slot?tag=v0.14.0#b87f26919c38e43a78fea429cf7b6b927940d0b4"
+version = "0.14.1"
+source = "git+https://github.com/cartridge-gg/slot?tag=v0.14.1#267f4fbcf30654f313c1bcedf7310bc93e586690"
 dependencies = [
  "account_sdk",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ alloy-sol-types = { version = "0.7.6", default-features = false }
 criterion = "0.5.1"
 
 # Slot integration. Dojo don't need to manually include `account_sdk` as dependency as `slot` already re-exports it.
-slot = { git = "https://github.com/cartridge-gg/slot", tag = "v0.14.0" }
+slot = { git = "https://github.com/cartridge-gg/slot", tag = "v0.14.1" }
 
 alloy-contract = { version = "0.2", default-features = false }
 alloy-json-rpc = { version = "0.2", default-features = false }


### PR DESCRIPTION
update to the new default Controller session expiry time https://github.com/cartridge-gg/slot/pull/89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the `slot` library to version `v0.14.1`, potentially enhancing performance and introducing new features.
- **Bug Fixes**
	- Included various bug fixes from the updated `slot` library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->