### PR TITLE
fix(katana): include msg sender in the tx calldata

### DIFF
--- a/crates/katana/rpc/rpc-types/src/message.rs
+++ b/crates/katana/rpc/rpc-types/src/message.rs
@@ -27,13 +27,18 @@ impl MsgFromL1 {
             &self.0.payload,
         );
 
+        // In an l1_handler transaction, the first element of the calldata is always the Ethereum
+        // address of the sender (msg.sender). https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/messaging-mechanism/#l1-l2-messages
+        let mut calldata = vec![Felt::from(self.0.from_address)];
+        calldata.extend(self.0.payload);
+
         L1HandlerTx {
             nonce,
             chain_id,
+            calldata,
             message_hash,
             paid_fee_on_l1,
             version: Felt::ZERO,
-            calldata: self.0.payload,
             contract_address: self.0.to_address.into(),
             entry_point_selector: self.0.entry_point_selector,
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced messaging functionality between L1 and L2 contracts.
	- Added a new section for estimating message fees in the messaging system.

- **Bug Fixes**
	- Updated the construction of calldata to include the sender's Ethereum address.

- **Documentation**
	- Improved comments in the test suite for better clarity on function signatures and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->