### PR TITLE
fix(torii-grpc): sql query for typed enums in nested arrays

### DIFF
--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -1074,10 +1074,10 @@ mod tests {
              \"Test-PlayerConfig$favorite_item.Some\", [Test-PlayerConfig].external_favorite_item \
              AS \"Test-PlayerConfig.favorite_item\" FROM entities JOIN [Test-Position] ON \
              entities.id = [Test-Position].entity_id  JOIN [Test-PlayerConfig] ON entities.id = \
-             [Test-PlayerConfig].entity_id  JOIN [Test-Position$vec] ON \
-             [Test-Position$vec].full_array_id = [Test-Position].full_array_id  LEFT JOIN \
-             [Test-PlayerConfig$favorite_item] ON [Test-PlayerConfig$favorite_item].full_array_id \
-             = [Test-PlayerConfig].full_array_id ORDER BY entities.event_id DESC";
+             [Test-PlayerConfig].entity_id  JOIN [Test-Position$vec] ON entities.id = \
+             [Test-Position$vec].entity_id  LEFT JOIN [Test-PlayerConfig$favorite_item] ON \
+             entities.id = [Test-PlayerConfig$favorite_item].entity_id ORDER BY entities.event_id \
+             DESC";
         // todo: completely tests arrays
         assert_eq!(query.0, expected_query);
     }

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -1075,16 +1075,15 @@ mod tests {
         .unwrap();
 
         let expected_query =
-            "SELECT entities.id, entities.keys, [Test-Position].external_player AS \
-             \"Test-Position.player\", [Test-Position$vec].external_x AS \"Test-Position$vec.x\", \
-             [Test-Position$vec].external_y AS \"Test-Position$vec.y\", \
-             [Test-PlayerConfig$favorite_item].external_Some AS \
-             \"Test-PlayerConfig$favorite_item.Some\", [Test-PlayerConfig].external_favorite_item \
-             AS \"Test-PlayerConfig.favorite_item\" FROM entities JOIN [Test-Position$vec] ON \
-             entities.id = [Test-Position$vec].entity_id  JOIN [Test-Position] ON entities.id = \
-             [Test-Position].entity_id  JOIN [Test-PlayerConfig$favorite_item] ON entities.id = \
-             [Test-PlayerConfig$favorite_item].entity_id  JOIN [Test-PlayerConfig] ON entities.id \
-             = [Test-PlayerConfig].entity_id ORDER BY entities.event_id DESC";
+            "SELECT entities.id, entities.keys, [Test-Position].external_player AS \"Test-Position.player\", \
+            [Test-Position$vec].external_x AS \"Test-Position$vec.x\", [Test-Position$vec].external_y AS \"Test-Position$vec.y\", \
+            [Test-PlayerConfig$favorite_item].external_Some AS \"Test-PlayerConfig$favorite_item.Some\", \
+            [Test-PlayerConfig].external_favorite_item AS \"Test-PlayerConfig.favorite_item\" \
+            FROM entities JOIN [Test-Position] ON entities.id = [Test-Position].entity_id  \
+            JOIN [Test-PlayerConfig] ON entities.id = [Test-PlayerConfig].entity_id  \
+            JOIN [Test-Position$vec] ON [Test-Position$vec].full_array_id = [Test-Position].full_array_id  \
+            LEFT JOIN [Test-PlayerConfig$favorite_item] ON [Test-PlayerConfig$favorite_item].full_array_id = [Test-PlayerConfig].full_array_id \
+            ORDER BY entities.event_id DESC";
         // todo: completely tests arrays
         assert_eq!(query.0, expected_query);
     }

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -396,15 +396,8 @@ pub fn build_sql_query(
         .iter()
         .map(|table| {
             let join_type = if table.is_optional { "LEFT JOIN" } else { "JOIN" };
-            let join_condition = if table.parent_table.is_none() {
-                format!("{entities_table}.id = [{}].{entity_relation_column}", table.table_name)
-            } else {
-                format!(
-                    "[{}].full_array_id = [{}].full_array_id",
-                    table.table_name,
-                    table.parent_table.as_ref().unwrap()
-                )
-            };
+            let join_condition =
+                format!("{entities_table}.id = [{}].{entity_relation_column}", table.table_name);
             format!(" {join_type} [{}] ON {join_condition}", table.table_name)
         })
         .collect::<Vec<_>>()
@@ -423,9 +416,8 @@ pub fn build_sql_query(
 
             let join_clause = tables
                 .iter()
-                .enumerate()
-                .map(|(idx, table)| {
-                    if idx == 0 {
+                .map(|table| {
+                    if table.parent_table.is_none() {
                         format!(
                             " JOIN [{}] ON {entities_table}.id = [{}].{entity_relation_column}",
                             table.table_name, table.table_name

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -254,7 +254,7 @@ pub fn build_sql_query(
     ) {
         match &ty {
             Ty::Struct(s) => {
-                let table_name = 
+                let table_name =
                     if path.is_empty() { name.to_string() } else { format!("{}${}", path, name) };
 
                 tables.push(TableInfo {
@@ -396,15 +396,15 @@ pub fn build_sql_query(
         .map(|table| {
             let join_type = if table.is_optional { "LEFT JOIN" } else { "JOIN" };
             let join_condition = if table.parent_table.is_none() {
-                format!("{entities_table}.id = [{}].{entity_relation_column}", 
-                    table.table_name)
+                format!("{entities_table}.id = [{}].{entity_relation_column}", table.table_name)
             } else {
-                format!("[{}].full_array_id = [{}].full_array_id",
+                format!(
+                    "[{}].full_array_id = [{}].full_array_id",
                     table.table_name,
-                    table.parent_table.as_ref().unwrap())
+                    table.parent_table.as_ref().unwrap()
+                )
             };
-            format!(" {join_type} [{}] ON {join_condition}", 
-                table.table_name)
+            format!(" {join_type} [{}] ON {join_condition}", table.table_name)
         })
         .collect::<Vec<_>>()
         .join(" ");
@@ -426,16 +426,13 @@ pub fn build_sql_query(
                 .map(|(idx, table)| {
                     if idx == 0 {
                         format!(
-                            " JOIN [{}] ON {entities_table}.id = \
-                             [{}].{entity_relation_column}",
-                            table.table_name,
-                            table.table_name
+                            " JOIN [{}] ON {entities_table}.id = [{}].{entity_relation_column}",
+                            table.table_name, table.table_name
                         )
                     } else {
                         let join_type = if table.is_optional { "LEFT JOIN" } else { "JOIN" };
                         format!(
-                            " {join_type} [{}] ON [{}].full_array_id = \
-                             [{}].full_array_id",
+                            " {join_type} [{}] ON [{}].full_array_id = [{}].full_array_id",
                             table.table_name,
                             table.table_name,
                             table.parent_table.as_ref().unwrap()

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -242,6 +242,7 @@ pub fn build_sql_query(
         depth: usize, // Track nesting depth for proper ordering
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn parse_ty(
         path: &str,
         name: &str,

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -1075,15 +1075,17 @@ mod tests {
         .unwrap();
 
         let expected_query =
-            "SELECT entities.id, entities.keys, [Test-Position].external_player AS \"Test-Position.player\", \
-            [Test-Position$vec].external_x AS \"Test-Position$vec.x\", [Test-Position$vec].external_y AS \"Test-Position$vec.y\", \
-            [Test-PlayerConfig$favorite_item].external_Some AS \"Test-PlayerConfig$favorite_item.Some\", \
-            [Test-PlayerConfig].external_favorite_item AS \"Test-PlayerConfig.favorite_item\" \
-            FROM entities JOIN [Test-Position] ON entities.id = [Test-Position].entity_id  \
-            JOIN [Test-PlayerConfig] ON entities.id = [Test-PlayerConfig].entity_id  \
-            JOIN [Test-Position$vec] ON [Test-Position$vec].full_array_id = [Test-Position].full_array_id  \
-            LEFT JOIN [Test-PlayerConfig$favorite_item] ON [Test-PlayerConfig$favorite_item].full_array_id = [Test-PlayerConfig].full_array_id \
-            ORDER BY entities.event_id DESC";
+            "SELECT entities.id, entities.keys, [Test-Position].external_player AS \
+             \"Test-Position.player\", [Test-Position$vec].external_x AS \"Test-Position$vec.x\", \
+             [Test-Position$vec].external_y AS \"Test-Position$vec.y\", \
+             [Test-PlayerConfig$favorite_item].external_Some AS \
+             \"Test-PlayerConfig$favorite_item.Some\", [Test-PlayerConfig].external_favorite_item \
+             AS \"Test-PlayerConfig.favorite_item\" FROM entities JOIN [Test-Position] ON \
+             entities.id = [Test-Position].entity_id  JOIN [Test-PlayerConfig] ON entities.id = \
+             [Test-PlayerConfig].entity_id  JOIN [Test-Position$vec] ON \
+             [Test-Position$vec].full_array_id = [Test-Position].full_array_id  LEFT JOIN \
+             [Test-PlayerConfig$favorite_item] ON [Test-PlayerConfig$favorite_item].full_array_id \
+             = [Test-PlayerConfig].full_array_id ORDER BY entities.event_id DESC";
         // todo: completely tests arrays
         assert_eq!(query.0, expected_query);
     }

--- a/crates/torii/grpc/src/types/schema.rs
+++ b/crates/torii/grpc/src/types/schema.rs
@@ -113,7 +113,7 @@ impl From<Enum> for proto::types::Enum {
     fn from(r#enum: Enum) -> Self {
         proto::types::Enum {
             name: r#enum.name,
-            option: r#enum.option.expect("option value") as u32,
+            option: r#enum.option.unwrap_or_default() as u32,
             options: r#enum.options.into_iter().map(Into::into).collect::<Vec<_>>(),
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `TableInfo` struct for enhanced SQL query construction.
- **Bug Fixes**
	- Improved error handling in the `From` implementation for the `Enum` struct to prevent runtime panics.
	- Updated handling of optional fields to provide default values, enhancing stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->