### PR TITLE
refactor(katana-tasks): separate tasks spawning responsibility from `TaskManager`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8176,6 +8176,7 @@ dependencies = [
  "katana-pool",
  "katana-tasks",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 

--- a/bin/katana/src/cli/node.rs
+++ b/bin/katana/src/cli/node.rs
@@ -232,7 +232,6 @@ impl NodeArgs {
         let node = katana_node::build(config).await.context("failed to build node")?;
 
         if !self.silent {
-            #[allow(deprecated)]
             let genesis = &node.backend.chain_spec.genesis;
             print_intro(&self, genesis);
         }
@@ -256,9 +255,10 @@ impl NodeArgs {
     }
 
     fn init_logging(&self) -> Result<()> {
-        const DEFAULT_LOG_FILTER: &str = "info,executor=trace,forking::backend=trace,server=debug,\
-                                          katana_core=trace,blockifier=off,jsonrpsee_server=off,\
-                                          hyper=off,messaging=debug,node=error";
+        const DEFAULT_LOG_FILTER: &str = "tasks=debug,info,executor=trace,forking::backend=trace,\
+                                          server=debug,katana_core=trace,blockifier=off,\
+                                          jsonrpsee_server=off,hyper=off,messaging=debug,\
+                                          node=error";
 
         LogTracer::init()?;
 

--- a/crates/katana/node-bindings/src/lib.rs
+++ b/crates/katana/node-bindings/src/lib.rs
@@ -622,15 +622,16 @@ mod tests {
     async fn can_launch_katana() {
         // this will launch katana with random ports
         let katana = Katana::new().spawn();
+
         // assert some default values
         assert_eq!(katana.accounts().len(), 10);
         assert_eq!(katana.chain_id(), short_string!("KATANA"));
         // assert that all accounts have private key
         assert!(katana.accounts().iter().all(|a| a.private_key.is_some()));
 
-        let provider = JsonRpcClient::new(HttpTransport::new(katana.endpoint_url()));
-        let result = provider.chain_id().await;
-        assert!(result.is_ok());
+        // try to connect as a provider
+        let provider = JsonRpcClient::new(HttpTransport::new(dbg!(katana.endpoint_url())));
+        assert!(provider.chain_id().await.is_ok())
     }
 
     #[test]

--- a/crates/katana/pipeline/Cargo.toml
+++ b/crates/katana/pipeline/Cargo.toml
@@ -15,4 +15,5 @@ anyhow.workspace = true
 async-trait.workspace = true
 futures.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true

--- a/crates/katana/tasks/src/lib.rs
+++ b/crates/katana/tasks/src/lib.rs
@@ -22,6 +22,7 @@ use tokio::task::JoinHandle;
 #[error("Failed to initialize task spawner: {0}")]
 pub struct TaskSpawnerInitError(tokio::runtime::TryCurrentError);
 
+// TODO: replace this with TaskSpawner in manager.rs
 /// A task spawner for spawning tasks on a tokio runtime. This is simple wrapper around a tokio's
 /// runtime [Handle] to easily spawn tasks on the runtime.
 ///

--- a/crates/katana/tasks/src/manager.rs
+++ b/crates/katana/tasks/src/manager.rs
@@ -1,6 +1,7 @@
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use futures::FutureExt;
@@ -9,6 +10,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 pub use tokio_util::sync::WaitForCancellationFuture as WaitForShutdownFuture;
 use tokio_util::task::TaskTracker;
+use tracing::trace;
 
 use crate::task::{TaskBuilder, TaskResult};
 
@@ -17,8 +19,22 @@ pub type TaskHandle<T> = JoinHandle<TaskResult<T>>;
 /// Usage for this task manager is mainly to spawn tasks that can be cancelled, and captures
 /// panicked tasks (which in the context of the task manager - a critical task) for graceful
 /// shutdown.
-#[derive(Debug, Clone)]
+///
+/// # Spawning tasks
+///
+/// To spawn tasks on the manager, call [`TaskManager::task_spawner`] to get a [`TaskSpawner`]
+/// instance. The [`TaskSpawner`] can then be used to spawn tasks on the manager.
+///
+/// # Tasks cancellation
+///
+/// When the manager is dropped, all tasks that have yet to complete will be cancelled.
+#[derive(Debug)]
 pub struct TaskManager {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
     /// A handle to the Tokio runtime.
     handle: Handle,
     /// Keep track of currently running tasks.
@@ -26,30 +42,34 @@ pub struct TaskManager {
     /// Used to cancel all running tasks.
     ///
     /// This is passed to all the tasks spawned by the manager.
-    pub(crate) on_cancel: CancellationToken,
+    on_cancel: CancellationToken,
 }
 
 impl TaskManager {
     /// Create a new [`TaskManager`] from the given Tokio runtime handle.
     pub fn new(handle: Handle) -> Self {
-        Self { handle, tracker: TaskTracker::new(), on_cancel: CancellationToken::new() }
+        Self {
+            inner: Arc::new(Inner {
+                handle,
+                tracker: TaskTracker::new(),
+                on_cancel: CancellationToken::new(),
+            }),
+        }
     }
 
+    /// Create a new [`TaskManager`] from the ambient Tokio runtime.
     pub fn current() -> Self {
         Self::new(Handle::current())
     }
 
-    pub fn spawn<F>(&self, fut: F) -> TaskHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        self.spawn_inner(fut)
+    /// Returns a [`TaskSpawner`] that can be used to spawn tasks on the manager.
+    pub fn task_spawner(&self) -> TaskSpawner {
+        TaskSpawner { inner: Arc::clone(&self.inner) }
     }
 
     /// Returns a future that can be awaited for the shutdown signal to be received.
     pub fn wait_for_shutdown(&self) -> WaitForShutdownFuture<'_> {
-        self.on_cancel.cancelled()
+        self.inner.on_cancel.cancelled()
     }
 
     /// Shuts down the manager and wait until all currently running tasks are finished, either due
@@ -58,15 +78,15 @@ impl TaskManager {
     /// No task can be spawned on the manager after this method is called.
     pub fn shutdown(&self) -> ShutdownFuture<'_> {
         let fut = Box::pin(async {
-            if !self.on_cancel.is_cancelled() {
-                self.on_cancel.cancel();
+            if !self.inner.on_cancel.is_cancelled() {
+                self.inner.on_cancel.cancel();
             }
 
             self.wait_for_shutdown().await;
 
             // need to close the tracker first before waiting
-            let _ = self.tracker.close();
-            self.tracker.wait().await;
+            let _ = self.inner.tracker.close();
+            self.inner.tracker.wait().await;
         });
 
         ShutdownFuture { fut }
@@ -74,22 +94,46 @@ impl TaskManager {
 
     /// Return the handle to the Tokio runtime that the manager is associated with.
     pub fn handle(&self) -> &Handle {
-        &self.handle
-    }
-
-    /// Returns a new [`TaskBuilder`] for building a task to be spawned on this manager.
-    pub fn build_task(&self) -> TaskBuilder<'_> {
-        TaskBuilder::new(self)
+        &self.inner.handle
     }
 
     /// Wait until all spawned tasks are completed.
     #[cfg(test)]
     async fn wait(&self) {
         // need to close the tracker first before waiting
-        let _ = self.tracker.close();
-        self.tracker.wait().await;
+        let _ = self.inner.tracker.close();
+        self.inner.tracker.wait().await;
         // reopen the tracker for spawning future tasks
-        let _ = self.tracker.reopen();
+        let _ = self.inner.tracker.reopen();
+    }
+}
+
+/// A spawner for spawning tasks on the [`TaskManager`] that it was derived from.
+///
+/// This is the main way to spawn tasks on a [`TaskManager`]. It can only be created
+/// by calling [`TaskManager::task_spawner`].
+#[derive(Debug, Clone)]
+pub struct TaskSpawner {
+    /// A handle to the [`TaskManager`] that this spawner is associated with.
+    inner: Arc<Inner>,
+}
+
+impl TaskSpawner {
+    /// Returns a new [`TaskBuilder`] for building a task.
+    pub fn build_task(&self) -> TaskBuilder<'_> {
+        TaskBuilder::new(self)
+    }
+
+    pub(crate) fn spawn<F>(&self, fut: F) -> TaskHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.spawn_inner(fut)
+    }
+
+    pub(crate) fn cancellation_token(&self) -> &CancellationToken {
+        &self.inner.on_cancel
     }
 
     fn spawn_inner<F>(&self, task: F) -> TaskHandle<F::Output>
@@ -98,15 +142,15 @@ impl TaskManager {
         F::Output: Send + 'static,
     {
         let task = self.make_cancellable(task);
-        let task = self.tracker.track_future(task);
-        self.handle.spawn(task)
+        let task = self.inner.tracker.track_future(task);
+        self.inner.handle.spawn(task)
     }
 
     fn make_cancellable<F>(&self, fut: F) -> impl Future<Output = TaskResult<F::Output>>
     where
         F: Future,
     {
-        let ct = self.on_cancel.clone();
+        let ct = self.inner.on_cancel.clone();
         async move {
             tokio::select! {
                 _ = ct.cancelled() => {
@@ -122,7 +166,8 @@ impl TaskManager {
 
 impl Drop for TaskManager {
     fn drop(&mut self) {
-        self.on_cancel.cancel();
+        trace!(target: "tasks", "Task manager is dropped, cancelling all ongoing tasks.");
+        self.inner.on_cancel.cancel();
     }
 }
 
@@ -156,19 +201,20 @@ mod tests {
     #[tokio::test]
     async fn normal_tasks() {
         let manager = TaskManager::current();
+        let spawner = manager.task_spawner();
 
-        manager.spawn(time::sleep(Duration::from_secs(1)));
-        manager.spawn(time::sleep(Duration::from_secs(1)));
-        manager.spawn(time::sleep(Duration::from_secs(1)));
+        spawner.build_task().spawn(time::sleep(Duration::from_secs(1)));
+        spawner.build_task().spawn(time::sleep(Duration::from_secs(1)));
+        spawner.build_task().spawn(time::sleep(Duration::from_secs(1)));
 
         // 3 tasks should be spawned on the manager
-        assert_eq!(manager.tracker.len(), 3);
+        assert_eq!(manager.inner.tracker.len(), 3);
 
         // wait until all task spawned to the manager have been completed
         manager.wait().await;
 
         assert!(
-            !manager.on_cancel.is_cancelled(),
+            !manager.inner.on_cancel.is_cancelled(),
             "cancellation signal shouldn't be sent on normal task completion"
         )
     }
@@ -176,26 +222,27 @@ mod tests {
     #[tokio::test]
     async fn task_with_graceful_shutdown() {
         let manager = TaskManager::current();
+        let spawner = manager.task_spawner();
 
         // mock long running normal task and a task with graceful shutdown
-        manager.build_task().spawn(async {
+        spawner.build_task().spawn(async {
             loop {
                 time::sleep(Duration::from_secs(1)).await
             }
         });
 
-        manager.build_task().spawn(async {
+        spawner.build_task().spawn(async {
             loop {
                 time::sleep(Duration::from_secs(1)).await
             }
         });
 
         // assert that 2 tasks should've been spawned
-        assert_eq!(manager.tracker.len(), 2);
+        assert_eq!(manager.inner.tracker.len(), 2);
 
         // Spawn a task with graceful shuwdown that finish immediately.
         // The long running task should be cancelled due to the graceful shutdown.
-        manager.build_task().graceful_shutdown().spawn(future::ready(()));
+        spawner.build_task().graceful_shutdown().spawn(future::ready(()));
 
         // wait until all task spawned to the manager have been completed
         manager.shutdown().await;
@@ -204,14 +251,14 @@ mod tests {
     #[tokio::test]
     async fn critical_task_implicit_graceful_shutdown() {
         let manager = TaskManager::current();
-        manager.build_task().critical().spawn(future::ready(()));
+        manager.task_spawner().build_task().critical().spawn(future::ready(()));
         manager.shutdown().await;
     }
 
     #[tokio::test]
     async fn critical_task_graceful_shudown_on_panicked() {
         let manager = TaskManager::current();
-        manager.build_task().critical().spawn(async { panic!("panicking") });
+        manager.task_spawner().build_task().critical().spawn(async { panic!("panicking") });
         manager.shutdown().await;
     }
 }


### PR DESCRIPTION
the idea is to separate task management into two components; `TaskManager` and `TaskSpawner`. `TaskSpawner` is derived from a `TaskManager` and thus can only be created from a `TaskManager` and is used to spawn any tasks to its associated manager. 

the issue that prompted this refactor is when due to the `Drop` implementation of `TaskManager`, where it will cancel all ongoing tasks. because `TaskManager` was cloned around, the underlying cancellation token is the same across all instances of `TaskManager`, and thus when one instance is dropped, it promptly cancelled all tasks of all manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced logging configuration for improved debugging.
	- New functions for clearer output of genesis state information during server startup.
	- Introduction of a new task spawner for better task management and execution.

- **Bug Fixes**
	- Improved error handling and logging for pipeline failures.

- **Documentation**
	- Updated comments and documentation to reflect new features and changes.

- **Refactor**
	- Structural improvements to task management and encapsulation for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->