### PR TITLE
Bump `serde_json` to `1.0.128`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12504,11 +12504,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.128"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]


### PR DESCRIPTION
ref: https://purplesyringa.moe/blog/i-sped-up-serde-json-strings-by-20-percent/

there's a significant improvement (20%) to `serde_json` introduced in version `1.0.121`. our current version is `1.0.120` but might as well bump to the latest version (`1.0.128`).