### PR TITLE
refactor(torii/graphql): use camelCase in graphql to be more consistent

### DIFF
--- a/crates/torii/graphql/src/mapping.rs
+++ b/crates/torii/graphql/src/mapping.rs
@@ -148,7 +148,7 @@ lazy_static! {
     pub static ref ERC_BALANCE_TYPE_MAPPING: TypeMapping = IndexMap::from([
         (Name::new("balance"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
         (Name::new("type"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("token_metadata"), TypeData::Simple(TypeRef::named(ERC_TOKEN_TYPE_NAME))),
+        (Name::new("tokenMetadata"), TypeData::Simple(TypeRef::named(ERC_TOKEN_TYPE_NAME))),
     ]);
 
     pub static ref ERC_TRANSFER_TYPE_MAPPING: TypeMapping = IndexMap::from([
@@ -156,15 +156,15 @@ lazy_static! {
         (Name::new("to"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
         (Name::new("amount"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
         (Name::new("type"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("executed_at"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("token_metadata"), TypeData::Simple(TypeRef::named(ERC_TOKEN_TYPE_NAME))),
+        (Name::new("executedAt"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("tokenMetadata"), TypeData::Simple(TypeRef::named(ERC_TOKEN_TYPE_NAME))),
     ]);
 
     pub static ref ERC_TOKEN_TYPE_MAPPING: TypeMapping = IndexMap::from([
         (Name::new("name"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
         (Name::new("symbol"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("token_id"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("tokenId"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
         (Name::new("decimals"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("contract_address"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("contractAddress"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
     ]);
 }

--- a/crates/torii/graphql/src/object/erc/erc_balance.rs
+++ b/crates/torii/graphql/src/object/erc/erc_balance.rs
@@ -80,15 +80,15 @@ async fn fetch_erc_balances(
                     (Name::new("name"), Value::String(row.name)),
                     (Name::new("symbol"), Value::String(row.symbol)),
                     // for erc20 there is no token_id
-                    (Name::new("token_id"), Value::Null),
+                    (Name::new("tokenId"), Value::Null),
                     (Name::new("decimals"), Value::String(row.decimals.to_string())),
-                    (Name::new("contract_address"), Value::String(row.contract_address.clone())),
+                    (Name::new("contractAddress"), Value::String(row.contract_address.clone())),
                 ]));
 
                 Value::Object(ValueMapping::from([
                     (Name::new("balance"), Value::String(row.balance)),
                     (Name::new("type"), Value::String(row.contract_type)),
-                    (Name::new("token_metadata"), token_metadata),
+                    (Name::new("tokenMetadata"), token_metadata),
                 ]))
             }
             "erc721" => {
@@ -97,17 +97,17 @@ async fn fetch_erc_balances(
                 assert!(token_id.len() == 2);
 
                 let token_metadata = Value::Object(ValueMapping::from([
-                    (Name::new("contract_address"), Value::String(row.contract_address.clone())),
+                    (Name::new("contractAddress"), Value::String(row.contract_address.clone())),
                     (Name::new("name"), Value::String(row.name)),
                     (Name::new("symbol"), Value::String(row.symbol)),
-                    (Name::new("token_id"), Value::String(token_id[1].to_string())),
+                    (Name::new("tokenId"), Value::String(token_id[1].to_string())),
                     (Name::new("decimals"), Value::String(row.decimals.to_string())),
                 ]));
 
                 Value::Object(ValueMapping::from([
                     (Name::new("balance"), Value::String(row.balance)),
                     (Name::new("type"), Value::String(row.contract_type)),
-                    (Name::new("token_metadata"), token_metadata),
+                    (Name::new("tokenMetadata"), token_metadata),
                 ]))
             }
             _ => {

--- a/crates/torii/graphql/src/object/erc/erc_transfer.rs
+++ b/crates/torii/graphql/src/object/erc/erc_transfer.rs
@@ -103,15 +103,15 @@ LIMIT {};
     for row in rows {
         let row = TransferQueryResultRaw::from_row(&row)?;
 
-        let transfer_value = match row.contract_type.as_str() {
-            "ERC20" | "Erc20" | "erc20" => {
+        let transfer_value = match row.contract_type.to_lowercase().as_str() {
+            "erc20" => {
                 let token_metadata = Value::Object(ValueMapping::from([
                     (Name::new("name"), Value::String(row.name)),
                     (Name::new("symbol"), Value::String(row.symbol)),
                     // for erc20 there is no token_id
-                    (Name::new("token_id"), Value::Null),
+                    (Name::new("tokenId"), Value::Null),
                     (Name::new("decimals"), Value::String(row.decimals.to_string())),
-                    (Name::new("contract_address"), Value::String(row.contract_address.clone())),
+                    (Name::new("contractAddress"), Value::String(row.contract_address.clone())),
                 ]));
 
                 Value::Object(ValueMapping::from([
@@ -119,11 +119,11 @@ LIMIT {};
                     (Name::new("to"), Value::String(row.to_address)),
                     (Name::new("amount"), Value::String(row.amount)),
                     (Name::new("type"), Value::String(row.contract_type)),
-                    (Name::new("executed_at"), Value::String(row.executed_at)),
-                    (Name::new("token_metadata"), token_metadata),
+                    (Name::new("executedAt"), Value::String(row.executed_at)),
+                    (Name::new("tokenMetadata"), token_metadata),
                 ]))
             }
-            "ERC721" | "Erc721" | "erc721" => {
+            "erc721" => {
                 // contract_address:token_id
                 let token_id = row.token_id.split(':').collect::<Vec<&str>>();
                 assert!(token_id.len() == 2);
@@ -131,9 +131,9 @@ LIMIT {};
                 let token_metadata = Value::Object(ValueMapping::from([
                     (Name::new("name"), Value::String(row.name)),
                     (Name::new("symbol"), Value::String(row.symbol)),
-                    (Name::new("token_id"), Value::String(token_id[1].to_string())),
+                    (Name::new("tokenId"), Value::String(token_id[1].to_string())),
                     (Name::new("decimals"), Value::String(row.decimals.to_string())),
-                    (Name::new("contract_address"), Value::String(row.contract_address.clone())),
+                    (Name::new("contractAddress"), Value::String(row.contract_address.clone())),
                 ]));
 
                 Value::Object(ValueMapping::from([
@@ -141,8 +141,8 @@ LIMIT {};
                     (Name::new("to"), Value::String(row.to_address)),
                     (Name::new("amount"), Value::String(row.amount)),
                     (Name::new("type"), Value::String(row.contract_type)),
-                    (Name::new("executed_at"), Value::String(row.executed_at)),
-                    (Name::new("token_metadata"), token_metadata),
+                    (Name::new("executedAt"), Value::String(row.executed_at)),
+                    (Name::new("tokenMetadata"), token_metadata),
                 ]))
             }
             _ => {


### PR DESCRIPTION
**Stack**:
- #2520
- #2515 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Standardized naming conventions for ERC token fields to camelCase, improving clarity and consistency in data structures.
- **Bug Fixes**
	- Enhanced case-insensitivity for contract type comparisons in ERC transfers.
- **Documentation**
	- Updated variable signatures to reflect new naming conventions for better understanding and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->