### PR TITLE
fix(Dockerfile): use tini from package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim as builder
 
-RUN apt-get update && apt install -y git libtool automake autoconf make
+RUN apt-get update && apt install -y git libtool automake autoconf make tini
 
 RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && cd curtailer \
@@ -16,9 +16,7 @@ RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
 
 FROM debian:bookworm-slim as base
 
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+COPY --from=builder /usr/bin/tini /tini
 ENTRYPOINT ["/tini", "--"]
 
 ARG TARGETPLATFORM


### PR DESCRIPTION
# Description

Simplified Dockerfile by installing tini directly
via package manager. Removed manual download and
permission setting steps.

<!--
A description of what this PR is solving.
-->

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Dockerfile to streamline the installation process by including the `tini` package.
	- Changed the `ENTRYPOINT` to use an absolute path for improved reliability.
	- Added a command to verify the version of `tini`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->