### PR TITLE
refactor(katana-primitives): replace `HashMap` with `BTreeMap` in state updates and genesis types

### DIFF
--- a/bin/saya/src/tests.rs
+++ b/bin/saya/src/tests.rs
@@ -71,7 +71,7 @@ async fn test_program_input_from_program_output() -> anyhow::Result<()> {
         ],
         state_updates: StateUpdates {
             nonce_updates: {
-                let mut map = std::collections::HashMap::new();
+                let mut map = std::collections::BTreeMap::new();
                 map.insert(
                     ContractAddress::from(Felt::from_str("1111").unwrap()),
                     Felt::from_str("22222").unwrap(),
@@ -84,8 +84,8 @@ async fn test_program_input_from_program_output() -> anyhow::Result<()> {
             )]
             .into_iter()
             .collect(),
-            contract_updates: {
-                let mut map = std::collections::HashMap::new();
+            deployed_contracts: {
+                let mut map = std::collections::BTreeMap::new();
                 map.insert(
                     ContractAddress::from(Felt::from_str("66666").unwrap()),
                     Felt::from_str("7777").unwrap(),
@@ -93,10 +93,11 @@ async fn test_program_input_from_program_output() -> anyhow::Result<()> {
                 map
             },
             declared_classes: {
-                let mut map = std::collections::HashMap::new();
+                let mut map = std::collections::BTreeMap::new();
                 map.insert(Felt::from_str("88888").unwrap(), Felt::from_str("99999").unwrap());
                 map
             },
+            ..Default::default()
         },
         world_da: None,
     };

--- a/crates/katana/controller/src/lib.rs
+++ b/crates/katana/controller/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use alloy_primitives::U256;
 use anyhow::Result;
@@ -131,7 +131,7 @@ pub mod json {
 fn get_contract_storage(
     credential_id: CredentialID,
     public_key: CoseKey,
-) -> Result<HashMap<StorageKey, StorageValue>> {
+) -> Result<BTreeMap<StorageKey, StorageValue>> {
     use slot::account_sdk::signers::DeviceError;
     use webauthn_rs_proto::auth::PublicKeyCredentialRequestOptions;
     use webauthn_rs_proto::{
@@ -186,7 +186,7 @@ fn get_contract_storage(
     let storage = get_storage_var_address(MULTIPLE_OWNERS_COMPONENT_SUB_STORAGE, &[guid])?;
 
     // 1 for boolean True in Cairo. Refer to the provided link above.
-    let storage_mapping = HashMap::from([(storage, Felt::ONE)]);
+    let storage_mapping = BTreeMap::from([(storage, Felt::ONE)]);
 
     Ok(storage_mapping)
 }

--- a/crates/katana/executor/src/implementation/blockifier/utils.rs
+++ b/crates/katana/executor/src/implementation/blockifier/utils.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::num::NonZeroU128;
 use std::sync::Arc;
 
@@ -403,12 +403,15 @@ pub(super) fn state_update_from_cached_state<S: StateDb>(
 
     let state_diff = state.0.lock().inner.to_state_diff().unwrap();
 
-    let mut declared_compiled_classes: HashMap<katana_primitives::class::ClassHash, CompiledClass> =
-        HashMap::new();
-    let mut declared_sierra_classes: HashMap<
+    let mut declared_compiled_classes: BTreeMap<
+        katana_primitives::class::ClassHash,
+        CompiledClass,
+    > = BTreeMap::new();
+
+    let mut declared_sierra_classes: BTreeMap<
         katana_primitives::class::ClassHash,
         FlattenedSierraClass,
-    > = HashMap::new();
+    > = BTreeMap::new();
 
     for class_hash in state_diff.compiled_class_hashes.keys() {
         let hash = class_hash.0;
@@ -427,27 +430,29 @@ pub(super) fn state_update_from_cached_state<S: StateDb>(
             .nonces
             .into_iter()
             .map(|(key, value)| (to_address(key), value.0))
-            .collect::<HashMap<
+            .collect::<BTreeMap<
                 katana_primitives::contract::ContractAddress,
                 katana_primitives::contract::Nonce,
             >>();
 
-    let storage_updates =
-        state_diff.storage.into_iter().fold(HashMap::new(), |mut storage, ((addr, key), value)| {
-            let entry: &mut HashMap<
+    let storage_updates = state_diff.storage.into_iter().fold(
+        BTreeMap::new(),
+        |mut storage, ((addr, key), value)| {
+            let entry: &mut BTreeMap<
                 katana_primitives::contract::StorageKey,
                 katana_primitives::contract::StorageValue,
             > = storage.entry(to_address(addr)).or_default();
             entry.insert(*key.0.key(), value);
             storage
-        });
+        },
+    );
 
-    let contract_updates =
+    let deployed_contracts =
         state_diff
             .class_hashes
             .into_iter()
             .map(|(key, value)| (to_address(key), value.0))
-            .collect::<HashMap<
+            .collect::<BTreeMap<
                 katana_primitives::contract::ContractAddress,
                 katana_primitives::class::ClassHash,
             >>();
@@ -457,7 +462,7 @@ pub(super) fn state_update_from_cached_state<S: StateDb>(
             .compiled_class_hashes
             .into_iter()
             .map(|(key, value)| (key.0, value.0))
-            .collect::<HashMap<
+            .collect::<BTreeMap<
                 katana_primitives::class::ClassHash,
                 katana_primitives::class::CompiledClassHash,
             >>();
@@ -468,8 +473,9 @@ pub(super) fn state_update_from_cached_state<S: StateDb>(
         state_updates: StateUpdates {
             nonce_updates,
             storage_updates,
-            contract_updates,
+            deployed_contracts,
             declared_classes,
+            ..Default::default()
         },
     }
 }
@@ -651,7 +657,7 @@ fn to_l2_l1_messages(
 #[cfg(test)]
 mod tests {
 
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     use katana_cairo::cairo_vm::types::builtin_name::BuiltinName;
     use katana_cairo::cairo_vm::vm::runners::cairo_runner::ExecutionResources;

--- a/crates/katana/executor/tests/executor.rs
+++ b/crates/katana/executor/tests/executor.rs
@@ -55,11 +55,7 @@ fn test_executor_with_valid_blocks_impl<EF: ExecutorFactory>(
 
     // ensure that all transactions succeeded, if not panic with the error message and tx index
     let has_failed = transactions.iter().enumerate().find_map(|(i, (_, res))| {
-        if let ExecutionResult::Failed { error } = res {
-            Some((i, error))
-        } else {
-            None
-        }
+        if let ExecutionResult::Failed { error } = res { Some((i, error)) } else { None }
     });
 
     if let Some((pos, error)) = has_failed {

--- a/crates/katana/executor/tests/executor.rs
+++ b/crates/katana/executor/tests/executor.rs
@@ -1,6 +1,6 @@
 mod fixtures;
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use fixtures::{state_provider, valid_blocks};
 use katana_executor::{ExecutionOutput, ExecutionResult, ExecutorFactory};
@@ -55,7 +55,11 @@ fn test_executor_with_valid_blocks_impl<EF: ExecutorFactory>(
 
     // ensure that all transactions succeeded, if not panic with the error message and tx index
     let has_failed = transactions.iter().enumerate().find_map(|(i, (_, res))| {
-        if let ExecutionResult::Failed { error } = res { Some((i, error)) } else { None }
+        if let ExecutionResult::Failed { error } = res {
+            Some((i, error))
+        } else {
+            None
+        }
     });
 
     if let Some((pos, error)) = has_failed {
@@ -283,16 +287,17 @@ fn test_executor_with_valid_blocks_impl<EF: ExecutorFactory>(
     assert_eq!(actual_txs, expected_txs);
 
     let actual_nonce_updates = states.state_updates.nonce_updates;
-    let expected_nonce_updates = HashMap::from([(main_account, felt!("3")), (new_acc, felt!("1"))]);
+    let expected_nonce_updates =
+        BTreeMap::from([(main_account, felt!("3")), (new_acc, felt!("1"))]);
 
     let actual_declared_classes = states.state_updates.declared_classes;
-    let expected_declared_classes = HashMap::from([(
+    let expected_declared_classes = BTreeMap::from([(
         felt!("0x420"),
         felt!("0x016c6081eb34ad1e0c5513234ed0c025b3c7f305902d291bad534cd6474c85bc"),
     )]);
 
-    let actual_contract_deployed = states.state_updates.contract_updates;
-    let expected_contract_deployed = HashMap::from([
+    let actual_contract_deployed = states.state_updates.deployed_contracts;
+    let expected_contract_deployed = BTreeMap::from([
         (new_acc, DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH),
         (deployed_contract.into(), DEFAULT_LEGACY_ERC20_CONTRACT_CLASS_HASH),
     ]);

--- a/crates/katana/executor/tests/simulate.rs
+++ b/crates/katana/executor/tests/simulate.rs
@@ -71,7 +71,7 @@ fn test_simulate_tx_impl<EF: ExecutorFactory>(
 
     assert!(states.state_updates.nonce_updates.is_empty(), "no state updates");
     assert!(states.state_updates.storage_updates.is_empty(), "no state updates");
-    assert!(states.state_updates.contract_updates.is_empty(), "no state updates");
+    assert!(states.state_updates.deployed_contracts.is_empty(), "no state updates");
     assert!(states.state_updates.declared_classes.is_empty(), "no state updates");
 
     assert!(states.declared_sierra_classes.is_empty(), "no new classes should be declared");

--- a/crates/katana/primitives/Cargo.toml
+++ b/crates/katana/primitives/Cargo.toml
@@ -25,8 +25,8 @@ flate2 = { workspace = true, optional = true }
 katana-cairo.workspace = true
 
 [dev-dependencies]
-assert_matches.workspace = true
 num-traits.workspace = true
+assert_matches.workspace = true
 similar-asserts.workspace = true
 
 [features]

--- a/crates/katana/primitives/src/genesis/allocation.rs
+++ b/crates/katana/primitives/src/genesis/allocation.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 
 use alloy_primitives::U256;
@@ -59,7 +59,7 @@ impl GenesisAllocation {
     }
 
     /// Get the storage values for this contract allocation.
-    pub fn storage(&self) -> Option<&HashMap<StorageKey, StorageValue>> {
+    pub fn storage(&self) -> Option<&BTreeMap<StorageKey, StorageValue>> {
         match self {
             Self::Contract(contract) => contract.storage.as_ref(),
             Self::Account(account) => account.storage(),
@@ -107,7 +107,7 @@ impl GenesisAccountAlloc {
         }
     }
 
-    pub fn storage(&self) -> Option<&HashMap<StorageKey, StorageValue>> {
+    pub fn storage(&self) -> Option<&BTreeMap<StorageKey, StorageValue>> {
         match self {
             Self::Account(account) => account.storage.as_ref(),
             Self::DevAccount(account) => account.storage.as_ref(),
@@ -136,7 +136,7 @@ pub struct GenesisContractAlloc {
     pub nonce: Option<Felt>,
     /// The initial storage values of the contract.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub storage: Option<HashMap<StorageKey, StorageValue>>,
+    pub storage: Option<BTreeMap<StorageKey, StorageValue>>,
 }
 
 /// Used mainly for development purposes where the account info including the
@@ -191,7 +191,7 @@ pub struct GenesisAccount {
     pub nonce: Option<Felt>,
     /// The initial storage values of the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub storage: Option<HashMap<StorageKey, StorageValue>>,
+    pub storage: Option<BTreeMap<StorageKey, StorageValue>>,
 }
 
 impl GenesisAccount {

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -1215,10 +1215,12 @@ mod tests {
     fn genesis_from_json_with_unresolved_paths() {
         let file = File::open("./src/genesis/test-genesis.json").unwrap();
         let json: GenesisJson = serde_json::from_reader(file).unwrap();
-        assert!(Genesis::try_from(json)
-            .unwrap_err()
-            .to_string()
-            .contains("Unresolved class artifact path"));
+        assert!(
+            Genesis::try_from(json)
+                .unwrap_err()
+                .to_string()
+                .contains("Unresolved class artifact path")
+        );
     }
 
     #[test]
@@ -1262,9 +1264,8 @@ mod tests {
             .expect("failed to load genesis file");
 
         let res = Genesis::try_from(json);
-        assert!(res
-            .unwrap_err()
-            .to_string()
-            .contains(&format!("Class name '{name}' already exists")))
+        assert!(
+            res.unwrap_err().to_string().contains(&format!("Class name '{name}' already exists"))
+        )
     }
 }

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -315,7 +315,8 @@ impl Default for Genesis {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    use std::collections::HashMap;
+    use std::str::FromStr;
 
     use allocation::GenesisAccount;
     use starknet::macros::felt;

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -2,7 +2,7 @@ pub mod allocation;
 pub mod constant;
 pub mod json;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -51,7 +51,7 @@ pub struct FeeTokenConfig {
     #[serde_as(as = "UfeHex")]
     pub class_hash: ClassHash,
     /// To initialize the fee token contract storage
-    pub storage: Option<HashMap<StorageKey, StorageValue>>,
+    pub storage: Option<BTreeMap<StorageKey, StorageValue>>,
 }
 
 #[serde_with::serde_as]
@@ -76,7 +76,7 @@ pub struct UniversalDeployerConfig {
     /// The address of the universal deployer contract.
     pub address: ContractAddress,
     /// To initialize the UD contract storage
-    pub storage: Option<HashMap<StorageKey, StorageValue>>,
+    pub storage: Option<BTreeMap<StorageKey, StorageValue>>,
 }
 
 /// Genesis block configuration.
@@ -98,7 +98,7 @@ pub struct Genesis {
     /// The genesis block L1 gas prices.
     pub gas_prices: GasPrices,
     /// The classes to declare in the genesis block.
-    pub classes: HashMap<ClassHash, GenesisClass>,
+    pub classes: BTreeMap<ClassHash, GenesisClass>,
     /// The fee token configuration.
     pub fee_token: FeeTokenConfig,
     /// The universal deployer (UDC) configuration.
@@ -174,7 +174,7 @@ impl Genesis {
             let address = *address;
 
             if let Some(hash) = alloc.class_hash() {
-                states.state_updates.contract_updates.insert(address, hash);
+                states.state_updates.deployed_contracts.insert(address, hash);
             }
 
             if let Some(nonce) = alloc.nonce() {
@@ -226,7 +226,7 @@ impl Genesis {
 
         states
             .state_updates
-            .contract_updates
+            .deployed_contracts
             .insert(self.fee_token.address, self.fee_token.class_hash);
         states.state_updates.storage_updates.insert(self.fee_token.address, fee_token_storage);
 
@@ -234,7 +234,7 @@ impl Genesis {
         if let Some(udc) = &self.universal_deployer {
             let storage = udc.storage.clone().unwrap_or_default();
 
-            states.state_updates.contract_updates.insert(udc.address, udc.class_hash);
+            states.state_updates.deployed_contracts.insert(udc.address, udc.class_hash);
             states.state_updates.storage_updates.insert(udc.address, storage);
         }
 
@@ -262,7 +262,7 @@ impl Default for Genesis {
             storage: None,
         };
 
-        let classes = HashMap::from([
+        let classes = BTreeMap::from([
             (
                 DEFAULT_LEGACY_ERC20_CONTRACT_CLASS_HASH,
                 GenesisClass {
@@ -315,7 +315,7 @@ impl Default for Genesis {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{collections::HashMap, str::FromStr};
 
     use allocation::GenesisAccount;
     use starknet::macros::felt;
@@ -326,7 +326,7 @@ mod tests {
     fn genesis_block_and_state_updates() {
         // setup initial states to test
 
-        let classes = HashMap::from([
+        let classes = BTreeMap::from([
             (
                 DEFAULT_LEGACY_UDC_CLASS_HASH,
                 GenesisClass {
@@ -368,7 +368,7 @@ mod tests {
             symbol: String::from("ETH"),
             decimals: 18,
             class_hash: DEFAULT_LEGACY_ERC20_CONTRACT_CLASS_HASH,
-            storage: Some(HashMap::from([
+            storage: Some(BTreeMap::from([
                 (felt!("0x111"), felt!("0x1")),
                 (felt!("0x222"), felt!("0x2")),
             ])),
@@ -384,7 +384,7 @@ mod tests {
                     balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                     class_hash: DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH,
                     nonce: Some(felt!("0x99")),
-                    storage: Some(HashMap::from([
+                    storage: Some(BTreeMap::from([
                         (felt!("0x1"), felt!("0x1")),
                         (felt!("0x2"), felt!("0x2")),
                     ])),
@@ -396,7 +396,7 @@ mod tests {
                     balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                     class_hash: Some(DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH),
                     nonce: Some(felt!("0x100")),
-                    storage: Some(HashMap::from([
+                    storage: Some(BTreeMap::from([
                         (felt!("0x100"), felt!("0x111")),
                         (felt!("0x200"), felt!("0x222")),
                     ])),
@@ -535,7 +535,7 @@ mod tests {
         );
 
         assert_eq!(
-            actual_state_updates.state_updates.contract_updates.get(&fee_token.address),
+            actual_state_updates.state_updates.deployed_contracts.get(&fee_token.address),
             Some(&fee_token.class_hash),
             "The fee token contract should be created"
         );
@@ -558,7 +558,7 @@ mod tests {
         );
 
         assert_eq!(
-            actual_state_updates.state_updates.contract_updates.get(&ud.address),
+            actual_state_updates.state_updates.deployed_contracts.get(&ud.address),
             Some(&ud.class_hash),
             "The universal deployer contract should be created"
         );
@@ -620,7 +620,7 @@ mod tests {
         // check that all contract allocations exist in the state updates
 
         assert_eq!(
-            actual_state_updates.state_updates.contract_updates.len(),
+            actual_state_updates.state_updates.deployed_contracts.len(),
             5,
             "5 contracts should be created: fee token, universal deployer, and 3 allocations"
         );
@@ -634,7 +634,7 @@ mod tests {
         );
 
         assert_eq!(
-            actual_state_updates.state_updates.contract_updates.get(&alloc_1_addr),
+            actual_state_updates.state_updates.deployed_contracts.get(&alloc_1_addr),
             allocations[0].1.class_hash().as_ref(),
             "allocation should exist"
         );
@@ -652,7 +652,7 @@ mod tests {
         let alloc_2_addr = allocations[1].0;
 
         assert_eq!(
-            actual_state_updates.state_updates.contract_updates.get(&alloc_2_addr),
+            actual_state_updates.state_updates.deployed_contracts.get(&alloc_2_addr),
             allocations[1].1.class_hash().as_ref(),
             "allocation should exist"
         );
@@ -670,7 +670,7 @@ mod tests {
         let alloc_3_addr = allocations[2].0;
 
         assert_eq!(
-            actual_state_updates.state_updates.contract_updates.get(&alloc_3_addr),
+            actual_state_updates.state_updates.deployed_contracts.get(&alloc_3_addr),
             allocations[2].1.class_hash().as_ref(),
             "allocation should exist"
         );
@@ -681,7 +681,7 @@ mod tests {
         );
         assert_eq!(
             actual_state_updates.state_updates.storage_updates.get(&alloc_3_addr).cloned(),
-            Some(HashMap::from([(OZ_ACCOUNT_CONTRACT_PUBKEY_STORAGE_SLOT, felt!("0x2"))])),
+            Some(BTreeMap::from([(OZ_ACCOUNT_CONTRACT_PUBKEY_STORAGE_SLOT, felt!("0x2"))])),
             "account allocation storage should be updated"
         );
 

--- a/crates/katana/primitives/src/state.rs
+++ b/crates/katana/primitives/src/state.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 
 use crate::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
 use crate::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
@@ -10,13 +11,17 @@ use crate::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StateUpdates {
     /// A mapping of contract addresses to their updated nonces.
-    pub nonce_updates: HashMap<ContractAddress, Nonce>,
+    pub nonce_updates: BTreeMap<ContractAddress, Nonce>,
     /// A mapping of contract addresses to their updated storage entries.
-    pub storage_updates: HashMap<ContractAddress, HashMap<StorageKey, StorageValue>>,
+    pub storage_updates: BTreeMap<ContractAddress, BTreeMap<StorageKey, StorageValue>>,
     /// A mapping of contract addresses to their updated class hashes.
-    pub contract_updates: HashMap<ContractAddress, ClassHash>,
+    pub deployed_contracts: BTreeMap<ContractAddress, ClassHash>,
     /// A mapping of newly declared class hashes to their compiled class hashes.
-    pub declared_classes: HashMap<ClassHash, CompiledClassHash>,
+    pub declared_classes: BTreeMap<ClassHash, CompiledClassHash>,
+    /// A mapping of newly declared legacy class hashes.
+    pub deprecated_declared_classes: BTreeSet<ClassHash>,
+    /// A mapping of replaced contract addresses to their new class hashes ie using `replace_class` syscall.
+    pub replaced_classes: BTreeMap<ContractAddress, ClassHash>,
 }
 
 /// State update with declared classes definition.
@@ -25,7 +30,7 @@ pub struct StateUpdatesWithDeclaredClasses {
     /// State updates.
     pub state_updates: StateUpdates,
     /// A mapping of class hashes to their sierra classes definition.
-    pub declared_sierra_classes: HashMap<ClassHash, FlattenedSierraClass>,
+    pub declared_sierra_classes: BTreeMap<ClassHash, FlattenedSierraClass>,
     /// A mapping of class hashes to their compiled classes definition.
-    pub declared_compiled_classes: HashMap<ClassHash, CompiledClass>,
+    pub declared_compiled_classes: BTreeMap<ClassHash, CompiledClass>,
 }

--- a/crates/katana/primitives/src/state.rs
+++ b/crates/katana/primitives/src/state.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::class::{ClassHash, CompiledClass, CompiledClassHash, FlattenedSierraClass};
 use crate::contract::{ContractAddress, Nonce, StorageKey, StorageValue};
@@ -20,7 +19,8 @@ pub struct StateUpdates {
     pub declared_classes: BTreeMap<ClassHash, CompiledClassHash>,
     /// A mapping of newly declared legacy class hashes.
     pub deprecated_declared_classes: BTreeSet<ClassHash>,
-    /// A mapping of replaced contract addresses to their new class hashes ie using `replace_class` syscall.
+    /// A mapping of replaced contract addresses to their new class hashes ie using `replace_class`
+    /// syscall.
     pub replaced_classes: BTreeMap<ContractAddress, ClassHash>,
 }
 

--- a/crates/katana/rpc/rpc-types/src/state_update.rs
+++ b/crates/katana/rpc/rpc-types/src/state_update.rs
@@ -46,7 +46,7 @@ impl From<katana_primitives::state::StateUpdates> for StateDiff {
             .collect();
 
         let deployed_contracts: Vec<DeployedContractItem> = value
-            .contract_updates
+            .deployed_contracts
             .into_iter()
             .map(|(addr, class_hash)| DeployedContractItem { address: addr.into(), class_hash })
             .collect();

--- a/crates/katana/storage/provider/src/providers/fork/state.rs
+++ b/crates/katana/storage/provider/src/providers/fork/state.rs
@@ -217,7 +217,7 @@ impl ContractClassProvider for ForkedSnapshot {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
     use starknet::macros::felt;
@@ -253,7 +253,7 @@ mod tests {
             let remote = SharedStateProvider::new_with_backend(backend.clone());
             let local = ForkedStateDb::new(remote.clone());
 
-            let nonce_updates = HashMap::from([(address, remote_nonce)]);
+            let nonce_updates = BTreeMap::from([(address, remote_nonce)]);
             let updates = StateUpdatesWithDeclaredClasses {
                 state_updates: StateUpdates { nonce_updates, ..Default::default() },
                 ..Default::default()
@@ -273,19 +273,19 @@ mod tests {
             let remote = SharedStateProvider::new_with_backend(backend.clone());
             let local = ForkedStateDb::new(remote.clone());
 
-            let nonce_updates = HashMap::from([(address, remote_nonce)]);
-            let contract_updates = HashMap::from([(address, class_hash)]);
+            let nonce_updates = BTreeMap::from([(address, remote_nonce)]);
+            let deployed_contracts = BTreeMap::from([(address, class_hash)]);
             let updates = StateUpdatesWithDeclaredClasses {
                 state_updates: StateUpdates {
                     nonce_updates,
-                    contract_updates,
+                    deployed_contracts,
                     ..Default::default()
                 },
                 ..Default::default()
             };
             remote.0.insert_updates(updates);
 
-            let nonce_updates = HashMap::from([(address, local_nonce)]);
+            let nonce_updates = BTreeMap::from([(address, local_nonce)]);
             let updates = StateUpdatesWithDeclaredClasses {
                 state_updates: StateUpdates { nonce_updates, ..Default::default() },
                 ..Default::default()
@@ -305,12 +305,12 @@ mod tests {
             let remote = SharedStateProvider::new_with_backend(backend.clone());
             let local = ForkedStateDb::new(remote.clone());
 
-            let contract_updates = HashMap::from([(address, class_hash)]);
-            let nonce_updates = HashMap::from([(address, local_nonce)]);
+            let deployed_contracts = BTreeMap::from([(address, class_hash)]);
+            let nonce_updates = BTreeMap::from([(address, local_nonce)]);
             let updates = StateUpdatesWithDeclaredClasses {
                 state_updates: StateUpdates {
                     nonce_updates,
-                    contract_updates,
+                    deployed_contracts,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -330,9 +330,9 @@ mod tests {
             let remote = SharedStateProvider::new_with_backend(backend.clone());
             let local = ForkedStateDb::new(remote.clone());
 
-            let contract_updates = HashMap::from([(address, class_hash)]);
+            let deployed_contracts = BTreeMap::from([(address, class_hash)]);
             let updates = StateUpdatesWithDeclaredClasses {
-                state_updates: StateUpdates { contract_updates, ..Default::default() },
+                state_updates: StateUpdates { deployed_contracts, ..Default::default() },
                 ..Default::default()
             };
             local.insert_updates(updates);

--- a/crates/katana/storage/provider/src/providers/in_memory/cache.rs
+++ b/crates/katana/storage/provider/src/providers/in_memory/cache.rs
@@ -55,7 +55,7 @@ impl<Db> CacheStateDb<Db> {
             info.nonce = nonce;
         }
 
-        for (contract_address, class_hash) in updates.state_updates.contract_updates {
+        for (contract_address, class_hash) in updates.state_updates.deployed_contracts {
             let info = contract_state.entry(contract_address).or_default();
             info.class_hash = class_hash;
         }

--- a/crates/katana/storage/provider/tests/fixtures.rs
+++ b/crates/katana/storage/provider/tests/fixtures.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use katana_db::mdbx;
@@ -92,21 +92,25 @@ pub fn mock_state_updates() -> [StateUpdatesWithDeclaredClasses; 3] {
 
     let state_update_1 = StateUpdatesWithDeclaredClasses {
         state_updates: StateUpdates {
-            nonce_updates: HashMap::from([(address_1, 1u8.into()), (address_2, 1u8.into())]),
-            storage_updates: HashMap::from([
+            nonce_updates: BTreeMap::from([(address_1, 1u8.into()), (address_2, 1u8.into())]),
+            storage_updates: BTreeMap::from([
                 (
                     address_1,
-                    HashMap::from([(1u8.into(), 100u32.into()), (2u8.into(), 101u32.into())]),
+                    BTreeMap::from([(1u8.into(), 100u32.into()), (2u8.into(), 101u32.into())]),
                 ),
                 (
                     address_2,
-                    HashMap::from([(1u8.into(), 200u32.into()), (2u8.into(), 201u32.into())]),
+                    BTreeMap::from([(1u8.into(), 200u32.into()), (2u8.into(), 201u32.into())]),
                 ),
             ]),
-            declared_classes: HashMap::from([(class_hash_1, compiled_class_hash_1)]),
-            contract_updates: HashMap::from([(address_1, class_hash_1), (address_2, class_hash_1)]),
+            declared_classes: BTreeMap::from([(class_hash_1, compiled_class_hash_1)]),
+            deployed_contracts: BTreeMap::from([
+                (address_1, class_hash_1),
+                (address_2, class_hash_1),
+            ]),
+            ..Default::default()
         },
-        declared_compiled_classes: HashMap::from([(
+        declared_compiled_classes: BTreeMap::from([(
             class_hash_1,
             DEFAULT_LEGACY_ERC20_CONTRACT_CASM.clone(),
         )]),
@@ -115,36 +119,44 @@ pub fn mock_state_updates() -> [StateUpdatesWithDeclaredClasses; 3] {
 
     let state_update_2 = StateUpdatesWithDeclaredClasses {
         state_updates: StateUpdates {
-            nonce_updates: HashMap::from([(address_1, 2u8.into())]),
-            storage_updates: HashMap::from([(
+            nonce_updates: BTreeMap::from([(address_1, 2u8.into())]),
+            storage_updates: BTreeMap::from([(
                 address_1,
-                HashMap::from([(felt!("1"), felt!("111")), (felt!("2"), felt!("222"))]),
+                BTreeMap::from([(felt!("1"), felt!("111")), (felt!("2"), felt!("222"))]),
             )]),
-            declared_classes: HashMap::from([(class_hash_2, compiled_class_hash_2)]),
-            contract_updates: HashMap::from([(address_2, class_hash_2)]),
+            declared_classes: BTreeMap::from([(class_hash_2, compiled_class_hash_2)]),
+            deployed_contracts: BTreeMap::from([(address_2, class_hash_2)]),
+            ..Default::default()
         },
-        declared_compiled_classes: HashMap::from([(class_hash_2, DEFAULT_LEGACY_UDC_CASM.clone())]),
+        declared_compiled_classes: BTreeMap::from([(
+            class_hash_2,
+            DEFAULT_LEGACY_UDC_CASM.clone(),
+        )]),
         ..Default::default()
     };
 
     let state_update_3 = StateUpdatesWithDeclaredClasses {
         state_updates: StateUpdates {
-            nonce_updates: HashMap::from([(address_1, 3u8.into()), (address_2, 2u8.into())]),
-            storage_updates: HashMap::from([
-                (address_1, HashMap::from([(3u8.into(), 77u32.into())])),
+            nonce_updates: BTreeMap::from([(address_1, 3u8.into()), (address_2, 2u8.into())]),
+            storage_updates: BTreeMap::from([
+                (address_1, BTreeMap::from([(3u8.into(), 77u32.into())])),
                 (
                     address_2,
-                    HashMap::from([(1u8.into(), 12u32.into()), (2u8.into(), 13u32.into())]),
+                    BTreeMap::from([(1u8.into(), 12u32.into()), (2u8.into(), 13u32.into())]),
                 ),
             ]),
-            contract_updates: HashMap::from([(address_1, class_hash_2), (address_2, class_hash_3)]),
-            declared_classes: HashMap::from([(class_hash_3, compiled_class_hash_3)]),
+            deployed_contracts: BTreeMap::from([
+                (address_1, class_hash_2),
+                (address_2, class_hash_3),
+            ]),
+            declared_classes: BTreeMap::from([(class_hash_3, compiled_class_hash_3)]),
+            ..Default::default()
         },
-        declared_compiled_classes: HashMap::from([(
+        declared_compiled_classes: BTreeMap::from([(
             class_hash_3,
             (*DOJO_WORLD_COMPILED_CLASS).clone(),
         )]),
-        declared_sierra_classes: HashMap::from([(
+        declared_sierra_classes: BTreeMap::from([(
             class_hash_3,
             (*DOJO_WORLD_SIERRA_CLASS).clone(),
         )]),

--- a/crates/saya/core/src/prover/program_input.rs
+++ b/crates/saya/core/src/prover/program_input.rs
@@ -668,12 +668,14 @@ fn test_serialize_to_prover_args() -> anyhow::Result<()> {
                 "0x115c": "0x22b"
             }
         },
-        "contract_updates":{
+        "deployed_contracts":{
             "0x1046a": "0x1e61"
         },
         "declared_classes":{
             "0x15b38": "0x1869f"
         },
+        "deprecated_declared_classes": [],
+        "replaced_classes": {},
         "message_to_starknet_segment":["0x7b","0x1c8","0x7b","0x80"],
         "message_to_appchain_segment":["0x6c","0x6d","0x6e","0x6f","0x1","0x70"]
     }"#;

--- a/crates/saya/core/src/prover/program_input.rs
+++ b/crates/saya/core/src/prover/program_input.rs
@@ -121,7 +121,7 @@ impl ProgramInput {
             .state_updates
             .storage_updates
             .get(&ContractAddress::from(world))
-            .unwrap_or(&std::collections::HashMap::new())
+            .unwrap_or(&std::collections::BTreeMap::new())
             .iter()
             .flat_map(|(k, v)| vec![*k, *v])
             .collect::<Vec<_>>();
@@ -134,8 +134,8 @@ impl ProgramInput {
         self.message_to_starknet_segment.extend(latter.message_to_starknet_segment);
 
         // the later state should overwrite the previous one.
-        latter.state_updates.contract_updates.into_iter().for_each(|(k, v)| {
-            self.state_updates.contract_updates.insert(k, v);
+        latter.state_updates.deployed_contracts.into_iter().for_each(|(k, v)| {
+            self.state_updates.deployed_contracts.insert(k, v);
         });
         latter.state_updates.declared_classes.into_iter().for_each(|(k, v)| {
             self.state_updates.declared_classes.insert(k, v);
@@ -187,7 +187,7 @@ impl ProgramInput {
             .state_updates
             .storage_updates
             .get(&ContractAddress::from(world))
-            .unwrap_or(&std::collections::HashMap::new())
+            .unwrap_or(&std::collections::BTreeMap::new())
             .iter()
             .flat_map(|(k, v)| vec![*k, *v])
             .collect::<Vec<_>>();
@@ -219,8 +219,8 @@ impl ProgramInput {
             }
         }
 
-        out.push(Felt::from(self.state_updates.contract_updates.len()));
-        for (k, v) in &self.state_updates.contract_updates {
+        out.push(Felt::from(self.state_updates.deployed_contracts.len()));
+        for (k, v) in &self.state_updates.deployed_contracts {
             out.push(**k);
             out.push(*v);
         }
@@ -553,7 +553,7 @@ fn test_deserialize_input() -> anyhow::Result<()> {
             .into_iter()
             .collect(),
 
-            contract_updates: vec![(
+            deployed_contracts: vec![(
                 ContractAddress::from(Felt::from_str("3")?),
                 Felt::from_str("437267489")?,
             )]
@@ -563,6 +563,8 @@ fn test_deserialize_input() -> anyhow::Result<()> {
             declared_classes: vec![(Felt::from_str("1234")?, Felt::from_str("12345")?)]
                 .into_iter()
                 .collect(),
+
+            ..Default::default()
         },
         world_da: None,
     };
@@ -621,7 +623,7 @@ fn test_serialize_input() -> anyhow::Result<()> {
             .into_iter()
             .collect(),
 
-            contract_updates: vec![(
+            deployed_contracts: vec![(
                 ContractAddress::from(Felt::from_str("3")?),
                 Felt::from_str("437267489")?,
             )]
@@ -631,6 +633,8 @@ fn test_serialize_input() -> anyhow::Result<()> {
             declared_classes: vec![(Felt::from_str("1234")?, Felt::from_str("12345")?)]
                 .into_iter()
                 .collect(),
+
+            ..Default::default()
         },
         world_da: Some(vec![
             Felt::from_str("2010")?,

--- a/crates/saya/core/src/prover/program_input.rs
+++ b/crates/saya/core/src/prover/program_input.rs
@@ -509,12 +509,14 @@ fn test_deserialize_input() -> anyhow::Result<()> {
             "0x457": "0x56ce",
             "0x45c": "0x56cf"
         },
-        "contract_updates":{
+        "deployed_contracts":{
             "0x3": "0x1a102c21"
         },
         "declared_classes":{
             "0x4d2": "0x3039"
-        }
+        },
+        "deprecated_declared_classes": [],
+        "replaced_classes": {}
     }"#;
     let mut expected = ProgramInput {
         prev_state_root: Felt::from_str("101")?,

--- a/crates/saya/core/src/prover/state_diff.rs
+++ b/crates/saya/core/src/prover/state_diff.rs
@@ -93,7 +93,7 @@ impl ProvedStateDiff {
         result.push_str(&format!(r#","contract_updates":{}"#, "{"));
         let contract_updates = self
             .state_updates
-            .contract_updates
+            .deployed_contracts
             .iter()
             .map(|(k, v)| format!(r#""{}":{}"#, k.0, v))
             .collect::<Vec<_>>()

--- a/crates/saya/provider/src/rpc/state.rs
+++ b/crates/saya/provider/src/rpc/state.rs
@@ -10,7 +10,7 @@
 //! to know if an address has been deployed or declared.
 //! To avoid this overhead, we may want to first generate an hashmap of such
 //! arrays to then have O(1) search.
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use alloy_primitives::U256;
 use katana_primitives::contract::ContractAddress;
@@ -40,7 +40,7 @@ pub fn state_updates_from_rpc(state_update: &StateUpdate) -> ProviderResult<Stat
 
         let address: ContractAddress = (*address).into();
 
-        let contract_entry = out.storage_updates.entry(address).or_insert_with(HashMap::new);
+        let contract_entry = out.storage_updates.entry(address).or_insert_with(BTreeMap::new);
 
         for e in entries {
             contract_entry.insert(e.key, e.value);
@@ -54,7 +54,7 @@ pub fn state_updates_from_rpc(state_update: &StateUpdate) -> ProviderResult<Stat
 
     for deployed in &state_diff.deployed_contracts {
         let DeployedContractItem { address, class_hash } = *deployed;
-        out.contract_updates.insert(address.into(), class_hash);
+        out.deployed_contracts.insert(address.into(), class_hash);
     }
 
     for decl in &state_diff.declared_classes {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced data structure management by transitioning from `HashMap` to `BTreeMap` for various state updates, improving order and performance.
	- Renamed `contract_updates` to `deployed_contracts` for clarity in state management.

- **Bug Fixes**
	- Adjusted serialization and deserialization processes to reflect the new `deployed_contracts` field.

- **Documentation**
	- Updated test cases to ensure consistency with the new data structures and field names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->