### PR TITLE
feat(torii): add transaction hash to erc_transfers table

### DIFF
--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -610,6 +610,8 @@ impl<P: Provider + Send + Sync + std::fmt::Debug + 'static> Engine<P> {
         let mut unique_contracts = HashSet::new();
         // Contract -> Cursor
         for (event_idx, event) in events.iter().enumerate() {
+            // NOTE: erc* processors expect the event_id to be in this format to get
+            // transaction_hash:
             let event_id =
                 format!("{:#064x}:{:#x}:{:#04x}", block_number, transaction_hash, event_idx);
 
@@ -681,6 +683,8 @@ impl<P: Provider + Send + Sync + std::fmt::Debug + 'static> Engine<P> {
 
                 unique_contracts.insert(event.from_address);
 
+                // NOTE: erc* processors expect the event_id to be in this format to get
+                // transaction_hash:
                 let event_id =
                     format!("{:#064x}:{:#x}:{:#04x}", block_number, *transaction_hash, event_idx);
 
@@ -898,4 +902,9 @@ where
         MaybePendingBlockWithTxHashes::Block(block) => Ok(block.timestamp),
         MaybePendingBlockWithTxHashes::PendingBlock(block) => Ok(block.timestamp),
     }
+}
+
+// event_id format: block_number:transaction_hash:event_idx
+pub(crate) fn get_transaction_hash_from_event_id(event_id: &str) -> String {
+    event_id.split(':').nth(1).unwrap().to_string()
 }

--- a/crates/torii/core/src/processors/erc20_transfer.rs
+++ b/crates/torii/core/src/processors/erc20_transfer.rs
@@ -7,6 +7,7 @@ use starknet::providers::Provider;
 use tracing::debug;
 
 use super::EventProcessor;
+use crate::engine::get_transaction_hash_from_event_id;
 use crate::sql::Sql;
 
 pub(crate) const LOG_TARGET: &str = "torii_core::processors::erc20_transfer";
@@ -40,7 +41,7 @@ where
         db: &mut Sql,
         _block_number: u64,
         block_timestamp: u64,
