### PR TITLE
chore: replace `reth-metrics-derive` with the new standalone version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4497,10 +4497,10 @@ dependencies = [
  "jemalloc-ctl",
  "jemallocator",
  "metrics",
+ "metrics-derive",
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
- "reth-metrics-derive",
  "thiserror",
  "tokio",
  "tracing",
@@ -9184,6 +9184,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "metrics-exporter-prometheus"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11446,18 +11458,6 @@ dependencies = [
  "bindgen 0.68.1",
  "cc",
  "libc",
-]
-
-[[package]]
-name = "reth-metrics-derive"
-version = "1.0.3"
-source = "git+https://github.com/paradigmxyz/reth.git?tag=v1.0.3#390f30aadebcdd509e72cc04327c3b854de076a6"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.77",
 ]
 
 [[package]]

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -14,10 +14,10 @@ tracing.workspace = true
 
 # Metrics
 metrics.workspace = true
+metrics-derive = "0.1"
 metrics-exporter-prometheus = "0.15.3"
 metrics-process = "2.1.0"
 metrics-util = "0.17.0"
-reth-metrics-derive = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.0.3" }
 
 [target.'cfg(not(windows))'.dependencies]
 jemalloc-ctl = { version = "0.5.0", optional = true }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -4,10 +4,10 @@ pub mod prometheus_exporter;
 use jemallocator as _;
 /// Re-export the metrics crate
 pub use metrics;
+/// Re-export the metrics derive macro
+pub use metrics_derive::Metrics;
 /// Re-export the metrics-process crate
 pub use metrics_process;
-/// Re-export the metrics derive macro
-pub use reth_metrics_derive::Metrics;
 
 // We use jemalloc for performance reasons
 #[cfg(all(feature = "jemalloc", unix))]


### PR DESCRIPTION
the reth team has made the previously named `reth-metrics-derive` into a standalone crate, `metrics-derive`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `metrics-derive` dependency, enhancing metrics functionality.
- **Bug Fixes**
	- Updated the source of the metrics derive macro for improved reliability.
- **Chores**
	- Removed outdated dependency on `reth-metrics-derive` to streamline package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->