### PR TITLE
feat(katana): retain transactions in pool until mined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8273,6 +8273,7 @@ name = "katana-pool"
 version = "1.0.0-rc.1"
 dependencies = [
  "futures",
+ "futures-util",
  "katana-executor",
  "katana-primitives",
  "katana-provider",

--- a/crates/katana/core/src/service/mod.rs
+++ b/crates/katana/core/src/service/mod.rs
@@ -10,10 +10,10 @@ use futures::channel::mpsc::Receiver;
 use futures::stream::{Fuse, Stream, StreamExt};
 use katana_executor::ExecutorFactory;
 use katana_pool::ordering::PoolOrd;
-use katana_pool::pool::PendingTransactions;
+use katana_pool::pending::PendingTransactions;
 use katana_pool::{TransactionPool, TxPool};
-use katana_primitives::Felt;
 use katana_primitives::transaction::ExecutableTxWithHash;
+use katana_primitives::Felt;
 use tracing::{error, info};
 
 use self::block_producer::BlockProducer;

--- a/crates/katana/core/src/service/mod.rs
+++ b/crates/katana/core/src/service/mod.rs
@@ -9,9 +9,11 @@ use block_producer::BlockProductionError;
 use futures::channel::mpsc::Receiver;
 use futures::stream::{Fuse, Stream, StreamExt};
 use katana_executor::ExecutorFactory;
+use katana_pool::ordering::PoolOrd;
+use katana_pool::pool::PendingTransactions;
 use katana_pool::{TransactionPool, TxPool};
-use katana_primitives::transaction::ExecutableTxWithHash;
 use katana_primitives::Felt;
+use katana_primitives::transaction::ExecutableTxWithHash;
 use tracing::{error, info};
 
 use self::block_producer::BlockProducer;
@@ -30,24 +32,40 @@ pub(crate) const LOG_TARGET: &str = "node";
 /// to construct a new block.
 #[must_use = "BlockProductionTask does nothing unless polled"]
 #[allow(missing_debug_implementations)]
-pub struct BlockProductionTask<EF: ExecutorFactory> {
+pub struct BlockProductionTask<EF, O>
+where
+    EF: ExecutorFactory,
+    O: PoolOrd<Transaction = ExecutableTxWithHash>,
+{
     /// creates new blocks
     pub(crate) block_producer: BlockProducer<EF>,
     /// the miner responsible to select transactions from the `pool´
-    pub(crate) miner: TransactionMiner,
+    pub(crate) miner: TransactionMiner<O>,
     /// the pool that holds all transactions
     pub(crate) pool: TxPool,
     /// Metrics for recording the service operations
     metrics: BlockProducerMetrics,
 }
 
-impl<EF: ExecutorFactory> BlockProductionTask<EF> {
-    pub fn new(pool: TxPool, miner: TransactionMiner, block_producer: BlockProducer<EF>) -> Self {
+impl<EF, O> BlockProductionTask<EF, O>
+where
+    EF: ExecutorFactory,
+    O: PoolOrd<Transaction = ExecutableTxWithHash>,
+{
+    pub fn new(
+        pool: TxPool,
+        miner: TransactionMiner<O>,
+        block_producer: BlockProducer<EF>,
+    ) -> Self {
         Self { block_producer, miner, pool, metrics: BlockProducerMetrics::default() }
     }
 }
 
-impl<EF: ExecutorFactory> Future for BlockProductionTask<EF> {
+impl<EF, O> Future for BlockProductionTask<EF, O>
+where
+    EF: ExecutorFactory,
+    O: PoolOrd<Transaction = ExecutableTxWithHash>,
+{
     type Output = Result<(), BlockProductionError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -65,6 +83,9 @@ impl<EF: ExecutorFactory> Future for BlockProductionTask<EF> {
                         let steps_used = outcome.stats.cairo_steps_used;
                         this.metrics.l1_gas_processed_total.increment(gas_used as u64);
                         this.metrics.cairo_steps_processed_total.increment(steps_used as u64);
+
+                        // remove mined transactions from the pool
+                        this.pool.remove_transactions(&outcome.txs);
                     }
 
                     Err(error) => {
@@ -74,7 +95,7 @@ impl<EF: ExecutorFactory> Future for BlockProductionTask<EF> {
                 }
             }
 
-            if let Poll::Ready(pool_txs) = this.miner.poll(&this.pool, cx) {
+            if let Poll::Ready(pool_txs) = this.miner.poll(cx) {
                 // miner returned a set of transaction that we feed to the producer
                 this.block_producer.queue(pool_txs);
             } else {
@@ -89,19 +110,34 @@ impl<EF: ExecutorFactory> Future for BlockProductionTask<EF> {
 
 /// The type which takes the transaction from the pool and feeds them to the block producer.
 #[derive(Debug)]
-pub struct TransactionMiner {
+pub struct TransactionMiner<O>
+where
+    O: PoolOrd<Transaction = ExecutableTxWithHash>,
+{
     /// stores whether there are pending transacions (if known)
     has_pending_txs: Option<bool>,
     /// Receives hashes of transactions that are ready from the pool
     rx: Fuse<Receiver<Felt>>,
+
+    pending_txs: PendingTransactions<ExecutableTxWithHash, O>,
 }
 
-impl TransactionMiner {
-    pub fn new(rx: Receiver<Felt>) -> Self {
-        Self { rx: rx.fuse(), has_pending_txs: None }
+impl<O> TransactionMiner<O>
+where
+    O: PoolOrd<Transaction = ExecutableTxWithHash>,
+{
+    pub fn new(
+        pending_txs: PendingTransactions<ExecutableTxWithHash, O>,
+        rx: Receiver<Felt>,
+    ) -> Self {
+        Self { pending_txs, rx: rx.fuse(), has_pending_txs: None }
     }
 
-    fn poll(&mut self, pool: &TxPool, cx: &mut Context<'_>) -> Poll<Vec<ExecutableTxWithHash>> {
+    fn poll(
+        &mut self,
+        // pool: &TxPool,
+        cx: &mut Context<'_>,
+    ) -> Poll<Vec<ExecutableTxWithHash>> {
         // drain the notification stream
         while let Poll::Ready(Some(_)) = Pin::new(&mut self.rx).poll_next(cx) {
             self.has_pending_txs = Some(true);
@@ -111,9 +147,14 @@ impl TransactionMiner {
             return Poll::Pending;
         }
 
+        let mut transactions = Vec::new();
+        while let Poll::Ready(Some(tx)) = self.pending_txs.poll_next_unpin(cx) {
+            transactions.push(tx.tx.as_ref().clone());
+        }
+
         // take all the transactions from the pool
-        let transactions =
-            pool.take_transactions().map(|tx| tx.tx.as_ref().clone()).collect::<Vec<_>>();
+        // let transactions =
+        //     pool.take_transactions().map(|tx| tx.tx.as_ref().clone()).collect::<Vec<_>>();
 
         if transactions.is_empty() {
             return Poll::Pending;

--- a/crates/katana/pipeline/src/stage/sequencing.rs
+++ b/crates/katana/pipeline/src/stage/sequencing.rs
@@ -54,7 +54,7 @@ impl<EF: ExecutorFactory> Sequencing<EF> {
 
     fn run_block_production(&self) -> TaskHandle<Result<(), BlockProductionError>> {
         let pool = self.pool.clone();
-        let miner = TransactionMiner::new(pool.add_listener());
+        let miner = TransactionMiner::new(pool.pending_transactions(), pool.add_listener());
         let block_producer = self.block_producer.clone();
 
         let service = BlockProductionTask::new(pool, miner, block_producer);

--- a/crates/katana/pipeline/src/stage/sequencing.rs
+++ b/crates/katana/pipeline/src/stage/sequencing.rs
@@ -53,11 +53,10 @@ impl<EF: ExecutorFactory> Sequencing<EF> {
     }
 
     fn run_block_production(&self) -> TaskHandle<Result<(), BlockProductionError>> {
-        let pool = self.pool.clone();
-        let miner = TransactionMiner::new(pool.pending_transactions(), pool.add_listener());
+        // Create a new transaction miner with a subscription to the pool's pending transactions.
+        let miner = TransactionMiner::new(self.pool.pending_transactions());
         let block_producer = self.block_producer.clone();
-
-        let service = BlockProductionTask::new(pool, miner, block_producer);
+        let service = BlockProductionTask::new(self.pool.clone(), miner, block_producer);
         self.task_spawner.build_task().name("Block production").spawn(service)
     }
 }

--- a/crates/katana/pool/Cargo.toml
+++ b/crates/katana/pool/Cargo.toml
@@ -13,8 +13,8 @@ katana-primitives.workspace = true
 katana-provider.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = [ "sync" ] }
 tracing.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
-tokio.workspace = true

--- a/crates/katana/pool/Cargo.toml
+++ b/crates/katana/pool/Cargo.toml
@@ -17,4 +17,5 @@ tokio = { workspace = true, features = [ "sync" ] }
 tracing.workspace = true
 
 [dev-dependencies]
+futures-util.workspace = true
 rand.workspace = true

--- a/crates/katana/pool/src/lib.rs
+++ b/crates/katana/pool/src/lib.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use futures::channel::mpsc::Receiver;
 use katana_primitives::transaction::{ExecutableTxWithHash, TxHash};
 use ordering::{FiFo, PoolOrd};
-use pool::Pool;
-use tx::{PendingTx, PoolTransaction};
+use pool::{PendingTransactions, Pool};
+use tx::PoolTransaction;
 use validation::error::InvalidTransactionError;
 use validation::stateful::TxValidator;
 use validation::Validator;
@@ -44,9 +44,7 @@ pub trait TransactionPool {
     /// Add a new transaction to the pool.
     fn add_transaction(&self, tx: Self::Transaction) -> PoolResult<TxHash>;
 
-    fn take_transactions(
-        &self,
-    ) -> impl Iterator<Item = PendingTx<Self::Transaction, Self::Ordering>>;
+    fn pending_transactions(&self) -> PendingTransactions<Self::Transaction, Self::Ordering>;
 
     /// Check if the pool contains a transaction with the given hash.
     fn contains(&self, hash: TxHash) -> bool;
@@ -55,6 +53,8 @@ pub trait TransactionPool {
     fn get(&self, hash: TxHash) -> Option<Arc<Self::Transaction>>;
 
     fn add_listener(&self) -> Receiver<TxHash>;
+
+    fn remove_transactions(&self, hashes: &[TxHash]);
 
     /// Get the total number of transactions in the pool.
     fn size(&self) -> usize;

--- a/crates/katana/pool/src/lib.rs
+++ b/crates/katana/pool/src/lib.rs
@@ -47,6 +47,8 @@ pub trait TransactionPool {
     /// Add a new transaction to the pool.
     fn add_transaction(&self, tx: Self::Transaction) -> PoolResult<TxHash>;
 
+    /// Returns a [`Stream`](futures::Stream) which yields pending transactions - transactions that
+    /// can be executed - from the pool.
     fn pending_transactions(&self) -> PendingTransactions<Self::Transaction, Self::Ordering>;
 
     /// Check if the pool contains a transaction with the given hash.
@@ -57,6 +59,7 @@ pub trait TransactionPool {
 
     fn add_listener(&self) -> Receiver<TxHash>;
 
+    /// Removes a list of transactions from the pool according to their hashes.
     fn remove_transactions(&self, hashes: &[TxHash]);
 
     /// Get the total number of transactions in the pool.

--- a/crates/katana/pool/src/lib.rs
+++ b/crates/katana/pool/src/lib.rs
@@ -1,7 +1,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
 pub mod ordering;
+pub mod pending;
 pub mod pool;
+pub mod subscription;
 pub mod tx;
 pub mod validation;
 
@@ -10,7 +12,8 @@ use std::sync::Arc;
 use futures::channel::mpsc::Receiver;
 use katana_primitives::transaction::{ExecutableTxWithHash, TxHash};
 use ordering::{FiFo, PoolOrd};
-use pool::{PendingTransactions, Pool};
+use pending::PendingTransactions;
+use pool::Pool;
 use tx::PoolTransaction;
 use validation::error::InvalidTransactionError;
 use validation::stateful::TxValidator;

--- a/crates/katana/pool/src/ordering.rs
+++ b/crates/katana/pool/src/ordering.rs
@@ -145,7 +145,7 @@ mod tests {
         });
 
         // Get pending transactions
-        let pendings = pool.take_transactions().collect::<Vec<_>>();
+        let pendings = pool.pending_transactions().collect::<Vec<_>>();
 
         // Assert that the transactions are in the order they were added (first to last)
         pendings.iter().zip(txs).for_each(|(pending, tx)| {
@@ -177,7 +177,7 @@ mod tests {
         });
 
         // Get pending transactions
-        let pending = pool.take_transactions().collect::<Vec<_>>();
+        let pending = pool.pending_transactions().collect::<Vec<_>>();
         assert_eq!(pending.len(), txs.len());
 
         // Assert that the transactions are ordered by tip (highest to lowest)

--- a/crates/katana/pool/src/pending.rs
+++ b/crates/katana/pool/src/pending.rs
@@ -1,0 +1,47 @@
+use std::collections::btree_set::IntoIter;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::{Stream, StreamExt};
+
+use crate::ordering::PoolOrd;
+use crate::subscription::PoolSubscription;
+use crate::tx::{PendingTx, PoolTransaction};
+
+/// an iterator that yields transactions from the pool that can be included in a block, sorted by
+/// by its priority.
+#[derive(Debug)]
+pub struct PendingTransactions<T, O: PoolOrd> {
+    pub(crate) all: IntoIter<PendingTx<T, O>>,
+    pub(crate) subscription: PoolSubscription<T, O>,
+}
+
+impl<T, O> Stream for PendingTransactions<T, O>
+where
+    T: PoolTransaction,
+    O: PoolOrd<Transaction = T>,
+{
+    type Item = PendingTx<T, O>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        if let Some(tx) = this.all.next() {
+            Poll::Ready(Some(tx))
+        } else {
+            this.subscription.poll_next_unpin(cx)
+        }
+    }
+}
+
+impl<T, O> Iterator for PendingTransactions<T, O>
+where
+    T: PoolTransaction,
+    O: PoolOrd<Transaction = T>,
+{
+    type Item = PendingTx<T, O>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.all.next()
+    }
+}

--- a/crates/katana/pool/src/pending.rs
+++ b/crates/katana/pool/src/pending.rs
@@ -5,15 +5,18 @@ use std::task::{Context, Poll};
 use futures::{Stream, StreamExt};
 
 use crate::ordering::PoolOrd;
-use crate::subscription::PoolSubscription;
+use crate::subscription::Subscription;
 use crate::tx::{PendingTx, PoolTransaction};
 
-/// an iterator that yields transactions from the pool that can be included in a block, sorted by
+/// An iterator that yields transactions from the pool that can be included in a block, sorted by
 /// by its priority.
 #[derive(Debug)]
 pub struct PendingTransactions<T, O: PoolOrd> {
+    /// Iterator over all the pending transactions at the time of the creation of this struct.
     pub(crate) all: IntoIter<PendingTx<T, O>>,
-    pub(crate) subscription: PoolSubscription<T, O>,
+    /// Subscription to the pool to get notified when new transactions are added. This is used to
+    /// wait on the new transactions after exhausting the `all` iterator.
+    pub(crate) subscription: Subscription<T, O>,
 }
 
 impl<T, O> Stream for PendingTransactions<T, O>
@@ -25,7 +28,6 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
-
         if let Some(tx) = this.all.next() {
             Poll::Ready(Some(tx))
         } else {
@@ -34,14 +36,104 @@ where
     }
 }
 
-impl<T, O> Iterator for PendingTransactions<T, O>
-where
-    T: PoolTransaction,
-    O: PoolOrd<Transaction = T>,
-{
-    type Item = PendingTx<T, O>;
+#[cfg(test)]
+mod tests {
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.all.next()
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use futures::StreamExt;
+    use tokio::task::yield_now;
+
+    use crate::pool::test_utils::PoolTx;
+    use crate::pool::Pool;
+    use crate::validation::NoopValidator;
+    use crate::{ordering, PoolTransaction, TransactionPool};
+
+    #[tokio::test]
+    async fn pending_transactions() {
+        let pool = Pool::new(NoopValidator::<PoolTx>::new(), ordering::FiFo::new());
+
+        let first_batch = [
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+        ];
+
+        for tx in &first_batch {
+            pool.add_transaction(tx.clone()).expect("failed to add tx");
+        }
+
+        let mut pendings = pool.pending_transactions();
+
+        // exhaust all the first batch transactions
+        for expected in &first_batch {
+            let actual = pendings.next().await.map(|t| t.tx).unwrap();
+            assert_eq!(expected, actual.as_ref());
+        }
+
+        let second_batch = [
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+            PoolTx::new(),
+        ];
+
+        for tx in &second_batch {
+            pool.add_transaction(tx.clone()).expect("failed to add tx");
+        }
+
+        // exhaust all the first batch transactions
+        for expected in &second_batch {
+            let actual = pendings.next().await.map(|t| t.tx).unwrap();
+            assert_eq!(expected, actual.as_ref());
+        }
+
+        // Check that all the added transaction is still in the pool because we haven't removed it
+        // yet.
+        let all = [first_batch, second_batch].concat();
+        for tx in all {
+            assert!(pool.contains(tx.hash()));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn subscription_stream_wakeup() {
+        let pool = Pool::new(NoopValidator::<PoolTx>::new(), ordering::FiFo::new());
+        let mut pending = pool.pending_transactions();
+
+        // Spawn a task that will add a transaction after a delay
+        let pool_clone = pool.clone();
+
+        let txs = [PoolTx::new(), PoolTx::new(), PoolTx::new()];
+        let txs_clone = txs.clone();
+
+        let has_polled_once = Arc::new(AtomicBool::new(false));
+        let has_polled_once_clone = has_polled_once.clone();
+
+        tokio::spawn(async move {
+            while !has_polled_once_clone.load(Ordering::SeqCst) {
+                yield_now().await;
+            }
+
+            for tx in txs_clone {
+                pool_clone.add_transaction(tx).expect("failed to add tx");
+            }
+        });
+
+        // Check that first poll_next returns Pending because no pending transaction has been added
+        // to the pool yet
+        assert!(futures_util::poll!(pending.next()).is_pending());
+        has_polled_once.store(true, Ordering::SeqCst);
+
+        for tx in txs {
+            let received = pending.next().await.unwrap();
+            assert_eq!(&tx, received.tx.as_ref());
+        }
     }
 }

--- a/crates/katana/pool/src/pool.rs
+++ b/crates/katana/pool/src/pool.rs
@@ -142,6 +142,8 @@ where
                         Ok(hash)
                     }
 
+                    // TODO: create a small cache for rejected transactions to respect the rpc spec
+                    // `getTransactionStatus`
                     ValidationOutcome::Invalid { error, .. } => {
                         warn!(hash = format!("{hash:#x}"), "Invalid transaction.");
                         Err(PoolError::InvalidTransaction(Box::new(error)))

--- a/crates/katana/pool/src/subscription.rs
+++ b/crates/katana/pool/src/subscription.rs
@@ -1,0 +1,59 @@
+use std::collections::BTreeSet;
+use std::future::Future;
+use std::pin::{pin, Pin};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::Stream;
+use parking_lot::RwLock;
+use tokio::sync::Notify;
+
+use crate::ordering::PoolOrd;
+use crate::tx::{PendingTx, PoolTransaction};
+
+#[derive(Debug)]
+pub struct PoolSubscription<T, O: PoolOrd> {
+    pub(crate) txs: Arc<RwLock<BTreeSet<PendingTx<T, O>>>>,
+    pub(crate) notify: Arc<Notify>,
+}
+
+impl<T, O: PoolOrd> Clone for PoolSubscription<T, O> {
+    fn clone(&self) -> Self {
+        Self { txs: self.txs.clone(), notify: self.notify.clone() }
+    }
+}
+
+impl<T, O> PoolSubscription<T, O>
+where
+    T: PoolTransaction,
+    O: PoolOrd<Transaction = T>,
+{
+    pub(crate) fn broadcast(&self, tx: PendingTx<T, O>) {
+        self.notify.notify_waiters();
+        self.txs.write().insert(tx);
+    }
+}
+
+impl<T, O> Stream for PoolSubscription<T, O>
+where
+    T: PoolTransaction,
+    O: PoolOrd<Transaction = T>,
+{
+    type Item = PendingTx<T, O>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            if let Some(tx) = this.txs.write().pop_first() {
+                return Poll::Ready(Some(tx));
+            }
+
+            if pin!(this.notify.notified()).poll(cx).is_pending() {
+                break;
+            }
+        }
+
+        Poll::Pending
+    }
+}


### PR DESCRIPTION
every block interval, the node would take transactions from the pool - removing it directly from the pool. this creates a small window (depending on the machine) that the transaction appears nonexistent. this is due to how the tx flows from the pool and executor. this applies for both instant and interval block production mode. 

for instant mining, the window is between tx being picked up from the pool and the tx being committed to db. while for interval, tx being picked up from the pool and the tx being [inserted into the pending block](https://github.com/dojoengine/dojo/blob/d09cbcffd8c8f2745770888f9d3f30d07b8555ae/crates/katana/executor/src/implementation/blockifier/mod.rs#L208).

when a tx is being queried thru the rpc, the node will first check if the it exist in the db, else find in the pending block (if interval mode). this pr adds a new (last) step, which is to try finding the tx in the pool if it doesn't exist anywhere else. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction management with the introduction of `PendingTransactions` and `Subscription` structures for improved handling of pending transactions.
	- Updated transaction retrieval methods in the Starknet API to utilize the transaction pool, enhancing robustness and error handling.

- **Bug Fixes**
	- Improved control flow in transaction retrieval methods to provide fallback mechanisms when transactions are not found.

- **Documentation**
	- Updated dependency management to include `tokio` for enhanced asynchronous capabilities.

- **Refactor**
	- Renamed methods and updated structures for clarity and consistency in transaction handling within the pool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->