### PR TITLE
feat(katana): fetch forked block data

### DIFF
--- a/crates/katana/rpc/rpc-api/src/starknet.rs
+++ b/crates/katana/rpc/rpc-api/src/starknet.rs
@@ -12,7 +12,7 @@ use katana_rpc_types::block::{
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
 use katana_rpc_types::message::MsgFromL1;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
-use katana_rpc_types::state_update::StateUpdate;
+use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::{
     BroadcastedDeclareTx, BroadcastedDeployAccountTx, BroadcastedInvokeTx, BroadcastedTx,
     DeclareTxResult, DeployAccountTxResult, InvokeTxResult, Tx,
@@ -61,7 +61,7 @@ pub trait StarknetApi {
 
     /// Get the information about the result of executing the requested block.
     #[method(name = "getStateUpdate")]
-    async fn get_state_update(&self, block_id: BlockIdOrTag) -> RpcResult<StateUpdate>;
+    async fn get_state_update(&self, block_id: BlockIdOrTag) -> RpcResult<MaybePendingStateUpdate>;
 
     /// Get the value of the storage at the given address and key
     #[method(name = "getStorageAt")]

--- a/crates/katana/rpc/rpc-types-builder/src/block.rs
+++ b/crates/katana/rpc/rpc-types-builder/src/block.rs
@@ -48,10 +48,12 @@ where
     }
 
     pub fn build_with_receipts(self) -> ProviderResult<Option<BlockWithReceipts>> {
-        let Some(block) = BlockProvider::block(&self.provider, self.block_id)? else {
+        let Some(hash) = BlockHashProvider::block_hash_by_id(&self.provider, self.block_id)? else {
             return Ok(None);
         };
 
+        let block = BlockProvider::block(&self.provider, self.block_id)?
+            .expect("should exist if block exists");
         let finality_status = BlockStatusProvider::block_status(&self.provider, self.block_id)?
             .expect("should exist if block exists");
         let receipts = ReceiptProvider::receipts_by_block(&self.provider, self.block_id)?
@@ -59,6 +61,6 @@ where
 
         let receipts_with_txs = block.body.into_iter().zip(receipts);
 
-        Ok(Some(BlockWithReceipts::new(block.header, finality_status, receipts_with_txs)))
+        Ok(Some(BlockWithReceipts::new(hash, block.header, finality_status, receipts_with_txs)))
     }
 }

--- a/crates/katana/rpc/rpc-types/src/block.rs
+++ b/crates/katana/rpc/rpc-types/src/block.rs
@@ -229,6 +229,7 @@ pub struct BlockWithReceipts(starknet::core::types::BlockWithReceipts);
 
 impl BlockWithReceipts {
     pub fn new(
+        hash: BlockHash,
         header: Header,
         finality_status: FinalityStatus,
         receipts: impl Iterator<Item = (TxWithHash, Receipt)>,
@@ -256,7 +257,7 @@ impl BlockWithReceipts {
                 FinalityStatus::AcceptedOnL1 => BlockStatus::AcceptedOnL1,
                 FinalityStatus::AcceptedOnL2 => BlockStatus::AcceptedOnL2,
             },
-            block_hash: header.parent_hash,
+            block_hash: hash,
             parent_hash: header.parent_hash,
             block_number: header.number,
             new_root: header.state_root,

--- a/crates/katana/rpc/rpc-types/src/block.rs
+++ b/crates/katana/rpc/rpc-types/src/block.rs
@@ -95,6 +95,19 @@ pub enum MaybePendingBlockWithTxs {
     Block(BlockWithTxs),
 }
 
+impl From<starknet::core::types::MaybePendingBlockWithTxs> for MaybePendingBlockWithTxs {
+    fn from(value: starknet::core::types::MaybePendingBlockWithTxs) -> Self {
+        match value {
+            starknet::core::types::MaybePendingBlockWithTxs::PendingBlock(block) => {
+                MaybePendingBlockWithTxs::Pending(PendingBlockWithTxs(block))
+            }
+            starknet::core::types::MaybePendingBlockWithTxs::Block(block) => {
+                MaybePendingBlockWithTxs::Block(BlockWithTxs(block))
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct BlockWithTxHashes(starknet::core::types::BlockWithTxHashes);
@@ -179,6 +192,19 @@ impl PendingBlockWithTxHashes {
 pub enum MaybePendingBlockWithTxHashes {
     Pending(PendingBlockWithTxHashes),
     Block(BlockWithTxHashes),
+}
+
+impl From<starknet::core::types::MaybePendingBlockWithTxHashes> for MaybePendingBlockWithTxHashes {
+    fn from(value: starknet::core::types::MaybePendingBlockWithTxHashes) -> Self {
+        match value {
+            starknet::core::types::MaybePendingBlockWithTxHashes::PendingBlock(block) => {
+                MaybePendingBlockWithTxHashes::Pending(PendingBlockWithTxHashes(block))
+            }
+            starknet::core::types::MaybePendingBlockWithTxHashes::Block(block) => {
+                MaybePendingBlockWithTxHashes::Block(BlockWithTxHashes(block))
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -296,4 +322,17 @@ impl PendingBlockWithReceipts {
 pub enum MaybePendingBlockWithReceipts {
     Pending(PendingBlockWithReceipts),
     Block(BlockWithReceipts),
+}
+
+impl From<starknet::core::types::MaybePendingBlockWithReceipts> for MaybePendingBlockWithReceipts {
+    fn from(value: starknet::core::types::MaybePendingBlockWithReceipts) -> Self {
+        match value {
+            starknet::core::types::MaybePendingBlockWithReceipts::PendingBlock(block) => {
+                MaybePendingBlockWithReceipts::Pending(PendingBlockWithReceipts(block))
+            }
+            starknet::core::types::MaybePendingBlockWithReceipts::Block(block) => {
+                MaybePendingBlockWithReceipts::Block(BlockWithReceipts(block))
+            }
+        }
+    }
 }

--- a/crates/katana/rpc/rpc-types/src/receipt.rs
+++ b/crates/katana/rpc/rpc-types/src/receipt.rs
@@ -121,6 +121,12 @@ impl TxReceipt {
 #[serde(transparent)]
 pub struct TxReceiptWithBlockInfo(starknet::core::types::TransactionReceiptWithBlockInfo);
 
+impl From<starknet::core::types::TransactionReceiptWithBlockInfo> for TxReceiptWithBlockInfo {
+    fn from(value: starknet::core::types::TransactionReceiptWithBlockInfo) -> Self {
+        Self(value)
+    }
+}
+
 impl TxReceiptWithBlockInfo {
     pub fn new(
         block: ReceiptBlock,

--- a/crates/katana/rpc/rpc-types/src/receipt.rs
+++ b/crates/katana/rpc/rpc-types/src/receipt.rs
@@ -119,7 +119,7 @@ impl TxReceipt {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct TxReceiptWithBlockInfo(starknet::core::types::TransactionReceiptWithBlockInfo);
+pub struct TxReceiptWithBlockInfo(pub starknet::core::types::TransactionReceiptWithBlockInfo);
 
 impl From<starknet::core::types::TransactionReceiptWithBlockInfo> for TxReceiptWithBlockInfo {
     fn from(value: starknet::core::types::TransactionReceiptWithBlockInfo) -> Self {

--- a/crates/katana/rpc/rpc-types/src/state_update.rs
+++ b/crates/katana/rpc/rpc-types/src/state_update.rs
@@ -10,6 +10,19 @@ pub enum MaybePendingStateUpdate {
     Update(StateUpdate),
 }
 
+impl From<starknet::core::types::MaybePendingStateUpdate> for MaybePendingStateUpdate {
+    fn from(value: starknet::core::types::MaybePendingStateUpdate) -> Self {
+        match value {
+            starknet::core::types::MaybePendingStateUpdate::PendingUpdate(pending) => {
+                MaybePendingStateUpdate::Pending(pending.into())
+            }
+            starknet::core::types::MaybePendingStateUpdate::Update(update) => {
+                MaybePendingStateUpdate::Update(update.into())
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct StateUpdate(starknet::core::types::StateUpdate);
@@ -24,7 +37,7 @@ pub struct StateDiff(pub starknet::core::types::StateDiff);
 
 impl From<starknet::core::types::StateUpdate> for StateUpdate {
     fn from(value: starknet::core::types::StateUpdate) -> Self {
-        StateUpdate(value)
+        Self(value)
     }
 }
 
@@ -63,7 +76,7 @@ impl From<katana_primitives::state::StateUpdates> for StateDiff {
             })
             .collect();
 
-        StateDiff(starknet::core::types::StateDiff {
+        Self(starknet::core::types::StateDiff {
             nonces,
             storage_diffs,
             declared_classes,
@@ -71,5 +84,11 @@ impl From<katana_primitives::state::StateUpdates> for StateDiff {
             replaced_classes: Default::default(),
             deprecated_declared_classes: Default::default(),
         })
+    }
+}
+
+impl From<starknet::core::types::PendingStateUpdate> for PendingStateUpdate {
+    fn from(value: starknet::core::types::PendingStateUpdate) -> Self {
+        Self(value)
     }
 }

--- a/crates/katana/rpc/rpc-types/src/transaction.rs
+++ b/crates/katana/rpc/rpc-types/src/transaction.rs
@@ -397,6 +397,12 @@ impl From<TxWithHash> for Tx {
     }
 }
 
+impl From<starknet::core::types::Transaction> for Tx {
+    fn from(value: starknet::core::types::Transaction) -> Self {
+        Self(value)
+    }
+}
+
 impl DeployAccountTxResult {
     pub fn new(transaction_hash: TxHash, contract_address: ContractAddress) -> Self {
         Self(DeployAccountTransactionResult {

--- a/crates/katana/rpc/rpc/Cargo.toml
+++ b/crates/katana/rpc/rpc/Cargo.toml
@@ -23,6 +23,7 @@ katana-tasks.workspace = true
 metrics.workspace = true
 starknet.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/katana/rpc/rpc/Cargo.toml
+++ b/crates/katana/rpc/rpc/Cargo.toml
@@ -24,6 +24,7 @@ metrics.workspace = true
 starknet.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 alloy = { git = "https://github.com/alloy-rs/alloy", features = [ "contract", "network", "node-bindings", "provider-http", "providers", "signer-local" ] }
@@ -45,4 +46,3 @@ serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
-url.workspace = true

--- a/crates/katana/rpc/rpc/src/starknet/forking.rs
+++ b/crates/katana/rpc/rpc/src/starknet/forking.rs
@@ -1,7 +1,14 @@
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::JsonRpcClient;
+use url::Url;
 
 #[derive(Debug)]
 pub struct ForkedClient {
-    pub client: JsonRpcClient<HttpTransport>,
+    pub(crate) inner: JsonRpcClient<HttpTransport>,
+}
+
+impl ForkedClient {
+    pub fn new(url: Url) -> Self {
+        Self { inner: JsonRpcClient::new(HttpTransport::new(url)) }
+    }
 }

--- a/crates/katana/rpc/rpc/src/starknet/forking.rs
+++ b/crates/katana/rpc/rpc/src/starknet/forking.rs
@@ -242,9 +242,7 @@ impl From<Error> for StarknetApiError {
     fn from(value: Error) -> Self {
         match value {
             Error::Provider(provider_error) => provider_error.into(),
-            Error::BlockOutOfRange => {
-                StarknetApiError::UnexpectedError { reason: value.to_string() }
-            }
+            Error::BlockOutOfRange => StarknetApiError::BlockNotFound,
         }
     }
 }

--- a/crates/katana/rpc/rpc/src/starknet/forking.rs
+++ b/crates/katana/rpc/rpc/src/starknet/forking.rs
@@ -1,14 +1,112 @@
+use katana_primitives::block::{BlockIdOrTag, BlockNumber};
+use katana_primitives::transaction::TxHash;
+use katana_rpc_types::block::{
+    MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
+};
+use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
+use katana_rpc_types::state_update::MaybePendingStateUpdate;
+use katana_rpc_types::transaction::Tx;
+use starknet::core::types::TransactionStatus;
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::JsonRpcClient;
+use starknet::providers::{JsonRpcClient, Provider};
 use url::Url;
 
+use super::StarknetApiResult;
+
 #[derive(Debug)]
-pub struct ForkedClient {
-    pub(crate) inner: JsonRpcClient<HttpTransport>,
+pub struct ForkedClient<P: Provider = JsonRpcClient<HttpTransport>> {
+    #[allow(unused)]
+    block: BlockNumber,
+    provider: P,
+}
+
+impl<P: Provider> ForkedClient<P> {
+    /// Creates a new forked client from the given [`Provider`] and block number.
+    pub fn new(provider: P, block: BlockNumber) -> Self {
+        Self { provider, block }
+    }
+
+    /// Returns the block number of the forked client.
+    pub fn block(&self) -> &BlockNumber {
+        &self.block
+    }
 }
 
 impl ForkedClient {
-    pub fn new(url: Url) -> Self {
-        Self { inner: JsonRpcClient::new(HttpTransport::new(url)) }
+    /// Creates a new forked client from the given HTTP URL and block number.
+    pub fn new_http(url: Url, block: BlockNumber) -> Self {
+        Self { provider: JsonRpcClient::new(HttpTransport::new(url)), block }
+    }
+}
+
+impl<P: Provider> ForkedClient<P> {
+    pub async fn get_transaction_by_hash(&self, hash: TxHash) -> StarknetApiResult<Tx> {
+        let tx = self.provider.get_transaction_by_hash(hash).await?;
+        Ok(tx.into())
+    }
+
+    pub async fn get_transaction_receipt(
+        &self,
+        hash: TxHash,
+    ) -> StarknetApiResult<TxReceiptWithBlockInfo> {
+        let receipt = self.provider.get_transaction_receipt(hash).await?;
+        Ok(receipt.into())
+    }
+
+    pub async fn get_transaction_status(
+        &self,
+        hash: TxHash,
+    ) -> StarknetApiResult<TransactionStatus> {
+        let status = self.provider.get_transaction_status(hash).await?;
+        Ok(status)
+    }
+
+    pub async fn get_transaction_by_block_id_and_index(
+        &self,
+        block_id: BlockIdOrTag,
+        index: u64,
+    ) -> StarknetApiResult<Tx> {
+        let tx = self.provider.get_transaction_by_block_id_and_index(block_id, index).await?;
+        Ok(tx.into())
+    }
+
+    pub async fn get_block_with_txs(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> StarknetApiResult<MaybePendingBlockWithTxs> {
+        let block = self.provider.get_block_with_txs(block_id).await?;
+        Ok(block.into())
+    }
+
+    pub async fn get_block_with_receipts(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> StarknetApiResult<MaybePendingBlockWithReceipts> {
+        let block = self.provider.get_block_with_receipts(block_id).await?;
+        Ok(block.into())
+    }
+
+    pub async fn get_block_with_tx_hashes(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> StarknetApiResult<MaybePendingBlockWithTxHashes> {
+        let block = self.provider.get_block_with_tx_hashes(block_id).await?;
+        Ok(block.into())
+    }
+
+    pub async fn get_block_transaction_count(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> StarknetApiResult<u64> {
+        let status = self.provider.get_block_transaction_count(block_id).await?;
+        Ok(status)
+    }
+
+    pub async fn get_state_update(
+        &self,
+        block_id: BlockIdOrTag,
+    ) -> StarknetApiResult<MaybePendingStateUpdate> {
+        let state_update = self.provider.get_state_update(block_id).await?;
+        Ok(state_update.into())
     }
 }

--- a/crates/katana/rpc/rpc/src/starknet/forking.rs
+++ b/crates/katana/rpc/rpc/src/starknet/forking.rs
@@ -3,20 +3,30 @@ use katana_primitives::transaction::TxHash;
 use katana_rpc_types::block::{
     MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
 };
+use katana_rpc_types::error::starknet::StarknetApiError;
 use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
 use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::Tx;
 use starknet::core::types::TransactionStatus;
 use starknet::providers::jsonrpc::HttpTransport;
-use starknet::providers::{JsonRpcClient, Provider};
+use starknet::providers::{JsonRpcClient, Provider, ProviderError};
 use url::Url;
 
-use super::StarknetApiResult;
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error originating from the underlying [`Provider`] implementation.
+    #[error("Provider error: {0}")]
+    Provider(#[from] ProviderError),
+
+    #[error("Block out of range")]
+    BlockOutOfRange,
+}
 
 #[derive(Debug)]
 pub struct ForkedClient<P: Provider = JsonRpcClient<HttpTransport>> {
-    #[allow(unused)]
+    /// The block number where the node is forked from.
     block: BlockNumber,
+    /// The Starknet Json RPC provider client for doing the request to the forked network.
     provider: P,
 }
 
@@ -40,7 +50,7 @@ impl ForkedClient {
 }
 
 impl<P: Provider> ForkedClient<P> {
-    pub async fn get_transaction_by_hash(&self, hash: TxHash) -> StarknetApiResult<Tx> {
+    pub async fn get_transaction_by_hash(&self, hash: TxHash) -> Result<Tx, Error> {
         let tx = self.provider.get_transaction_by_hash(hash).await?;
         Ok(tx.into())
     }
@@ -48,56 +58,154 @@ impl<P: Provider> ForkedClient<P> {
     pub async fn get_transaction_receipt(
         &self,
         hash: TxHash,
-    ) -> StarknetApiResult<TxReceiptWithBlockInfo> {
+    ) -> Result<TxReceiptWithBlockInfo, Error> {
         let receipt = self.provider.get_transaction_receipt(hash).await?;
+
+        if let starknet::core::types::ReceiptBlock::Block { block_number, .. } = receipt.block {
+            if block_number > self.block {
+                return Err(Error::BlockOutOfRange);
+            }
+        }
+
         Ok(receipt.into())
     }
 
-    pub async fn get_transaction_status(
-        &self,
-        hash: TxHash,
-    ) -> StarknetApiResult<TransactionStatus> {
-        let status = self.provider.get_transaction_status(hash).await?;
-        Ok(status)
+    pub async fn get_transaction_status(&self, hash: TxHash) -> Result<TransactionStatus, Error> {
+        let (receipt, status) = tokio::join!(
+            self.get_transaction_receipt(hash),
+            self.provider.get_transaction_status(hash)
+        );
+
+        // We get the receipt first to check if the block number is within the forked range.
+        let _ = receipt?;
+
+        Ok(status?)
     }
 
     pub async fn get_transaction_by_block_id_and_index(
         &self,
         block_id: BlockIdOrTag,
-        index: u64,
-    ) -> StarknetApiResult<Tx> {
-        let tx = self.provider.get_transaction_by_block_id_and_index(block_id, index).await?;
-        Ok(tx.into())
+        idx: u64,
+    ) -> Result<Tx, Error> {
+        match block_id {
+            BlockIdOrTag::Number(num) => {
+                if num > self.block {
+                    return Err(Error::BlockOutOfRange);
+                }
+
+                let tx = self.provider.get_transaction_by_block_id_and_index(block_id, idx).await?;
+                Ok(tx.into())
+            }
+
+            BlockIdOrTag::Hash(hash) => {
+                let (block, tx) = tokio::join!(
+                    self.provider.get_block_with_tx_hashes(BlockIdOrTag::Hash(hash)),
+                    self.provider.get_transaction_by_block_id_and_index(block_id, idx)
+                );
+
+                let number = match block? {
+                    starknet::core::types::MaybePendingBlockWithTxHashes::Block(block) => {
+                        block.block_number
+                    }
+                    starknet::core::types::MaybePendingBlockWithTxHashes::PendingBlock(_) => {
+                        panic!("shouldn't be possible to be pending")
+                    }
+                };
+
+                if number > self.block {
+                    return Err(Error::BlockOutOfRange);
+                }
+
+                Ok(tx?.into())
+            }
+
+            BlockIdOrTag::Tag(_) => {
+                panic!("shouldn't be possible to be tag")
+            }
+        }
     }
 
     pub async fn get_block_with_txs(
         &self,
         block_id: BlockIdOrTag,
-    ) -> StarknetApiResult<MaybePendingBlockWithTxs> {
+    ) -> Result<MaybePendingBlockWithTxs, Error> {
         let block = self.provider.get_block_with_txs(block_id).await?;
-        Ok(block.into())
+
+        match block {
+            starknet::core::types::MaybePendingBlockWithTxs::Block(ref b) => {
+                if b.block_number > self.block {
+                    Err(Error::BlockOutOfRange)
+                } else {
+                    Ok(block.into())
+                }
+            }
+
+            starknet::core::types::MaybePendingBlockWithTxs::PendingBlock(_) => {
+                panic!("shouldn't be possible to be pending")
+            }
+        }
     }
 
     pub async fn get_block_with_receipts(
         &self,
         block_id: BlockIdOrTag,
-    ) -> StarknetApiResult<MaybePendingBlockWithReceipts> {
+    ) -> Result<MaybePendingBlockWithReceipts, Error> {
         let block = self.provider.get_block_with_receipts(block_id).await?;
+
+        match block {
+            starknet::core::types::MaybePendingBlockWithReceipts::Block(ref b) => {
+                if b.block_number > self.block {
+                    return Err(Error::BlockOutOfRange);
+                }
+            }
+            starknet::core::types::MaybePendingBlockWithReceipts::PendingBlock(_) => {
+                panic!("shouldn't be possible to be pending")
+            }
+        }
+
         Ok(block.into())
     }
 
     pub async fn get_block_with_tx_hashes(
         &self,
         block_id: BlockIdOrTag,
-    ) -> StarknetApiResult<MaybePendingBlockWithTxHashes> {
+    ) -> Result<MaybePendingBlockWithTxHashes, Error> {
         let block = self.provider.get_block_with_tx_hashes(block_id).await?;
+
+        match block {
+            starknet::core::types::MaybePendingBlockWithTxHashes::Block(ref b) => {
+                if b.block_number > self.block {
+                    return Err(Error::BlockOutOfRange);
+                }
+            }
+            starknet::core::types::MaybePendingBlockWithTxHashes::PendingBlock(_) => {
+                panic!("shouldn't be possible to be pending")
+            }
+        }
+
         Ok(block.into())
     }
 
-    pub async fn get_block_transaction_count(
-        &self,
-        block_id: BlockIdOrTag,
-    ) -> StarknetApiResult<u64> {
+    pub async fn get_block_transaction_count(&self, block_id: BlockIdOrTag) -> Result<u64, Error> {
+        match block_id {
+            BlockIdOrTag::Number(num) if num > self.block => {
+                return Err(Error::BlockOutOfRange);
+            }
+            BlockIdOrTag::Hash(hash) => {
+                let block =
+                    self.provider.get_block_with_tx_hashes(BlockIdOrTag::Hash(hash)).await?;
+                if let starknet::core::types::MaybePendingBlockWithTxHashes::Block(b) = block {
+                    if b.block_number > self.block {
+                        return Err(Error::BlockOutOfRange);
+                    }
+                }
+            }
+            BlockIdOrTag::Tag(_) => {
+                panic!("shouldn't be possible to be tag")
+            }
+            _ => {}
+        }
+
         let status = self.provider.get_block_transaction_count(block_id).await?;
         Ok(status)
     }
@@ -105,8 +213,38 @@ impl<P: Provider> ForkedClient<P> {
     pub async fn get_state_update(
         &self,
         block_id: BlockIdOrTag,
-    ) -> StarknetApiResult<MaybePendingStateUpdate> {
+    ) -> Result<MaybePendingStateUpdate, Error> {
+        match block_id {
+            BlockIdOrTag::Number(num) if num > self.block => {
+                return Err(Error::BlockOutOfRange);
+            }
+            BlockIdOrTag::Hash(hash) => {
+                let block =
+                    self.provider.get_block_with_tx_hashes(BlockIdOrTag::Hash(hash)).await?;
+                if let starknet::core::types::MaybePendingBlockWithTxHashes::Block(b) = block {
+                    if b.block_number > self.block {
+                        return Err(Error::BlockOutOfRange);
+                    }
+                }
+            }
+            BlockIdOrTag::Tag(_) => {
+                panic!("shouldn't be possible to be tag")
+            }
+            _ => {}
+        }
+
         let state_update = self.provider.get_state_update(block_id).await?;
         Ok(state_update.into())
+    }
+}
+
+impl From<Error> for StarknetApiError {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::Provider(provider_error) => provider_error.into(),
+            Error::BlockOutOfRange => {
+                StarknetApiError::UnexpectedError { reason: value.to_string() }
+            }
+        }
     }
 }

--- a/crates/katana/rpc/rpc/src/starknet/forking.rs
+++ b/crates/katana/rpc/rpc/src/starknet/forking.rs
@@ -1,0 +1,7 @@
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
+
+#[derive(Debug)]
+pub struct ForkedClient {
+    pub client: JsonRpcClient<HttpTransport>,
+}

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -869,16 +869,15 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
                     }
                 }
 
-                let block_num = provider
-                    .convert_block_id(block_id)?
-                    .map(BlockHashOrNumber::Num)
-                    .ok_or(StarknetApiError::BlockNotFound)?;
+                if let Some(num) = provider.convert_block_id(block_id)? {
+                    let block = katana_rpc_types_builder::BlockBuilder::new(num.into(), provider)
+                        .build_with_tx_hash()?
+                        .map(MaybePendingBlockWithTxHashes::Block);
 
-                let block = katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
-                    .build_with_tx_hash()?
-                    .map(MaybePendingBlockWithTxHashes::Block);
-
-                StarknetApiResult::Ok(block)
+                    StarknetApiResult::Ok(block)
+                } else {
+                    StarknetApiResult::Ok(None)
+                }
             })
             .await?;
 

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -46,7 +46,6 @@ use katana_tasks::{BlockingTaskPool, TokioTaskSpawner};
 use starknet::core::types::{
     ContractClass, EventsPage, PriceUnit, TransactionExecutionStatus, TransactionStatus,
 };
-use starknet::providers::Provider;
 
 use crate::utils;
 use crate::utils::events::{Cursor, EventBlockId};
@@ -321,7 +320,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(count) = count {
             Ok(count)
         } else if let Some(client) = &self.inner.forked_client {
-            let status = client.inner.get_block_transaction_count(block_id).await?;
+            let status = client.get_block_transaction_count(block_id).await?;
             Ok(status)
         } else {
             Err(StarknetApiError::BlockNotFound)
@@ -391,8 +390,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(tx) = tx {
             Ok(tx.into())
         } else if let Some(client) = &self.inner.forked_client {
-            let tx = client.inner.get_transaction_by_block_id_and_index(block_id, index).await?;
-            Ok(tx.into())
+            Ok(client.get_transaction_by_block_id_and_index(block_id, index).await?)
         } else {
             Err(StarknetApiError::InvalidTxnIndex)
         }
@@ -430,8 +428,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(tx) = tx {
             Ok(tx)
         } else if let Some(client) = &self.inner.forked_client {
-            let tx = client.inner.get_transaction_by_hash(hash).await?;
-            Ok(tx.into())
+            Ok(client.get_transaction_by_hash(hash).await?)
         } else {
             Err(StarknetApiError::TxnHashNotFound)
         }
@@ -480,8 +477,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(receipt) = receipt {
             Ok(receipt)
         } else if let Some(client) = &self.inner.forked_client {
-            let receipt = client.inner.get_transaction_receipt(hash).await?;
-            Ok(receipt.into())
+            Ok(client.get_transaction_receipt(hash).await?)
         } else {
             Err(StarknetApiError::TxnHashNotFound)
         }
@@ -684,8 +680,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(status) = status {
             Ok(status)
         } else if let Some(client) = &self.inner.forked_client {
-            let status = client.inner.get_transaction_status(hash).await?;
-            Ok(status)
+            Ok(client.get_transaction_status(hash).await?)
         } else {
             Err(StarknetApiError::TxnHashNotFound)
         }
@@ -753,8 +748,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(block) = block {
             Ok(block)
         } else if let Some(client) = &self.inner.forked_client {
-            let block = client.inner.get_block_with_txs(block_id).await?;
-            Ok(block.into())
+            Ok(client.get_block_with_txs(block_id).await?)
         } else {
             Err(StarknetApiError::BlockNotFound)
         }
@@ -819,8 +813,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(block) = block {
             Ok(block)
         } else if let Some(client) = &self.inner.forked_client {
-            let block = client.inner.get_block_with_receipts(block_id).await?;
-            Ok(block.into())
+            Ok(client.get_block_with_receipts(block_id).await?)
         } else {
             Err(StarknetApiError::BlockNotFound)
         }
@@ -887,8 +880,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(block) = block {
             Ok(block)
         } else if let Some(client) = &self.inner.forked_client {
-            let block = client.inner.get_block_with_tx_hashes(block_id).await?;
-            Ok(block.into())
+            Ok(client.get_block_with_tx_hashes(block_id).await?)
         } else {
             Err(StarknetApiError::BlockNotFound)
         }
@@ -927,8 +919,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
         if let Some(state_update) = state_update {
             Ok(state_update)
         } else if let Some(client) = &self.inner.forked_client {
-            let state_update = client.inner.get_state_update(block_id).await?;
-            Ok(state_update.into())
+            Ok(client.get_state_update(block_id).await?)
         } else {
             Err(StarknetApiError::BlockNotFound)
         }

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -45,11 +45,11 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
     }
 
     async fn get_transaction_by_hash(&self, transaction_hash: Felt) -> RpcResult<Tx> {
-        Ok(self.transaction(transaction_hash).await?.into())
+        Ok(self.transaction(transaction_hash).await?)
     }
 
     async fn get_block_transaction_count(&self, block_id: BlockIdOrTag) -> RpcResult<u64> {
-        self.on_io_blocking_task(move |this| Ok(this.block_tx_count(block_id)?)).await
+        Ok(self.block_tx_count(block_id).await?)
     }
 
     async fn get_class_at(

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -1,27 +1,22 @@
 use jsonrpsee::core::{async_trait, Error, RpcResult};
-use katana_executor::{EntryPointCall, ExecutionResult, ExecutorFactory};
-use katana_primitives::block::{BlockHashOrNumber, BlockIdOrTag, FinalityStatus, PartialHeader};
-use katana_primitives::da::L1DataAvailabilityMode;
+use katana_executor::{EntryPointCall, ExecutorFactory};
+use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash, TxHash};
 use katana_primitives::Felt;
-use katana_provider::traits::block::{BlockHashProvider, BlockIdReader, BlockNumberProvider};
-use katana_provider::traits::transaction::TransactionProvider;
 use katana_rpc_api::starknet::StarknetApiServer;
 use katana_rpc_types::block::{
     BlockHashAndNumber, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
-    MaybePendingBlockWithTxs, PendingBlockWithReceipts, PendingBlockWithTxHashes,
-    PendingBlockWithTxs,
+    MaybePendingBlockWithTxs,
 };
 use katana_rpc_types::error::starknet::StarknetApiError;
 use katana_rpc_types::event::{EventFilterWithPage, EventsPage};
 use katana_rpc_types::message::MsgFromL1;
-use katana_rpc_types::receipt::{ReceiptBlock, TxReceiptWithBlockInfo};
-use katana_rpc_types::state_update::StateUpdate;
+use katana_rpc_types::receipt::TxReceiptWithBlockInfo;
+use katana_rpc_types::state_update::MaybePendingStateUpdate;
 use katana_rpc_types::transaction::{BroadcastedTx, Tx};
 use katana_rpc_types::{
     ContractClass, FeeEstimate, FeltAsHex, FunctionCall, SimulationFlagForEstimateFee,
 };
-use katana_rpc_types_builder::ReceiptBuilder;
 use starknet::core::types::{BlockTag, TransactionStatus};
 
 use super::StarknetApi;
@@ -72,59 +67,7 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         &self,
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithTxHashes> {
-        self.on_io_blocking_task(move |this| {
-            let provider = this.inner.backend.blockchain.provider();
-
-            if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                if let Some(executor) = this.pending_executor() {
-                    let block_env = executor.read().block_env();
-                    let latest_hash = provider.latest_hash().map_err(StarknetApiError::from)?;
-
-                    let l1_gas_prices = block_env.l1_gas_prices.clone();
-                    let l1_data_gas_prices = block_env.l1_data_gas_prices.clone();
-
-                    let header = PartialHeader {
-                        l1_da_mode: L1DataAvailabilityMode::Calldata,
-                        l1_data_gas_prices,
-                        l1_gas_prices,
-                        number: block_env.number,
-                        parent_hash: latest_hash,
-                        timestamp: block_env.timestamp,
-                        protocol_version: this.inner.backend.chain_spec.version.clone(),
-                        sequencer_address: block_env.sequencer_address,
-                    };
-
-                    // TODO(kariy): create a method that can perform this filtering for us instead
-                    // of doing it manually.
-
-                    // A block should only include successful transactions, we filter out the failed
-                    // ones (didn't pass validation stage).
-                    let transactions = executor
-                        .read()
-                        .transactions()
-                        .iter()
-                        .filter(|(_, receipt)| receipt.is_success())
-                        .map(|(tx, _)| tx.hash)
-                        .collect::<Vec<_>>();
-
-                    return Ok(MaybePendingBlockWithTxHashes::Pending(
-                        PendingBlockWithTxHashes::new(header, transactions),
-                    ));
-                }
-            }
-
-            let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                .map_err(StarknetApiError::from)?
-                .map(BlockHashOrNumber::Num)
-                .ok_or(StarknetApiError::BlockNotFound)?;
-
-            katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
-                .build_with_tx_hash()
-                .map_err(StarknetApiError::from)?
-                .map(MaybePendingBlockWithTxHashes::Block)
-                .ok_or(Error::from(StarknetApiError::BlockNotFound))
-        })
-        .await
+        Ok(self.block_with_tx_hashes(block_id).await?)
     }
 
     async fn get_transaction_by_block_id_and_index(
@@ -132,219 +75,32 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
         block_id: BlockIdOrTag,
         index: u64,
     ) -> RpcResult<Tx> {
-        self.on_io_blocking_task(move |this| {
-            // TEMP: have to handle pending tag independently for now
-            let tx = if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                let Some(executor) = this.pending_executor() else {
-                    return Err(StarknetApiError::BlockNotFound.into());
-                };
-
-                let executor = executor.read();
-                let pending_txs = executor.transactions();
-                pending_txs.get(index as usize).map(|(tx, _)| tx.clone())
-            } else {
-                let provider = &this.inner.backend.blockchain.provider();
-
-                let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                    .map_err(StarknetApiError::from)?
-                    .map(BlockHashOrNumber::Num)
-                    .ok_or(StarknetApiError::BlockNotFound)?;
-
-                TransactionProvider::transaction_by_block_and_idx(provider, block_num, index)
-                    .map_err(StarknetApiError::from)?
-            };
-
-            Ok(tx.ok_or(StarknetApiError::InvalidTxnIndex)?.into())
-        })
-        .await
+        Ok(self.transaction_by_block_id_and_index(block_id, index).await?)
     }
 
     async fn get_block_with_txs(
         &self,
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithTxs> {
-        self.on_io_blocking_task(move |this| {
-            let provider = this.inner.backend.blockchain.provider();
-
-            if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                if let Some(executor) = this.pending_executor() {
-                    let block_env = executor.read().block_env();
-                    let latest_hash = provider.latest_hash().map_err(StarknetApiError::from)?;
-
-                    let l1_gas_prices = block_env.l1_gas_prices.clone();
-                    let l1_data_gas_prices = block_env.l1_data_gas_prices.clone();
-
-                    let header = PartialHeader {
-                        l1_da_mode: L1DataAvailabilityMode::Calldata,
-                        l1_gas_prices,
-                        l1_data_gas_prices,
-                        number: block_env.number,
-                        parent_hash: latest_hash,
-                        timestamp: block_env.timestamp,
-                        sequencer_address: block_env.sequencer_address,
-                        protocol_version: this.inner.backend.chain_spec.version.clone(),
-                    };
-
-                    // TODO(kariy): create a method that can perform this filtering for us instead
-                    // of doing it manually.
-
-                    // A block should only include successful transactions, we filter out the failed
-                    // ones (didn't pass validation stage).
-                    let transactions = executor
-                        .read()
-                        .transactions()
-                        .iter()
-                        .filter(|(_, receipt)| receipt.is_success())
-                        .map(|(tx, _)| tx.clone())
-                        .collect::<Vec<_>>();
-
-                    return Ok(MaybePendingBlockWithTxs::Pending(PendingBlockWithTxs::new(
-                        header,
-                        transactions,
-                    )));
-                }
-            }
-
-            let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-                .map(BlockHashOrNumber::Num)
-                .ok_or(StarknetApiError::BlockNotFound)?;
-
-            katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
-                .build()
-                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-                .map(MaybePendingBlockWithTxs::Block)
-                .ok_or(Error::from(StarknetApiError::BlockNotFound))
-        })
-        .await
+        Ok(self.block_with_txs(block_id).await?)
     }
 
     async fn get_block_with_receipts(
         &self,
         block_id: BlockIdOrTag,
     ) -> RpcResult<MaybePendingBlockWithReceipts> {
-        self.on_io_blocking_task(move |this| {
-            let provider = this.inner.backend.blockchain.provider();
-
-            if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                if let Some(executor) = this.pending_executor() {
-                    let block_env = executor.read().block_env();
-                    let latest_hash = provider.latest_hash().map_err(StarknetApiError::from)?;
-
-                    let l1_gas_prices = block_env.l1_gas_prices.clone();
-                    let l1_data_gas_prices = block_env.l1_data_gas_prices.clone();
-
-                    let header = PartialHeader {
-                        l1_da_mode: L1DataAvailabilityMode::Calldata,
-                        l1_gas_prices,
-                        l1_data_gas_prices,
-                        number: block_env.number,
-                        parent_hash: latest_hash,
-                        protocol_version: this.inner.backend.chain_spec.version.clone(),
-                        timestamp: block_env.timestamp,
-                        sequencer_address: block_env.sequencer_address,
-                    };
-
-                    let receipts = executor
-                        .read()
-                        .transactions()
-                        .iter()
-                        .filter_map(|(tx, result)| match result {
-                            ExecutionResult::Success { receipt, .. } => {
-                                Some((tx.clone(), receipt.clone()))
-                            }
-                            ExecutionResult::Failed { .. } => None,
-                        })
-                        .collect::<Vec<_>>();
-
-                    return Ok(MaybePendingBlockWithReceipts::Pending(
-                        PendingBlockWithReceipts::new(header, receipts.into_iter()),
-                    ));
-                }
-            }
-
-            let block_num = BlockIdReader::convert_block_id(provider, block_id)
-                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-                .map(BlockHashOrNumber::Num)
-                .ok_or(StarknetApiError::BlockNotFound)?;
-
-            let block = katana_rpc_types_builder::BlockBuilder::new(block_num, provider)
-                .build_with_receipts()
-                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-                .ok_or(Error::from(StarknetApiError::BlockNotFound))?;
-
-            Ok(MaybePendingBlockWithReceipts::Block(block))
-        })
-        .await
+        Ok(self.block_with_receipts(block_id).await?)
     }
 
-    async fn get_state_update(&self, block_id: BlockIdOrTag) -> RpcResult<StateUpdate> {
-        self.on_io_blocking_task(move |this| {
-            let provider = this.inner.backend.blockchain.provider();
-
-            let block_id = match block_id {
-                BlockIdOrTag::Number(num) => BlockHashOrNumber::Num(num),
-                BlockIdOrTag::Hash(hash) => BlockHashOrNumber::Hash(hash),
-
-                BlockIdOrTag::Tag(BlockTag::Latest) => BlockNumberProvider::latest_number(provider)
-                    .map(BlockHashOrNumber::Num)
-                    .map_err(|_| StarknetApiError::BlockNotFound)?,
-
-                BlockIdOrTag::Tag(BlockTag::Pending) => {
-                    return Err(StarknetApiError::BlockNotFound.into());
-                }
-            };
-
-            katana_rpc_types_builder::StateUpdateBuilder::new(block_id, provider)
-                .build()
-                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?
-                .ok_or(Error::from(StarknetApiError::BlockNotFound))
-        })
-        .await
+    async fn get_state_update(&self, block_id: BlockIdOrTag) -> RpcResult<MaybePendingStateUpdate> {
+        Ok(self.state_update(block_id).await?)
     }
 
     async fn get_transaction_receipt(
         &self,
         transaction_hash: Felt,
     ) -> RpcResult<TxReceiptWithBlockInfo> {
-        self.on_io_blocking_task(move |this| {
-            let provider = this.inner.backend.blockchain.provider();
-            let receipt = ReceiptBuilder::new(transaction_hash, provider)
-                .build()
-                .map_err(|e| StarknetApiError::UnexpectedError { reason: e.to_string() })?;
-
-            match receipt {
-                Some(receipt) => Ok(receipt),
-
-                None => {
-                    let executor = this.pending_executor();
-                    let pending_receipt = executor
-                        .and_then(|executor| {
-                            executor.read().transactions().iter().find_map(|(tx, res)| {
-                                if tx.hash == transaction_hash {
-                                    match res {
-                                        ExecutionResult::Failed { .. } => None,
-                                        ExecutionResult::Success { receipt, .. } => {
-                                            Some(receipt.clone())
-                                        }
-                                    }
-                                } else {
-                                    None
-                                }
-                            })
-                        })
-                        .ok_or(Error::from(StarknetApiError::TxnHashNotFound))?;
-
-                    Ok(TxReceiptWithBlockInfo::new(
-                        ReceiptBlock::Pending,
-                        transaction_hash,
-                        FinalityStatus::AcceptedOnL2,
-                        pending_receipt,
-                    ))
-                }
-            }
-        })
-        .await
+        Ok(self.receipt(transaction_hash).await?)
     }
 
     async fn get_class_hash_at(

--- a/crates/katana/rpc/rpc/src/starknet/trace.rs
+++ b/crates/katana/rpc/rpc/src/starknet/trace.rs
@@ -96,7 +96,7 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
 
                 ExecutionResult::Failed { error } => {
                     let error = StarknetApiError::TransactionExecutionError {
-                        transaction_index: i,
+                        transaction_index: i as u64,
                         execution_error: error.to_string(),
                     };
                     return Err(error);

--- a/crates/katana/rpc/rpc/tests/common/mod.rs
+++ b/crates/katana/rpc/rpc/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -68,4 +70,22 @@ pub fn split_felt(felt: Felt) -> (Felt, Felt) {
     let low: Felt = (felt.to_biguint() & Felt::from(u128::MAX).to_biguint()).into();
     let high = felt.to_biguint() >> 128;
     (low, Felt::from(high))
+}
+
+/// Assert that the given error is a Starknet error from a
+/// [`AccountError`](starknet::accounts::AccountError).
+#[macro_export]
+macro_rules! assert_account_starknet_err {
+    ($err:expr, $api_err:pat) => {
+        assert_matches!($err, AccountError::Provider(ProviderError::StarknetError($api_err)))
+    };
+}
+
+/// Assert that the given error is a Starknet error from a
+/// [`ProviderError`](starknet::providers::ProviderError).
+#[macro_export]
+macro_rules! assert_provider_starknet_err {
+    ($err:expr, $api_err:pat) => {
+        assert_matches!($err, ProviderError::StarknetError($api_err))
+    };
 }

--- a/crates/katana/rpc/rpc/tests/forking.rs
+++ b/crates/katana/rpc/rpc/tests/forking.rs
@@ -1,0 +1,141 @@
+use anyhow::Result;
+use assert_matches::assert_matches;
+use cainome::rs::abigen_legacy;
+use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
+use jsonrpsee::http_client::HttpClientBuilder;
+use katana_node::config::fork::ForkingConfig;
+use katana_node::config::SequencingConfig;
+use katana_primitives::block::{BlockHashOrNumber, BlockIdOrTag, BlockNumber};
+use katana_primitives::chain::NamedChainId;
+use katana_primitives::genesis::constant::DEFAULT_ETH_FEE_TOKEN_ADDRESS;
+use katana_primitives::transaction::TxHash;
+use katana_primitives::{felt, Felt};
+use katana_rpc_api::dev::DevApiClient;
+use starknet::core::types::MaybePendingBlockWithTxs;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::{JsonRpcClient, Provider};
+use url::Url;
+
+const SEPOLIA_CHAIN_ID: Felt = NamedChainId::SN_SEPOLIA;
+const SEPOLIA_URL: &str = "https://api.cartridge.gg/x/starknet/sepolia";
+const FORK_BLOCK_NUMBER: BlockNumber = 268_471;
+
+fn forking_cfg() -> ForkingConfig {
+    ForkingConfig {
+        url: Url::parse(SEPOLIA_URL).unwrap(),
+        block: Some(BlockHashOrNumber::Num(FORK_BLOCK_NUMBER)),
+    }
+}
+
+fn provider(url: Url) -> JsonRpcClient<HttpTransport> {
+    JsonRpcClient::new(HttpTransport::new(url))
+}
+
+type LocalTestVector = Vec<(BlockNumber, TxHash)>;
+
+async fn forked_sequencer() -> (TestSequencer, impl Provider, LocalTestVector) {
+    let mut config = get_default_test_config(SequencingConfig::default());
+    config.forking = Some(forking_cfg());
+
+    let sequencer = TestSequencer::start(config).await;
+    let provider = provider(sequencer.url());
+
+    let mut txs_vector: LocalTestVector = Vec::new();
+
+    {
+        // create some emtpy blocks and dummy transactions
+        abigen_legacy!(FeeToken, "crates/katana/rpc/rpc/tests/test_data/erc20.json");
+        let contract = FeeToken::new(DEFAULT_ETH_FEE_TOKEN_ADDRESS.into(), sequencer.account());
+        let client = HttpClientBuilder::default().build(sequencer.url()).unwrap();
+
+        for i in 0..10 {
+            let amount = Uint256 { low: Felt::ONE, high: Felt::ZERO };
+            let res = contract.transfer(&Felt::ONE, &amount).send().await.unwrap();
+            client.generate_block().await.expect("failed to create block");
+            txs_vector.push((FORK_BLOCK_NUMBER + i, res.transaction_hash));
+        }
+    }
+
+    (sequencer, provider, txs_vector)
+}
+
+#[tokio::test]
+async fn can_fork() -> Result<()> {
+    let (_sequencer, provider, _) = forked_sequencer().await;
+
+    let block = provider.block_number().await?;
+    let chain = provider.chain_id().await?;
+
+    assert_eq!(chain, SEPOLIA_CHAIN_ID);
+    assert_eq!(block, FORK_BLOCK_NUMBER + 10);
+
+    Ok(())
+}
+
+async fn assert_get_block_methods(provider: &impl Provider, num: BlockNumber) -> Result<()> {
+    let id = BlockIdOrTag::Number(num);
+
+    let block = provider.get_block_with_txs(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_number == num);
+
+    let block = provider.get_block_with_receipts(id).await?;
+    assert_matches!(block, starknet::core::types::MaybePendingBlockWithReceipts::Block(b) if b.block_number == num);
+
+    let block = provider.get_block_with_tx_hashes(id).await?;
+    assert_matches!(block, starknet::core::types::MaybePendingBlockWithTxHashes::Block(b) if b.block_number == num);
+
+    let result = provider.get_block_transaction_count(id).await;
+    assert!(result.is_ok());
+
+    let state = provider.get_state_update(id).await?;
+    assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn forked_blocks() -> Result<()> {
+    let (_sequencer, provider, _) = forked_sequencer().await;
+
+    let block_num = FORK_BLOCK_NUMBER;
+    assert_get_block_methods(&provider, block_num).await?;
+
+    let block_num = FORK_BLOCK_NUMBER - 5;
+    assert_get_block_methods(&provider, block_num).await?;
+
+    let block_num = FORK_BLOCK_NUMBER + 5;
+    assert_get_block_methods(&provider, block_num).await?;
+
+    Ok(())
+}
+
+async fn assert_get_transaction_methods(provider: &impl Provider, tx_hash: TxHash) -> Result<()> {
+    let tx = provider.get_transaction_by_hash(tx_hash).await?;
+    assert_eq!(*tx.transaction_hash(), tx_hash);
+    let tx = provider.get_transaction_receipt(tx_hash).await?;
+    assert_eq!(*tx.receipt.transaction_hash(), tx_hash);
+    let result = provider.get_transaction_status(tx_hash).await;
+    assert!(result.is_ok());
+    Ok(())
+}
+
+#[tokio::test]
+async fn forked_transactions() -> Result<()> {
+    let (_sequencer, provider, local_only_data) = forked_sequencer().await;
+
+    // https://sepolia.voyager.online/tx/0x5ae12c42a01c71cff20e1ce5bdeeb07cd2d5ddbc86e1157d4bdf2e71dc2d866
+    // transaction in block num 268_533
+    let tx_hash = felt!("0x5ae12c42a01c71cff20e1ce5bdeeb07cd2d5ddbc86e1157d4bdf2e71dc2d866");
+    assert_get_transaction_methods(&provider, tx_hash).await?;
+
+    // get local only transactions
+    for (_, tx_hash) in local_only_data {
+        assert_get_transaction_methods(&provider, tx_hash).await?;
+    }
+
+    // https://sepolia.voyager.online/tx/0x3e336c36a1cba6f3a69d8b5aeed95f81ea0499edbdf2762d00ff641310ecc10
+    // transaction in block num 268_473 (plus 3 after the fork block number)
+    let tx_hash = felt!("0x3e336c36a1cba6f3a69d8b5aeed95f81ea0499edbdf2762d00ff641310ecc10");
+
+    Ok(())
+}

--- a/crates/katana/rpc/rpc/tests/forking.rs
+++ b/crates/katana/rpc/rpc/tests/forking.rs
@@ -82,20 +82,28 @@ async fn can_fork() -> Result<()> {
 async fn assert_get_block_methods(provider: &impl Provider, num: BlockNumber) -> Result<()> {
     let id = BlockIdOrTag::Number(num);
 
-    let block = provider.get_block_with_txs(id).await?;
+    let block =
+        provider.get_block_with_txs(id).await.context(format!("failed to get block {num}"))?;
     assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_number == num);
 
-    let block = provider.get_block_with_receipts(id).await?;
+    let block = provider
+        .get_block_with_receipts(id)
+        .await
+        .context(format!("failed to get block {num} w/ receipts"))?;
     assert_matches!(block, starknet::core::types::MaybePendingBlockWithReceipts::Block(b) if b.block_number == num);
 
-    let block = provider.get_block_with_tx_hashes(id).await?;
+    let block = provider
+        .get_block_with_tx_hashes(id)
+        .await
+        .context(format!("failed to get block {num} w/ hashes"))?;
     assert_matches!(block, starknet::core::types::MaybePendingBlockWithTxHashes::Block(b) if b.block_number == num);
 
     let result = provider.get_block_transaction_count(id).await;
     assert!(result.is_ok());
 
-    let state = provider.get_state_update(id).await?;
-    assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
+    // TODO: uncomment this once we include genesis forked state update
+    // let state = provider.get_state_update(id).await?;
+    // assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
 
     Ok(())
 }
@@ -104,19 +112,51 @@ async fn assert_get_block_methods(provider: &impl Provider, num: BlockNumber) ->
 async fn forked_blocks() -> Result<()> {
     let (_sequencer, provider, _) = setup_test().await;
 
-    let block_num = FORK_BLOCK_NUMBER;
+    // -----------------------------------------------------------------------
+    // Get the forked block
+
+    // https://sepolia.voyager.online/block/0x208950cfcbba73ecbda1c14e4d58d66a8d60655ea1b9dcf07c16014ae8a93cd
+    let block_num = FORK_BLOCK_NUMBER; // 268471
     assert_get_block_methods(&provider, block_num).await?;
 
-    let block_num = FORK_BLOCK_NUMBER - 5;
+    // -----------------------------------------------------------------------
+    // Get a block before the forked block
+
+    // https://sepolia.voyager.online/block/0x42dc67af5003d212ac6cd784e72db945ea4d619898f30f422358ff215cbe1e4
+    let block_num = FORK_BLOCK_NUMBER - 5; // 268466
     assert_get_block_methods(&provider, block_num).await?;
+
+    // -----------------------------------------------------------------------
+    // Get a block that is locally generated
 
     let block_num = FORK_BLOCK_NUMBER + 5;
     assert_get_block_methods(&provider, block_num).await?;
 
     // -----------------------------------------------------------------------
+    // Get a block that only exist in the forked chain
+
+    // https://sepolia.voyager.online/block/0x347a9fa25700e7a2d8f26b39c0ecf765be9a78c559b9cae722a659f25182d10
+    // We only created 10 local blocks so this is fine.
+    let id = BlockIdOrTag::Number(270_328);
+    let result = provider.get_block_with_txs(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_with_receipts(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_with_tx_hashes(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_transaction_count(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_state_update(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    // -----------------------------------------------------------------------
     // Get block that doesn't exist on the both the forked and local chain
 
-    let id = BlockIdOrTag::Number(BlockNumber::MAX);
+    let id = BlockIdOrTag::Number(i64::MAX as u64);
     let result = provider.get_block_with_txs(id).await.unwrap_err();
     assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
 
@@ -139,13 +179,13 @@ async fn assert_get_transaction_methods(provider: &impl Provider, tx_hash: TxHas
     let tx = provider
         .get_transaction_by_hash(tx_hash)
         .await
-        .with_context(|| format!("failed to get tx {tx_hash:#x}"))?;
+        .context(format!("failed to get tx {tx_hash:#x}"))?;
     assert_eq!(*tx.transaction_hash(), tx_hash);
 
     let tx = provider
         .get_transaction_receipt(tx_hash)
         .await
-        .with_context(|| format!("failed to get receipt {tx_hash:#x}"))?;
+        .context(format!("failed to get receipt {tx_hash:#x}"))?;
     assert_eq!(*tx.receipt.transaction_hash(), tx_hash);
 
     let result = provider.get_transaction_status(tx_hash).await;

--- a/crates/katana/rpc/rpc/tests/forking.rs
+++ b/crates/katana/rpc/rpc/tests/forking.rs
@@ -1,15 +1,15 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use assert_matches::assert_matches;
 use cainome::rs::abigen_legacy;
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use katana_node::config::fork::ForkingConfig;
 use katana_node::config::SequencingConfig;
-use katana_primitives::block::{BlockHashOrNumber, BlockIdOrTag, BlockNumber};
+use katana_primitives::block::{BlockHash, BlockHashOrNumber, BlockIdOrTag, BlockNumber};
 use katana_primitives::chain::NamedChainId;
 use katana_primitives::genesis::constant::DEFAULT_ETH_FEE_TOKEN_ADDRESS;
 use katana_primitives::transaction::TxHash;
 use katana_primitives::{felt, Felt};
-use starknet::core::types::{MaybePendingBlockWithTxs, StarknetError};
+use starknet::core::types::{MaybePendingBlockWithTxHashes, StarknetError};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider, ProviderError};
 use url::Url;
@@ -27,7 +27,7 @@ fn forking_cfg() -> ForkingConfig {
     }
 }
 
-type LocalTestVector = Vec<(BlockNumber, TxHash)>;
+type LocalTestVector = Vec<((BlockNumber, BlockHash), TxHash)>;
 
 /// A helper function for setting a test environment, forked from the SN_SEPOLIA chain.
 /// This function will forked Sepolia at block [`FORK_BLOCK_NUMBER`] and create 10 blocks, each has
@@ -53,7 +53,16 @@ async fn setup_test() -> (TestSequencer, impl Provider, LocalTestVector) {
         let res = contract.transfer(&Felt::ONE, &amount).send().await.unwrap();
         let _ = dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider).await.unwrap();
 
-        txs_vector.push((FORK_BLOCK_NUMBER + i, res.transaction_hash));
+        let block_num = FORK_BLOCK_NUMBER + i;
+
+        let block_id = BlockIdOrTag::Number(block_num);
+        let block = provider.get_block_with_tx_hashes(block_id).await.unwrap();
+        let block_hash = match block {
+            MaybePendingBlockWithTxHashes::Block(b) => b.block_hash,
+            _ => panic!("Expected a block"),
+        };
+
+        txs_vector.push(((FORK_BLOCK_NUMBER + i, block_hash), res.transaction_hash));
     }
 
     (sequencer, provider, txs_vector)
@@ -72,24 +81,29 @@ async fn can_fork() -> Result<()> {
     Ok(())
 }
 
-async fn assert_get_block_methods(provider: &impl Provider, num: BlockNumber) -> Result<()> {
+#[tokio::test]
+async fn forked_blocks_from_num() -> Result<()> {
+    use starknet::core::types::{
+        MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
+    };
+
+    let (_sequencer, provider, local_only_block) = setup_test().await;
+
+    // -----------------------------------------------------------------------
+    // Get the forked block
+    // https://sepolia.voyager.online/block/0x208950cfcbba73ecbda1c14e4d58d66a8d60655ea1b9dcf07c16014ae8a93cd
+
+    let num = FORK_BLOCK_NUMBER; // 268471
     let id = BlockIdOrTag::Number(num);
 
-    let block =
-        provider.get_block_with_txs(id).await.context(format!("failed to get block {num}"))?;
+    let block = provider.get_block_with_txs(id).await?;
     assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_number == num);
 
-    let block = provider
-        .get_block_with_receipts(id)
-        .await
-        .context(format!("failed to get block {num} w/ receipts"))?;
-    assert_matches!(block, starknet::core::types::MaybePendingBlockWithReceipts::Block(b) if b.block_number == num);
+    let block = provider.get_block_with_receipts(id).await?;
+    assert_matches!(block, MaybePendingBlockWithReceipts::Block(b) if b.block_number == num);
 
-    let block = provider
-        .get_block_with_tx_hashes(id)
-        .await
-        .context(format!("failed to get block {num} w/ hashes"))?;
-    assert_matches!(block, starknet::core::types::MaybePendingBlockWithTxHashes::Block(b) if b.block_number == num);
+    let block = provider.get_block_with_tx_hashes(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxHashes::Block(b) if b.block_number == num);
 
     let result = provider.get_block_transaction_count(id).await;
     assert!(result.is_ok());
@@ -98,32 +112,51 @@ async fn assert_get_block_methods(provider: &impl Provider, num: BlockNumber) ->
     // let state = provider.get_state_update(id).await?;
     // assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
 
-    Ok(())
-}
-
-#[tokio::test]
-async fn forked_blocks() -> Result<()> {
-    let (_sequencer, provider, _) = setup_test().await;
-
-    // -----------------------------------------------------------------------
-    // Get the forked block
-
-    // https://sepolia.voyager.online/block/0x208950cfcbba73ecbda1c14e4d58d66a8d60655ea1b9dcf07c16014ae8a93cd
-    let block_num = FORK_BLOCK_NUMBER; // 268471
-    assert_get_block_methods(&provider, block_num).await?;
-
     // -----------------------------------------------------------------------
     // Get a block before the forked block
 
     // https://sepolia.voyager.online/block/0x42dc67af5003d212ac6cd784e72db945ea4d619898f30f422358ff215cbe1e4
-    let block_num = FORK_BLOCK_NUMBER - 5; // 268466
-    assert_get_block_methods(&provider, block_num).await?;
+    let num = FORK_BLOCK_NUMBER - 5; // 268466
+    let id = BlockIdOrTag::Number(num);
+
+    let block = provider.get_block_with_txs(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_number == num);
+
+    let block = provider.get_block_with_receipts(id).await?;
+    assert_matches!(block, MaybePendingBlockWithReceipts::Block(b) if b.block_number == num);
+
+    let block = provider.get_block_with_tx_hashes(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxHashes::Block(b) if b.block_number == num);
+
+    let result = provider.get_block_transaction_count(id).await;
+    assert!(result.is_ok());
+
+    // TODO: uncomment this once we include genesis forked state update
+    // let state = provider.get_state_update(id).await?;
+    // assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
 
     // -----------------------------------------------------------------------
     // Get a block that is locally generated
 
-    let block_num = FORK_BLOCK_NUMBER + 5;
-    assert_get_block_methods(&provider, block_num).await?;
+    for ((num, _), _) in local_only_block {
+        let id = BlockIdOrTag::Number(num);
+
+        let block = provider.get_block_with_txs(id).await?;
+        assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_number == num);
+
+        let block = provider.get_block_with_receipts(id).await?;
+        assert_matches!(block, starknet::core::types::MaybePendingBlockWithReceipts::Block(b) if b.block_number == num);
+
+        let block = provider.get_block_with_tx_hashes(id).await?;
+        assert_matches!(block, starknet::core::types::MaybePendingBlockWithTxHashes::Block(b) if b.block_number == num);
+
+        let count = provider.get_block_transaction_count(id).await?;
+        assert_eq!(count, 1, "all the locally generated blocks should have 1 tx");
+
+        // TODO: uncomment this once we include genesis forked state update
+        // let state = provider.get_state_update(id).await?;
+        // assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
+    }
 
     // -----------------------------------------------------------------------
     // Get a block that only exist in the forked chain
@@ -168,21 +201,123 @@ async fn forked_blocks() -> Result<()> {
     Ok(())
 }
 
-async fn assert_get_transaction_methods(provider: &impl Provider, tx_hash: TxHash) -> Result<()> {
-    let tx = provider
-        .get_transaction_by_hash(tx_hash)
-        .await
-        .context(format!("failed to get tx {tx_hash:#x}"))?;
-    assert_eq!(*tx.transaction_hash(), tx_hash);
+#[tokio::test]
+async fn forked_blocks_from_hash() -> Result<()> {
+    use starknet::core::types::{
+        MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes, MaybePendingBlockWithTxs,
+    };
 
-    let tx = provider
-        .get_transaction_receipt(tx_hash)
-        .await
-        .context(format!("failed to get receipt {tx_hash:#x}"))?;
-    assert_eq!(*tx.receipt.transaction_hash(), tx_hash);
+    let (_sequencer, provider, local_only_block) = setup_test().await;
 
-    let result = provider.get_transaction_status(tx_hash).await;
+    // -----------------------------------------------------------------------
+    // Get the forked block
+
+    // https://sepolia.voyager.online/block/0x208950cfcbba73ecbda1c14e4d58d66a8d60655ea1b9dcf07c16014ae8a93cd
+    let hash = felt!("0x208950cfcbba73ecbda1c14e4d58d66a8d60655ea1b9dcf07c16014ae8a93cd"); // 268471
+    let id = BlockIdOrTag::Hash(hash);
+
+    let block = provider.get_block_with_txs(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_hash == hash);
+
+    let block = provider.get_block_with_receipts(id).await?;
+    assert_matches!(block, MaybePendingBlockWithReceipts::Block(b) if b.block_hash == hash);
+
+    let block = provider.get_block_with_tx_hashes(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxHashes::Block(b) if b.block_hash == hash);
+
+    let result = provider.get_block_transaction_count(id).await;
     assert!(result.is_ok());
+
+    // TODO: uncomment this once we include genesis forked state update
+    // let state = provider.get_state_update(id).await?;
+    // assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
+
+    // -----------------------------------------------------------------------
+    // Get a block before the forked block
+    // https://sepolia.voyager.online/block/0x42dc67af5003d212ac6cd784e72db945ea4d619898f30f422358ff215cbe1e4
+
+    let hash = felt!("0x42dc67af5003d212ac6cd784e72db945ea4d619898f30f422358ff215cbe1e4"); // 268466
+    let id = BlockIdOrTag::Hash(hash);
+
+    let block = provider.get_block_with_txs(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_hash == hash);
+
+    let block = provider.get_block_with_receipts(id).await?;
+    assert_matches!(block, MaybePendingBlockWithReceipts::Block(b) if b.block_hash == hash);
+
+    let block = provider.get_block_with_tx_hashes(id).await?;
+    assert_matches!(block, MaybePendingBlockWithTxHashes::Block(b) if b.block_hash == hash);
+
+    let result = provider.get_block_transaction_count(id).await;
+    assert!(result.is_ok());
+
+    // TODO: uncomment this once we include genesis forked state update
+    // let state = provider.get_state_update(id).await?;
+    // assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
+
+    // -----------------------------------------------------------------------
+    // Get a block that is locally generated
+
+    for ((_, hash), _) in local_only_block {
+        let id = BlockIdOrTag::Hash(hash);
+
+        let block = provider.get_block_with_txs(id).await?;
+        assert_matches!(block, MaybePendingBlockWithTxs::Block(b) if b.block_hash == hash);
+
+        let block = provider.get_block_with_receipts(id).await?;
+        assert_matches!(block, MaybePendingBlockWithReceipts::Block(b) if b.block_hash == hash);
+
+        let block = provider.get_block_with_tx_hashes(id).await?;
+        assert_matches!(block, MaybePendingBlockWithTxHashes::Block(b) if b.block_hash == hash);
+
+        let result = provider.get_block_transaction_count(id).await;
+        assert!(result.is_ok());
+
+        // TODO: uncomment this once we include genesis forked state update
+        // let state = provider.get_state_update(id).await?;
+        // assert_matches!(state, starknet::core::types::MaybePendingStateUpdate::Update(_));
+    }
+
+    // -----------------------------------------------------------------------
+    // Get a block that only exist in the forked chain
+
+    // https://sepolia.voyager.online/block/0x347a9fa25700e7a2d8f26b39c0ecf765be9a78c559b9cae722a659f25182d10
+    // We only created 10 local blocks so this is fine.
+    let id = BlockIdOrTag::Number(270_328);
+    let result = provider.get_block_with_txs(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_with_receipts(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_with_tx_hashes(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_transaction_count(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_state_update(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    // -----------------------------------------------------------------------
+    // Get block that doesn't exist on the both the forked and local chain
+
+    let id = BlockIdOrTag::Number(i64::MAX as u64);
+    let result = provider.get_block_with_txs(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_with_receipts(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_with_tx_hashes(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_block_transaction_count(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
+    let result = provider.get_state_update(id).await.unwrap_err();
+    assert_provider_starknet_err!(result, StarknetError::BlockNotFound);
+
     Ok(())
 }
 
@@ -196,18 +331,41 @@ async fn forked_transactions() -> Result<()> {
     // https://sepolia.voyager.online/tx/0x81207d4244596678e186f6ab9c833fe40a4b35291e8a90b9a163f7f643df9f
     // Transaction in block num FORK_BLOCK_NUMBER - 1
     let tx_hash = felt!("0x81207d4244596678e186f6ab9c833fe40a4b35291e8a90b9a163f7f643df9f");
-    assert_get_transaction_methods(&provider, tx_hash).await?;
+
+    let tx = provider.get_transaction_by_hash(tx_hash).await?;
+    assert_eq!(*tx.transaction_hash(), tx_hash);
+
+    let tx = provider.get_transaction_receipt(tx_hash).await?;
+    assert_eq!(*tx.receipt.transaction_hash(), tx_hash);
+
+    let result = provider.get_transaction_status(tx_hash).await;
+    assert!(result.is_ok());
 
     // https://sepolia.voyager.online/tx/0x1b18d62544d4ef749befadabcec019d83218d3905abd321b4c1b1fc948d5710
     // Transaction in block num FORK_BLOCK_NUMBER - 2
     let tx_hash = felt!("0x1b18d62544d4ef749befadabcec019d83218d3905abd321b4c1b1fc948d5710");
-    assert_get_transaction_methods(&provider, tx_hash).await?;
+
+    let tx = provider.get_transaction_by_hash(tx_hash).await?;
+    assert_eq!(*tx.transaction_hash(), tx_hash);
+
+    let tx = provider.get_transaction_receipt(tx_hash).await?;
+    assert_eq!(*tx.receipt.transaction_hash(), tx_hash);
+
+    let result = provider.get_transaction_status(tx_hash).await;
+    assert!(result.is_ok());
 
     // -----------------------------------------------------------------------
     // Get the locally created transactions.
 
     for (_, tx_hash) in local_only_data {
-        assert_get_transaction_methods(&provider, tx_hash).await?;
+        let tx = provider.get_transaction_by_hash(tx_hash).await?;
+        assert_eq!(*tx.transaction_hash(), tx_hash);
+
+        let tx = provider.get_transaction_receipt(tx_hash).await?;
+        assert_eq!(*tx.receipt.transaction_hash(), tx_hash);
+
+        let result = provider.get_transaction_status(tx_hash).await;
+        assert!(result.is_ok());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
resolves #1466 

enable fetching block data from the forked chain. current forking feature only covers up to state data only. meaning doing any operations that requires only doing contract executions - estimate fee, tx execution - are allowed. 

this is a pretty simple solution as it just forwards the request to the forked network provider but doesn't do any caching of the requested data.

## Unsupported methods:

rpc methods that this PR doesn't yet cover.

- `getEvents`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `ForkedClient` for enhanced interaction with Starknet blockchain forks.
	- Added methods for fetching transactions and blocks, including support for pending state updates.

- **Bug Fixes**
	- Improved error handling in the Starknet API, allowing for better representation of various error types.

- **Documentation**
	- Updated method signatures and descriptions to reflect new functionalities and changes.

- **Tests**
	- Enhanced testing framework for forking functionality, ensuring robust validation of blockchain interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->