### PR TITLE
rm useless `#[allow(deprecated)]`

### DIFF
--- a/crates/dojo-test-utils/src/sequencer.rs
+++ b/crates/dojo-test-utils/src/sequencer.rs
@@ -35,7 +35,6 @@ pub struct TestSequencer {
 }
 
 impl TestSequencer {
-    #[allow(deprecated)]
     pub async fn start(config: Config) -> Self {
         let handle = katana_node::build(config)
             .await
@@ -81,7 +80,6 @@ impl TestSequencer {
         &self,
         index: usize,
     ) -> SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet> {
-        #[allow(deprecated)]
         let accounts: Vec<_> =
             self.handle.node.backend.chain_spec.genesis.accounts().collect::<_>();
 

--- a/crates/katana/rpc/rpc/src/dev.rs
+++ b/crates/katana/rpc/rpc/src/dev.rs
@@ -92,7 +92,6 @@ impl<EF: ExecutorFactory> DevApiServer for DevApi<EF> {
         Ok(())
     }
 
-    #[allow(deprecated)]
     async fn predeployed_accounts(&self) -> Result<Vec<Account>, Error> {
         Ok(self.backend.chain_spec.genesis.accounts().map(|e| Account::new(*e.0, e.1)).collect())
     }

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -470,7 +470,6 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
 
             // If the node is run with transaction validation disabled, then we should not validate
             // transactions when estimating the fee even if the `SKIP_VALIDATE` flag is not set.
-            #[allow(deprecated)]
             let should_validate = !(skip_validate
                 || this.inner.backend.executor_factory.execution_flags().skip_validate);
             let flags = katana_executor::SimulationFlag {

--- a/crates/katana/rpc/rpc/src/starknet/trace.rs
+++ b/crates/katana/rpc/rpc/src/starknet/trace.rs
@@ -64,13 +64,11 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
 
         // If the node is run with transaction validation disabled, then we should not validate
         // even if the `SKIP_VALIDATE` flag is not set.
-        #[allow(deprecated)]
         let should_validate = !(simulation_flags.contains(&SimulationFlag::SkipValidate)
             || self.inner.backend.executor_factory.execution_flags().skip_validate);
 
         // If the node is run with fee charge disabled, then we should disable charing fees even
         // if the `SKIP_FEE_CHARGE` flag is not set.
-        #[allow(deprecated)]
         let should_skip_fee = !(simulation_flags.contains(&SimulationFlag::SkipFeeCharge)
             || self.inner.backend.executor_factory.execution_flags().skip_fee_transfer);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for fee estimation and transaction simulation in the Starknet API.
	- Added `estimate_fee` and `estimate_message_fee` methods for enhanced transaction processing.
	- New `simulate_txs` method for simulating transactions based on user-defined parameters.

- **Bug Fixes**
	- Improved error handling and filtering for block and transaction retrieval methods.

- **Deprecation Notices**
	- Marked `predeployed_accounts` method as deprecated for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->