### PR TITLE
docs: fix typo (n-06)

### DIFF
--- a/crates/dojo/core/src/contract/components/upgradeable.cairo
+++ b/crates/dojo/core/src/contract/components/upgradeable.cairo
@@ -50,9 +50,10 @@ pub mod upgradeable_cpt {
             );
             assert(new_class_hash.is_non_zero(), Errors::INVALID_CLASS);
 
-            // Seems like the match doesn't catch the error if the entrypoint is
-            // not found. This is observed on public network like Sepolia.
-            // On the cairo runner, behavior seems to be as expected.
+            // Currently - any syscall that fails on starknet - fails the transaction, and it won't
+            // be included in any block.
+            // The test runner does not simulate this, but instead simulates the future behavior
+            // when errors can be recovered from.
             match starknet::syscalls::library_call_syscall(
                 new_class_hash, selector!("dojo_name"), [].span(),
             ) {

--- a/crates/dojo/core/src/contract/components/upgradeable.cairo
+++ b/crates/dojo/core/src/contract/components/upgradeable.cairo
@@ -50,8 +50,9 @@ pub mod upgradeable_cpt {
             );
             assert(new_class_hash.is_non_zero(), Errors::INVALID_CLASS);
 
-            // Seems like the match doesn't catch the error is the entrypoint is
-            // not found.
+            // Seems like the match doesn't catch the error if the entrypoint is
+            // not found. This is observed on public network like Sepolia.
+            // On the cairo runner, behavior seems to be as expected.
             match starknet::syscalls::library_call_syscall(
                 new_class_hash, selector!("dojo_name"), [].span(),
             ) {


### PR DESCRIPTION
A transaction hash showing the behavior on Sepolia:
`0xee9e5900239cf8d9c7f5cb5e67c814edcdd6e90d6eceefa342ffb5304ff892`

Some code to reproduce (on the Cairo test runner, it runs as expected):
```rust
#[starknet::contract]
mod c1 {
    use starknet::ClassHash;

    #[storage]
    struct Storage {}
    
    #[event]
    #[derive(Drop, starknet::Event)]
    pub enum Event {
        Syscalled: Syscalled,
    }

    #[derive(Drop, starknet::Event)]
    pub struct Syscalled {
        pub success: bool,
    }

    #[abi(per_item)]
    #[generate_trait]
    impl Impl1 of Impl1Trait {
        #[external(v0)]
        fn call_f2(ref self: ContractState, class_hash: ClassHash) {
            let success = match starknet::syscalls::library_call_syscall(
                class_hash, selector!("f2"), [].span(),
            ) {
                Result::Ok(_) => true,
                Result::Err(_) => false,
            };

            self.emit(Syscalled { success });
        }
    }
}

#[starknet::contract]
mod c2 {
    #[storage]
    struct Storage {}

    #[abi(per_item)]
    #[generate_trait]
    impl Impl1 of Impl1Trait {
        #[external(v0)]
        fn f2(ref self: ContractState) {            
        }
    }    
}

#[starknet::contract]
mod c3 {
    #[storage]
    struct Storage {}
}

#[cfg(test)]
mod tests {
    use super::{c1, c2, c3};
    use starknet::ContractAddress;

    type TestClassHash = felt252;

    fn deploy_contract(class_hash: TestClassHash) -> ContractAddress {
        let salt = core::testing::get_available_gas();

        let (addr, _) = starknet::syscalls::deploy_syscall(
            class_hash.try_into().unwrap(),
            salt.into(),
            [].span(),
            true
        )
            .unwrap();
    
        addr
    }

    #[test]
    fn success() {
        let c1 = deploy_contract(c1::TEST_CLASS_HASH);

        let _ = starknet::syscalls::call_contract_syscall(
            c1,
            selector!("call_f2"),
            [c2::TEST_CLASS_HASH.try_into().unwrap()].span(),
        )
            .expect('call_f2 on c1 should succeed');

        let event = starknet::testing::pop_log::<c1::Event>(c1).expect('c1 should emit Syscalled');

        if let c1::Event::Syscalled(syscalled) = event {
            assert!(syscalled.success);
        } else {
            panic!("event should be Syscalled");
        }
    }

    #[test]
    fn fail() {
        let c1 = deploy_contract(c1::TEST_CLASS_HASH);

        let _ = starknet::syscalls::call_contract_syscall(
            c1,
            selector!("call_f2"),
            [c3::TEST_CLASS_HASH.try_into().unwrap()].span(),
        )
            .expect('call_f2 on c1 should fail');

        let event = starknet::testing::pop_log::<c1::Event>(c1).expect('c1 should emit Syscalled');

        if let c1::Event::Syscalled(syscalled) = event {
            assert!(!syscalled.success);
        } else {
            panic!("event should be Syscalled");
        }
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated comments for clarity regarding the behavior of the `upgrade` method on public networks.
	- Enhanced explanations of the match statement's functionality in the context of the `upgradeable` module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->