### PR TITLE
refactor(katana): rename simulation flags for consistency

### DIFF
--- a/crates/katana/executor/benches/concurrent.rs
+++ b/crates/katana/executor/benches/concurrent.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkGroup, Criterion};
 use katana_executor::implementation::blockifier::BlockifierFactory;
-use katana_executor::{ExecutorFactory, SimulationFlag};
+use katana_executor::{ExecutionFlags, ExecutorFactory};
 use katana_primitives::env::{BlockEnv, CfgEnv};
 use katana_primitives::transaction::ExecutableTxWithHash;
 use katana_provider::test_utils;
@@ -28,7 +28,7 @@ fn concurrent(c: &mut Criterion) {
     group.warm_up_time(Duration::from_millis(200));
 
     let provider = test_utils::test_provider();
-    let flags = SimulationFlag::new().skip_validate();
+    let flags = ExecutionFlags::new().with_account_validation(false);
 
     let tx = tx();
     let envs = envs();
@@ -40,7 +40,7 @@ fn blockifier(
     group: &mut BenchmarkGroup<'_, WallTime>,
     concurrency_size: usize,
     provider: impl StateFactoryProvider,
-    flags: SimulationFlag,
+    flags: ExecutionFlags,
     (block_env, cfg_env): (BlockEnv, CfgEnv),
     tx: ExecutableTxWithHash,
 ) {

--- a/crates/katana/executor/benches/execution.rs
+++ b/crates/katana/executor/benches/execution.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use blockifier::state::cached_state::CachedState;
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkGroup, Criterion};
-use katana_executor::{SimulationFlag, StateProviderDb};
+use katana_executor::{ExecutionFlags, StateProviderDb};
 use katana_primitives::env::{BlockEnv, CfgEnv};
 use katana_primitives::transaction::ExecutableTxWithHash;
 use katana_provider::test_utils;
@@ -19,7 +19,7 @@ fn executor_transact(c: &mut Criterion) {
     group.warm_up_time(Duration::from_millis(200));
 
     let provider = test_utils::test_provider();
-    let flags = SimulationFlag::new();
+    let flags = ExecutionFlags::new();
 
     let tx = tx();
     let envs = envs();
@@ -30,7 +30,7 @@ fn executor_transact(c: &mut Criterion) {
 fn blockifier(
     group: &mut BenchmarkGroup<'_, WallTime>,
     provider: impl StateFactoryProvider,
-    execution_flags: &SimulationFlag,
+    execution_flags: &ExecutionFlags,
     block_envs: &(BlockEnv, CfgEnv),
     tx: ExecutableTxWithHash,
 ) {

--- a/crates/katana/executor/src/abstraction/executor.rs
+++ b/crates/katana/executor/src/abstraction/executor.rs
@@ -6,8 +6,8 @@ use katana_primitives::Felt;
 use katana_provider::traits::state::StateProvider;
 
 use crate::{
-    EntryPointCall, ExecutionError, ExecutionOutput, ExecutionResult, ExecutorResult,
-    ResultAndStates, SimulationFlag,
+    EntryPointCall, ExecutionError, ExecutionFlags, ExecutionOutput, ExecutionResult,
+    ExecutorResult, ResultAndStates,
 };
 
 /// A type that can create [BlockExecutor] instance.
@@ -30,7 +30,7 @@ pub trait ExecutorFactory: Send + Sync + 'static + core::fmt::Debug {
     fn cfg(&self) -> &CfgEnv;
 
     /// Returns the execution flags set by the factory.
-    fn execution_flags(&self) -> &SimulationFlag;
+    fn execution_flags(&self) -> &ExecutionFlags;
 }
 
 /// An executor that can execute a block of transactions.
@@ -61,14 +61,14 @@ pub trait ExecutorExt {
     fn simulate(
         &self,
         transactions: Vec<ExecutableTxWithHash>,
-        flags: SimulationFlag,
+        flags: ExecutionFlags,
     ) -> Vec<ResultAndStates>;
 
     /// Get the fee estimation for the given transactions.
     fn estimate_fee(
         &self,
         transactions: Vec<ExecutableTxWithHash>,
-        flags: SimulationFlag,
+        flags: ExecutionFlags,
     ) -> Vec<Result<TxFeeInfo, ExecutionError>>;
 
     /// Perform a contract entry point call and return the output.

--- a/crates/katana/executor/src/abstraction/mod.rs
+++ b/crates/katana/executor/src/abstraction/mod.rs
@@ -19,55 +19,59 @@ pub type ExecutorResult<T> = Result<T, error::ExecutorError>;
 /// Transaction execution simulation flags.
 ///
 /// These flags can be used to control the behavior of the transaction execution, such as skipping
-/// the transaction execution or validation, or ignoring the maximum fee when validating the
-/// transaction.
-#[derive(Debug, Clone, Default)]
-pub struct SimulationFlag {
-    /// Skip the transaction execution.
-    pub skip_execute: bool,
-    /// Skip the transaction validation.
-    pub skip_validate: bool,
-    /// Skip checking nonce when validating the transaction.
-    pub skip_nonce_check: bool,
-    /// Skip the fee transfer after the transaction execution.
-    pub skip_fee_transfer: bool,
-    /// Ignore the maximum fee when validating the transaction.
-    pub ignore_max_fee: bool,
+/// the transaction validation, or ignoring any fee related checks.
+#[derive(Debug, Clone)]
+pub struct ExecutionFlags {
+    /// Determine whether to perform the transaction sender's account validation logic.
+    account_validation: bool,
+    /// Determine whether to perform fee related checks and operations ie., fee transfer.
+    fee: bool,
+    /// Determine whether to perform transaction's sender nonce check.
+    nonce_check: bool,
 }
 
-impl SimulationFlag {
+impl Default for ExecutionFlags {
+    fn default() -> Self {
+        Self { account_validation: true, fee: true, nonce_check: true }
+    }
+}
+
+impl ExecutionFlags {
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Enables the skip execution flag.
-    pub fn skip_execute(mut self) -> Self {
-        self.skip_execute = true;
+    /// Set whether to enable or disable the account validation.
+    pub fn with_account_validation(mut self, enable: bool) -> Self {
+        self.account_validation = enable;
         self
     }
 
-    /// Enables the skip validation flag.
-    pub fn skip_validate(mut self) -> Self {
-        self.skip_validate = true;
+    /// Set whether to enable or disable the fee related operations.
+    pub fn with_fee(mut self, enable: bool) -> Self {
+        self.fee = enable;
         self
     }
 
-    /// Enables the skip nonce check flag.
-    pub fn skip_nonce_check(mut self) -> Self {
-        self.skip_nonce_check = true;
+    /// Set whether to enable or disable the nonce check.
+    pub fn with_nonce_check(mut self, enable: bool) -> Self {
+        self.nonce_check = enable;
         self
     }
 
-    /// Enables the skip fee transfer flag.
-    pub fn skip_fee_transfer(mut self) -> Self {
-        self.skip_fee_transfer = true;
-        self
+    /// Returns whether the account validation is enabled.
+    pub fn account_validation(&self) -> bool {
+        self.account_validation
     }
 
-    /// Enables the ignore max fee flag.
-    pub fn ignore_max_fee(mut self) -> Self {
-        self.ignore_max_fee = true;
-        self
+    /// Returns whether the fee related operations are enabled.
+    pub fn fee(&self) -> bool {
+        self.fee
+    }
+
+    /// Returns whether the nonce check is enabled.
+    pub fn nonce_check(&self) -> bool {
+        self.nonce_check
     }
 }
 
@@ -109,22 +113,27 @@ pub enum ExecutionResult {
 }
 
 impl ExecutionResult {
+    /// Creates a new successful execution result.
     pub fn new_success(receipt: Receipt, trace: TxExecInfo) -> Self {
         ExecutionResult::Success { receipt, trace }
     }
 
+    /// Creates a new failed execution result with the given error.
     pub fn new_failed(error: impl Into<ExecutionError>) -> Self {
         ExecutionResult::Failed { error: error.into() }
     }
 
+    /// Returns `true` if the execution was successful.
     pub fn is_success(&self) -> bool {
         matches!(self, ExecutionResult::Success { .. })
     }
 
+    /// Returns `true` if the execution failed.
     pub fn is_failed(&self) -> bool {
         !self.is_success()
     }
 
+    /// Returns the receipt of the execution if it was successful. Otherwise, returns `None`.
     pub fn receipt(&self) -> Option<&Receipt> {
         match self {
             ExecutionResult::Success { receipt, .. } => Some(receipt),
@@ -132,6 +141,7 @@ impl ExecutionResult {
         }
     }
 
+    /// Returns the execution info if it was successful. Otherwise, returns `None`.
     pub fn trace(&self) -> Option<&TxExecInfo> {
         match self {
             ExecutionResult::Success { trace, .. } => Some(trace),

--- a/crates/katana/executor/src/implementation/blockifier/utils.rs
+++ b/crates/katana/executor/src/implementation/blockifier/utils.rs
@@ -56,30 +56,30 @@ use katana_provider::traits::contract::ContractClassProvider;
 use starknet::core::utils::parse_cairo_short_string;
 
 use super::state::{CachedState, StateDb};
-use crate::abstraction::{EntryPointCall, SimulationFlag};
+use crate::abstraction::{EntryPointCall, ExecutionFlags};
 use crate::utils::build_receipt;
 use crate::{ExecutionError, ExecutionResult};
 
 pub fn transact<S: StateReader>(
     state: &mut cached_state::CachedState<S>,
     block_context: &BlockContext,
-    simulation_flags: &SimulationFlag,
+    simulation_flags: &ExecutionFlags,
     tx: ExecutableTxWithHash,
 ) -> ExecutionResult {
     fn transact_inner<S: StateReader>(
         state: &mut cached_state::CachedState<S>,
         block_context: &BlockContext,
-        simulation_flags: &SimulationFlag,
+        simulation_flags: &ExecutionFlags,
         tx: Transaction,
     ) -> Result<(TransactionExecutionInfo, TxFeeInfo), ExecutionError> {
-        let validate = !simulation_flags.skip_validate;
-        let charge_fee = !simulation_flags.skip_fee_transfer;
+        let validate = simulation_flags.account_validation();
+        let charge_fee = simulation_flags.fee();
         // Blockifier doesn't provide a way to fully skip nonce check during the tx validation
         // stage. The `nonce_check` flag in `tx.execute()` only 'relaxes' the check for
         // nonce that is equal or higher than the current (expected) account nonce.
         //
         // Related commit on Blockifier: https://github.com/dojoengine/blockifier/commit/2410b6055453f247d48759f223c34b3fb5fa777
-        let nonce_check = !simulation_flags.skip_nonce_check;
+        let nonce_check = simulation_flags.nonce_check();
 
         let fee_type = get_fee_type_from_tx(&tx);
         let info = match tx {

--- a/crates/katana/executor/src/implementation/noop.rs
+++ b/crates/katana/executor/src/implementation/noop.rs
@@ -10,8 +10,8 @@ use katana_provider::traits::state::StateProvider;
 use katana_provider::ProviderResult;
 
 use crate::abstraction::{
-    BlockExecutor, EntryPointCall, ExecutionOutput, ExecutionResult, ExecutorExt, ExecutorFactory,
-    ExecutorResult, ResultAndStates, SimulationFlag,
+    BlockExecutor, EntryPointCall, ExecutionFlags, ExecutionOutput, ExecutionResult, ExecutorExt,
+    ExecutorFactory, ExecutorResult, ResultAndStates,
 };
 use crate::ExecutionError;
 
@@ -19,7 +19,7 @@ use crate::ExecutionError;
 #[derive(Debug, Default)]
 pub struct NoopExecutorFactory {
     cfg: CfgEnv,
-    execution_flags: SimulationFlag,
+    execution_flags: ExecutionFlags,
 }
 
 impl NoopExecutorFactory {
@@ -55,7 +55,7 @@ impl ExecutorFactory for NoopExecutorFactory {
         &self.cfg
     }
 
-    fn execution_flags(&self) -> &SimulationFlag {
+    fn execution_flags(&self) -> &ExecutionFlags {
         &self.execution_flags
     }
 }
@@ -69,7 +69,7 @@ impl ExecutorExt for NoopExecutor {
     fn simulate(
         &self,
         transactions: Vec<ExecutableTxWithHash>,
-        flags: SimulationFlag,
+        flags: ExecutionFlags,
     ) -> Vec<ResultAndStates> {
         let _ = transactions;
         let _ = flags;
@@ -79,7 +79,7 @@ impl ExecutorExt for NoopExecutor {
     fn estimate_fee(
         &self,
         transactions: Vec<ExecutableTxWithHash>,
-        flags: SimulationFlag,
+        flags: ExecutionFlags,
     ) -> Vec<Result<TxFeeInfo, ExecutionError>> {
         let _ = transactions;
         let _ = flags;

--- a/crates/katana/executor/tests/fixtures/mod.rs
+++ b/crates/katana/executor/tests/fixtures/mod.rs
@@ -2,7 +2,7 @@ pub mod transaction;
 
 use alloy_primitives::U256;
 use katana_executor::implementation::noop::NoopExecutorFactory;
-use katana_executor::{ExecutorFactory, SimulationFlag};
+use katana_executor::{ExecutionFlags, ExecutorFactory};
 use katana_primitives::block::{
     Block, ExecutableBlock, FinalityStatus, GasPrices, PartialHeader, SealedBlockWithStatus,
 };
@@ -249,8 +249,8 @@ pub fn cfg() -> CfgEnv {
 pub fn flags(
     #[default(false)] skip_validate: bool,
     #[default(false)] skip_fee_transfer: bool,
-) -> SimulationFlag {
-    SimulationFlag { skip_validate, skip_fee_transfer, ..Default::default() }
+) -> ExecutionFlags {
+    ExecutionFlags::new().with_account_validation(!skip_validate).with_fee(!skip_fee_transfer)
 }
 
 /// A fixture that provides a default `ExecutorFactory` implementation.
@@ -265,12 +265,12 @@ pub fn executor_factory<EF: ExecutorFactory>(
 #[cfg(feature = "blockifier")]
 pub mod blockifier {
     use katana_executor::implementation::blockifier::BlockifierFactory;
-    use katana_executor::SimulationFlag;
+    use katana_executor::ExecutionFlags;
 
     use super::{cfg, flags, CfgEnv};
 
     #[rstest::fixture]
-    pub fn factory(cfg: CfgEnv, #[with(true)] flags: SimulationFlag) -> BlockifierFactory {
+    pub fn factory(cfg: CfgEnv, #[with(true)] flags: ExecutionFlags) -> BlockifierFactory {
         BlockifierFactory::new(cfg, flags)
     }
 }

--- a/crates/katana/executor/tests/simulate.rs
+++ b/crates/katana/executor/tests/simulate.rs
@@ -2,7 +2,7 @@ mod fixtures;
 
 use fixtures::transaction::executable_tx;
 use fixtures::{executor_factory, state_provider};
-use katana_executor::{ExecutionOutput, ExecutorFactory, SimulationFlag};
+use katana_executor::{ExecutionFlags, ExecutionOutput, ExecutorFactory};
 use katana_primitives::block::GasPrices;
 use katana_primitives::env::BlockEnv;
 use katana_primitives::fee::PriceUnit;
@@ -19,17 +19,17 @@ fn block_env() -> BlockEnv {
 
 #[template]
 #[rstest::rstest]
-#[case::tx(executable_tx::default(), SimulationFlag::new())]
-#[case::tx_skip_validate(executable_tx::default(), SimulationFlag::new().skip_validate())]
-#[case::tx_no_signature_skip_validate(executable_tx::partial_1(false), SimulationFlag::new().skip_validate())]
+#[case::tx(executable_tx::default(), ExecutionFlags::new())]
+#[case::tx_skip_validate(executable_tx::default(), ExecutionFlags::new().with_account_validation(false))]
+#[case::tx_no_signature_skip_validate(executable_tx::partial_1(false), ExecutionFlags::new().with_account_validation(false))]
 #[should_panic]
-#[case::tx_no_signature(executable_tx::partial_1(false), SimulationFlag::new())]
+#[case::tx_no_signature(executable_tx::partial_1(false), ExecutionFlags::new())]
 fn simulate_tx<EF: ExecutorFactory>(
     executor_factory: EF,
     block_env: BlockEnv,
     state_provider: Box<dyn StateProvider>,
     #[case] tx: ExecutableTxWithHash,
-    #[case] flags: SimulationFlag,
+    #[case] flags: ExecutionFlags,
 ) {
 }
 
@@ -39,7 +39,7 @@ fn test_simulate_tx_impl<EF: ExecutorFactory>(
     block_env: BlockEnv,
     state_provider: Box<dyn StateProvider>,
     tx: ExecutableTxWithHash,
-    flags: SimulationFlag,
+    flags: ExecutionFlags,
 ) {
     let transactions = vec![tx];
     let mut executor = executor_factory.with_state_and_block_env(state_provider, block_env);
@@ -91,7 +91,7 @@ mod blockifier {
         block_env: BlockEnv,
         state_provider: Box<dyn StateProvider>,
         #[case] tx: ExecutableTxWithHash,
-        #[case] flags: SimulationFlag,
+        #[case] flags: ExecutionFlags,
     ) {
         test_simulate_tx_impl(executor_factory, block_env, state_provider, tx, flags);
     }

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -25,7 +25,7 @@ use katana_core::service::block_producer::BlockProducer;
 use katana_core::service::messaging::MessagingConfig;
 use katana_db::mdbx::DbEnv;
 use katana_executor::implementation::blockifier::BlockifierFactory;
-use katana_executor::{ExecutorFactory, SimulationFlag};
+use katana_executor::{ExecutionFlags, ExecutorFactory};
 use katana_pipeline::{stage, Pipeline};
 use katana_pool::ordering::FiFo;
 use katana_pool::validation::stateful::TxValidator;
@@ -169,13 +169,11 @@ pub async fn build(mut config: Config) -> Result<Node> {
         },
     };
 
-    let simulation_flags = SimulationFlag {
-        skip_validate: !config.dev.account_validation,
-        skip_fee_transfer: !config.dev.fee,
-        ..Default::default()
-    };
+    let execution_flags = ExecutionFlags::new()
+        .with_account_validation(config.dev.account_validation)
+        .with_fee(config.dev.fee);
 
-    let executor_factory = Arc::new(BlockifierFactory::new(cfg_env, simulation_flags));
+    let executor_factory = Arc::new(BlockifierFactory::new(cfg_env, execution_flags));
 
     // --- build backend
 

--- a/crates/katana/pool/src/validation/stateful.rs
+++ b/crates/katana/pool/src/validation/stateful.rs
@@ -12,7 +12,7 @@ use katana_executor::implementation::blockifier::blockifier::transaction::transa
 use katana_executor::implementation::blockifier::utils::{
     block_context_from_envs, to_address, to_executor_tx,
 };
-use katana_executor::{SimulationFlag, StateProviderDb};
+use katana_executor::{ExecutionFlags, StateProviderDb};
 use katana_primitives::contract::{ContractAddress, Nonce};
 use katana_primitives::env::{BlockEnv, CfgEnv};
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash};
@@ -35,7 +35,7 @@ struct Inner {
     // execution context
     cfg_env: CfgEnv,
     block_env: BlockEnv,
-    execution_flags: SimulationFlag,
+    execution_flags: ExecutionFlags,
     state: Arc<Box<dyn StateProvider>>,
 
     pool_nonces: HashMap<ContractAddress, Nonce>,
@@ -44,7 +44,7 @@ struct Inner {
 impl TxValidator {
     pub fn new(
         state: Box<dyn StateProvider>,
-        execution_flags: SimulationFlag,
+        execution_flags: ExecutionFlags,
         cfg_env: CfgEnv,
         block_env: BlockEnv,
         permit: Arc<Mutex<()>>,
@@ -143,8 +143,8 @@ impl Validator for TxValidator {
         let result = validate(
             this.prepare(),
             tx,
-            this.execution_flags.skip_validate || skip_validate,
-            this.execution_flags.skip_fee_transfer,
+            !this.execution_flags.account_validation() || skip_validate,
+            !this.execution_flags.fee(),
         );
 
         match result {

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -94,7 +94,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         &self,
         transactions: Vec<ExecutableTxWithHash>,
         block_id: BlockIdOrTag,
-        flags: katana_executor::SimulationFlag,
+        flags: katana_executor::ExecutionFlags,
     ) -> Result<Vec<FeeEstimate>, StarknetApiError> {
         // get the state and block env at the specified block for execution
         let state = self.state(&block_id)?;

--- a/crates/katana/rpc/rpc/src/starknet/trace.rs
+++ b/crates/katana/rpc/rpc/src/starknet/trace.rs
@@ -64,19 +64,17 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
 
         // If the node is run with transaction validation disabled, then we should not validate
         // even if the `SKIP_VALIDATE` flag is not set.
-        let should_validate = !(simulation_flags.contains(&SimulationFlag::SkipValidate)
-            || self.inner.backend.executor_factory.execution_flags().skip_validate);
+        let should_validate = !simulation_flags.contains(&SimulationFlag::SkipValidate)
+            && self.inner.backend.executor_factory.execution_flags().account_validation();
 
         // If the node is run with fee charge disabled, then we should disable charing fees even
         // if the `SKIP_FEE_CHARGE` flag is not set.
-        let should_skip_fee = !(simulation_flags.contains(&SimulationFlag::SkipFeeCharge)
-            || self.inner.backend.executor_factory.execution_flags().skip_fee_transfer);
+        let should_skip_fee = !simulation_flags.contains(&SimulationFlag::SkipFeeCharge)
+            && self.inner.backend.executor_factory.execution_flags().fee();
 
-        let flags = katana_executor::SimulationFlag {
-            skip_validate: !should_validate,
-            skip_fee_transfer: !should_skip_fee,
-            ..Default::default()
-        };
+        let flags = katana_executor::ExecutionFlags::new()
+            .with_account_validation(should_validate)
+            .with_fee(!should_skip_fee);
 
         // get the state and block env at the specified block for execution
         let state = self.state(&block_id)?;


### PR DESCRIPTION
also removes some unused flags. the flags were introduced back in https://github.com/dojoengine/dojo/pull/1561 when we were trying to integrate both blockifier and starknet_in_rust. but some of the flags (ie `skip_execute` and `skip_max_fee`) is starknet_in_rust specific. but now that we no longer need to accomodate for starknet-in-rust due to its deprecation #2200, better to just remove it to keep things simple and clean. 

also i decided to rename the fields and omit the `skip_*` prefix as it gets kinda confusing sometimes, esp when we need to determine the execution flag based on the rpc flags as well ie in https://github.com/dojoengine/dojo/blob/17f25640cb2495e0223e5844e3c98f52a7aa901c/crates/katana/rpc/rpc/src/starknet/read.rs#L479-L495