### PR TITLE
fix: time difference calculations for new_tps

### DIFF
--- a/crates/torii/core/src/executor.rs
+++ b/crates/torii/core/src/executor.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::mem;
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use dojo_types::schema::{Struct, Ty};
@@ -333,8 +334,10 @@ impl<'c> Executor<'c> {
                         let new_tps = if new_timestamp - cursor_timestamp != 0 {
                             num_transactions / (new_timestamp - cursor_timestamp)
                         } else {
-                            let now = Instant::now();
-                            num_transactions / (now.elapsed().as_secs() - cursor_timestamp)
+                            let current_time =
+                                SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+
+                            num_transactions / (current_time - cursor_timestamp)
                         };
 
                         cursor.last_pending_block_contract_tx =


### PR DESCRIPTION
# Description
Fixes panic `attempt to subtract with overflow`

## Related issue
Closes #2654



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction per second (TPS) calculation for improved accuracy by using the current system time.
  
- **Bug Fixes**
	- Addressed timing discrepancies in TPS calculations to reflect actual current time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->