### PR TITLE
Bump `slot` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "account_sdk"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/controller#61d2fd0cd856daa01b2da52b762368542c03da6f"
+source = "git+https://github.com/cartridge-gg/controller?rev=61d2fd0#61d2fd0cd856daa01b2da52b762368542c03da6f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12826,7 +12826,7 @@ dependencies = [
 [[package]]
 name = "slot"
 version = "0.17.0"
-source = "git+https://github.com/cartridge-gg/slot?rev=544cbc6#544cbc60162795ca83377c8b1d959bae6ba0e073"
+source = "git+https://github.com/cartridge-gg/slot?rev=942be15#942be15fae2f17a9f520c18ceddcbae00037a695"
 dependencies = [
  "account_sdk",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ alloy-sol-types = { version = "0.8.3", default-features = false }
 criterion = "0.5.1"
 
 # Slot integration. Dojo don't need to manually include `account_sdk` as dependency as `slot` already re-exports it.
-slot = { git = "https://github.com/cartridge-gg/slot", rev = "544cbc6" }
+slot = { git = "https://github.com/cartridge-gg/slot", rev = "942be15" }
 
 alloy-contract = { version = "0.3", default-features = false }
 alloy-json-rpc = { version = "0.3", default-features = false }


### PR DESCRIPTION
ref https://github.com/cartridge-gg/slot/pull/108

the rev includes the exact rev of `account_sdk`. basically preventing cargo from resolving `account_sdk` into a rev that introduce breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `slot` package dependency to a new commit reference, ensuring improved functionality and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->