### PR TITLE
refactor: use now as timestamp for delta calc for pending blocks

### DIFF
--- a/crates/torii/core/src/executor.rs
+++ b/crates/torii/core/src/executor.rs
@@ -322,7 +322,8 @@ impl<'c> Executor<'c> {
                         let new_tps = if new_timestamp - cursor_timestamp != 0 {
                             num_transactions / (new_timestamp - cursor_timestamp)
                         } else {
-                            num_transactions
+                            let now = Instant::now();
+                            num_transactions / (now.elapsed().as_secs() - cursor_timestamp)
                         };
 
                         cursor.last_pending_block_contract_tx =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved transaction per second (TPS) calculation for cursor updates, enhancing performance reliability.

- **Bug Fixes**
	- Introduced a fallback mechanism to prevent division by zero in TPS calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->