### PR TITLE
refactor(katana): include protocol version in chainspec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3936,6 +3945,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64009896348fc5af4222e9cf7d7d82a95a256c634ebcf61c53e4ea461422242"
 
 [[package]]
 name = "crossbeam-channel"
@@ -6576,6 +6591,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6654,6 +6678,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.12",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -8209,6 +8247,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "num-traits 0.2.19",
+ "postcard",
  "rand 0.8.5",
  "rstest 0.18.2",
  "serde",
@@ -10570,6 +10609,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "serde",
 ]
 

--- a/crates/katana/core/src/backend/mod.rs
+++ b/crates/katana/core/src/backend/mod.rs
@@ -7,7 +7,6 @@ use katana_primitives::block::{
 use katana_primitives::chain_spec::ChainSpec;
 use katana_primitives::env::BlockEnv;
 use katana_primitives::transaction::TxHash;
-use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::Felt;
 use katana_provider::traits::block::{BlockHashProvider, BlockWriter};
 use parking_lot::RwLock;
@@ -66,7 +65,7 @@ impl<EF: ExecutorFactory> Backend<EF> {
         let partial_header = PartialHeader {
             number: block_number,
             parent_hash: prev_hash,
-            version: CURRENT_STARKNET_VERSION,
+            version: self.chain_spec.version.clone(),
             timestamp: block_env.timestamp,
             sequencer_address: block_env.sequencer_address,
             gas_prices: GasPrices {

--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -14,7 +14,6 @@ use katana_primitives::block::{BlockHashOrNumber, ExecutableBlock, PartialHeader
 use katana_primitives::receipt::Receipt;
 use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{ExecutableTxWithHash, TxHash, TxWithHash};
-use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_provider::error::ProviderError;
 use katana_provider::traits::block::{BlockHashProvider, BlockNumberProvider};
 use katana_provider::traits::env::BlockEnvProvider;
@@ -581,7 +580,7 @@ impl<EF: ExecutorFactory> InstantBlockProducer<EF> {
                 timestamp: block_env.timestamp,
                 gas_prices: block_env.l1_gas_prices.clone(),
                 sequencer_address: block_env.sequencer_address,
-                version: CURRENT_STARKNET_VERSION,
+                version: backend.chain_spec.version.clone(),
             },
         };
 

--- a/crates/katana/executor/tests/fixtures/mod.rs
+++ b/crates/katana/executor/tests/fixtures/mod.rs
@@ -21,7 +21,7 @@ use katana_primitives::transaction::{
     ExecutableTxWithHash, InvokeTx, InvokeTxV1,
 };
 use katana_primitives::utils::class::{parse_compiled_class, parse_sierra_class};
-use katana_primitives::version::Version;
+use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::{address, Felt};
 use katana_provider::providers::in_memory::InMemoryProvider;
 use katana_provider::traits::block::BlockWriter;
@@ -88,7 +88,7 @@ pub fn state_provider(chain: &ChainSpec) -> Box<dyn StateProvider> {
 /// [state_provider].
 #[rstest::fixture]
 pub fn valid_blocks() -> [ExecutableBlock; 3] {
-    let version = Version::new(0, 13, 0);
+    let version = CURRENT_STARKNET_VERSION;
     let chain_id = ChainId::parse("KATANA").unwrap();
     let sequencer_address = ContractAddress(1u64.into());
 
@@ -102,7 +102,7 @@ pub fn valid_blocks() -> [ExecutableBlock; 3] {
     [
         ExecutableBlock {
             header: PartialHeader {
-                version,
+                version: version.clone(),
                 number: 1,
                 timestamp: 100,
                 sequencer_address,
@@ -150,7 +150,7 @@ pub fn valid_blocks() -> [ExecutableBlock; 3] {
         },
         ExecutableBlock {
             header: PartialHeader {
-                version,
+                version: version.clone(),
                 number: 2,
                 timestamp: 200,
                 sequencer_address,

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -33,6 +33,7 @@ use katana_pool::validation::stateful::TxValidator;
 use katana_pool::TxPool;
 use katana_primitives::block::FinalityStatus;
 use katana_primitives::env::{CfgEnv, FeeTokenAddressses};
+use katana_primitives::version::Version;
 use katana_provider::providers::fork::ForkedProvider;
 use katana_provider::providers::in_memory::InMemoryProvider;
 use katana_rpc::dev::DevApi;
@@ -203,6 +204,8 @@ pub async fn build(mut config: Config) -> Result<Node> {
         let MaybePendingBlockWithTxHashes::Block(block) = block else {
             panic!("block to be forked is a pending block")
         };
+
+        config.chain.version = Version::parse(&block.starknet_version)?;
 
         // adjust the genesis to match the forked block
         config.chain.genesis.number = block.block_number;

--- a/crates/katana/primitives/Cargo.toml
+++ b/crates/katana/primitives/Cargo.toml
@@ -28,6 +28,7 @@ num-bigint = "0.4.6"
 
 [dev-dependencies]
 assert_matches.workspace = true
+postcard = "1.0.10"
 rstest.workspace = true
 similar-asserts.workspace = true
 

--- a/crates/katana/primitives/src/chain_spec.rs
+++ b/crates/katana/primitives/src/chain_spec.rs
@@ -20,7 +20,7 @@ use crate::genesis::constant::{
 use crate::genesis::Genesis;
 use crate::state::StateUpdatesWithDeclaredClasses;
 use crate::utils::split_u256;
-use crate::version::CURRENT_STARKNET_VERSION;
+use crate::version::{Version, CURRENT_STARKNET_VERSION};
 
 /// A chain specification.
 // TODO: include l1 core contract
@@ -33,6 +33,8 @@ pub struct ChainSpec {
     pub genesis: Genesis,
     /// The chain fee token contract.
     pub fee_contracts: FeeContracts,
+    /// The protocol version.
+    pub version: Version,
 }
 
 /// Tokens that can be used for transaction fee payments in the chain. As
@@ -49,7 +51,7 @@ pub struct FeeContracts {
 impl ChainSpec {
     pub fn block(&self) -> Block {
         let header = Header {
-            version: CURRENT_STARKNET_VERSION,
+            version: self.version.clone(),
             number: self.genesis.number,
             timestamp: self.genesis.timestamp,
             state_root: self.genesis.state_root,
@@ -155,7 +157,7 @@ lazy_static! {
         let id = ChainId::parse("KATANA").unwrap();
         let genesis = Genesis::default();
         let fee_contracts = FeeContracts { eth: DEFAULT_ETH_FEE_TOKEN_ADDRESS, strk: DEFAULT_STRK_FEE_TOKEN_ADDRESS };
-        ChainSpec { id, genesis, fee_contracts }
+        ChainSpec { id, genesis, fee_contracts, version: CURRENT_STARKNET_VERSION }
     };
 }
 
@@ -314,6 +316,7 @@ mod tests {
         ];
         let chain_spec = ChainSpec {
             id: ChainId::SEPOLIA,
+            version: CURRENT_STARKNET_VERSION,
             genesis: Genesis {
                 classes,
                 allocations: BTreeMap::from(allocations.clone()),

--- a/crates/katana/primitives/src/version.rs
+++ b/crates/katana/primitives/src/version.rs
@@ -1,87 +1,138 @@
-use anyhow::anyhow;
-
 /// The currently supported version of the Starknet protocol.
-pub static CURRENT_STARKNET_VERSION: Version = Version::new(0, 12, 2); // version 0.12.2
+pub const CURRENT_STARKNET_VERSION: Version = Version::new([0, 13, 1, 1]); // version 0.13.1.1
 
 /// Starknet protocol version.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Version {
-    major: u64,
-    minor: u64,
-    patch: u64,
+    segments: [u8; 4],
 }
 
 impl Version {
-    pub const fn new(major: u64, minor: u64, patch: u64) -> Self {
-        Self { major, minor, patch }
+    pub const fn new(segments: [u8; 4]) -> Self {
+        Self { segments }
     }
 
     pub fn parse(version: &str) -> anyhow::Result<Self> {
-        let mut parts = version.split('.');
+        let segments: Result<Vec<u8>, _> = version.split('.').map(|s| s.parse::<u8>()).collect();
 
-        if parts.clone().count() > 3 {
-            return Err(anyhow!("invalid version format"));
+        match segments {
+            Ok(segments) if segments.len() == 4 => {
+                let mut arr = [0u8; 4];
+                arr.copy_from_slice(&segments);
+                Ok(Self { segments: arr })
+            }
+            _ => Err(anyhow::anyhow!("invalid version format")),
         }
+    }
+}
 
-        let major = parts.next().map(|s| s.parse::<u64>()).transpose()?.unwrap_or_default();
-        let minor = parts.next().map(|s| s.parse::<u64>()).transpose()?.unwrap_or_default();
-        let patch = parts.next().map(|s| s.parse::<u64>()).transpose()?.unwrap_or_default();
-
-        Ok(Self::new(major, minor, patch))
+impl std::default::Default for Version {
+    fn default() -> Self {
+        Version::new([0, 1, 0, 0])
     }
 }
 
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{major}.{minor}.{patch}",
-            major = self.major,
-            minor = self.minor,
-            patch = self.patch
-        )
+        for (i, segment) in self.segments.iter().enumerate() {
+            if i == self.segments.len() - 1 {
+                if i != 0 {
+                    write!(f, ".{segment}")?;
+                }
+            } else if i == 0 {
+                write!(f, "{segment}")?;
+            } else {
+                write!(f, ".{segment}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde {
+    use super::*;
+
+    impl ::serde::Serialize for Version {
+        fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            if serializer.is_human_readable() {
+                serializer.serialize_str(&self.to_string())
+            } else {
+                self.segments.serialize(serializer)
+            }
+        }
+    }
+
+    impl<'de> ::serde::Deserialize<'de> for Version {
+        fn deserialize<D: ::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            if deserializer.is_human_readable() {
+                let s = String::deserialize(deserializer)?;
+                Version::parse(&s).map_err(::serde::de::Error::custom)
+            } else {
+                Ok(Version::new(<[u8; 4]>::deserialize(deserializer)?))
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
 
     #[test]
-    fn parse_semver_valid() {
+    fn parse_version_valid() {
+        let version = "1.9.0.0";
+        let parsed = Version::parse(version).unwrap();
+        assert_eq!(parsed.segments, [1, 9, 0, 0]);
+        assert_eq!(String::from("1.9.0.0"), parsed.to_string());
+    }
+
+    #[test]
+    fn parse_version_missing_parts() {
         let version = "1.9.0";
-        let parsed = super::Version::parse(version).unwrap();
-        assert_eq!(parsed.major, 1);
-        assert_eq!(parsed.minor, 9);
-        assert_eq!(parsed.patch, 0);
-        assert_eq!(String::from("1.9.0"), parsed.to_string());
+        assert!(Version::parse(version).is_err());
     }
 
     #[test]
-    fn parse_semver_missing_parts() {
-        let version = "1.9";
-        let parsed = super::Version::parse(version).unwrap();
-        assert_eq!(parsed.major, 1);
-        assert_eq!(parsed.minor, 9);
-        assert_eq!(parsed.patch, 0);
-        assert_eq!(String::from("1.9.0"), parsed.to_string());
+    fn parse_version_invalid_digit_should_fail() {
+        let version = "0.fv.1.0";
+        assert!(Version::parse(version).is_err());
     }
 
     #[test]
-    fn parse_semver_invalid_digit_should_fail() {
-        let version = "0.fv.1";
-        assert!(super::Version::parse(version).is_err());
+    fn parse_version_missing_digit_should_fail() {
+        let version = "1...";
+        assert!(Version::parse(version).is_err());
     }
 
     #[test]
-    fn parse_semver_missing_digit_should_fail() {
-        let version = "1..";
-        assert!(super::Version::parse(version).is_err());
-    }
-
-    #[test]
-    fn parse_semver_too_many_parts_should_fail() {
+    fn parse_version_many_parts_should_succeed() {
         let version = "1.2.3.4";
-        assert!(super::Version::parse(version).is_err());
+        let parsed = Version::parse(version).unwrap();
+        assert_eq!(parsed.segments, [1, 2, 3, 4]);
+        assert_eq!(String::from("1.2.3.4"), parsed.to_string());
+    }
+
+    #[cfg(feature = "serde")]
+    mod serde {
+        use super::*;
+
+        #[test]
+        fn rt_human_readable() {
+            let version = Version::new([1, 2, 3, 4]);
+            let serialized = serde_json::to_string(&version).unwrap();
+            assert_eq!(serialized, "\"1.2.3.4\"");
+            let deserialized: Version = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(version, deserialized);
+        }
+
+        #[test]
+        fn rt_non_human_readable() {
+            let version = Version::new([1, 2, 3, 4]);
+            let serialized = postcard::to_stdvec(&version).unwrap();
+            let deserialized: Version = postcard::from_bytes(&serialized).unwrap();
+            assert_eq!(version, deserialized);
+        }
     }
 }

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -2,7 +2,6 @@ use jsonrpsee::core::{async_trait, Error, RpcResult};
 use katana_executor::{EntryPointCall, ExecutionResult, ExecutorFactory};
 use katana_primitives::block::{BlockHashOrNumber, BlockIdOrTag, FinalityStatus, PartialHeader};
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash, TxHash};
-use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::Felt;
 use katana_provider::traits::block::{BlockHashProvider, BlockIdReader, BlockNumberProvider};
 use katana_provider::traits::transaction::TransactionProvider;
@@ -87,7 +86,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                         gas_prices,
                         parent_hash: latest_hash,
                         timestamp: block_env.timestamp,
-                        version: CURRENT_STARKNET_VERSION,
+                        version: this.inner.backend.chain_spec.version.clone(),
                         sequencer_address: block_env.sequencer_address,
                     };
 
@@ -174,9 +173,9 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                         number: block_env.number,
                         gas_prices,
                         parent_hash: latest_hash,
-                        version: CURRENT_STARKNET_VERSION,
                         timestamp: block_env.timestamp,
                         sequencer_address: block_env.sequencer_address,
+                        version: this.inner.backend.chain_spec.version.clone(),
                     };
 
                     // TODO(kariy): create a method that can perform this filtering for us instead
@@ -231,7 +230,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
                         number: block_env.number,
                         gas_prices,
                         parent_hash: latest_hash,
-                        version: CURRENT_STARKNET_VERSION,
+                        version: this.inner.backend.chain_spec.version.clone(),
                         timestamp: block_env.timestamp,
                         sequencer_address: block_env.sequencer_address,
                     };


### PR DESCRIPTION
partially resolves #wrong version #2539 

- refactor version struct to handle starknet protocol version format
- include version protocol in chainspec
- use the version in chainspec when creating blocks instead of hardcoding the value
- in forked mode, use the protocol version of the forked network