### PR TITLE
fix: remove dojo plugin dep

### DIFF
--- a/crates/dojo-core/Scarb.lock
+++ b/crates/dojo-core/Scarb.lock
@@ -4,11 +4,3 @@ version = 1
 [[package]]
 name = "dojo"
 version = "1.0.0-alpha.4"
-dependencies = [
- "dojo_plugin",
-]
-
-[[package]]
-name = "dojo_plugin"
-version = "1.0.0-alpha.4"
-source = "git+https://github.com/dojoengine/dojo?rev=f15def33#f15def330c0d099e79351d11c197f63e8cc1ff36"

--- a/crates/dojo-core/Scarb.toml
+++ b/crates/dojo-core/Scarb.toml
@@ -8,7 +8,4 @@ version = "1.0.0-alpha.4"
 [dependencies]
 starknet = "=2.7.0"
 
-[dev-dependencies]
-dojo_plugin = { git = "https://github.com/dojoengine/dojo", rev = "f15def33" }
-
 [lib]

--- a/crates/dojo-core/Scarb.toml
+++ b/crates/dojo-core/Scarb.toml
@@ -6,7 +6,9 @@ name = "dojo"
 version = "1.0.0-alpha.4"
 
 [dependencies]
-dojo_plugin = { git = "https://github.com/dojoengine/dojo", rev = "f15def33" }
 starknet = "=2.7.0"
+
+[dev-dependencies]
+dojo_plugin = { git = "https://github.com/dojoengine/dojo", rev = "f15def33" }
 
 [lib]

--- a/crates/dojo-world/src/metadata.rs
+++ b/crates/dojo-world/src/metadata.rs
@@ -73,21 +73,17 @@ pub fn dojo_metadata_from_package(package: &Package, ws: &Workspace<'_>) -> Resu
     }
 
     // If not dojo dependent, we should skip metadata gathering.
-    if !package
-        .manifest
-        .summary
-        .dependencies
-        .iter()
-        .any(|dep| dep.name.as_str() == "dojo")
-    {
-        // Some tests (like dojo-core) may depend on dojo, but there is no dojo dependency in the manifest.
-        // In case the profile config file exists, we extract the default namespace from it.
+    if !package.manifest.summary.dependencies.iter().any(|dep| dep.name.as_str() == "dojo") {
+        // Some tests (like dojo-core) may depend on dojo, but there is no dojo dependency in the
+        // manifest. In case the profile config file exists, we extract the default
+        // namespace from it.
         if let Ok(profile_config) = ProfileConfig::new(
             &Utf8PathBuf::from(package.manifest_path().parent().unwrap()),
             ws.current_profile()?,
         ) {
-            let mut metadata = DojoMetadata::default();
-            metadata.namespace = profile_config.namespace;
+            let metadata =
+                DojoMetadata { namespace: profile_config.namespace, ..Default::default() };
+
             return Ok(metadata);
         } else {
             tracing::trace!(target: LOG_TARGET, package = ?package.manifest_path(), "No dojo dependency or profile config file found, skipping metadata collection.");

--- a/examples/spawn-and-move/Scarb.lock
+++ b/examples/spawn-and-move/Scarb.lock
@@ -18,9 +18,6 @@ dependencies = [
 [[package]]
 name = "dojo"
 version = "1.0.0-alpha.4"
-dependencies = [
- "dojo_plugin",
-]
 
 [[package]]
 name = "dojo_examples"
@@ -30,8 +27,3 @@ dependencies = [
  "bestiary",
  "dojo",
 ]
-
-[[package]]
-name = "dojo_plugin"
-version = "1.0.0-alpha.4"
-source = "git+https://github.com/dojoengine/dojo?rev=f15def33#f15def330c0d099e79351d11c197f63e8cc1ff36"


### PR DESCRIPTION
For historical reasons, we were fetching the dojo plugin with scarb. However, the plugin is actually loaded in `sozo` binary.

Hence, we don't need to fetch this plugin, which will also allow decoupling of Dojo core in an other repo and ease the fetch of Dojo core by downstream usages in game development.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified metadata gathering logic based on package dependencies.
	- Introduced a new pathway for loading metadata from a profile configuration file.

- **Chores**
	- Removed the `dojo_plugin` dependency to streamline project management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->