### PR TITLE
feat(katana): exit on block production error

### DIFF
--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -34,9 +34,6 @@ pub enum BlockProductionError {
     #[error(transparent)]
     Provider(#[from] ProviderError),
 
-    #[error("block mining task cancelled")]
-    BlockMiningTaskCancelled,
-
     #[error("transaction execution task cancelled")]
     ExecutionTaskCancelled,
 

--- a/crates/katana/core/src/service/mod.rs
+++ b/crates/katana/core/src/service/mod.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use block_producer::BlockProductionError;
 use futures::channel::mpsc::Receiver;
 use futures::stream::{Fuse, Stream, StreamExt};
 use katana_executor::ExecutorFactory;
@@ -47,7 +48,7 @@ impl<EF: ExecutorFactory> BlockProductionTask<EF> {
 }
 
 impl<EF: ExecutorFactory> Future for BlockProductionTask<EF> {
-    type Output = ();
+    type Output = Result<(), BlockProductionError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
@@ -68,6 +69,7 @@ impl<EF: ExecutorFactory> Future for BlockProductionTask<EF> {
 
                     Err(error) => {
                         error!(target: LOG_TARGET, %error, "Mining block.");
+                        return Poll::Ready(Err(error));
                     }
                 }
             }

--- a/crates/katana/pipeline/src/stage/sequencing.rs
+++ b/crates/katana/pipeline/src/stage/sequencing.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures::future;
 use katana_core::backend::Backend;
-use katana_core::service::block_producer::BlockProducer;
+use katana_core::service::block_producer::{BlockProducer, BlockProductionError};
 use katana_core::service::messaging::{MessagingConfig, MessagingService, MessagingTask};
 use katana_core::service::{BlockProductionTask, TransactionMiner};
 use katana_executor::ExecutorFactory;
@@ -52,7 +52,7 @@ impl<EF: ExecutorFactory> Sequencing<EF> {
         }
     }
 
-    fn run_block_production(&self) -> TaskHandle<()> {
+    fn run_block_production(&self) -> TaskHandle<Result<(), BlockProductionError>> {
         let pool = self.pool.clone();
         let miner = TransactionMiner::new(pool.add_listener());
         let block_producer = self.block_producer.clone();

--- a/crates/katana/storage/db/src/mdbx/tx.rs
+++ b/crates/katana/storage/db/src/mdbx/tx.rs
@@ -118,7 +118,9 @@ impl DbTxMut for Tx<RW> {
     fn put<T: Table>(&self, key: T::Key, value: T::Value) -> Result<(), DatabaseError> {
         let key = key.encode();
         let value = value.compress();
-        self.inner.put(self.get_dbi::<T>()?, key, value, WriteFlags::UPSERT).unwrap();
+        self.inner.put(self.get_dbi::<T>()?, &key, value, WriteFlags::UPSERT).map_err(|error| {
+            DatabaseError::Write { error, table: T::NAME, key: Box::from(key.as_ref()) }
+        })?;
         Ok(())
     }
 


### PR DESCRIPTION
resolves #1650 

currently, katana silently fails when an error happen during block production. this create some issues in the context of Slot hosting as unexpected behaviours can happen when the the instance is running out of storage. returning immediately upon failing makes it easier to detect this issue


```console
2024-11-04T20:16:50.274691Z TRACE executor: Transaction resource usage. usage="steps: 3387 | memory holes: 32 | ec_op_builtin: 3 | pedersen_builtin: 16 | range_check_builtin: 65"
2024-11-04T20:16:50.336923Z ERROR node: Mining block. error=failed to write to db table CompiledClasses with key [7, 119, 132, 31, 135, 177, 34, 199, 133, 3, 124, 123, 169, 131, 85, 12, 179, 94, 71, 107, 237, 129, 83, 90, 108, 155, 91, 255, 242, 24, 57, 6]: No space left on device
2024-11-04T20:16:50.337613Z ERROR Stage{id=Sequencing}: pipeline: Block production task finished unexpectedly. reason=Ok(Completed(Err(Provider(Database(Write { error: Other(28), table: "CompiledClasses", key: [7, 119, 132, 31, 135, 177, 34, 199, 133, 3, 124, 123, 169, 131, 85, 12, 179, 94, 71, 107, 237, 129, 83, 90, 108, 155, 91, 255, 242, 24, 57, 6] })))))
2024-11-04T20:16:50.337666Z  INFO pipeline: Pipeline finished.
2024-11-04T20:16:50.337680Z DEBUG tasks: Task with graceful shutdown completed. task="Pipeline"
2024-11-04T20:16:50.337764Z  INFO katana::cli::node: Shutting down.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error type, `BlockProductionError`, improving error handling in block production tasks.
- **Bug Fixes**
	- Enhanced error handling in the `put` method to prevent potential panics and provide better context for database write errors.
- **Documentation**
	- Updated method signatures to reflect changes in error handling and return types for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->