### PR TITLE
chore: implement `From<BigUint>` for address type

### DIFF
--- a/crates/katana/controller/src/lib.rs
+++ b/crates/katana/controller/src/lib.rs
@@ -47,8 +47,7 @@ fn add_controller_account_inner(genesis: &mut Genesis, user: slot::account::Acco
             storage: Some(get_contract_storage(credential_id, public_key)?),
         };
 
-        let address =
-            ContractAddress::from(Felt::from_bytes_be(&user.contract_address.to_bytes_be()));
+        let address = ContractAddress::from(user.contract_address);
 
         (address, GenesisAllocation::Contract(account))
     };
@@ -97,9 +96,7 @@ pub mod json {
                 storage: Some(get_contract_storage(credential_id, public_key)?),
             };
 
-            let address = ContractAddress::from(Felt::from_bytes_be(
-                &user.account.contract_address.to_bytes_be(),
-            ));
+            let address = ContractAddress::from(user.account.contract_address);
 
             (address, account)
         };

--- a/crates/katana/primitives/src/contract.rs
+++ b/crates/katana/primitives/src/contract.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use num_bigint::BigUint;
 use starknet::core::utils::normalize_address;
 
 use crate::class::ClassHash;
@@ -47,6 +48,18 @@ impl From<Felt> for ContractAddress {
 impl From<ContractAddress> for Felt {
     fn from(value: ContractAddress) -> Self {
         value.0
+    }
+}
+
+impl From<&BigUint> for ContractAddress {
+    fn from(biguint: &BigUint) -> Self {
+        Self::new(Felt::from_bytes_le_slice(&biguint.to_bytes_le()))
+    }
+}
+
+impl From<BigUint> for ContractAddress {
+    fn from(biguint: BigUint) -> Self {
+        Self::new(Felt::from_bytes_le_slice(&biguint.to_bytes_le()))
     }
 }
 

--- a/crates/katana/primitives/src/da/encoding.rs
+++ b/crates/katana/primitives/src/da/encoding.rs
@@ -139,7 +139,7 @@ pub fn decode_state_updates(value: &[BigUint]) -> Result<StateUpdates, EncodingE
 
     for _ in 0..total_updates {
         let address = iter.next().ok_or(EncodingError::MissingAddress)?;
-        let address: ContractAddress = Felt::from(address).into();
+        let address = ContractAddress::from(address);
 
         let metadata = iter.next().ok_or(EncodingError::MissingMetadata)?;
         let metadata = Metadata::decode(metadata)?;
@@ -308,6 +308,7 @@ mod tests {
     use starknet::macros::felt;
 
     use super::*;
+    use crate::address;
 
     macro_rules! biguint {
         ($s:expr) => {
@@ -352,9 +353,9 @@ mod tests {
         assert_eq!(state_updates.declared_classes.len(), 1);
         assert_eq!(state_updates.deployed_contracts.len(), 0);
 
-        let address: ContractAddress =
-            felt!("2019172390095051323869047481075102003731246132997057518965927979101413600827")
-                .into();
+        let address = address!(
+            "2019172390095051323869047481075102003731246132997057518965927979101413600827"
+        );
 
         assert_eq!(state_updates.nonce_updates.get(&address), Some(&Felt::ONE));
 

--- a/crates/katana/storage/provider/src/providers/fork/state.rs
+++ b/crates/katana/storage/provider/src/providers/fork/state.rs
@@ -219,6 +219,7 @@ impl ContractClassProvider for ForkedSnapshot {
 mod tests {
     use std::collections::BTreeMap;
 
+    use katana_primitives::address;
     use katana_primitives::state::{StateUpdates, StateUpdatesWithDeclaredClasses};
     use starknet::macros::felt;
 
@@ -229,7 +230,7 @@ mod tests {
     fn test_get_nonce() {
         let backend = create_forked_backend("http://localhost:8080", 1);
 
-        let address: ContractAddress = felt!("1").into();
+        let address = address!("1");
         let class_hash = felt!("11");
         let remote_nonce = felt!("111");
         let local_nonce = felt!("1111");

--- a/crates/katana/storage/provider/src/test_utils.rs
+++ b/crates/katana/storage/provider/src/test_utils.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use alloy_primitives::U256;
 use katana_db::mdbx::{test_utils, DbEnvKind};
+use katana_primitives::address;
 use katana_primitives::block::{BlockHash, FinalityStatus};
 use katana_primitives::class::CompiledClass;
 use katana_primitives::contract::ContractAddress;
@@ -49,7 +50,7 @@ fn initialize_test_provider<P: BlockWriter>(provider: &P) {
 /// - An account with simple `__execute__` function, deployed at address `0x1`.
 pub fn create_genesis_for_testing() -> Genesis {
     let class_hash = felt!("0x111");
-    let address = ContractAddress::from(felt!("0x1"));
+    let address = address!("0x1");
 
     // TODO: we should have a genesis builder that can do all of this for us.
     let class = {


### PR DESCRIPTION
a little clean up on `ContractAddress` type 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to create snapshots of the state in the `ForkedStateDb`.
	- Enhanced flexibility for constructing `ContractAddress` from `BigUint`.
  
- **Improvements**
	- Simplified address handling in encoding and decoding processes.
	- Enhanced error handling for metadata decoding.

- **Bug Fixes**
	- Updated logic to prioritize local state over remote state for nonce and storage retrieval.

- **Tests**
	- Updated test cases to reflect changes in address handling and state retrieval logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->