### PR TITLE
katana: include `starknet` api as default 

### DIFF
--- a/crates/katana/node/src/config/rpc.rs
+++ b/crates/katana/node/src/config/rpc.rs
@@ -37,11 +37,11 @@ impl RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
+            allowed_origins: None,
             addr: DEFAULT_RPC_ADDR,
             port: DEFAULT_RPC_PORT,
             max_connections: DEFAULT_RPC_MAX_CONNECTIONS,
-            allowed_origins: None,
-            apis: HashSet::new(),
+            apis: HashSet::from([ApiKind::Starknet]),
         }
     }
 }


### PR DESCRIPTION
ref #2508 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated default configuration for the RPC settings to include support for the `Starknet` API.
  
- **Bug Fixes**
	- Ensured that the `apis` field is now correctly initialized, enhancing the overall functionality of the RPC configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->