### PR TITLE
feat: separate the resource registration and permission phase for tes…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
       - run: |
           chmod +x /tmp/bins/sozo
           /tmp/bins/sozo --manifest-path crates/dojo/core/Scarb.toml test
+          /tmp/bins/sozo --manifest-path crates/dojo/core-cairo-test/Scarb.toml test
 
   dojo-spawn-and-move-example-test:
     needs: build
@@ -148,6 +149,7 @@ jobs:
       - run: |
           chmod +x /tmp/bins/sozo
           /tmp/bins/sozo --manifest-path examples/spawn-and-move/Scarb.toml test
+          /tmp/bins/sozo --manifest-path examples/simple/Scarb.toml test
 
   clippy:
     runs-on: ubuntu-latest-4-cores

--- a/crates/dojo/core-cairo-test/src/lib.cairo
+++ b/crates/dojo/core-cairo-test/src/lib.cairo
@@ -10,7 +10,7 @@ pub use utils::{GasCounter, assert_array, GasCounterTrait};
 #[cfg(target: "test")]
 pub use world::{
     deploy_contract, deploy_with_world_address, spawn_test_world, NamespaceDef, TestResource,
-    ContractDef, ContractDefTrait
+    ContractDef, ContractDefTrait, WorldStorageTestTrait,
 };
 
 #[cfg(test)]