-        _event_id: &str,
+        event_id: &str,
         event: &Event,
     ) -> Result<(), Error> {
         let token_address = event.from_address;
@@ -49,9 +50,18 @@ where
 
         let value = U256Cainome::cairo_deserialize(&event.data, 0)?;
         let value = U256::from_words(value.low, value.high);
+        let transaction_hash = get_transaction_hash_from_event_id(event_id);
 
-        db.handle_erc20_transfer(token_address, from, to, value, world.provider(), block_timestamp)
-            .await?;
+        db.handle_erc20_transfer(
+            token_address,
+            from,
+            to,
+            value,
+            world.provider(),
+            block_timestamp,
+            &transaction_hash,
+        )
+        .await?;
         debug!(target: LOG_TARGET,from = ?from, to = ?to, value = ?value, "ERC20 Transfer");
 
         Ok(())

--- a/crates/torii/core/src/processors/erc721_legacy_transfer.rs
+++ b/crates/torii/core/src/processors/erc721_legacy_transfer.rs
@@ -7,6 +7,7 @@ use starknet::providers::Provider;
 use tracing::debug;
 
 use super::EventProcessor;
+use crate::engine::get_transaction_hash_from_event_id;
 use crate::sql::Sql;
 
 pub(crate) const LOG_TARGET: &str = "torii_core::processors::erc721_legacy_transfer";
@@ -40,7 +41,7 @@ where
         db: &mut Sql,
         _block_number: u64,
         block_timestamp: u64,
-        _event_id: &str,
+        event_id: &str,
         event: &Event,
     ) -> Result<(), Error> {
         let token_address = event.from_address;
@@ -49,6 +50,7 @@ where
 
         let token_id = U256Cainome::cairo_deserialize(&event.data, 2)?;
         let token_id = U256::from_words(token_id.low, token_id.high);
+        let transaction_hash = get_transaction_hash_from_event_id(event_id);
 
         db.handle_erc721_transfer(
             token_address,
@@ -57,6 +59,7 @@ where
             token_id,
             world.provider(),
             block_timestamp,
+            &transaction_hash,
         )
         .await?;
         debug!(target: LOG_TARGET, from = ?from, to = ?to, token_id = ?token_id, "ERC721 Transfer");

--- a/crates/torii/core/src/sql/erc.rs
+++ b/crates/torii/core/src/sql/erc.rs
@@ -25,6 +25,7 @@ impl Sql {
         amount: U256,
         provider: &P,
         block_timestamp: u64,
+        transaction_hash: &str,
     ) -> Result<()> {
         // contract_address
         let token_id = felt_to_sql_string(&contract_address);
@@ -43,6 +44,7 @@ impl Sql {
             amount,
             &token_id,
             block_timestamp,
+            transaction_hash,
         )?;
 
         if from_address != Felt::ZERO {
@@ -79,6 +81,7 @@ impl Sql {
         token_id: U256,
         provider: &P,
         block_timestamp: u64,
+        transaction_hash: &str,
     ) -> Result<()> {
         // contract_address:id
         let token_id = felt_and_u256_to_sql_string(&contract_address, &token_id);
@@ -96,6 +99,7 @@ impl Sql {
             U256::from(1u8),
             &token_id,
             block_timestamp,
+            transaction_hash,
         )?;
 
         // from_address/contract_address:id
@@ -307,6 +311,7 @@ impl Sql {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn store_erc_transfer_event(
         &mut self,
         contract_address: Felt,
@@ -315,9 +320,11 @@ impl Sql {
         amount: U256,
         token_id: &str,
         block_timestamp: u64,
+        transaction_hash: &str,
     ) -> Result<()> {
         let insert_query = "INSERT INTO erc_transfers (contract_address, from_address, \
-                            to_address, amount, token_id, executed_at) VALUES (?, ?, ?, ?, ?, ?)";
+                            to_address, amount, token_id, executed_at, transaction_hash) VALUES \
+                            (?, ?, ?, ?, ?, ?, ?)";
 
         self.executor.send(QueryMessage::other(
             insert_query.to_string(),
@@ -328,6 +335,7 @@ impl Sql {
                 Argument::String(u256_to_sql_string(&amount)),
                 Argument::String(token_id.to_string()),
                 Argument::String(utc_dt_string_from_timestamp(block_timestamp)),
+                Argument::String(transaction_hash.to_string()),
             ],
         ))?;
 

--- a/crates/torii/graphql/src/mapping.rs
+++ b/crates/torii/graphql/src/mapping.rs
@@ -146,25 +146,26 @@ lazy_static! {
     ]);
 
     pub static ref ERC_BALANCE_TYPE_MAPPING: TypeMapping = IndexMap::from([
-        (Name::new("balance"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("type"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("tokenMetadata"), TypeData::Simple(TypeRef::named(ERC_TOKEN_TYPE_NAME))),
+        (Name::new("balance"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("type"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("tokenMetadata"), TypeData::Simple(TypeRef::named_nn(ERC_TOKEN_TYPE_NAME))),
     ]);
 
     pub static ref ERC_TRANSFER_TYPE_MAPPING: TypeMapping = IndexMap::from([
-        (Name::new("from"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("to"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("amount"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("type"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("executedAt"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("tokenMetadata"), TypeData::Simple(TypeRef::named(ERC_TOKEN_TYPE_NAME))),
+        (Name::new("from"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("to"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("amount"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("type"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("executedAt"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("tokenMetadata"), TypeData::Simple(TypeRef::named_nn(ERC_TOKEN_TYPE_NAME))),
+        (Name::new("transactionHash"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
     ]);
 
     pub static ref ERC_TOKEN_TYPE_MAPPING: TypeMapping = IndexMap::from([
-        (Name::new("name"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("symbol"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("tokenId"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("decimals"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
-        (Name::new("contractAddress"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("name"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("symbol"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("tokenId"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("decimals"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("contractAddress"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
     ]);
 }

--- a/crates/torii/graphql/src/object/erc/erc_transfer.rs
+++ b/crates/torii/graphql/src/object/erc/erc_transfer.rs
@@ -79,7 +79,8 @@ SELECT
     t.name,
     t.symbol,
     t.decimals,
-    c.contract_type
+    c.contract_type,
+    et.transaction_hash
 FROM
     erc_transfers et
 JOIN
@@ -121,6 +122,7 @@ LIMIT {};
                     (Name::new("type"), Value::String(row.contract_type)),
                     (Name::new("executedAt"), Value::String(row.executed_at)),
                     (Name::new("tokenMetadata"), token_metadata),
+                    (Name::new("transactionHash"), Value::String(row.transaction_hash.clone())),
                 ]))
             }
             "erc721" => {
@@ -143,6 +145,7 @@ LIMIT {};
                     (Name::new("type"), Value::String(row.contract_type)),
                     (Name::new("executedAt"), Value::String(row.executed_at)),
                     (Name::new("tokenMetadata"), token_metadata),
+                    (Name::new("transactionHash"), Value::String(row.transaction_hash.clone())),
                 ]))
             }
             _ => {
@@ -178,4 +181,5 @@ struct TransferQueryResultRaw {
     pub symbol: String,
     pub decimals: u8,
     pub contract_type: String,
+    pub transaction_hash: String,
 }

--- a/crates/torii/migrations/20241011103804_add_transaction_hash_in_erc_transfers_table.sql
+++ b/crates/torii/migrations/20241011103804_add_transaction_hash_in_erc_transfers_table.sql
@@ -1,0 +1,1 @@
+ALTER TABLE erc_transfers ADD COLUMN transaction_hash TEXT NOT NULL;


### PR DESCRIPTION
**Stack**:
- #2527
- #2526
- #2520 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to extract transaction hashes from event IDs, enhancing event processing capabilities.
	- Added a `transaction_hash` field to the `erc_transfers` table for improved data capture during token transfers.

- **Bug Fixes**
	- Updated method signatures across various processors to ensure the transaction hash is utilized correctly.

- **Documentation**
	- Enhanced comments in processing methods to clarify expectations for event ID formatting.

- **Style**
	- Updated field names in mappings to follow camelCase formatting and ensure non-nullable types.

- **Chores**
	- Modified database schema to include the new `transaction_hash` column in the `erc_transfers` table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->