### PR TITLE
fix(torii/core): properly update transaction hash while processing pending block

### DIFF
--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -737,6 +737,7 @@ impl<P: Provider + Send + Sync + std::fmt::Debug + 'static> Engine<P> {
 
         for contract in unique_contracts {
             let entry = cursor_map.entry(contract).or_insert((*transaction_hash, 0));
+            entry.0 = *transaction_hash;
             entry.1 += 1;
         }
 


### PR DESCRIPTION
**Stack**:
- #2689
- #2685
- #2624
- #2623 ⬅
- #2621
- #2597
- #2572
- #2544
- #2527


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*