--- a/crates/dojo/core-cairo-test/src/lib.cairo
+++ b/crates/dojo/core-cairo-test/src/lib.cairo
@@ -45,8 +45,8 @@ mod tests {
     mod world {
         mod acl;
         //mod entities;
-    //mod resources;
-    //mod world;
+        //mod resources;
+        mod world;
     }
 
     mod utils {

--- a/crates/dojo/core-cairo-test/src/tests/contract.cairo
+++ b/crates/dojo/core-cairo-test/src/tests/contract.cairo
@@ -69,6 +69,7 @@ pub mod test_contract_upgrade {
 #[available_gas(7000000)]
 fn test_upgrade_from_world() {
     let world = deploy_world();
+    let world = world.dispatcher;
 
     let base_address = world
         .register_contract('salt', "dojo", test_contract::TEST_CLASS_HASH.try_into().unwrap());
@@ -85,6 +86,7 @@ fn test_upgrade_from_world() {
 #[should_panic(expected: ('ENTRYPOINT_NOT_FOUND', 'ENTRYPOINT_FAILED'))]
 fn test_upgrade_from_world_not_world_provider() {
     let world = deploy_world();
+    let world = world.dispatcher;
 
     let _ = world
         .register_contract('salt', "dojo", test_contract::TEST_CLASS_HASH.try_into().unwrap());
@@ -98,6 +100,7 @@ fn test_upgrade_from_world_not_world_provider() {
 #[should_panic(expected: ('must be called by world', 'ENTRYPOINT_FAILED'))]
 fn test_upgrade_direct() {
     let world = deploy_world();
+    let world = world.dispatcher;
 
     let base_address = world
         .register_contract('salt', "dojo", test_contract::TEST_CLASS_HASH.try_into().unwrap());
@@ -174,6 +177,7 @@ mod invalid_model_world {
 )]
 fn test_register_namespace_empty_name() {
     let world = deploy_world();
+    let world = world.dispatcher;
 
     world.register_namespace("");
 }

--- a/crates/dojo/core-cairo-test/src/tests/helpers.cairo
+++ b/crates/dojo/core-cairo-test/src/tests/helpers.cairo
@@ -5,7 +5,7 @@ use dojo::world::{
 };
 use dojo::model::Model;
 
-use crate::world::{spawn_test_world, NamespaceDef, TestResource, ContractDefTrait};
+use crate::world::{spawn_test_world, NamespaceDef, TestResource};
 
 pub const DOJO_NSH: felt252 = 0x309e09669bc1fdc1dd6563a7ef862aa6227c97d099d08cc7b81bad58a7443fa;
 
@@ -238,7 +238,7 @@ pub fn deploy_world_and_bar() -> (IWorldDispatcher, IbarDispatcher) {
     let namespace_def = NamespaceDef {
         namespace: "dojo", resources: [
             TestResource::Model(m_Foo::TEST_CLASS_HASH.try_into().unwrap()),
-            TestResource::Contract(ContractDefTrait::new(bar::TEST_CLASS_HASH, "bar")),
+            TestResource::Model(bar::TEST_CLASS_HASH.try_into().unwrap()),
         ].span(),
     };
 

--- a/crates/dojo/core-cairo-test/src/tests/world/acl.cairo
+++ b/crates/dojo/core-cairo-test/src/tests/world/acl.cairo
@@ -10,6 +10,8 @@ use crate::tests::expanded::selector_attack::{attacker_model, attacker_contract}
 fn test_owner() {
     let (world, foo_selector) = deploy_world_and_foo();
 
+    let world = world.dispatcher;
+
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
 
@@ -34,6 +36,7 @@ fn test_owner() {
 #[should_panic(expected: ("Resource `42` is not registered", 'ENTRYPOINT_FAILED'))]
 fn test_grant_owner_not_registered_resource() {
     let world = deploy_world();
+    let world = world.dispatcher;
 
     // 42 is not a registered resource ID
     world.grant_owner(42, 69.try_into().unwrap());
@@ -43,6 +46,7 @@ fn test_grant_owner_not_registered_resource() {
 #[should_panic(expected: ('CONTRACT_NOT_DEPLOYED', 'ENTRYPOINT_FAILED'))]
 fn test_grant_owner_through_malicious_contract() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -65,6 +69,7 @@ fn test_grant_owner_through_malicious_contract() {
 )]
 fn test_grant_owner_fails_for_non_owner() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -79,6 +84,7 @@ fn test_grant_owner_fails_for_non_owner() {
 #[should_panic(expected: ('CONTRACT_NOT_DEPLOYED', 'ENTRYPOINT_FAILED'))]
 fn test_revoke_owner_through_malicious_contract() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -102,6 +108,7 @@ fn test_revoke_owner_through_malicious_contract() {
 )]
 fn test_revoke_owner_fails_for_non_owner() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -118,6 +125,7 @@ fn test_revoke_owner_fails_for_non_owner() {
 #[available_gas(6000000)]
 fn test_writer() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     assert(!world.is_writer(foo_selector, 69.try_into().unwrap()), 'should not be writer');
 
@@ -131,6 +139,7 @@ fn test_writer() {
 #[test]
 fn test_writer_not_registered_resource() {
     let world = deploy_world();
+    let world = world.dispatcher;
 
     // 42 is not a registered resource ID
     !world.is_writer(42, 69.try_into().unwrap());
@@ -140,6 +149,7 @@ fn test_writer_not_registered_resource() {
 #[should_panic(expected: ('CONTRACT_NOT_DEPLOYED', 'ENTRYPOINT_FAILED'))]
 fn test_grant_writer_through_malicious_contract() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -162,6 +172,7 @@ fn test_grant_writer_through_malicious_contract() {
 )]
 fn test_grant_writer_fails_for_non_owner() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -176,6 +187,7 @@ fn test_grant_writer_fails_for_non_owner() {
 #[should_panic(expected: ('CONTRACT_NOT_DEPLOYED', 'ENTRYPOINT_FAILED'))]
 fn test_revoke_writer_through_malicious_contract() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -199,6 +211,7 @@ fn test_revoke_writer_through_malicious_contract() {
 )]
 fn test_revoke_writer_fails_for_non_owner() {
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let alice = starknet::contract_address_const::<0xa11ce>();
     let bob = starknet::contract_address_const::<0xb0b>();
@@ -221,6 +234,7 @@ fn test_revoke_writer_fails_for_non_owner() {
 )]
 fn test_not_writer_with_known_contract() {
     let (world, _) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     let account = starknet::contract_address_const::<0xb0b>();
     world.grant_owner(bytearray_hash(@"dojo"), account);
@@ -259,6 +273,7 @@ fn test_register_model_namespace_not_owner() {
 
     // Owner deploys the world and register Foo model.
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     assert(world.is_owner(foo_selector, owner), 'should be owner');
 
@@ -290,6 +305,7 @@ fn test_register_contract_namespace_not_owner() {
 
     // Owner deploys the world and register Foo model.
     let (world, foo_selector) = deploy_world_and_foo();
+    let world = world.dispatcher;
 
     assert(world.is_owner(foo_selector, owner), 'should be owner');
 

--- a/crates/dojo/core-cairo-test/src/world.cairo
+++ b/crates/dojo/core-cairo-test/src/world.cairo
@@ -2,18 +2,49 @@ use core::option::OptionTrait;
 use core::result::ResultTrait;
 use core::traits::{Into, TryInto};
 
-use starknet::{ContractAddress, ClassHash, syscalls::deploy_syscall};
+use starknet::{ContractAddress, syscalls::deploy_syscall};
 
 use dojo::world::{world, IWorldDispatcher, IWorldDispatcherTrait, WorldStorageTrait, WorldStorage};
+
+pub type TestClassHash = felt252;
 
 /// In Cairo test runner, all the classes are expected to be declared already.
 /// If a contract belong to an other crate, it must be added to the `build-external-contract`,
 /// event for testing, since Scarb does not do that automatically anymore.
+///
+/// The [`TestResource`] enum uses a felt252 to represent the class hash, this avoids
+/// having to write `bar::TEST_CLASS_HASH.try_into().unwrap()` in the test file, simply use
+/// `bar::TEST_CLASS_HASH`.
 #[derive(Drop)]
 pub enum TestResource {
-    Event: ClassHash,
-    Model: ClassHash,
-    Contract: ContractDef,
+    Event: TestClassHash,
+    Model: TestClassHash,
+    Contract: TestClassHash,
+}
+
+#[derive(Drop, Copy)]
+pub enum ContractDescriptor {
+    /// Address of the contract.
+    Address: ContractAddress,
+    /// Namespace and name of the contract.
+    Named: (@ByteArray, @ByteArray),
+}
+
+/// Definition of a contract to register in the world.
+///
+/// You can use this struct for a dojo contract, but also for an external contract.
+/// The only difference is the `init_calldata`, which is only used for dojo contracts.
+/// If the `contract` is an external contract (hence an address), then `init_calldata` is ignored.
+#[derive(Drop, Copy)]
+pub struct ContractDef {
+    /// The contract to grant permission to.
+    pub contract: ContractDescriptor,
+    /// Selectors of the resources that the contract is granted writer access to.
+    pub writer_of: Span<felt252>,
+    /// Selector of the resource that the contract is the owner of.
+    pub owner_of: Span<felt252>,
+    /// Calldata for dojo_init.
+    pub init_calldata: Span<felt252>,
 }
 
 #[derive(Drop)]
@@ -22,25 +53,14 @@ pub struct NamespaceDef {
     pub resources: Span<TestResource>,
 }
 
-#[derive(Drop)]
-pub struct ContractDef {
-    /// Class hash, use `felt252` instead of `ClassHash` as TEST_CLASS_HASH is a `felt252`.
-    pub class_hash: felt252,
-    /// Name of the contract.
-    pub name: ByteArray,
-    /// Calldata for dojo_init.
-    pub init_calldata: Span<felt252>,
-    /// Selectors of the resources that the contract is granted writer access to.
-    pub writer_of: Span<felt252>,
-    /// Selector of the resource that the contract is the owner of.
-    pub owner_of: Span<felt252>,
-}
-
 #[generate_trait]
 pub impl ContractDefImpl of ContractDefTrait {
-    fn new(class_hash: felt252, name: ByteArray) -> ContractDef {
+    fn new(namespace: @ByteArray, name: @ByteArray,) -> ContractDef {
         ContractDef {
-            class_hash, name, init_calldata: [].span(), writer_of: [].span(), owner_of: [].span()
+            contract: ContractDescriptor::Named((namespace, name)),
+            writer_of: [].span(),
+            owner_of: [].span(),
+            init_calldata: [].span()
         }
     }
 
@@ -92,6 +112,10 @@ pub fn deploy_with_world_address(class_hash: felt252, world: IWorldDispatcher) -
 
 /// Spawns a test world registering provided resources into namespaces.
 ///
+/// This function only deploys the world and registers the resources, it does not initialize the
+/// contracts or any permissions.
+/// The first namespace is used as the default namespace when [`WorldStorage`] is returned.
+///
 /// # Arguments
 ///
 /// * `namespaces_defs` - Definitions of namespaces to register.
@@ -122,37 +146,64 @@ pub fn spawn_test_world(namespaces_defs: Span<NamespaceDef>) -> WorldStorage {
             first_namespace = Option::Some(namespace.clone());
         }
 
-        let namespace_hash = dojo::utils::bytearray_hash(@namespace);
-
         for r in ns
             .resources
             .clone() {
                 match r {
-                    TestResource::Event(ch) => { world.register_event(namespace.clone(), *ch); },
-                    TestResource::Model(ch) => { world.register_model(namespace.clone(), *ch); },
-                    TestResource::Contract(def) => {
-                        let class_hash: ClassHash = (*def.class_hash).try_into().unwrap();
-                        let contract_address = world
-                            .register_contract(*def.class_hash, namespace.clone(), class_hash);
-
-                        for target in *def
-                            .writer_of {
-                                world.grant_writer(*target, contract_address);
-                            };
-
-                        for target in *def
-                            .owner_of {
-                                world.grant_owner(*target, contract_address);
-                            };
-
-                        let selector = dojo::utils::selector_from_namespace_and_name(
-                            namespace_hash, def.name
-                        );
-                        world.init_contract(selector, *def.init_calldata);
+                    TestResource::Event(ch) => {
+                        world.register_event(namespace.clone(), (*ch).try_into().unwrap());
                     },
+                    TestResource::Model(ch) => {
+                        world.register_model(namespace.clone(), (*ch).try_into().unwrap());
+                    },
+                    TestResource::Contract(ch) => {
+                        world.register_contract(*ch, namespace.clone(), (*ch).try_into().unwrap());
+                    }
                 }
             }
     };
 
     WorldStorageTrait::new(world, @first_namespace.unwrap())
+}
+
+#[generate_trait]
+pub impl WorldStorageInternalTestImpl of WorldStorageTestTrait {
+    fn sync_perms_and_inits(self: @WorldStorage, contracts: Span<ContractDef>) {
+        // First, sync permissions as sozo is doing.
+        for c in contracts {
+            let contract_address = match c.contract {
+                ContractDescriptor::Address(address) => *address,
+                ContractDescriptor::Named((
+                    namespace, name
+                )) => {
+                    let selector = dojo::utils::selector_from_names(*namespace, *name);
+                    match (*self.dispatcher).resource(selector) {
+                        dojo::world::Resource::Contract((address, _)) => address,
+                        _ => panic!("Contract not found"),
+                    }
+                },
+            };
+
+            for w in *c.writer_of {
+                (*self.dispatcher).grant_writer(*w, contract_address);
+            };
+
+            for o in *c.owner_of {
+                (*self.dispatcher).grant_owner(*o, contract_address);
+            };
+        };
+
+        // Then, calls the dojo_init for each contract that is a dojo contract.
+        for c in contracts {
+            match c.contract {
+                ContractDescriptor::Address(_) => {},
+                ContractDescriptor::Named((
+                    namespace, name
+                )) => {
+                    let selector = dojo::utils::selector_from_names(*namespace, *name);
+                    (*self.dispatcher).init_contract(selector, *c.init_calldata);
+                }
+            }
+        };
+    }
 }

--- a/crates/dojo/core-cairo-test/src/world.cairo
+++ b/crates/dojo/core-cairo-test/src/world.cairo
@@ -64,8 +64,23 @@ pub impl ContractDefImpl of ContractDefTrait {
         }
     }
 
+    fn new_address(address: ContractAddress) -> ContractDef {
+        ContractDef {
+            contract: ContractDescriptor::Address(address),
+            writer_of: [].span(),
+            owner_of: [].span(),
+            init_calldata: [].span()
+        }
+    }
+
     fn with_init_calldata(mut self: ContractDef, init_calldata: Span<felt252>) -> ContractDef {
-        self.init_calldata = init_calldata;
+        match self.contract {
+            ContractDescriptor::Address(_) => panic!(
+                "Cannot set init_calldata for address descriptor"
+            ),
+            ContractDescriptor::Named(_) => self.init_calldata = init_calldata,
+        };
+
         self
     }
 

--- a/crates/dojo/core/src/world/storage.cairo
+++ b/crates/dojo/core/src/world/storage.cairo
@@ -40,8 +40,8 @@ pub impl WorldStorageInternalImpl of WorldStorageTrait {
         }
     }
 
-    fn contract_selector(self: @WorldStorage, contract_name: @ByteArray) -> felt252 {
-        dojo::utils::selector_from_namespace_and_name(*self.namespace_hash, contract_name)
+    fn resource_selector(self: @WorldStorage, name: @ByteArray) -> felt252 {
+        dojo::utils::selector_from_namespace_and_name(*self.namespace_hash, name)
     }
 }
 

--- a/examples/simple/src/lib.cairo
+++ b/examples/simple/src/lib.cairo
@@ -115,23 +115,27 @@ pub mod c3 {}
 #[cfg(test)]
 mod tests {
     use dojo::model::ModelStorage;
-    use dojo_cairo_test::{spawn_test_world, NamespaceDef, TestResource, ContractDefTrait};
+    use dojo_cairo_test::{
+        spawn_test_world, NamespaceDef, TestResource, ContractDefTrait, WorldStorageTestTrait
+    };
     use super::{c1, m_M, M};
 
     #[test]
     fn test_1() {
         let ndef = NamespaceDef {
             namespace: "ns", resources: [
-                TestResource::Model(m_M::TEST_CLASS_HASH.try_into().unwrap()),
-                TestResource::Contract(
-                    ContractDefTrait::new(c1::TEST_CLASS_HASH, "c1")
-                        .with_init_calldata([0xff].span())
-                        .with_writer_of([dojo::utils::bytearray_hash(@"ns")].span())
-                )
+                TestResource::Model(m_M::TEST_CLASS_HASH),
+                TestResource::Contract(c1::TEST_CLASS_HASH),
             ].span()
         };
 
         let world = spawn_test_world([ndef].span());
+
+        let c1_def = ContractDefTrait::new(@"ns", @"c1")
+            .with_writer_of([dojo::utils::bytearray_hash(@"ns")].span())
+            .with_init_calldata([0xff].span());
+
+        world.sync_perms_and_inits([c1_def].span());
 
         let m: M = world.read_model(0);
         assert!(m.v == 0xff, "invalid b");

--- a/scripts/cairo_fmt.sh
+++ b/scripts/cairo_fmt.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-scarb --manifest-path examples/spawn-and-move/Scarb.toml fmt --check
-scarb --manifest-path examples/simple/Scarb.toml fmt --check
-scarb --manifest-path crates/dojo/core/Scarb.toml fmt --check
-scarb --manifest-path crates/dojo/core-cairo-test/Scarb.toml fmt --check
+option="--check"
+
+if [ "$1" == "--fix" ]; then
+    option=""
+fi
+
+scarb --manifest-path examples/spawn-and-move/Scarb.toml fmt $option
+scarb --manifest-path examples/simple/Scarb.toml fmt $option
+scarb --manifest-path crates/dojo/core/Scarb.toml fmt $option
+scarb --manifest-path crates/dojo/core-cairo-test/Scarb.toml fmt $option


### PR DESCRIPTION
Before, the `ContractDef` was containing the class for registration and the contract definition for permissions and initialization.

However, to test more efficiently, we prefer first registering the resources, and then apply permissions and init exactly like sozo is doing.

This PR aims at providing this behavior, where:
1. Usage of `NamespaceDef` to register all resources.
2. Usage of `sync_perms_and_inits` where permissions are first applied, and then the contracts are initialized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `WorldStorageTestTrait` for enhanced testing capabilities.
	- Updated contract management with a new `ContractDescriptor` for simplified resource handling.
	- Enhanced model handling in the `MyInterfaceImpl` and `ActionsImpl` implementations.
	- Added new test commands for the `sozo` binary in CI workflow, expanding testing coverage.

- **Bug Fixes**
	- Improved error handling and state validation in the `reset_player_config` method.

- **Documentation**
	- Expanded import statements in testing modules for better clarity and functionality.

- **Refactor**
	- Streamlined model interactions and resource definitions across various modules.
	- Renamed `contract_selector` to `resource_selector` for broader functionality in `WorldStorageInternalImpl`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->