### PR TITLE
Invalidate model cache when model is registered/updated

### DIFF
--- a/crates/torii/core/src/cache.rs
+++ b/crates/torii/core/src/cache.rs
@@ -121,4 +121,9 @@ impl ModelCache {
     pub async fn clear(&self) {
         self.cache.write().await.clear();
     }
+
+    pub async fn remove(&self, selector: &Felt) {
+        let mut cache = self.cache.write().await;
+        cache.remove(selector);
+    }
 }

--- a/crates/torii/core/src/sql.rs
+++ b/crates/torii/core/src/sql.rs
@@ -194,6 +194,7 @@ impl Sql {
             &mut 0,
         );
 
+        self.model_cache.remove(&selector).await;
         // we set the model in the cache directly
         // because entities might be using it before the query queue is processed
         self.model_cache


### PR DESCRIPTION
Added a remove method in cache.rs to allow cache invalidation.
Used this remove method before inserting the new model during registration.

Fixed #1202 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous method for removing models from the cache, enhancing cache management.
	- Updated model registration to immediately reflect changes in the cache, ensuring real-time accuracy.
  
- **Improvements**
	- Enhanced clarity and robustness in handling entity and model IDs during database operations.
	- Refined SQL statement handling for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->