### PR TITLE
refactor(katana): remove events trace log

### DIFF
--- a/crates/katana/executor/src/implementation/blockifier/mod.rs
+++ b/crates/katana/executor/src/implementation/blockifier/mod.rs
@@ -198,7 +198,6 @@ impl<'a> BlockExecutor<'a> for StarknetVMProcessor<'a> {
                     }
 
                     crate::utils::log_resources(&trace.actual_resources);
-                    crate::utils::log_events(receipt.events());
                 }
 
                 ExecutionResult::Failed { error } => {

--- a/crates/katana/executor/src/utils.rs
+++ b/crates/katana/executor/src/utils.rs
@@ -24,16 +24,6 @@ pub fn log_resources(resources: &TxResources) {
     trace!(target: LOG_TARGET, usage = mapped_strings.join(" | "), "Transaction resource usage.");
 }
 
-pub fn log_events(events: &[Event]) {
-    for e in events {
-        trace!(
-            target: LOG_TARGET,
-            keys = e.keys.iter().map(|key| format!("{key:#x}")).collect::<Vec<_>>().join(", "),
-            "Event emitted.",
-        );
-    }
-}
-
 pub(crate) fn build_receipt(tx: TxRef<'_>, fee: TxFeeInfo, info: &TxExecInfo) -> Receipt {
     let events = events_from_exec_info(info);
     let revert_error = info.revert_error.clone();


### PR DESCRIPTION
this remove the `trace!` log for transaction events that is emitted after the execution of every transaction.

for transaction that emits a lot of event (definitely yes, in the case of dojo application) the logs are being emitted are too much. and afaik most people dont even find it particularly THAT useful.

below is an example of the events log from the Dojo example project:

<img width="1063" alt="Screenshot 2024-10-22 at 4 10 29 PM" src="https://github.com/user-attachments/assets/ee5d7193-0e5c-4e27-ac65-534fb217a8ea">

not sure who is autistic enough (too bad im not) to even find these logs useful. maybe useful in the case of identifying the transactions based on the number of events (or a specific event hash) but in most scenario, these logs are ignored. emitting these logs however, (especially when there are a lot of events) are not free, they takes a some amount of resources, and in the case of Slot, storing these logs takes up most of the storage capacity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `BlockifierFactory` for enhanced configuration and simulation of blockchain transactions.
	- Added methods for simulating transactions and estimating fees with improved error handling and logging.

- **Bug Fixes**
	- Enhanced logging for transaction execution results, including detailed insights for successful transactions and failures.

- **Chores**
	- Removed the `log_events` function, streamlining event logging processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->