### PR TITLE
Remove call to `cartridge_deployController` for Controller deployment

### DIFF
--- a/bin/sozo/src/commands/options/account/controller.rs
+++ b/bin/sozo/src/commands/options/account/controller.rs
@@ -41,7 +41,7 @@ pub type ControllerSessionAccount<P> = SessionAccount<Arc<P>>;
 /// # Supported networks
 ///
 /// * Starknet mainnet
-/// * Stakrnet sepolia
+/// * Starknet sepolia
 /// * Slot hosted networks
 #[tracing::instrument(
     name = "create_controller",


### PR DESCRIPTION
we no longer need to explicitly call the `cartridge_deployController` when a Controller account doesn't exist. this is already being handled when the session is being created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Streamlined account creation process by removing the deployment check for controller accounts.
	- Enhanced session management for creating new accounts.

- **Documentation**
	- Expanded comments to clarify the behavior of the account creation function regarding supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->