### PR TITLE
fix(sozo): fix profile detection and UI rework

### DIFF
--- a/bin/sozo/src/commands/execute.rs
+++ b/bin/sozo/src/commands/execute.rs
@@ -7,6 +7,7 @@ use dojo_types::naming;
 use dojo_utils::Invoker;
 use dojo_world::contracts::naming::ensure_namespace;
 use scarb::core::Config;
+use sozo_ops::migration_ui::MigrationUi;
 use sozo_scarbext::WorkspaceExt;
 use sozo_walnut::WalnutDebugger;
 use starknet::core::types::{Call, Felt};
@@ -79,11 +80,14 @@ impl ExecuteArgs {
         );
 
         config.tokio_handle().block_on(async {
+            let mut spinner = MigrationUi::new("").with_silent();
+
             let (world_diff, account, _) = utils::get_world_diff_and_account(
                 self.account,
                 self.starknet.clone(),
                 self.world,
                 &ws,
+                &mut spinner,
             )
             .await?;
 

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -100,7 +100,8 @@ pub struct Banner {
 
 /// Prints the migration banner.
 async fn print_banner(ws: &Workspace<'_>, starknet: &StarknetOptions) -> Result<()> {
-    let (provider, rpc_url) = starknet.provider(None)?;
+    let profile_config = ws.load_profile_config()?;
+    let (provider, rpc_url) = starknet.provider(profile_config.env.as_ref())?;
 
     let chain_id = provider.chain_id().await?;
     let chain_id = parse_cairo_short_string(&chain_id)

--- a/bin/sozo/src/commands/options/account/mod.rs
+++ b/bin/sozo/src/commands/options/account/mod.rs
@@ -106,8 +106,8 @@ impl AccountOptions {
         let account_address = self.account_address(env_metadata)?;
 
         let signer = self.signer.signer(env_metadata, false)?;
-        trace!(?signer, "Signer obtained.");
 
+        trace!("Fetching chain id...");
         let chain_id = provider.chain_id().await?;
         trace!(?chain_id);
 

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -9,6 +9,7 @@ use dojo_world::local::WorldLocal;
 use katana_rpc_api::starknet::RPC_SPEC_VERSION;
 use scarb::core::{TomlManifest, Workspace};
 use semver::Version;
+use sozo_ops::migration_ui::MigrationUi;
 use sozo_scarbext::WorkspaceExt;
 use starknet::accounts::{Account, ConnectedAccount};
 use starknet::core::types::Felt;
@@ -144,6 +145,7 @@ pub async fn get_world_diff_and_account(
     starknet: StarknetOptions,
     world: WorldOptions,
     ws: &Workspace<'_>,
+    ui: &mut MigrationUi,
 ) -> Result<(WorldDiff, SozoAccount<JsonRpcClient<HttpTransport>>, String)> {
     let profile_config = ws.load_profile_config()?;
     let env = profile_config.env.as_ref();
@@ -151,11 +153,16 @@ pub async fn get_world_diff_and_account(
     let (world_diff, provider, rpc_url) =
         get_world_diff_and_provider(starknet.clone(), world, ws).await?;
 
+    // Ensures we don't interfere with the spinner if a password must be prompted.
+    ui.stop();
+
     let account = {
         account
             .account(provider, world_diff.world_info.address, &starknet, env, &world_diff)
             .await?
     };
+
+    ui.restart("Verifying account...");
 
     if !dojo_utils::is_deployed(account.address(), &account.provider()).await? {
         return Err(anyhow!("Account with address {:#x} doesn't exist.", account.address()));

--- a/crates/dojo/utils/src/keystore.rs
+++ b/crates/dojo/utils/src/keystore.rs
@@ -8,6 +8,6 @@ pub fn prompt_password_if_needed(maybe_password: Option<&str>, no_wait: bool) ->
     } else if no_wait {
         Err(anyhow!("Could not find password. Please specify the password."))
     } else {
-        Ok(rpassword::prompt_password("Enter password: ")?.to_owned())
+        Ok(rpassword::prompt_password("Enter the keystore password: ")?.to_owned())
     }
 }

--- a/crates/dojo/world/src/local/artifact_to_local.rs
+++ b/crates/dojo/world/src/local/artifact_to_local.rs
@@ -21,6 +21,11 @@ const EVENT_INTF: &str = "dojo::event::interface::IEvent";
 
 impl WorldLocal {
     pub fn from_directory<P: AsRef<Path>>(dir: P, profile_config: ProfileConfig) -> Result<Self> {
+        trace!(
+            ?profile_config,
+            directory = %dir.as_ref().to_string_lossy(),
+            "Loading world from directory."
+        );
         let mut resources = vec![];
 
         let mut world_class = None;

--- a/crates/sozo/ops/src/lib.rs
+++ b/crates/sozo/ops/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod account;
 pub mod migrate;
+pub mod migration_ui;
 
 #[cfg(test)]
 pub mod tests;

--- a/crates/sozo/ops/src/migrate/mod.rs
+++ b/crates/sozo/ops/src/migrate/mod.rs
@@ -19,7 +19,6 @@
 //!    initialization of contracts can mutate resources.
 
 use std::collections::HashMap;
-use std::fmt;
 use std::str::FromStr;
 
 use cainome::cairo_serde::{ByteArray, ClassHash, ContractAddress};
@@ -30,13 +29,14 @@ use dojo_world::diff::{Manifest, ResourceDiff, WorldDiff, WorldStatus};
 use dojo_world::local::ResourceLocal;
 use dojo_world::remote::ResourceRemote;
 use dojo_world::{utils, ResourceType};
-use spinoff::Spinner;
 use starknet::accounts::{ConnectedAccount, SingleOwnerAccount};
 use starknet::core::types::{Call, FlattenedSierraClass};
 use starknet::providers::AnyProvider;
 use starknet::signers::LocalWallet;
 use starknet_crypto::Felt;
 use tracing::trace;
+
+use crate::migration_ui::MigrationUi;
 
 pub mod error;
 pub use error::MigrationError;
@@ -61,36 +61,6 @@ pub struct MigrationResult {
     pub manifest: Manifest,
 }
 
-pub enum MigrationUi {
-    Spinner(Spinner),
-    None,
-}
-
-impl fmt::Debug for MigrationUi {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Spinner(_) => write!(f, "Spinner"),
-            Self::None => write!(f, "None"),
-        }
-    }
-}
-
-impl MigrationUi {
-    pub fn update_text(&mut self, text: &'static str) {
-        match self {
-            Self::Spinner(s) => s.update_text(text),
-            Self::None => (),
-        }
-    }
-
-    pub fn stop_and_persist(&mut self, symbol: &'static str, text: &'static str) {
-        match self {
-            Self::Spinner(s) => s.stop_and_persist(symbol, text),
-            Self::None => (),
-        }
-    }
-}
-
 impl<A> Migration<A>
 where
     A: ConnectedAccount + Sync + Send,
@@ -113,23 +83,17 @@ where
     /// spinner.
     pub async fn migrate(
         &self,
-        spinner: &mut MigrationUi,
+        ui: &mut MigrationUi,
     ) -> Result<MigrationResult, MigrationError<A::SignError>> {
-        spinner.update_text("Deploying world...");
+        ui.update_text("Deploying world...");
         let world_has_changed = self.ensure_world().await?;
 
-        let resources_have_changed = if !self.diff.is_synced() {
-            spinner.update_text("Syncing resources...");
-            self.sync_resources().await?
-        } else {
-            false
-        };
+        let resources_have_changed =
+            if !self.diff.is_synced() { self.sync_resources(ui).await? } else { false };
 
-        spinner.update_text("Syncing permissions...");
-        let permissions_have_changed = self.sync_permissions().await?;
+        let permissions_have_changed = self.sync_permissions(ui).await?;
 
-        spinner.update_text("Initializing contracts...");
-        let contracts_have_changed = self.initialize_contracts().await?;
+        let contracts_have_changed = self.initialize_contracts(ui).await?;
 
         Ok(MigrationResult {
             has_changes: world_has_changed
@@ -152,7 +116,12 @@ where
     /// found in the [`ProfileConfig`].
     ///
     /// Returns true if at least one contract has been initialized, false otherwise.
-    async fn initialize_contracts(&self) -> Result<bool, MigrationError<A::SignError>> {
+    async fn initialize_contracts(
+        &self,
+        ui: &mut MigrationUi,
+    ) -> Result<bool, MigrationError<A::SignError>> {
+        ui.update_text("Initializing contracts...");
+
         let mut invoker = Invoker::new(&self.world.account, self.txn_config);
 
         let init_call_args = if let Some(init_call_args) = &self.profile_config.init_call_args {
@@ -235,10 +204,21 @@ where
 
         let has_changed = !invoker.calls.is_empty();
 
-        if self.do_multicall() {
-            invoker.multicall().await?;
-        } else {
-            invoker.invoke_all_sequentially().await?;
+        if !ordered_init_calls.is_empty() {
+            if self.do_multicall() {
+                let ui_text = format!("Initializing {} contracts...", ordered_init_calls.len());
+                ui.update_text_boxed(ui_text);
+
+                invoker.multicall().await?;
+            } else {
+                let ui_text = format!(
+                    "Initializing {} contracts (sequentially)...",
+                    ordered_init_calls.len()
+                );
+                ui.update_text_boxed(ui_text);
+
+                invoker.invoke_all_sequentially().await?;
+            }
         }
 
         Ok(has_changed)
@@ -257,7 +237,12 @@ where
     /// overlay resource, which can contain also writers.
     ///
     /// Returns true if at least one permission has changed, false otherwise.
-    async fn sync_permissions(&self) -> Result<bool, MigrationError<A::SignError>> {
+    async fn sync_permissions(
+        &self,
+        ui: &mut MigrationUi,
+    ) -> Result<bool, MigrationError<A::SignError>> {
+        ui.update_text("Syncing permissions...");
+
         let mut invoker = Invoker::new(&self.world.account, self.txn_config);
 
         // Only takes the local permissions that are not already set onchain to apply them.
@@ -296,8 +281,14 @@ where
         let has_changed = !invoker.calls.is_empty();
 
         if self.do_multicall() {
+            let ui_text = format!("Syncing {} permissions...", invoker.calls.len());
+            ui.update_text_boxed(ui_text);
+
             invoker.multicall().await?;
         } else {
+            let ui_text = format!("Syncing {} permissions (sequentially)...", invoker.calls.len());
+            ui.update_text_boxed(ui_text);
+
             invoker.invoke_all_sequentially().await?;
         }
 
@@ -307,13 +298,19 @@ where
     /// Syncs the resources by declaring the classes and registering/upgrading the resources.
     ///
     /// Returns true if at least one resource has changed, false otherwise.
-    async fn sync_resources(&self) -> Result<bool, MigrationError<A::SignError>> {
+    async fn sync_resources(
+        &self,
+        ui: &mut MigrationUi,
+    ) -> Result<bool, MigrationError<A::SignError>> {
+        ui.update_text("Syncing resources...");
+
         let mut invoker = Invoker::new(&self.world.account, self.txn_config);
 
         // Namespaces must be synced first, since contracts, models and events are namespaced.
         self.namespaces_getcalls(&mut invoker).await?;
 
         let mut classes: HashMap<Felt, FlattenedSierraClass> = HashMap::new();
+        let mut n_resources = 0;
 
         // Collects the calls and classes to be declared to sync the resources.
         for resource in self.diff.resources.values() {
@@ -327,16 +324,19 @@ where
                         self.contracts_calls_classes(resource).await?;
                     invoker.extend_calls(contract_calls);
                     classes.extend(contract_classes);
+                    n_resources += 1;
                 }
                 ResourceType::Model => {
                     let (model_calls, model_classes) = self.models_calls_classes(resource).await?;
                     invoker.extend_calls(model_calls);
                     classes.extend(model_classes);
+                    n_resources += 1;
                 }
                 ResourceType::Event => {
                     let (event_calls, event_classes) = self.events_calls_classes(resource).await?;
                     invoker.extend_calls(event_calls);
                     classes.extend(event_classes);
+                    n_resources += 1;
                 }
                 _ => continue,
             }
@@ -350,11 +350,16 @@ where
         // Since migrator account from `self.world.account` is under the [`ConnectedAccount`] trait,
         // we can group it with the predeployed accounts which are concrete types.
         let accounts = self.get_accounts().await;
+        let n_classes = classes.len();
 
         if accounts.is_empty() {
             trace!("Declaring classes with migrator account.");
             let mut declarer = Declarer::new(&self.world.account, self.txn_config);
             declarer.extend_classes(classes.into_iter().collect());
+
+            let ui_text = format!("Declaring {} classes...", n_classes);
+            ui.update_text_boxed(ui_text);
+
             declarer.declare_all().await?;
         } else {
             trace!("Declaring classes with {} accounts.", accounts.len());
@@ -367,6 +372,10 @@ where
                 let declarer_idx = idx % declarers.len();
                 declarers[declarer_idx].add_class(casm_class_hash, class);
             }
+
+            let ui_text =
+                format!("Declaring {} classes with {} accounts...", n_classes, declarers.len());
+            ui.update_text_boxed(ui_text);
 
             let declarers_futures =
                 futures::future::join_all(declarers.into_iter().map(|d| d.declare_all())).await;
@@ -388,8 +397,14 @@ where
         }
 
         if self.do_multicall() {
+            let ui_text = format!("Registering {} resources...", n_resources);
+            ui.update_text_boxed(ui_text);
+
             invoker.multicall().await?;
         } else {
+            let ui_text = format!("Registering {} resources (sequentially)...", n_resources);
+            ui.update_text_boxed(ui_text);
+
             invoker.invoke_all_sequentially().await?;
         }
 

--- a/crates/sozo/ops/src/migration_ui.rs
+++ b/crates/sozo/ops/src/migration_ui.rs
@@ -1,0 +1,80 @@
+//! A simple UI for the migration that can be used to display a spinner.
+
+use std::fmt;
+
+use spinoff::spinners::SpinnerFrames;
+use spinoff::{spinner, spinners, Spinner};
+
+/// A simple UI for the migration that can be used to display a spinner.
+pub struct MigrationUi {
+    spinner: Spinner,
+    default_frames: SpinnerFrames,
+    silent: bool,
+}
+
+impl fmt::Debug for MigrationUi {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "spinner silent: {}", self.silent)
+    }
+}
+
+impl MigrationUi {
+    /// Returns a new instance with the default frames.
+    pub fn new(text: &'static str) -> Self {
+        let frames = spinner!(["⛩️ ", "🎃", "👻", "🧟", "💀"], 500);
+        let spinner = Spinner::new(frames.clone(), text, None);
+        Self { spinner, default_frames: frames, silent: false }
+    }
+
+    /// Returns a new instance with the silent flag set.
+    pub fn with_silent(mut self) -> Self {
+        self.silent = true;
+        self
+    }
+
+    /// Updates the text of the spinner.
+    pub fn update_text(&mut self, text: &'static str) {
+        if self.silent {
+            return;
+        }
+
+        self.spinner.update_text(text);
+    }
+
+    /// Updates the text of the spinner with a boxed string.
+    pub fn update_text_boxed(&mut self, text: String) {
+        self.update_text(Box::leak(text.into_boxed_str()));
+    }
+
+    /// Stops the spinner and persists the text.
+    pub fn stop_and_persist_boxed(&mut self, symbol: &'static str, text: String) {
+        self.stop_and_persist(symbol, Box::leak(text.into_boxed_str()));
+    }
+
+    /// Stops the spinner and persists the text.
+    pub fn stop_and_persist(&mut self, symbol: &'static str, text: &'static str) {
+        if self.silent {
+            return;
+        }
+
+        self.spinner.stop_and_persist(symbol, text);
+    }
+
+    /// Stops the spinner without additional text.
+    pub fn stop(&mut self) {
+        if self.silent {
+            return;
+        }
+
+        self.spinner.stop();
+    }
+
+    /// Restarts the spinner with the default frames if it has been stopped.
+    pub fn restart(&mut self, text: &'static str) {
+        if self.silent {
+            return;
+        }
+
+        self.spinner = Spinner::new(self.default_frames.clone(), text, None);
+    }
+}

--- a/examples/simple/Scarb.toml
+++ b/examples/simple/Scarb.toml
@@ -17,3 +17,5 @@ dojo_cairo_test = { path = "../../crates/dojo/core-cairo-test" }
 
 [features]
 default = []
+
+[profile.sepolia]

--- a/examples/simple/dojo_sepolia.toml
+++ b/examples/simple/dojo_sepolia.toml
@@ -1,13 +1,13 @@
 [world]
 description = "Simple world."
 name = "simple"
-seed = "simple"
+seed = "simple2"
 
 [env]
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
 # Default account for katana with seed = 0
 account_address = "0x4ba5ae775eb7da75f092b3b30b03bce15c3476337ef5f9e3cdf18db7a7534bd"
-keystore_path = "/Users/glihm/.snaccounts/glihm-sepolia.key"
+keystore_path = "/path/keystore"
 #world_address = "0x077c0dc7c1aba7f8842aff393ce6aa71fa675b4ced1bc927f7fc971b6acd92fc"
 
 [namespace]

--- a/examples/simple/dojo_sepolia.toml
+++ b/examples/simple/dojo_sepolia.toml
@@ -1,0 +1,30 @@
+[world]
+description = "Simple world."
+name = "simple"
+seed = "simple"
+
+[env]
+rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
+# Default account for katana with seed = 0
+account_address = "0x4ba5ae775eb7da75f092b3b30b03bce15c3476337ef5f9e3cdf18db7a7534bd"
+keystore_path = "/path/sepolia.key"
+#world_address = "0x077c0dc7c1aba7f8842aff393ce6aa71fa675b4ced1bc927f7fc971b6acd92fc"
+
+[namespace]
+default = "ns"
+mappings = { "ns" = ["c1", "M"], "ns2" = ["c1", "M"] }
+
+[init_call_args]
+"ns-c1" = ["0xfffe"]
+"ns2-c1" = ["0xfffe"]
+
+[writers]
+"ns" = ["ns-c1", "ns-c2"]
+"ns-M" = ["ns-c2",  "ns-c1", "ns2-c1"]
+
+[owners]
+"ns" = ["ns-c1"]
+
+[migration]
+order_inits = ["ns-c2", "ns-c1"]
+skip_contracts = ["ns-c3"]

--- a/examples/simple/dojo_sepolia.toml
+++ b/examples/simple/dojo_sepolia.toml
@@ -7,7 +7,7 @@ seed = "simple"
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
 # Default account for katana with seed = 0
 account_address = "0x4ba5ae775eb7da75f092b3b30b03bce15c3476337ef5f9e3cdf18db7a7534bd"
-keystore_path = "/path/sepolia.key"
+keystore_path = "/Users/glihm/.snaccounts/glihm-sepolia.key"
 #world_address = "0x077c0dc7c1aba7f8842aff393ce6aa71fa675b4ced1bc927f7fc971b6acd92fc"
 
 [namespace]

--- a/examples/simple/manifest_sepolia.json
+++ b/examples/simple/manifest_sepolia.json
@@ -1,0 +1,1956 @@
+{
+  "world": {
+    "class_hash": "0x139239a99d627697b19b9856beaef7896fc75375caf3d750dd76982a7afeb78",
+    "address": "0x4bb1b5116e5ed181392417f0c18ade13246cb30447e4dba0f8421c80bb77e2e",
+    "seed": "simple",
+    "name": "simple",
+    "abi": [
+      {
+        "type": "impl",
+        "name": "World",
+        "interface_name": "dojo::world::iworld::IWorld"
+      },
+      {
+        "type": "struct",
+        "name": "core::byte_array::ByteArray",
+        "members": [
+          {
+            "name": "data",
+            "type": "core::array::Array::<core::bytes_31::bytes31>"
+          },
+          {
+            "name": "pending_word",
+            "type": "core::felt252"
+          },
+          {
+            "name": "pending_word_len",
+            "type": "core::integer::u32"
+          }
+        ]
+      },
+      {
+        "type": "enum",
+        "name": "dojo::world::resource::Resource",
+        "variants": [
+          {
+            "name": "Model",
+            "type": "(core::starknet::contract_address::ContractAddress, core::felt252)"
+          },
+          {
+            "name": "Event",
+            "type": "(core::starknet::contract_address::ContractAddress, core::felt252)"
+          },
+          {
+            "name": "Contract",
+            "type": "(core::starknet::contract_address::ContractAddress, core::felt252)"
+          },
+          {
+            "name": "Namespace",
+            "type": "core::byte_array::ByteArray"
+          },
+          {
+            "name": "World",
+            "type": "()"
+          },
+          {
+            "name": "Unregistered",
+            "type": "()"
+          }
+        ]
+      },
+      {
+        "type": "struct",
+        "name": "dojo::model::metadata::ResourceMetadata",
+        "members": [
+          {
+            "name": "resource_id",
+            "type": "core::felt252"
+          },
+          {
+            "name": "metadata_uri",
+            "type": "core::byte_array::ByteArray"
+          }
+        ]
+      },
+      {
+        "type": "struct",
+        "name": "core::array::Span::<core::felt252>",
+        "members": [
+          {
+            "name": "snapshot",
+            "type": "@core::array::Array::<core::felt252>"
+          }
+        ]
+      },
+      {
+        "type": "enum",
+        "name": "core::bool",
+        "variants": [
+          {
+            "name": "False",
+            "type": "()"
+          },
+          {
+            "name": "True",
+            "type": "()"
+          }
+        ]
+      },
+      {
+        "type": "enum",
+        "name": "dojo::model::definition::ModelIndex",
+        "variants": [
+          {
+            "name": "Keys",
+            "type": "core::array::Span::<core::felt252>"
+          },
+          {
+            "name": "Id",
+            "type": "core::felt252"
+          },
+          {
+            "name": "MemberId",
+            "type": "(core::felt252, core::felt252)"
+          }
+        ]
+      },
+      {
+        "type": "struct",
+        "name": "core::array::Span::<core::integer::u8>",
+        "members": [
+          {
+            "name": "snapshot",
+            "type": "@core::array::Array::<core::integer::u8>"
+          }
+        ]
+      },
+      {
+        "type": "struct",
+        "name": "dojo::meta::layout::FieldLayout",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252"
+          },
+          {
+            "name": "layout",
+            "type": "dojo::meta::layout::Layout"
+          }
+        ]
+      },
+      {
+        "type": "struct",
+        "name": "core::array::Span::<dojo::meta::layout::FieldLayout>",
+        "members": [
+          {
+            "name": "snapshot",
+            "type": "@core::array::Array::<dojo::meta::layout::FieldLayout>"
+          }
+        ]
+      },
+      {
+        "type": "struct",
+        "name": "core::array::Span::<dojo::meta::layout::Layout>",
+        "members": [
+          {
+            "name": "snapshot",
+            "type": "@core::array::Array::<dojo::meta::layout::Layout>"
+          }
+        ]
+      },
+      {
+        "type": "enum",
+        "name": "dojo::meta::layout::Layout",
+        "variants": [
+          {
+            "name": "Fixed",
+            "type": "core::array::Span::<core::integer::u8>"
+          },
+          {
+            "name": "Struct",
+            "type": "core::array::Span::<dojo::meta::layout::FieldLayout>"
+          },
+          {
+            "name": "Tuple",
+            "type": "core::array::Span::<dojo::meta::layout::Layout>"
+          },
+          {
+            "name": "Array",
+            "type": "core::array::Span::<dojo::meta::layout::Layout>"
+          },
+          {
+            "name": "ByteArray",
+            "type": "()"
+          },
+          {
+            "name": "Enum",
+            "type": "core::array::Span::<dojo::meta::layout::FieldLayout>"
+          }
+        ]
+      },
+      {
+        "type": "interface",
+        "name": "dojo::world::iworld::IWorld",
+        "items": [
+          {
+            "type": "function",
+            "name": "resource",
+            "inputs": [
+              {
+                "name": "selector",
+                "type": "core::felt252"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "dojo::world::resource::Resource"
+              }
+            ],
+            "state_mutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "uuid",
+            "inputs": [],
+            "outputs": [
+              {
+                "type": "core::integer::u32"
+              }
+            ],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "metadata",
+            "inputs": [
+              {
+                "name": "resource_selector",
+                "type": "core::felt252"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "dojo::model::metadata::ResourceMetadata"
+              }
+            ],
+            "state_mutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "set_metadata",
+            "inputs": [
+              {
+                "name": "metadata",
+                "type": "dojo::model::metadata::ResourceMetadata"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "register_namespace",
+            "inputs": [
+              {
+                "name": "namespace",
+                "type": "core::byte_array::ByteArray"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "register_event",
+            "inputs": [
+              {
+                "name": "namespace",
+                "type": "core::byte_array::ByteArray"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "register_model",
+            "inputs": [
+              {
+                "name": "namespace",
+                "type": "core::byte_array::ByteArray"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "register_contract",
+            "inputs": [
+              {
+                "name": "salt",
+                "type": "core::felt252"
+              },
+              {
+                "name": "namespace",
+                "type": "core::byte_array::ByteArray"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "init_contract",
+            "inputs": [
+              {
+                "name": "selector",
+                "type": "core::felt252"
+              },
+              {
+                "name": "init_calldata",
+                "type": "core::array::Span::<core::felt252>"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "upgrade_event",
+            "inputs": [
+              {
+                "name": "namespace",
+                "type": "core::byte_array::ByteArray"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "upgrade_model",
+            "inputs": [
+              {
+                "name": "namespace",
+                "type": "core::byte_array::ByteArray"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "upgrade_contract",
+            "inputs": [
+              {
+                "name": "namespace",
+                "type": "core::byte_array::ByteArray"
+              },
+              {
+                "name": "class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "emit_event",
+            "inputs": [
+              {
+                "name": "event_selector",
+                "type": "core::felt252"
+              },
+              {
+                "name": "keys",
+                "type": "core::array::Span::<core::felt252>"
+              },
+              {
+                "name": "values",
+                "type": "core::array::Span::<core::felt252>"
+              },
+              {
+                "name": "historical",
+                "type": "core::bool"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "entity",
+            "inputs": [
+              {
+                "name": "model_selector",
+                "type": "core::felt252"
+              },
+              {
+                "name": "index",
+                "type": "dojo::model::definition::ModelIndex"
+              },
+              {
+                "name": "layout",
+                "type": "dojo::meta::layout::Layout"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::array::Span::<core::felt252>"
+              }
+            ],
+            "state_mutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "set_entity",
+            "inputs": [
+              {
+                "name": "model_selector",
+                "type": "core::felt252"
+              },
+              {
+                "name": "index",
+                "type": "dojo::model::definition::ModelIndex"
+              },
+              {
+                "name": "values",
+                "type": "core::array::Span::<core::felt252>"
+              },
+              {
+                "name": "layout",
+                "type": "dojo::meta::layout::Layout"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "delete_entity",
+            "inputs": [
+              {
+                "name": "model_selector",
+                "type": "core::felt252"
+              },
+              {
+                "name": "index",
+                "type": "dojo::model::definition::ModelIndex"
+              },
+              {
+                "name": "layout",
+                "type": "dojo::meta::layout::Layout"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "is_owner",
+            "inputs": [
+              {
+                "name": "resource",
+                "type": "core::felt252"
+              },
+              {
+                "name": "address",
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::bool"
+              }
+            ],
+            "state_mutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "grant_owner",
+            "inputs": [
+              {
+                "name": "resource",
+                "type": "core::felt252"
+              },
+              {
+                "name": "address",
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "revoke_owner",
+            "inputs": [
+              {
+                "name": "resource",
+                "type": "core::felt252"
+              },
+              {
+                "name": "address",
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "is_writer",
+            "inputs": [
+              {
+                "name": "resource",
+                "type": "core::felt252"
+              },
+              {
+                "name": "contract",
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "outputs": [
+              {
+                "type": "core::bool"
+              }
+            ],
+            "state_mutability": "view"
+          },
+          {
+            "type": "function",
+            "name": "grant_writer",
+            "inputs": [
+              {
+                "name": "resource",
+                "type": "core::felt252"
+              },
+              {
+                "name": "contract",
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          },
+          {
+            "type": "function",
+            "name": "revoke_writer",
+            "inputs": [
+              {
+                "name": "resource",
+                "type": "core::felt252"
+              },
+              {
+                "name": "contract",
+                "type": "core::starknet::contract_address::ContractAddress"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          }
+        ]
+      },
+      {
+        "type": "impl",
+        "name": "UpgradeableWorld",
+        "interface_name": "dojo::world::iworld::IUpgradeableWorld"
+      },
+      {
+        "type": "interface",
+        "name": "dojo::world::iworld::IUpgradeableWorld",
+        "items": [
+          {
+            "type": "function",
+            "name": "upgrade",
+            "inputs": [
+              {
+                "name": "new_class_hash",
+                "type": "core::starknet::class_hash::ClassHash"
+              }
+            ],
+            "outputs": [],
+            "state_mutability": "external"
+          }
+        ]
+      },
+      {
+        "type": "constructor",
+        "name": "constructor",
+        "inputs": [
+          {
+            "name": "world_class_hash",
+            "type": "core::starknet::class_hash::ClassHash"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::WorldSpawned",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "creator",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          },
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::WorldUpgraded",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::NamespaceRegistered",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "namespace",
+            "type": "core::byte_array::ByteArray",
+            "kind": "key"
+          },
+          {
+            "name": "hash",
+            "type": "core::felt252",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::ModelRegistered",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray",
+            "kind": "key"
+          },
+          {
+            "name": "namespace",
+            "type": "core::byte_array::ByteArray",
+            "kind": "key"
+          },
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          },
+          {
+            "name": "address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::EventRegistered",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray",
+            "kind": "key"
+          },
+          {
+            "name": "namespace",
+            "type": "core::byte_array::ByteArray",
+            "kind": "key"
+          },
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          },
+          {
+            "name": "address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::ContractRegistered",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "name",
+            "type": "core::byte_array::ByteArray",
+            "kind": "key"
+          },
+          {
+            "name": "namespace",
+            "type": "core::byte_array::ByteArray",
+            "kind": "key"
+          },
+          {
+            "name": "address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          },
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          },
+          {
+            "name": "salt",
+            "type": "core::felt252",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::ModelUpgraded",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          },
+          {
+            "name": "address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          },
+          {
+            "name": "prev_address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::EventUpgraded",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          },
+          {
+            "name": "address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          },
+          {
+            "name": "prev_address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::ContractUpgraded",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "class_hash",
+            "type": "core::starknet::class_hash::ClassHash",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::ContractInitialized",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "init_calldata",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::EventEmitted",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "system_address",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "key"
+          },
+          {
+            "name": "historical",
+            "type": "core::bool",
+            "kind": "key"
+          },
+          {
+            "name": "keys",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          },
+          {
+            "name": "values",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::MetadataUpdate",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "resource",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "uri",
+            "type": "core::byte_array::ByteArray",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::StoreSetRecord",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "entity_id",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "keys",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          },
+          {
+            "name": "values",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::StoreUpdateRecord",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "entity_id",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "values",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::StoreUpdateMember",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "entity_id",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "member_selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "values",
+            "type": "core::array::Span::<core::felt252>",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::StoreDelRecord",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "selector",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "entity_id",
+            "type": "core::felt252",
+            "kind": "key"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::WriterUpdated",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "resource",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "contract",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "key"
+          },
+          {
+            "name": "value",
+            "type": "core::bool",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::OwnerUpdated",
+        "kind": "struct",
+        "members": [
+          {
+            "name": "resource",
+            "type": "core::felt252",
+            "kind": "key"
+          },
+          {
+            "name": "contract",
+            "type": "core::starknet::contract_address::ContractAddress",
+            "kind": "key"
+          },
+          {
+            "name": "value",
+            "type": "core::bool",
+            "kind": "data"
+          }
+        ]
+      },
+      {
+        "type": "event",
+        "name": "dojo::world::world_contract::world::Event",
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "WorldSpawned",
+            "type": "dojo::world::world_contract::world::WorldSpawned",
+            "kind": "nested"
+          },
+          {
+            "name": "WorldUpgraded",
+            "type": "dojo::world::world_contract::world::WorldUpgraded",
+            "kind": "nested"
+          },
+          {
+            "name": "NamespaceRegistered",
+            "type": "dojo::world::world_contract::world::NamespaceRegistered",
+            "kind": "nested"
+          },
+          {
+            "name": "ModelRegistered",
+            "type": "dojo::world::world_contract::world::ModelRegistered",
+            "kind": "nested"
+          },
+          {
+            "name": "EventRegistered",
+            "type": "dojo::world::world_contract::world::EventRegistered",
+            "kind": "nested"
+          },
+          {
+            "name": "ContractRegistered",
+            "type": "dojo::world::world_contract::world::ContractRegistered",
+            "kind": "nested"
+          },
+          {
+            "name": "ModelUpgraded",
+            "type": "dojo::world::world_contract::world::ModelUpgraded",
+            "kind": "nested"
+          },
+          {
+            "name": "EventUpgraded",
+            "type": "dojo::world::world_contract::world::EventUpgraded",
+            "kind": "nested"
+          },
+          {
+            "name": "ContractUpgraded",
+            "type": "dojo::world::world_contract::world::ContractUpgraded",
+            "kind": "nested"
+          },
+          {
+            "name": "ContractInitialized",
+            "type": "dojo::world::world_contract::world::ContractInitialized",
+            "kind": "nested"
+          },
+          {
+            "name": "EventEmitted",
+            "type": "dojo::world::world_contract::world::EventEmitted",
+            "kind": "nested"
+          },
+          {
+            "name": "MetadataUpdate",
+            "type": "dojo::world::world_contract::world::MetadataUpdate",
+            "kind": "nested"
+          },
+          {
+            "name": "StoreSetRecord",
+            "type": "dojo::world::world_contract::world::StoreSetRecord",
+            "kind": "nested"
+          },
+          {
+            "name": "StoreUpdateRecord",
+            "type": "dojo::world::world_contract::world::StoreUpdateRecord",
+            "kind": "nested"
+          },
+          {
+            "name": "StoreUpdateMember",
+            "type": "dojo::world::world_contract::world::StoreUpdateMember",
+            "kind": "nested"
+          },
+          {
+            "name": "StoreDelRecord",
+            "type": "dojo::world::world_contract::world::StoreDelRecord",
+            "kind": "nested"
+          },
+          {
+            "name": "WriterUpdated",
+            "type": "dojo::world::world_contract::world::WriterUpdated",
+            "kind": "nested"
+          },
+          {
+            "name": "OwnerUpdated",
+            "type": "dojo::world::world_contract::world::OwnerUpdated",
+            "kind": "nested"
+          }
+        ]
+      }
+    ]
+  },
+  "contracts": [
+    {
+      "address": "0x16501c6eeae49a38af2a34e8c50a5ba6ac08c655e9c9b77b1306aad73aaca9d",
+      "class_hash": "0x13767b87a8459556babbcf8cbdf2800181b462ef47f6fdafc14fc14fc1dae57",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "c1__ContractImpl",
+          "interface_name": "dojo::contract::interface::IContract"
+        },
+        {
+          "type": "struct",
+          "name": "core::byte_array::ByteArray",
+          "members": [
+            {
+              "name": "data",
+              "type": "core::array::Array::<core::bytes_31::bytes31>"
+            },
+            {
+              "name": "pending_word",
+              "type": "core::felt252"
+            },
+            {
+              "name": "pending_word_len",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::interface::IContract",
+          "items": [
+            {
+              "type": "function",
+              "name": "dojo_name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "dojo_init",
+          "inputs": [
+            {
+              "name": "v",
+              "type": "core::felt252"
+            }
+          ],
+          "outputs": [],
+          "state_mutability": "view"
+        },
+        {
+          "type": "impl",
+          "name": "MyInterfaceImpl",
+          "interface_name": "dojo_simple::MyInterface"
+        },
+        {
+          "type": "interface",
+          "name": "dojo_simple::MyInterface",
+          "items": [
+            {
+              "type": "function",
+              "name": "system_1",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                },
+                {
+                  "name": "v",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "system_2",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "system_3",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                },
+                {
+                  "name": "v",
+                  "type": "core::integer::u32"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "system_4",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "WorldProviderImpl",
+          "interface_name": "dojo::contract::components::world_provider::IWorldProvider"
+        },
+        {
+          "type": "struct",
+          "name": "dojo::world::iworld::IWorldDispatcher",
+          "members": [
+            {
+              "name": "contract_address",
+              "type": "core::starknet::contract_address::ContractAddress"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::world_provider::IWorldProvider",
+          "items": [
+            {
+              "type": "function",
+              "name": "world_dispatcher",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::world::iworld::IWorldDispatcher"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "UpgradeableImpl",
+          "interface_name": "dojo::contract::components::upgradeable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::upgradeable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "constructor",
+          "name": "constructor",
+          "inputs": []
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "class_hash",
+              "type": "core::starknet::class_hash::ClassHash",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "Upgraded",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+              "kind": "nested"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+          "kind": "enum",
+          "variants": []
+        },
+        {
+          "type": "event",
+          "name": "dojo_simple::c1::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "UpgradeableEvent",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+              "kind": "nested"
+            },
+            {
+              "name": "WorldProviderEvent",
+              "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+              "kind": "nested"
+            }
+          ]
+        }
+      ],
+      "init_calldata": [
+        "0xfffe"
+      ],
+      "tag": "ns-c1",
+      "systems": []
+    },
+    {
+      "address": "0x707ff87e1260619aa7c41ebd7f12a32d8cc358565e539c9f7b85140af3ca285",
+      "class_hash": "0x1eef253239f61c49444c41990940fa8fee51b021d19e48c20d31f45bc465d46",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "c2__ContractImpl",
+          "interface_name": "dojo::contract::interface::IContract"
+        },
+        {
+          "type": "struct",
+          "name": "core::byte_array::ByteArray",
+          "members": [
+            {
+              "name": "data",
+              "type": "core::array::Array::<core::bytes_31::bytes31>"
+            },
+            {
+              "name": "pending_word",
+              "type": "core::felt252"
+            },
+            {
+              "name": "pending_word_len",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::interface::IContract",
+          "items": [
+            {
+              "type": "function",
+              "name": "dojo_name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "dojo_init",
+          "inputs": [],
+          "outputs": [],
+          "state_mutability": "view"
+        },
+        {
+          "type": "impl",
+          "name": "WorldProviderImpl",
+          "interface_name": "dojo::contract::components::world_provider::IWorldProvider"
+        },
+        {
+          "type": "struct",
+          "name": "dojo::world::iworld::IWorldDispatcher",
+          "members": [
+            {
+              "name": "contract_address",
+              "type": "core::starknet::contract_address::ContractAddress"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::world_provider::IWorldProvider",
+          "items": [
+            {
+              "type": "function",
+              "name": "world_dispatcher",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::world::iworld::IWorldDispatcher"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "UpgradeableImpl",
+          "interface_name": "dojo::contract::components::upgradeable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::upgradeable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "constructor",
+          "name": "constructor",
+          "inputs": []
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "class_hash",
+              "type": "core::starknet::class_hash::ClassHash",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "Upgraded",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+              "kind": "nested"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+          "kind": "enum",
+          "variants": []
+        },
+        {
+          "type": "event",
+          "name": "dojo_simple::c2::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "UpgradeableEvent",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+              "kind": "nested"
+            },
+            {
+              "name": "WorldProviderEvent",
+              "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+              "kind": "nested"
+            }
+          ]
+        }
+      ],
+      "init_calldata": [],
+      "tag": "ns-c2",
+      "systems": []
+    },
+    {
+      "address": "0x41c67324187d806f29b4d02be6b358b9d0f68db4ae070d826d3a8149feba80f",
+      "class_hash": "0x4be29e651d49e58fba33f71ab6fe7fe101ee811842d07852b70d43a407fef2a",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "c3__ContractImpl",
+          "interface_name": "dojo::contract::interface::IContract"
+        },
+        {
+          "type": "struct",
+          "name": "core::byte_array::ByteArray",
+          "members": [
+            {
+              "name": "data",
+              "type": "core::array::Array::<core::bytes_31::bytes31>"
+            },
+            {
+              "name": "pending_word",
+              "type": "core::felt252"
+            },
+            {
+              "name": "pending_word_len",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::interface::IContract",
+          "items": [
+            {
+              "type": "function",
+              "name": "dojo_name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "dojo_init",
+          "inputs": [],
+          "outputs": [],
+          "state_mutability": "view"
+        },
+        {
+          "type": "impl",
+          "name": "WorldProviderImpl",
+          "interface_name": "dojo::contract::components::world_provider::IWorldProvider"
+        },
+        {
+          "type": "struct",
+          "name": "dojo::world::iworld::IWorldDispatcher",
+          "members": [
+            {
+              "name": "contract_address",
+              "type": "core::starknet::contract_address::ContractAddress"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::world_provider::IWorldProvider",
+          "items": [
+            {
+              "type": "function",
+              "name": "world_dispatcher",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::world::iworld::IWorldDispatcher"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "UpgradeableImpl",
+          "interface_name": "dojo::contract::components::upgradeable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::upgradeable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "constructor",
+          "name": "constructor",
+          "inputs": []
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "class_hash",
+              "type": "core::starknet::class_hash::ClassHash",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "Upgraded",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+              "kind": "nested"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+          "kind": "enum",
+          "variants": []
+        },
+        {
+          "type": "event",
+          "name": "dojo_simple::c3::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "UpgradeableEvent",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+              "kind": "nested"
+            },
+            {
+              "name": "WorldProviderEvent",
+              "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+              "kind": "nested"
+            }
+          ]
+        }
+      ],
+      "init_calldata": [],
+      "tag": "ns-c3",
+      "systems": []
+    },
+    {
+      "address": "0x5d52f8c5bd309ba73977008086d7c7f9c0d2991d2e29e96f01f99bf2065f88e",
+      "class_hash": "0x13767b87a8459556babbcf8cbdf2800181b462ef47f6fdafc14fc14fc1dae57",
+      "abi": [
+        {
+          "type": "impl",
+          "name": "c1__ContractImpl",
+          "interface_name": "dojo::contract::interface::IContract"
+        },
+        {
+          "type": "struct",
+          "name": "core::byte_array::ByteArray",
+          "members": [
+            {
+              "name": "data",
+              "type": "core::array::Array::<core::bytes_31::bytes31>"
+            },
+            {
+              "name": "pending_word",
+              "type": "core::felt252"
+            },
+            {
+              "name": "pending_word_len",
+              "type": "core::integer::u32"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::interface::IContract",
+          "items": [
+            {
+              "type": "function",
+              "name": "dojo_name",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "core::byte_array::ByteArray"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "function",
+          "name": "dojo_init",
+          "inputs": [
+            {
+              "name": "v",
+              "type": "core::felt252"
+            }
+          ],
+          "outputs": [],
+          "state_mutability": "view"
+        },
+        {
+          "type": "impl",
+          "name": "MyInterfaceImpl",
+          "interface_name": "dojo_simple::MyInterface"
+        },
+        {
+          "type": "interface",
+          "name": "dojo_simple::MyInterface",
+          "items": [
+            {
+              "type": "function",
+              "name": "system_1",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                },
+                {
+                  "name": "v",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "system_2",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [
+                {
+                  "type": "core::felt252"
+                }
+              ],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "system_3",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                },
+                {
+                  "name": "v",
+                  "type": "core::integer::u32"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            },
+            {
+              "type": "function",
+              "name": "system_4",
+              "inputs": [
+                {
+                  "name": "k",
+                  "type": "core::felt252"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "WorldProviderImpl",
+          "interface_name": "dojo::contract::components::world_provider::IWorldProvider"
+        },
+        {
+          "type": "struct",
+          "name": "dojo::world::iworld::IWorldDispatcher",
+          "members": [
+            {
+              "name": "contract_address",
+              "type": "core::starknet::contract_address::ContractAddress"
+            }
+          ]
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::world_provider::IWorldProvider",
+          "items": [
+            {
+              "type": "function",
+              "name": "world_dispatcher",
+              "inputs": [],
+              "outputs": [
+                {
+                  "type": "dojo::world::iworld::IWorldDispatcher"
+                }
+              ],
+              "state_mutability": "view"
+            }
+          ]
+        },
+        {
+          "type": "impl",
+          "name": "UpgradeableImpl",
+          "interface_name": "dojo::contract::components::upgradeable::IUpgradeable"
+        },
+        {
+          "type": "interface",
+          "name": "dojo::contract::components::upgradeable::IUpgradeable",
+          "items": [
+            {
+              "type": "function",
+              "name": "upgrade",
+              "inputs": [
+                {
+                  "name": "new_class_hash",
+                  "type": "core::starknet::class_hash::ClassHash"
+                }
+              ],
+              "outputs": [],
+              "state_mutability": "external"
+            }
+          ]
+        },
+        {
+          "type": "constructor",
+          "name": "constructor",
+          "inputs": []
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+          "kind": "struct",
+          "members": [
+            {
+              "name": "class_hash",
+              "type": "core::starknet::class_hash::ClassHash",
+              "kind": "data"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "Upgraded",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Upgraded",
+              "kind": "nested"
+            }
+          ]
+        },
+        {
+          "type": "event",
+          "name": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+          "kind": "enum",
+          "variants": []
+        },
+        {
+          "type": "event",
+          "name": "dojo_simple::c1::Event",
+          "kind": "enum",
+          "variants": [
+            {
+              "name": "UpgradeableEvent",
+              "type": "dojo::contract::components::upgradeable::upgradeable_cpt::Event",
+              "kind": "nested"
+            },
+            {
+              "name": "WorldProviderEvent",
+              "type": "dojo::contract::components::world_provider::world_provider_cpt::Event",
+              "kind": "nested"
+            }
+          ]
+        }
+      ],
+      "init_calldata": [
+        "0xfffe"
+      ],
+      "tag": "ns2-c1",
+      "systems": []
+    }
+  ],
+  "models": [
+    {
+      "members": [],
+      "class_hash": "0xb35ce9998d1524acfc8b0318aed7375b0d977b6362a2f7af23be2950aa96fd",
+      "tag": "M"
+    },
+    {
+      "members": [],
+      "class_hash": "0xb35ce9998d1524acfc8b0318aed7375b0d977b6362a2f7af23be2950aa96fd",
+      "tag": "M"
+    }
+  ],
+  "events": [
+    {
+      "members": [],
+      "class_hash": "0x65aa33d998d733abc890ee36503fe1df8e7c01f2cf1a92b147bd424a1af56d7",
+      "tag": "E"
+    },
+    {
+      "members": [],
+      "class_hash": "0x58568a90180a44515609dbaf69bb0c1aa56f29e93688f4bfdab10268fe68ce1",
+      "tag": "EH"
+    }
+  ]
+}

--- a/examples/simple/manifest_sepolia.json
+++ b/examples/simple/manifest_sepolia.json
@@ -1,8 +1,8 @@
 {
   "world": {
     "class_hash": "0x139239a99d627697b19b9856beaef7896fc75375caf3d750dd76982a7afeb78",
-    "address": "0x4bb1b5116e5ed181392417f0c18ade13246cb30447e4dba0f8421c80bb77e2e",
-    "seed": "simple",
+    "address": "0x1f21e5883353346629ec313c950e998982c12411c1d86e12b97bf26540760c1",
+    "seed": "simple2",
     "name": "simple",
     "abi": [
       {
@@ -1121,7 +1121,7 @@
   },
   "contracts": [
     {
-      "address": "0x16501c6eeae49a38af2a34e8c50a5ba6ac08c655e9c9b77b1306aad73aaca9d",
+      "address": "0x79e0b2874810d3b146a6d992a77ce30637d9868b7399ef772d5c09323cf8a81",
       "class_hash": "0x13767b87a8459556babbcf8cbdf2800181b462ef47f6fdafc14fc14fc1dae57",
       "abi": [
         {
@@ -1362,7 +1362,7 @@
       "systems": []
     },
     {
-      "address": "0x707ff87e1260619aa7c41ebd7f12a32d8cc358565e539c9f7b85140af3ca285",
+      "address": "0x2794aa5eca46ac459d20105c8d33ec05ccdaa08d6b93a65fec58f2f3c25a3d0",
       "class_hash": "0x1eef253239f61c49444c41990940fa8fee51b021d19e48c20d31f45bc465d46",
       "abi": [
         {
@@ -1525,7 +1525,7 @@
       "systems": []
     },
     {
-      "address": "0x41c67324187d806f29b4d02be6b358b9d0f68db4ae070d826d3a8149feba80f",
+      "address": "0x689805c618f85331489e1799dd76d18d4998b8b05b3d595cfb9f3193593ee3b",
       "class_hash": "0x4be29e651d49e58fba33f71ab6fe7fe101ee811842d07852b70d43a407fef2a",
       "abi": [
         {
@@ -1688,7 +1688,7 @@
       "systems": []
     },
     {
-      "address": "0x5d52f8c5bd309ba73977008086d7c7f9c0d2991d2e29e96f01f99bf2065f88e",
+      "address": "0x2f8b1d849ac131c974f35972c8c7d8ec7ce1b4f2d9e250cde0b246090ca45ff",
       "class_hash": "0x13767b87a8459556babbcf8cbdf2800181b462ef47f6fdafc14fc14fc1dae57",
       "abi": [
         {

--- a/xtask/generate-test-db/src/main.rs
+++ b/xtask/generate-test-db/src/main.rs
@@ -10,7 +10,8 @@ use dojo_world::contracts::WorldContract;
 use dojo_world::diff::{Manifest, WorldDiff};
 use katana_runner::{KatanaRunner, KatanaRunnerConfig};
 use scarb::compiler::Profile;
-use sozo_ops::migrate::{Migration, MigrationUi};
+use sozo_ops::migrate::Migration;
+use sozo_ops::migration_ui::MigrationUi;
 use sozo_scarbext::WorkspaceExt;
 use starknet::core::types::Felt;
 
@@ -55,7 +56,7 @@ async fn migrate_spawn_and_move(db_path: &Path) -> Result<Manifest> {
         profile_config,
         runner.url().to_string(),
     )
-    .migrate(&mut MigrationUi::None)
+    .migrate(&mut MigrationUi::new("").with_silent())
     .await?;
 
     Ok(result.manifest)
@@ -102,7 +103,7 @@ async fn migrate_types_test(db_path: &Path) -> Result<Manifest> {
         profile_config,
         runner.url().to_string(),
     )
-    .migrate(&mut MigrationUi::None)
+    .migrate(&mut MigrationUi::new("").with_silent())
     .await?;
 
     Ok(result.manifest)


### PR DESCRIPTION
# Description

Reworked the UI to be more usable, and aware of the profile. Which was causing the RPC URL not being taken correctly from the profile to display the banner.

The `MigrationUi` has also be reworked with a bit more information about the migration and ensures the keystone prompt is not hidden by the spinner.
