### PR TITLE
chore(katana): `address!` macro for creating `ContractAddress` instance 

### DIFF
--- a/bin/saya/src/tests.rs
+++ b/bin/saya/src/tests.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use cairo_proof_parser::output::extract_output;
 use katana_primitives::contract::ContractAddress;
 use katana_primitives::state::StateUpdates;
+use katana_primitives::{address, felt};
 use saya_core::prover::extract::program_input_from_program_output;
 use saya_core::prover::{
     prove_diff, HttpProverParams, MessageToAppchain, MessageToStarknet, ProgramInput, ProveProgram,
@@ -43,27 +44,27 @@ async fn test_program_input_from_program_output() -> anyhow::Result<()> {
         config_hash: Felt::from_str("104").unwrap(),
         message_to_starknet_segment: vec![
             MessageToStarknet {
-                from_address: ContractAddress::from(Felt::from_str("105").unwrap()),
-                to_address: ContractAddress::from(Felt::from_str("106").unwrap()),
+                from_address: address!("105"),
+                to_address: address!("106"),
                 payload: vec![Felt::from_str("107").unwrap()],
             },
             MessageToStarknet {
-                from_address: ContractAddress::from(Felt::from_str("105").unwrap()),
-                to_address: ContractAddress::from(Felt::from_str("106").unwrap()),
+                from_address: address!("105"),
+                to_address: address!("106"),
                 payload: vec![Felt::from_str("107").unwrap()],
             },
         ],
         message_to_appchain_segment: vec![
             MessageToAppchain {
-                from_address: ContractAddress::from(Felt::from_str("108").unwrap()),
-                to_address: ContractAddress::from(Felt::from_str("109").unwrap()),
+                from_address: address!("108"),
+                to_address: address!("109"),
                 nonce: Felt::from_str("110").unwrap(),
                 selector: Felt::from_str("111").unwrap(),
                 payload: vec![Felt::from_str("112").unwrap()],
             },
             MessageToAppchain {
-                from_address: ContractAddress::from(Felt::from_str("108").unwrap()),
-                to_address: ContractAddress::from(Felt::from_str("109").unwrap()),
+                from_address: address!("108"),
+                to_address: address!("109"),
                 nonce: Felt::from_str("110").unwrap(),
                 selector: Felt::from_str("111").unwrap(),
                 payload: vec![Felt::from_str("112").unwrap()],
@@ -72,24 +73,18 @@ async fn test_program_input_from_program_output() -> anyhow::Result<()> {
         state_updates: StateUpdates {
             nonce_updates: {
                 let mut map = std::collections::BTreeMap::new();
-                map.insert(
-                    ContractAddress::from(Felt::from_str("1111").unwrap()),
-                    Felt::from_str("22222").unwrap(),
-                );
+                map.insert(address!("1111"), felt!("22222"));
                 map
             },
             storage_updates: vec![(
-                ContractAddress::from(Felt::from_str("333")?),
+                address!("333"),
                 vec![(Felt::from_str("4444")?, Felt::from_str("555")?)].into_iter().collect(),
             )]
             .into_iter()
             .collect(),
             deployed_contracts: {
                 let mut map = std::collections::BTreeMap::new();
-                map.insert(
-                    ContractAddress::from(Felt::from_str("66666").unwrap()),
-                    Felt::from_str("7777").unwrap(),
-                );
+                map.insert(address!("66666"), felt!("7777"));
                 map
             },
             declared_classes: {

--- a/crates/katana/executor/src/implementation/blockifier/state.rs
+++ b/crates/katana/executor/src/implementation/blockifier/state.rs
@@ -238,7 +238,7 @@ mod tests {
         DEFAULT_OZ_ACCOUNT_CONTRACT_CASM,
     };
     use katana_primitives::utils::class::{parse_compiled_class, parse_sierra_class};
-    use katana_primitives::Felt;
+    use katana_primitives::{address, Felt};
     use katana_provider::providers::in_memory::InMemoryProvider;
     use katana_provider::traits::contract::ContractClassWriter;
     use katana_provider::traits::state::{StateFactoryProvider, StateProvider, StateWriter};
@@ -256,7 +256,7 @@ mod tests {
     }
 
     fn state_provider() -> Box<dyn StateProvider> {
-        let address = ContractAddress::from(felt!("0x67"));
+        let address = address!("0x67");
         let nonce = felt!("0x7");
         let storage_key = felt!("0x1");
         let storage_value = felt!("0x2");
@@ -284,7 +284,7 @@ mod tests {
         let state = state_provider();
         let cached_state = CachedState::new(StateProviderDb::new(state));
 
-        let address = ContractAddress::from(felt!("0x67"));
+        let address = address!("0x67");
         let legacy_class_hash = felt!("0x111");
         let storage_key = felt!("0x1");
 
@@ -319,7 +319,7 @@ mod tests {
         let sp = state_provider();
 
         // cache_state native data
-        let new_address = ContractAddress::from(felt!("0xdead"));
+        let new_address = address!("0xdead");
         let new_storage_key = felt!("0xf00");
         let new_storage_value = felt!("0xba");
         let new_legacy_class_hash = felt!("0x1234");
@@ -391,7 +391,7 @@ mod tests {
         // assert that can fetch data from the underlyign state provider
         let sp: Box<dyn StateProvider> = Box::new(cached_state);
 
-        let address = ContractAddress::from(felt!("0x67"));
+        let address = address!("0x67");
         let class_hash = felt!("0x123");
         let legacy_class_hash = felt!("0x111");
 
@@ -454,7 +454,7 @@ mod tests {
     fn fetch_non_existant_data() -> anyhow::Result<()> {
         let db = InMemoryProvider::new();
 
-        let address = ContractAddress::from(felt!("0x1"));
+        let address = address!("0x1");
         let class_hash = felt!("0x123");
         let storage_key = felt!("0x1");
 
@@ -463,7 +463,7 @@ mod tests {
         // only return None if the contract does not exist. The intended behaviour for
         // StateProvider::storage is to return None if the storage key or contract address
         // does not exist.
-        let edge_address = ContractAddress::from(felt!("0x2"));
+        let edge_address = address!("0x2");
         db.set_class_hash_of_contract(edge_address, class_hash)?;
 
         let sp = db.latest()?;

--- a/crates/katana/executor/tests/executor.rs
+++ b/crates/katana/executor/tests/executor.rs
@@ -11,7 +11,7 @@ use katana_primitives::genesis::constant::{
     DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH, DEFAULT_PREFUNDED_ACCOUNT_BALANCE, DEFAULT_UDC_ADDRESS,
 };
 use katana_primitives::transaction::TxWithHash;
-use katana_primitives::Felt;
+use katana_primitives::{address, Felt};
 use katana_provider::traits::state::StateProvider;
 use starknet::core::utils::{
     get_storage_var_address, get_udc_deployed_address, UdcUniqueSettings, UdcUniqueness,
@@ -26,11 +26,10 @@ fn test_executor_with_valid_blocks_impl<EF: ExecutorFactory>(
     let cfg_env = factory.cfg();
 
     // the contract address of the main account used to send most of the transactions
-    let main_account: ContractAddress =
-        felt!("0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114").into();
+    let main_account =
+        address!("0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114");
     // the contract address of the account deployed using the `DeployAccount` tx
-    let new_acc: ContractAddress =
-        felt!("0x3ddfa445a70b927497249f94ff7431fc2e2abc761a34417fd4891beb7c2db85").into();
+    let new_acc = address!("0x3ddfa445a70b927497249f94ff7431fc2e2abc761a34417fd4891beb7c2db85");
 
     let mut executor = factory.with_state(state);
     let mut expected_txs: Vec<TxWithHash> = Vec::with_capacity(3);

--- a/crates/katana/executor/tests/fixtures/mod.rs
+++ b/crates/katana/executor/tests/fixtures/mod.rs
@@ -21,7 +21,7 @@ use katana_primitives::transaction::{
 };
 use katana_primitives::utils::class::{parse_compiled_class, parse_sierra_class};
 use katana_primitives::version::Version;
-use katana_primitives::Felt;
+use katana_primitives::{address, Felt};
 use katana_provider::providers::in_memory::InMemoryProvider;
 use katana_provider::traits::block::BlockWriter;
 use katana_provider::traits::state::{StateFactoryProvider, StateProvider};
@@ -88,9 +88,8 @@ pub fn valid_blocks() -> [ExecutableBlock; 3] {
     let chain_id = ChainId::parse("KATANA").unwrap();
     let sequencer_address = ContractAddress(1u64.into());
 
-    let sender_address = ContractAddress(felt!(
-        "0x06b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114"
-    ));
+    let sender_address =
+        address!("0x06b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114");
 
     let gas_prices = GasPrices { eth: 100 * u128::pow(10, 9), strk: 100 * u128::pow(10, 9) };
 
@@ -169,9 +168,9 @@ pub fn valid_blocks() -> [ExecutableBlock; 3] {
                         class_hash: felt!(
                             "0x5400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c"
                         ),
-                        contract_address: ContractAddress(felt!(
+                        contract_address: address!(
                             "0x3ddfa445a70b927497249f94ff7431fc2e2abc761a34417fd4891beb7c2db85"
-                        )),
+                        ),
                     },
                 ))),
             ],

--- a/crates/katana/primitives/src/contract.rs
+++ b/crates/katana/primitives/src/contract.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 
-use derive_more::Deref;
 use starknet::core::utils::normalize_address;
 
 use crate::class::ClassHash;
@@ -15,13 +14,21 @@ pub type StorageValue = Felt;
 pub type Nonce = Felt;
 
 /// Represents a contract address.
-#[derive(Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Debug, Deref)]
+#[derive(Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ContractAddress(#[deref] pub Felt);
+pub struct ContractAddress(pub Felt);
 
 impl ContractAddress {
     pub fn new(address: Felt) -> Self {
         ContractAddress(normalize_address(address))
+    }
+}
+
+impl core::ops::Deref for ContractAddress {
+    type Target = Felt;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -41,6 +48,13 @@ impl From<ContractAddress> for Felt {
     fn from(value: ContractAddress) -> Self {
         value.0
     }
+}
+
+#[macro_export]
+macro_rules! address {
+    ($value:expr) => {
+        ContractAddress::new($crate::felt!($value))
+    };
 }
 
 /// Represents a generic contract instance information.

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -677,6 +677,7 @@ mod tests {
     use starknet::macros::felt;
 
     use super::*;
+    use crate::address;
 
     #[test]
     fn deserialize_from_json() {
@@ -690,7 +691,7 @@ mod tests {
         assert_eq!(json.gas_prices.eth, 1111);
         assert_eq!(json.gas_prices.strk, 2222);
 
-        assert_eq!(json.fee_token.address, Some(ContractAddress::from(felt!("0x55"))));
+        assert_eq!(json.fee_token.address, Some(address!("0x55")));
         assert_eq!(json.fee_token.name, String::from("ETHER"));
         assert_eq!(json.fee_token.symbol, String::from("ETH"));
         assert_eq!(json.fee_token.class, Some(ClassNameOrHash::Name(String::from("MyErc20"))));
@@ -702,9 +703,7 @@ mod tests {
 
         assert_eq!(
             json.universal_deployer.clone().unwrap().address,
-            Some(ContractAddress::from(felt!(
-                "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
-            )))
+            Some(address!("0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"))
         );
         assert_eq!(json.universal_deployer.unwrap().class, None);
         assert_eq!(
@@ -712,18 +711,10 @@ mod tests {
             Some(BTreeMap::from([(felt!("0x111"), felt!("0x1")), (felt!("0x222"), felt!("0x2")),]))
         );
 
-        let acc_1 = ContractAddress::from(felt!(
-            "0x66efb28ac62686966ae85095ff3a772e014e7fbf56d4c5f6fac5606d4dde23a"
-        ));
-        let acc_2 = ContractAddress::from(felt!(
-            "0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114"
-        ));
-        let acc_3 = ContractAddress::from(felt!(
-            "0x79156ecb3d8f084001bb498c95e37fa1c4b40dbb35a3ae47b77b1ad535edcb9"
-        ));
-        let acc_4 = ContractAddress::from(felt!(
-            "0x053a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
-        ));
+        let acc_1 = address!("0x66efb28ac62686966ae85095ff3a772e014e7fbf56d4c5f6fac5606d4dde23a");
+        let acc_2 = address!("0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114");
+        let acc_3 = address!("0x79156ecb3d8f084001bb498c95e37fa1c4b40dbb35a3ae47b77b1ad535edcb9");
+        let acc_4 = address!("0x053a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf");
 
         assert_eq!(json.accounts.len(), 4);
 
@@ -766,15 +757,12 @@ mod tests {
 
         assert_eq!(json.contracts.len(), 3);
 
-        let contract_1 = ContractAddress::from(felt!(
-            "0x29873c310fbefde666dc32a1554fea6bb45eecc84f680f8a2b0a8fbb8cb89af"
-        ));
-        let contract_2 = ContractAddress::from(felt!(
-            "0xe29882a1fcba1e7e10cad46212257fea5c752a4f9b1b1ec683c503a2cf5c8a"
-        ));
-        let contract_3 = ContractAddress::from(felt!(
-            "0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c"
-        ));
+        let contract_1 =
+            address!("0x29873c310fbefde666dc32a1554fea6bb45eecc84f680f8a2b0a8fbb8cb89af");
+        let contract_2 =
+            address!("0xe29882a1fcba1e7e10cad46212257fea5c752a4f9b1b1ec683c503a2cf5c8a");
+        let contract_3 =
+            address!("0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c");
 
         assert_eq!(
             json.contracts[&contract_1].balance,
@@ -924,7 +912,7 @@ mod tests {
         ]);
 
         let expected_fee_token = FeeTokenConfig {
-            address: ContractAddress::from(felt!("0x55")),
+            address: address!("0x55"),
             name: String::from("ETHER"),
             symbol: String::from("ETH"),
             decimals: 18,
@@ -935,27 +923,16 @@ mod tests {
             ])),
         };
 
-        let acc_1 = ContractAddress::from(felt!(
-            "0x66efb28ac62686966ae85095ff3a772e014e7fbf56d4c5f6fac5606d4dde23a"
-        ));
-        let acc_2 = ContractAddress::from(felt!(
-            "0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114"
-        ));
-        let acc_3 = ContractAddress::from(felt!(
-            "0x79156ecb3d8f084001bb498c95e37fa1c4b40dbb35a3ae47b77b1ad535edcb9"
-        ));
-        let acc_4 = ContractAddress::from(felt!(
-            "0x053a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
-        ));
-        let contract_1 = ContractAddress::from(felt!(
-            "0x29873c310fbefde666dc32a1554fea6bb45eecc84f680f8a2b0a8fbb8cb89af"
-        ));
-        let contract_2 = ContractAddress::from(felt!(
-            "0xe29882a1fcba1e7e10cad46212257fea5c752a4f9b1b1ec683c503a2cf5c8a"
-        ));
-        let contract_3 = ContractAddress::from(felt!(
-            "0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c"
-        ));
+        let acc_1 = address!("0x66efb28ac62686966ae85095ff3a772e014e7fbf56d4c5f6fac5606d4dde23a");
+        let acc_2 = address!("0x6b86e40118f29ebe393a75469b4d926c7a44c2e2681b6d319520b7c1156d114");
+        let acc_3 = address!("0x79156ecb3d8f084001bb498c95e37fa1c4b40dbb35a3ae47b77b1ad535edcb9");
+        let acc_4 = address!("0x053a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf");
+        let contract_1 =
+            address!("0x29873c310fbefde666dc32a1554fea6bb45eecc84f680f8a2b0a8fbb8cb89af");
+        let contract_2 =
+            address!("0xe29882a1fcba1e7e10cad46212257fea5c752a4f9b1b1ec683c503a2cf5c8a");
+        let contract_3 =
+            address!("0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c");
 
         let expected_allocations = BTreeMap::from([
             (
@@ -1042,15 +1019,15 @@ mod tests {
             fee_token: expected_fee_token,
             allocations: expected_allocations,
             timestamp: 5123512314u64,
-            sequencer_address: ContractAddress::from(felt!("0x100")),
+            sequencer_address: address!("0x100"),
             state_root: felt!("0x99"),
             parent_hash: felt!("0x999"),
             gas_prices: GasPrices { eth: 1111, strk: 2222 },
             universal_deployer: Some(UniversalDeployerConfig {
                 class_hash: DEFAULT_LEGACY_UDC_CLASS_HASH,
-                address: ContractAddress::from(felt!(
+                address: address!(
                     "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
-                )),
+                ),
                 storage: Some([(felt!("0x10"), felt!("0x100"))].into()),
             }),
         };
@@ -1162,9 +1139,7 @@ mod tests {
         };
 
         let allocations = BTreeMap::from([(
-            ContractAddress::from(felt!(
-                "0x66efb28ac62686966ae85095ff3a772e014e7fbf56d4c5f6fac5606d4dde23a"
-            )),
+            address!("0x66efb28ac62686966ae85095ff3a772e014e7fbf56d4c5f6fac5606d4dde23a"),
             GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
                 public_key: felt!("0x1"),
                 balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
@@ -1182,7 +1157,7 @@ mod tests {
             timestamp: 5123512314u64,
             state_root: felt!("0x99"),
             parent_hash: felt!("0x999"),
-            sequencer_address: ContractAddress(felt!("0x100")),
+            sequencer_address: address!("0x100"),
             gas_prices: GasPrices { eth: 1111, strk: 2222 },
             universal_deployer: Some(UniversalDeployerConfig {
                 class_hash: DEFAULT_LEGACY_UDC_CLASS_HASH,

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -322,6 +322,7 @@ mod tests {
     use starknet::macros::felt;
 
     use super::*;
+    use crate::address;
 
     #[test]
     fn genesis_block_and_state_updates() {
@@ -377,7 +378,7 @@ mod tests {
 
         let allocations = [
             (
-                ContractAddress::from(felt!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")),
+                address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
                 GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
                     public_key: felt!(
                         "0x01ef15c18599971b7beced415a40f0c7deacfd9b0d1819e03d723d8bc943cfca"
@@ -392,7 +393,7 @@ mod tests {
                 })),
             ),
             (
-                ContractAddress::from(felt!("0xdeadbeef")),
+                address!("0xdeadbeef"),
                 GenesisAllocation::Contract(GenesisContractAlloc {
                     balance: Some(U256::from_str("0xD3C21BCECCEDA1000000").unwrap()),
                     class_hash: Some(DEFAULT_OZ_ACCOUNT_CONTRACT_CLASS_HASH),
@@ -404,7 +405,7 @@ mod tests {
                 }),
             ),
             (
-                ContractAddress::from(felt!("0x2")),
+                address!("0x2"),
                 GenesisAllocation::Account(GenesisAccountAlloc::Account(GenesisAccount {
                     public_key: felt!("0x2"),
                     balance: Some(U256::ZERO),
@@ -416,7 +417,7 @@ mod tests {
         ];
 
         let ud = UniversalDeployerConfig {
-            address: ContractAddress(felt!("0xb00b1e5")),
+            address: address!("0xb00b1e5"),
             class_hash: DEFAULT_LEGACY_UDC_CLASS_HASH,
             storage: Some([(felt!("0x10"), felt!("0x100"))].into()),
         };
@@ -429,7 +430,7 @@ mod tests {
             timestamp: 5123512314u64,
             state_root: felt!("0x99"),
             parent_hash: felt!("0x999"),
-            sequencer_address: ContractAddress(felt!("0x100")),
+            sequencer_address: address!("0x100"),
             gas_prices: GasPrices { eth: 1111, strk: 2222 },
             universal_deployer: Some(ud.clone()),
         };

--- a/crates/katana/primitives/src/lib.rs
+++ b/crates/katana/primitives/src/lib.rs
@@ -19,4 +19,6 @@ pub mod conversion;
 pub mod state;
 pub mod utils;
 
+pub use contract::ContractAddress;
 pub use starknet::core::types::{Felt, FromStrError};
+pub use starknet::macros::felt;

--- a/crates/katana/storage/db/src/mdbx/mod.rs
+++ b/crates/katana/storage/db/src/mdbx/mod.rs
@@ -208,7 +208,7 @@ mod tests {
 
     use katana_primitives::block::Header;
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
-    use katana_primitives::Felt;
+    use katana_primitives::{address, Felt};
     use starknet::macros::felt;
 
     use super::*;
@@ -348,7 +348,7 @@ mod tests {
         let tx = db.tx_mut().expect(ERROR_INIT_TX);
 
         let mut cursor = tx.cursor::<ContractInfo>().unwrap();
-        let key: ContractAddress = felt!("0x1337").into();
+        let key = address!("0x1337");
 
         let account = GenericContractInfo::default();
         cursor.upsert(key, account).expect(ERROR_UPSERT);
@@ -462,7 +462,7 @@ mod tests {
     #[test]
     fn db_dup_sort() {
         let env = create_test_db(DbEnvKind::RW);
-        let key = ContractAddress::from(felt!("0xa2c122be93b0074270ebee7f6b7292c7deb45047"));
+        let key = address!("0xa2c122be93b0074270ebee7f6b7292c7deb45047");
 
         // PUT (0,0)
         let value00 = StorageEntry::default();

--- a/crates/katana/storage/db/src/tables.rs
+++ b/crates/katana/storage/db/src/tables.rs
@@ -284,6 +284,7 @@ mod tests {
         assert_eq!(Tables::StorageChangeSet.table_type(), TableType::Table);
     }
 
+    use katana_primitives::address;
     use katana_primitives::block::{BlockHash, BlockNumber, FinalityStatus, Header};
     use katana_primitives::class::{ClassHash, CompiledClass, CompiledClassHash};
     use katana_primitives::contract::{ContractAddress, GenericContractInfo};
@@ -338,8 +339,8 @@ mod tests {
             (TxHash, felt!("0x123456789")),
             (TxNumber, 100),
             (ClassHash, felt!("0x123456789")),
-            (ContractAddress, ContractAddress(felt!("0x123456789"))),
-            (ContractStorageKey, ContractStorageKey { contract_address : ContractAddress(felt!("0x123456789")), key : felt!("0x123456789")})
+            (ContractAddress, address!("0x123456789")),
+            (ContractStorageKey, ContractStorageKey { contract_address : address!("0x123456789"), key : felt!("0x123456789")})
         }
     }
 

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -769,6 +769,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use katana_db::mdbx::DbEnvKind;
+    use katana_primitives::address;
     use katana_primitives::block::{
         Block, BlockHashOrNumber, FinalityStatus, Header, SealedBlockWithStatus,
     };
@@ -805,19 +806,19 @@ mod tests {
         StateUpdatesWithDeclaredClasses {
             state_updates: StateUpdates {
                 nonce_updates: BTreeMap::from([
-                    (ContractAddress::from(felt!("1")), felt!("1")),
-                    (ContractAddress::from(felt!("2")), felt!("2")),
+                    (address!("1"), felt!("1")),
+                    (address!("2"), felt!("2")),
                 ]),
                 deployed_contracts: BTreeMap::from([
-                    (ContractAddress::from(felt!("1")), felt!("3")),
-                    (ContractAddress::from(felt!("2")), felt!("4")),
+                    (address!("1"), felt!("3")),
+                    (address!("2"), felt!("4")),
                 ]),
                 declared_classes: BTreeMap::from([
                     (felt!("3"), felt!("89")),
                     (felt!("4"), felt!("90")),
                 ]),
                 storage_updates: BTreeMap::from([(
-                    ContractAddress::from(felt!("1")),
+                    address!("1"),
                     BTreeMap::from([(felt!("1"), felt!("1")), (felt!("2"), felt!("2"))]),
                 )]),
                 ..Default::default()
@@ -830,15 +831,15 @@ mod tests {
         StateUpdatesWithDeclaredClasses {
             state_updates: StateUpdates {
                 nonce_updates: BTreeMap::from([
-                    (ContractAddress::from(felt!("1")), felt!("5")),
-                    (ContractAddress::from(felt!("2")), felt!("6")),
+                    (address!("1"), felt!("5")),
+                    (address!("2"), felt!("6")),
                 ]),
                 deployed_contracts: BTreeMap::from([
-                    (ContractAddress::from(felt!("1")), felt!("77")),
-                    (ContractAddress::from(felt!("2")), felt!("66")),
+                    (address!("1"), felt!("77")),
+                    (address!("2"), felt!("66")),
                 ]),
                 storage_updates: BTreeMap::from([(
-                    ContractAddress::from(felt!("1")),
+                    address!("1"),
                     BTreeMap::from([(felt!("1"), felt!("100")), (felt!("2"), felt!("200"))]),
                 )]),
                 ..Default::default()
@@ -895,8 +896,8 @@ mod tests {
 
         let state_prov = StateFactoryProvider::latest(&provider).unwrap();
 
-        let nonce1 = state_prov.nonce(ContractAddress::from(felt!("1"))).unwrap().unwrap();
-        let nonce2 = state_prov.nonce(ContractAddress::from(felt!("2"))).unwrap().unwrap();
+        let nonce1 = state_prov.nonce(address!("1")).unwrap().unwrap();
+        let nonce2 = state_prov.nonce(address!("2")).unwrap().unwrap();
 
         let class_hash1 = state_prov.class_hash_of_contract(felt!("1").into()).unwrap().unwrap();
         let class_hash2 = state_prov.class_hash_of_contract(felt!("2").into()).unwrap().unwrap();
@@ -906,10 +907,8 @@ mod tests {
         let compiled_hash2 =
             state_prov.compiled_class_hash_of_class_hash(class_hash2).unwrap().unwrap();
 
-        let storage1 =
-            state_prov.storage(ContractAddress::from(felt!("1")), felt!("1")).unwrap().unwrap();
-        let storage2 =
-            state_prov.storage(ContractAddress::from(felt!("1")), felt!("2")).unwrap().unwrap();
+        let storage1 = state_prov.storage(address!("1"), felt!("1")).unwrap().unwrap();
+        let storage2 = state_prov.storage(address!("1"), felt!("2")).unwrap().unwrap();
 
         // assert values are populated correctly
 
@@ -992,16 +991,14 @@ mod tests {
 
         let state_prov = StateFactoryProvider::latest(&provider).unwrap();
 
-        let nonce1 = state_prov.nonce(ContractAddress::from(felt!("1"))).unwrap().unwrap();
-        let nonce2 = state_prov.nonce(ContractAddress::from(felt!("2"))).unwrap().unwrap();
+        let nonce1 = state_prov.nonce(address!("1")).unwrap().unwrap();
+        let nonce2 = state_prov.nonce(address!("2")).unwrap().unwrap();
 
         let class_hash1 = state_prov.class_hash_of_contract(felt!("1").into()).unwrap().unwrap();
         let class_hash2 = state_prov.class_hash_of_contract(felt!("2").into()).unwrap().unwrap();
 
-        let storage1 =
-            state_prov.storage(ContractAddress::from(felt!("1")), felt!("1")).unwrap().unwrap();
-        let storage2 =
-            state_prov.storage(ContractAddress::from(felt!("1")), felt!("2")).unwrap().unwrap();
+        let storage1 = state_prov.storage(address!("1"), felt!("1")).unwrap().unwrap();
+        let storage2 = state_prov.storage(address!("1"), felt!("2")).unwrap().unwrap();
 
         assert_eq!(nonce1, felt!("5"));
         assert_eq!(nonce2, felt!("6"));

--- a/crates/katana/storage/provider/tests/fixtures.rs
+++ b/crates/katana/storage/provider/tests/fixtures.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use katana_db::mdbx;
+use katana_primitives::address;
 use katana_primitives::block::{
     BlockHashOrNumber, FinalityStatus, Header, SealedBlock, SealedBlockWithStatus, SealedHeader,
 };
@@ -78,8 +79,8 @@ pub fn db_provider() -> BlockchainProvider<DbProvider> {
 
 #[rstest::fixture]
 pub fn mock_state_updates() -> [StateUpdatesWithDeclaredClasses; 3] {
-    let address_1 = ContractAddress::from(felt!("1"));
-    let address_2 = ContractAddress::from(felt!("2"));
+    let address_1 = address!("1");
+    let address_2 = address!("2");
 
     let class_hash_1 = felt!("11");
     let compiled_class_hash_1 = felt!("1000");

--- a/crates/saya/core/src/prover/program_input.rs
+++ b/crates/saya/core/src/prover/program_input.rs
@@ -488,11 +488,17 @@ impl MessageToAppchain {
     }
 }
 
-#[test]
-fn test_deserialize_input() -> anyhow::Result<()> {
+#[cfg(test)]
+mod tests {
     use std::str::FromStr;
 
-    let input = r#"{
+    use katana_primitives::{address, felt};
+
+    use super::*;
+
+    #[test]
+    fn test_deserialize_input() -> anyhow::Result<()> {
+        let input = r#"{
         "prev_state_root":"0x65",
         "block_number": 102,
         "block_hash":"0x67",
@@ -518,144 +524,123 @@ fn test_deserialize_input() -> anyhow::Result<()> {
         "deprecated_declared_classes": [],
         "replaced_classes": {}
     }"#;
-    let mut expected = ProgramInput {
-        prev_state_root: Felt::from_str("101")?,
-        block_number: 102,
-        block_hash: Felt::from_str("103")?,
-        config_hash: Felt::from_str("104")?,
-        message_to_starknet_segment: vec![MessageToStarknet {
-            from_address: ContractAddress::from(Felt::from_str("105")?),
-            to_address: ContractAddress::from(Felt::from_str("106")?),
-            payload: vec![Felt::from_str("1")?],
-        }],
-        message_to_appchain_segment: vec![MessageToAppchain {
-            from_address: ContractAddress::from(Felt::from_str("108")?),
-            to_address: ContractAddress::from(Felt::from_str("109")?),
-            nonce: Felt::from_str("110")?,
-            selector: Felt::from_str("111")?,
-            payload: vec![Felt::from_str("112")?],
-        }],
-        state_updates: StateUpdates {
-            storage_updates: vec![(
-                ContractAddress::from(Felt::from_str("42")?),
-                vec![
-                    (Felt::from_str("2010")?, Felt::from_str("1200")?),
-                    (Felt::from_str("2012")?, Felt::from_str("1300")?),
+        let mut expected = ProgramInput {
+            prev_state_root: Felt::from_str("101")?,
+            block_number: 102,
+            block_hash: Felt::from_str("103")?,
+            config_hash: Felt::from_str("104")?,
+            message_to_starknet_segment: vec![MessageToStarknet {
+                from_address: address!("105"),
+                to_address: address!("106"),
+                payload: vec![felt!("1")],
+            }],
+            message_to_appchain_segment: vec![MessageToAppchain {
+                from_address: address!("108"),
+                to_address: address!("109"),
+                nonce: felt!("110"),
+                selector: felt!("111"),
+                payload: vec![Felt::from_str("112")?],
+            }],
+            state_updates: StateUpdates {
+                storage_updates: vec![(
+                    address!("42"),
+                    vec![
+                        (felt!("2010"), felt!("1200")),
+                        (Felt::from_str("2012")?, Felt::from_str("1300")?),
+                    ]
+                    .into_iter()
+                    .collect(),
+                )]
+                .into_iter()
+                .collect(),
+
+                nonce_updates: vec![
+                    (address!("1111"), felt!("22222")),
+                    (address!("1116"), felt!("22223")),
                 ]
                 .into_iter()
                 .collect(),
-            )]
-            .into_iter()
-            .collect(),
 
-            nonce_updates: vec![
-                (ContractAddress::from(Felt::from_str("1111")?), Felt::from_str("22222")?),
-                (ContractAddress::from(Felt::from_str("1116")?), Felt::from_str("22223")?),
-            ]
-            .into_iter()
-            .collect(),
+                deployed_contracts: vec![(address!("3"), felt!("437267489"))].into_iter().collect(),
 
-            deployed_contracts: vec![(
-                ContractAddress::from(Felt::from_str("3")?),
-                Felt::from_str("437267489")?,
-            )]
-            .into_iter()
-            .collect(),
+                declared_classes: vec![(Felt::from_str("1234")?, Felt::from_str("12345")?)]
+                    .into_iter()
+                    .collect(),
 
-            declared_classes: vec![(Felt::from_str("1234")?, Felt::from_str("12345")?)]
-                .into_iter()
-                .collect(),
+                ..Default::default()
+            },
+            world_da: None,
+        };
+        let mut deserialized = serde_json::from_str::<ProgramInput>(input)?;
+        assert_eq!(expected, deserialized);
 
-            ..Default::default()
-        },
-        world_da: None,
-    };
-    let mut deserialized = serde_json::from_str::<ProgramInput>(input)?;
-    assert_eq!(expected, deserialized);
-
-    deserialized.fill_da(Felt::from_str("42")?);
-    expected.world_da = Some(vec![
-        Felt::from_str("2010")?,
-        Felt::from_str("1200")?,
-        Felt::from_str("2012")?,
-        Felt::from_str("1300")?,
-    ]);
-
-    Ok(())
-}
-
-#[test]
-fn test_serialize_input() -> anyhow::Result<()> {
-    use std::str::FromStr;
-
-    let input = ProgramInput {
-        prev_state_root: Felt::from_str("101")?,
-        block_number: 102,
-        block_hash: Felt::from_str("103")?,
-        config_hash: Felt::from_str("104")?,
-        message_to_starknet_segment: vec![MessageToStarknet {
-            from_address: ContractAddress::from(Felt::from_str("105")?),
-            to_address: ContractAddress::from(Felt::from_str("106")?),
-            payload: vec![Felt::from_str("1")?],
-        }],
-        message_to_appchain_segment: vec![MessageToAppchain {
-            from_address: ContractAddress::from(Felt::from_str("108")?),
-            to_address: ContractAddress::from(Felt::from_str("109")?),
-            nonce: Felt::from_str("110")?,
-            selector: Felt::from_str("111")?,
-            payload: vec![Felt::from_str("112")?],
-        }],
-        state_updates: StateUpdates {
-            storage_updates: vec![(
-                ContractAddress::from(Felt::from_str("42")?),
-                vec![
-                    (Felt::from_str("2010")?, Felt::from_str("1200")?),
-                    (Felt::from_str("2012")?, Felt::from_str("1300")?),
-                ]
-                .into_iter()
-                .collect(),
-            )]
-            .into_iter()
-            .collect(),
-
-            nonce_updates: vec![
-                (ContractAddress::from(Felt::from_str("1111")?), Felt::from_str("22222")?),
-                (ContractAddress::from(Felt::from_str("1116")?), Felt::from_str("22223")?),
-            ]
-            .into_iter()
-            .collect(),
-
-            deployed_contracts: vec![(
-                ContractAddress::from(Felt::from_str("3")?),
-                Felt::from_str("437267489")?,
-            )]
-            .into_iter()
-            .collect(),
-
-            declared_classes: vec![(Felt::from_str("1234")?, Felt::from_str("12345")?)]
-                .into_iter()
-                .collect(),
-
-            ..Default::default()
-        },
-        world_da: Some(vec![
+        deserialized.fill_da(Felt::from_str("42")?);
+        expected.world_da = Some(vec![
             Felt::from_str("2010")?,
             Felt::from_str("1200")?,
             Felt::from_str("2012")?,
             Felt::from_str("1300")?,
-        ]),
-    };
+        ]);
 
-    let serialized = serde_json::to_string::<ProgramInput>(&input.clone())?;
-    let deserialized = serde_json::from_str::<ProgramInput>(&serialized)?;
-    assert_eq!(input, deserialized);
+        Ok(())
+    }
 
-    Ok(())
-}
+    #[test]
+    fn test_serialize_input() -> anyhow::Result<()> {
+        use std::str::FromStr;
 
-#[test]
-fn test_serialize_to_prover_args() -> anyhow::Result<()> {
-    let input = r#"{
+        let input = ProgramInput {
+            prev_state_root: Felt::from_str("101")?,
+            block_number: 102,
+            block_hash: Felt::from_str("103")?,
+            config_hash: felt!("104"),
+            message_to_starknet_segment: vec![MessageToStarknet {
+                from_address: address!("105"),
+                to_address: address!("106"),
+                payload: vec![felt!("1")],
+            }],
+            message_to_appchain_segment: vec![MessageToAppchain {
+                from_address: address!("108"),
+                to_address: address!("109"),
+                nonce: felt!("110"),
+                selector: felt!("111"),
+                payload: vec![felt!("112")],
+            }],
+            state_updates: StateUpdates {
+                storage_updates: vec![(
+                    address!("42"),
+                    vec![(felt!("2010"), felt!("1200")), (felt!("2012"), felt!("1300"))]
+                        .into_iter()
+                        .collect(),
+                )]
+                .into_iter()
+                .collect(),
+
+                nonce_updates: vec![
+                    (address!("1111"), felt!("22222")),
+                    (address!("1116"), felt!("22223")),
+                ]
+                .into_iter()
+                .collect(),
+
+                deployed_contracts: vec![(address!("3"), felt!("437267489"))].into_iter().collect(),
+                declared_classes: vec![(felt!("1234"), felt!("12345"))].into_iter().collect(),
+
+                ..Default::default()
+            },
+            world_da: Some(vec![felt!("2010"), felt!("1200"), felt!("2012"), felt!("1300")]),
+        };
+
+        let serialized = serde_json::to_string::<ProgramInput>(&input.clone())?;
+        let deserialized = serde_json::from_str::<ProgramInput>(&serialized)?;
+        assert_eq!(input, deserialized);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_serialize_to_prover_args() -> anyhow::Result<()> {
+        let input = r#"{
         "prev_state_root":"0x65",
         "block_number":102,
         "block_hash":"0x67",
@@ -679,22 +664,21 @@ fn test_serialize_to_prover_args() -> anyhow::Result<()> {
         "message_to_starknet_segment":["0x7b","0x1c8","0x7b","0x80"],
         "message_to_appchain_segment":["0x6c","0x6d","0x6e","0x6f","0x1","0x70"]
     }"#;
-    let mut input = serde_json::from_str::<ProgramInput>(input)?;
-    input.fill_da(Felt::from_str("333")?);
+        let mut input = serde_json::from_str::<ProgramInput>(input)?;
+        input.fill_da(felt!("333"));
 
-    // println!("{:?}", input);
+        let serialized = input.serialize_to_prover_args();
 
-    let serialized = input.serialize_to_prover_args();
+        let expected = vec![
+            101, 102, 103, 104, 1, 1111, 22222, 1, 333, 1, 4444, 555, 1, 66666, 7777, 1, 88888,
+            99999, 4, 123, 456, 1, 128, 6, 108, 109, 110, 111, 1, 112, 1, 4444, 555, 0u64,
+        ]
+        .into_iter()
+        .map(Felt::from)
+        .collect::<Vec<_>>();
 
-    let expected = vec![
-        101, 102, 103, 104, 1, 1111, 22222, 1, 333, 1, 4444, 555, 1, 66666, 7777, 1, 88888, 99999,
-        4, 123, 456, 1, 128, 6, 108, 109, 110, 111, 1, 112, 1, 4444, 555, 0u64,
-    ]
-    .into_iter()
-    .map(Felt::from)
-    .collect::<Vec<_>>();
+        assert_eq!(serialized, expected);
 
-    assert_eq!(serialized, expected);
-
-    Ok(())
+        Ok(())
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new test functions for serialization and deserialization of `ProgramInput`.
- **Improvements**
	- Standardized the creation of contract addresses using the `address!` macro across various test cases, enhancing code clarity and consistency.
	- Updated the handling of `Felt` values with the `felt!` macro, improving readability.
- **Bug Fixes**
	- Ensured that serialization and deserialization processes are consistent and functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->