### PR TITLE
opt(torii-grpc): parallelize queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14819,6 +14819,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper 0.14.30",
+ "itertools 0.12.1",
  "katana-runner",
  "num-traits 0.2.19",
  "parking_lot 0.12.3",

--- a/crates/torii/grpc/Cargo.toml
+++ b/crates/torii/grpc/Cargo.toml
@@ -13,6 +13,7 @@ futures.workspace = true
 num-traits.workspace = true
 parking_lot.workspace = true
 rayon.workspace = true
+itertools.workspace = true
 starknet-crypto.workspace = true
 starknet.workspace = true
 thiserror.workspace = true

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -290,18 +290,14 @@ impl DojoWorld {
             sqlx::query_as(&query).bind(limit).bind(offset).fetch_all(&self.pool).await?;
 
         // Group entities by their model combinations
-        let mut model_groups: HashMap<Vec<Felt>, Vec<String>> = HashMap::new();
+        let mut model_groups: HashMap<String, Vec<String>> = HashMap::new();
         for (entity_id, models_str) in db_entities {
-            let model_ids: Vec<Felt> = models_str
-                .split(',')
-                .map(Felt::from_str)
-                .collect::<Result<_, _>>()
-                .map_err(ParseError::FromStr)?;
-            model_groups.entry(model_ids).or_default().push(entity_id);
+            model_groups.entry(models_str).or_default().push(entity_id);
         }
 
         let mut entities = Vec::new();
         for (model_ids, entity_ids) in model_groups {
+            let model_ids = model_ids.split(',').map(|id| Felt::from_str(id).unwrap()).collect::<Vec<_>>();
             let schemas =
                 self.model_cache.models(&model_ids).await?.into_iter().map(|m| m.schema).collect();
 
@@ -461,18 +457,14 @@ impl DojoWorld {
             .await?;
 
         // Group entities by their model combinations
-        let mut model_groups: HashMap<Vec<Felt>, Vec<String>> = HashMap::new();
+        let mut model_groups: HashMap<String, Vec<String>> = HashMap::new();
         for (entity_id, models_str) in db_entities {
-            let model_ids: Vec<Felt> = models_str
-                .split(',')
-                .map(Felt::from_str)
-                .collect::<Result<_, _>>()
-                .map_err(ParseError::FromStr)?;
-            model_groups.entry(model_ids).or_default().push(entity_id);
+            model_groups.entry(models_str).or_default().push(entity_id);
         }
 
         let mut entities = Vec::new();
         for (model_ids, entity_ids) in model_groups {
+            let model_ids = model_ids.split(',').map(|id| Felt::from_str(id).unwrap()).collect::<Vec<_>>();
             let schemas =
                 self.model_cache.models(&model_ids).await?.into_iter().map(|m| m.schema).collect();
 
@@ -708,18 +700,14 @@ impl DojoWorld {
         let db_entities: Vec<(String, String)> = db_query.fetch_all(&self.pool).await?;
 
         // Group entities by their model combinations
-        let mut model_groups: HashMap<Vec<Felt>, Vec<String>> = HashMap::new();
+        let mut model_groups: HashMap<String, Vec<String>> = HashMap::new();
         for (entity_id, models_str) in db_entities {
-            let model_ids: Vec<Felt> = models_str
-                .split(',')
-                .map(Felt::from_str)
-                .collect::<Result<_, _>>()
-                .map_err(ParseError::FromStr)?;
-            model_groups.entry(model_ids).or_default().push(entity_id);
+            model_groups.entry(models_str).or_default().push(entity_id);
         }
 
         let mut entities = Vec::new();
         for (model_ids, entity_ids) in model_groups {
+            let model_ids = model_ids.split(',').map(|id| Felt::from_str(id).unwrap()).collect::<Vec<_>>();
             let schemas =
                 self.model_cache.models(&model_ids).await?.into_iter().map(|m| m.schema).collect();
 

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -460,13 +460,19 @@ impl DojoWorld {
             .fetch_all(&self.pool)
             .await?;
 
-        let mut entities = Vec::with_capacity(db_entities.len());
-        for (entity_id, models_strs) in &db_entities {
-            let model_ids: Vec<Felt> = models_strs
+        // Group entities by their model combinations
+        let mut model_groups: HashMap<Vec<Felt>, Vec<String>> = HashMap::new();
+        for (entity_id, models_str) in db_entities {
+            let model_ids: Vec<Felt> = models_str
                 .split(',')
                 .map(Felt::from_str)
                 .collect::<Result<_, _>>()
                 .map_err(ParseError::FromStr)?;
+            model_groups.entry(model_ids).or_default().push(entity_id);
+        }
+
+        let mut entities = Vec::new();
+        for (model_ids, entity_ids) in model_groups {
             let schemas =
                 self.model_cache.models(&model_ids).await?.into_iter().map(|m| m.schema).collect();
 
@@ -474,20 +480,43 @@ impl DojoWorld {
                 &schemas,
                 table,
                 entity_relation_column,
-                Some(&format!("{table}.id = ?")),
-                Some(&format!("{table}.id = ?")),
+                Some(&format!(
+                    "{table}.id IN ({})",
+                    entity_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",")
+                )),
+                Some(&format!(
+                    "{table}.id IN ({})",
+                    entity_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",")
+                )),
                 None,
                 None,
             )?;
 
-            let row = sqlx::query(&entity_query).bind(entity_id).fetch_one(&self.pool).await?;
+            let mut query = sqlx::query(&entity_query);
+            for id in &entity_ids {
+                query = query.bind(id);
+            }
+            let rows = query.fetch_all(&self.pool).await?;
+
             let mut arrays_rows = HashMap::new();
-            for (name, query) in arrays_queries {
-                let rows = sqlx::query(&query).bind(entity_id).fetch_all(&self.pool).await?;
-                arrays_rows.insert(name, rows);
+            for (name, array_query) in arrays_queries {
+                let mut query = sqlx::query(&array_query);
+                for id in &entity_ids {
+                    query = query.bind(id);
+                }
+                let array_rows = query.fetch_all(&self.pool).await?;
+                arrays_rows.insert(name, array_rows);
             }
 
-            entities.push(map_row_to_entity(&row, &arrays_rows, schemas.clone())?);
+            let arrays_rows = Arc::new(arrays_rows);
+            let schemas = Arc::new(schemas);
+
+            let group_entities: Result<Vec<_>, Error> = rows
+                .par_iter()
+                .map(|row| map_row_to_entity(row, &arrays_rows, (*schemas).clone()))
+                .collect();
+
+            entities.extend(group_entities?);
         }
 
         Ok((entities, total_count))

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -964,11 +964,8 @@ fn build_composite_clause(
                 // Generate a unique alias for each model
                 let counter = model_counters.entry(model.clone()).or_insert(0);
                 *counter += 1;
-                let alias = if *counter == 1 {
-                    model.clone()
-                } else {
-                    format!("{model}_{}", *counter - 1)
-                };
+                let alias =
+                    if *counter == 1 { model.clone() } else { format!("{model}_{}", *counter - 1) };
 
                 join_clauses.push(format!(
                     "LEFT JOIN {table_name} AS [{alias}] ON [{table}].id = [{alias}].entity_id"

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -736,7 +736,16 @@ impl DojoWorld {
         query: proto::types::Query,
     ) -> Result<proto::world::RetrieveEntitiesResponse, Error> {
         let (entities, total_count) = match query.clause {
-            None => self.entities_all(table, model_relation_table, entity_relation_column, query.limit, query.offset).await?,
+            None => {
+                self.entities_all(
+                    table,
+                    model_relation_table,
+                    entity_relation_column,
+                    query.limit,
+                    query.offset,
+                )
+                .await?
+            }
             Some(clause) => {
                 let clause_type =
                     clause.clause_type.ok_or(QueryError::MissingParam("clause_type".into()))?;
@@ -867,12 +876,12 @@ fn build_keys_pattern(clause: &proto::types::KeysClause) -> Result<String, Error
         clause
             .keys
             .iter()
-        .map(|bytes| {
-            if bytes.is_empty() {
-                return Ok("0x[0-9a-fA-F]+".to_string());
-            }
-            Ok(format!("{:#x}", Felt::from_bytes_be_slice(bytes)))
-        })
+            .map(|bytes| {
+                if bytes.is_empty() {
+                    return Ok("0x[0-9a-fA-F]+".to_string());
+                }
+                Ok(format!("{:#x}", Felt::from_bytes_be_slice(bytes)))
+            })
             .collect::<Result<Vec<_>, Error>>()?
     };
     let mut keys_pattern = format!("^{}", keys.join("/"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced performance for large dataset handling in the DojoWorld functionality through parallel processing of database queries.
	- Improved efficiency by grouping entities for batch processing, reducing database calls.
	- Integrated the `itertools` library for enhanced collection manipulation capabilities.

- **Bug Fixes**
	- Optimized mapping of database rows to entities, ensuring faster execution times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->