### PR TITLE
feat: introspection for bytes31

### DIFF
--- a/crates/dojo/lang/src/derive_macros/introspect/utils.rs
+++ b/crates/dojo/lang/src/derive_macros/introspect/utils.rs
@@ -6,6 +6,7 @@ pub struct TypeIntrospection(pub usize, pub Vec<usize>);
 // Provides type introspection information for primitive types
 pub fn primitive_type_introspection() -> HashMap<String, TypeIntrospection> {
     HashMap::from([
+        ("bytes31".into(), TypeIntrospection(1, vec![248])),
         ("felt252".into(), TypeIntrospection(1, vec![251])),
         ("bool".into(), TypeIntrospection(1, vec![1])),
         ("u8".into(), TypeIntrospection(1, vec![8])),


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the primitive type introspection to include the new type `"bytes31"` for enhanced type mapping.
  
- **Bug Fixes**
	- No bug fixes were included in this release. 

- **Documentation**
	- Updated introspection output to reflect the addition of the new type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->