### PR TITLE
feat(katana): new command line interface (breaking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
           sudo apt update && sudo apt install ./hurl_3.0.0_amd64.deb
           chmod +x /tmp/bins/katana
           chmod +x /tmp/bins/sozo
-          nohup /tmp/bins/katana --accounts 2 --disable-fee &
+          nohup /tmp/bins/katana --dev.accounts 2 --dev.no-fee &
       - run: |
           /tmp/bins/sozo --manifest-path examples/spawn-and-move/Scarb.toml build
           /tmp/bins/sozo --manifest-path examples/spawn-and-move/Scarb.toml migrate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
           sudo apt update && sudo apt install ./hurl_3.0.0_amd64.deb
           chmod +x /tmp/bins/katana
           chmod +x /tmp/bins/sozo
-          nohup /tmp/bins/katana --dev.accounts 2 --dev.no-fee &
+          nohup /tmp/bins/katana --dev --dev.accounts 2 --dev.no-fee &
       - run: |
           /tmp/bins/sozo --manifest-path examples/spawn-and-move/Scarb.toml build
           /tmp/bins/sozo --manifest-path examples/spawn-and-move/Scarb.toml migrate

--- a/bin/katana/src/cli/node.rs
+++ b/bin/katana/src/cli/node.rs
@@ -77,7 +77,6 @@ pub struct NodeArgs {
     ///
     /// Configure the messaging to allow Katana listening/sending messages on a
     /// settlement chain that can be Ethereum or an other Starknet sequencer.
-    /// The configuration file details and examples can be found here: <https://book.dojoengine.org/toolchain/katana/reference#messaging>
     #[arg(long)]
     #[arg(value_name = "PATH")]
     #[arg(value_parser = katana_core::service::messaging::MessagingConfig::parse)]

--- a/bin/katana/src/cli/node.rs
+++ b/bin/katana/src/cli/node.rs
@@ -51,30 +51,30 @@ use crate::utils::{parse_block_hash_or_number, parse_genesis, parse_seed};
 
 #[derive(Parser, Debug)]
 pub struct NodeArgs {
+    /// Don't print anything on startup.
     #[arg(long)]
-    #[arg(help = "Don't print anything on startup.")]
     pub silent: bool,
 
+    /// Disable auto and interval mining, and mine on demand instead via an endpoint.
     #[arg(long)]
     #[arg(conflicts_with = "block_time")]
-    #[arg(help = "Disable auto and interval mining, and mine on demand instead via an endpoint.")]
     pub no_mining: bool,
 
+    /// Block time in milliseconds for interval mining.
     #[arg(short, long)]
     #[arg(value_name = "MILLISECONDS")]
-    #[arg(help = "Block time in milliseconds for interval mining.")]
     pub block_time: Option<u64>,
 
+    /// Directory path of the database to initialize from.
+    ///
+    /// The path must either be an empty directory or a directory which already contains a
+    /// previously initialized Katana database.
     #[arg(long)]
     #[arg(value_name = "PATH")]
-    #[arg(help = "Directory path of the database to initialize from.")]
-    #[arg(long_help = "Directory path of the database to initialize from. The path must either \
-                       be an empty directory or a directory which already contains a previously \
-                       initialized Katana database.")]
     pub db_dir: Option<PathBuf>,
 
+    /// The Starknet RPC provider to fork the network from.
     #[arg(long = "fork.rpc-url", value_name = "URL", alias = "rpc-url")]
-    #[arg(help = "The Starknet RPC provider to fork the network from.")]
     pub fork_rpc_url: Option<Url>,
 
     #[arg(long = "fork.block", value_name = "BLOCK_ID", alias = "fork-block-number")]
@@ -84,17 +84,18 @@ pub struct NodeArgs {
     #[arg(value_parser = parse_block_hash_or_number)]
     pub fork_block: Option<BlockHashOrNumber>,
 
+    /// Output logs in JSON format.
     #[arg(long)]
-    #[arg(help = "Output logs in JSON format.")]
     pub json_log: bool,
 
+    /// Configure the messaging with an other chain.
+    ///
+    /// Configure the messaging to allow Katana listening/sending messages on a
+    /// settlement chain that can be Ethereum or an other Starknet sequencer.
+    /// The configuration file details and examples can be found here: https://book.dojoengine.org/toolchain/katana/reference#messaging
     #[arg(long)]
     #[arg(value_name = "PATH")]
     #[arg(value_parser = katana_core::service::messaging::MessagingConfig::parse)]
-    #[arg(help = "Configure the messaging with an other chain.")]
-    #[arg(long_help = "Configure the messaging to allow Katana listening/sending messages on a \
-                       settlement chain that can be Ethereum or an other Starknet sequencer. \
-                       The configuration file details and examples can be found here: https://book.dojoengine.org/toolchain/katana/reference#messaging")]
     pub messaging: Option<MessagingConfig>,
 
     #[command(flatten)]
@@ -140,24 +141,24 @@ pub struct MetricsOptions {
 #[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Server options")]
 pub struct ServerOptions {
+    /// HTTP-RPC server listening interface.
     #[arg(long = "http.addr", value_name = "ADDRESS")]
     #[arg(default_value_t = DEFAULT_RPC_ADDR)]
-    #[arg(help = "The IP address the server will listen on.")]
     pub http_addr: IpAddr,
 
+    /// HTTP-RPC server listening port.
     #[arg(long = "http.port", value_name = "PORT")]
     #[arg(default_value_t = DEFAULT_RPC_PORT)]
-    #[arg(help = "Port number to listen on.")]
     pub http_port: u16,
 
+    /// Comma separated list of domains from which to accept cross origin requests.
     #[arg(long = "http.corsdomain")]
     #[arg(value_delimiter = ',')]
-    #[arg(help = "Enables the CORS layer and sets the allowed origins, separated by commas.")]
     pub http_cors_domain: Option<Vec<String>>,
 
+    /// Maximum number of concurrent connections allowed.
     #[arg(long = "rpc.max-connections", value_name = "COUNT")]
     #[arg(default_value_t = DEFAULT_RPC_MAX_CONNECTIONS)]
-    #[arg(help = "Maximum number of concurrent connections allowed.")]
     pub max_connections: u32,
 }
 
@@ -176,30 +177,31 @@ pub struct StarknetOptions {
 #[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Environment options")]
 pub struct EnvironmentOptions {
+    /// The chain ID.
+    ///
+    /// The chain ID. If a raw hex string (`0x` prefix) is provided, then it'd
+    /// used as the actual chain ID. Otherwise, it's represented as the raw
+    /// ASCII values. It must be a valid Cairo short string.
     #[arg(long)]
-    #[arg(help = "The chain ID.")]
-    #[arg(long_help = "The chain ID. If a raw hex string (`0x` prefix) is provided, then it'd \
-                       used as the actual chain ID. Otherwise, it's represented as the raw \
-                       ASCII values. It must be a valid Cairo short string.")]
     #[arg(value_parser = ChainId::parse)]
     pub chain_id: Option<ChainId>,
 
+    /// The maximum number of steps available for the account validation logic.
     #[arg(long)]
-    #[arg(help = "The maximum number of steps available for the account validation logic.")]
     pub validate_max_steps: Option<u32>,
 
+    /// The maximum number of steps available for the account execution logic.
     #[arg(long)]
-    #[arg(help = "The maximum number of steps available for the account execution logic.")]
     pub invoke_max_steps: Option<u32>,
 
+    /// The L1 ETH gas price. (denominated in wei)
     #[arg(long = "l1-eth-gas-price", value_name = "WEI")]
-    #[arg(help = "The L1 ETH gas price. (denominated in wei)")]
     #[arg(requires = "l1_strk_gas_price")]
     pub l1_eth_gas_price: Option<u128>,
 
+    /// The L1 STRK gas price. (denominated in fri)
     #[arg(long = "l1-strk-gas-price", value_name = "FRI")]
     #[arg(requires = "l1_eth_data_gas_price")]
-    #[arg(help = "The L1 STRK gas price. (denominated in fri)")]
     pub l1_strk_gas_price: Option<u128>,
 
     #[arg(long = "l1-eth-data-gas-price", value_name = "WEI")]

--- a/bin/katana/src/cli/node.rs
+++ b/bin/katana/src/cli/node.rs
@@ -86,7 +86,7 @@ pub struct NodeArgs {
     ///
     /// Configure the messaging to allow Katana listening/sending messages on a
     /// settlement chain that can be Ethereum or an other Starknet sequencer.
-    /// The configuration file details and examples can be found here: https://book.dojoengine.org/toolchain/katana/reference#messaging
+    /// The configuration file details and examples can be found here: <https://book.dojoengine.org/toolchain/katana/reference#messaging>
     #[arg(long)]
     #[arg(value_name = "PATH")]
     #[arg(value_parser = katana_core::service::messaging::MessagingConfig::parse)]

--- a/bin/katana/src/cli/node.rs
+++ b/bin/katana/src/cli/node.rs
@@ -125,16 +125,14 @@ pub struct MetricsOptions {
     pub metrics: bool,
 
     /// The metrics will be served at the given address.
-    #[arg(long = "metrics.addr")]
-    #[arg(value_name = "ADD")]
     #[arg(requires = "metrics")]
+    #[arg(long = "metrics.addr", value_name = "ADDRESS")]
     #[arg(default_value_t = DEFAULT_METRICS_ADDR)]
     pub metrics_addr: IpAddr,
 
     /// The metrics will be served at the given port.
-    #[arg(long = "metrics.port")]
-    #[arg(value_name = "PORT")]
     #[arg(requires = "metrics")]
+    #[arg(long = "metrics.port", value_name = "PORT")]
     #[arg(default_value_t = DEFAULT_METRICS_PORT)]
     pub metrics_port: u16,
 }
@@ -142,25 +140,25 @@ pub struct MetricsOptions {
 #[derive(Debug, Args, Clone)]
 #[command(next_help_heading = "Server options")]
 pub struct ServerOptions {
-    #[arg(short, long)]
-    #[arg(default_value_t = DEFAULT_RPC_PORT)]
-    #[arg(help = "Port number to listen on.")]
-    pub port: u16,
-
-    #[arg(long)]
+    #[arg(long = "http.addr", value_name = "ADDRESS")]
     #[arg(default_value_t = DEFAULT_RPC_ADDR)]
     #[arg(help = "The IP address the server will listen on.")]
-    pub host: IpAddr,
+    pub http_addr: IpAddr,
 
-    #[arg(long)]
+    #[arg(long = "http.port", value_name = "PORT")]
+    #[arg(default_value_t = DEFAULT_RPC_PORT)]
+    #[arg(help = "Port number to listen on.")]
+    pub http_port: u16,
+
+    #[arg(long = "http.corsdomain")]
+    #[arg(value_delimiter = ',')]
+    #[arg(help = "Enables the CORS layer and sets the allowed origins, separated by commas.")]
+    pub http_cors_domain: Option<Vec<String>>,
+
+    #[arg(long = "rpc.max-connections", value_name = "COUNT")]
     #[arg(default_value_t = DEFAULT_RPC_MAX_CONNECTIONS)]
     #[arg(help = "Maximum number of concurrent connections allowed.")]
     pub max_connections: u32,
-
-    #[arg(long)]
-    #[arg(value_delimiter = ',')]
-    #[arg(help = "Enables the CORS layer and sets the allowed origins, separated by commas.")]
-    pub allowed_origins: Option<Vec<String>>,
 }
 
 #[derive(Debug, Args, Clone)]
@@ -329,10 +327,10 @@ impl NodeArgs {
 
         RpcConfig {
             apis,
-            port: self.server.port,
-            addr: self.server.host,
+            port: self.server.http_port,
+            addr: self.server.http_addr,
             max_connections: self.server.max_connections,
-            allowed_origins: self.server.allowed_origins.clone(),
+            cors_domain: self.server.http_cors_domain.clone(),
         }
     }
 

--- a/bin/katana/src/utils.rs
+++ b/bin/katana/src/utils.rs
@@ -1,6 +1,9 @@
+use std::fmt::Display;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use clap::builder::PossibleValue;
+use clap::ValueEnum;
 use katana_primitives::block::{BlockHash, BlockHashOrNumber, BlockNumber};
 use katana_primitives::genesis::json::GenesisJson;
 use katana_primitives::genesis::Genesis;
@@ -31,6 +34,34 @@ pub fn parse_block_hash_or_number(value: &str) -> Result<BlockHashOrNumber> {
     } else {
         let num = value.parse::<BlockNumber>().context("could not parse block number")?;
         Ok(BlockHashOrNumber::Num(num))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LogFormat {
+    Json,
+    Full,
+}
+
+impl ValueEnum for LogFormat {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Json, Self::Full]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Self::Json => Some(PossibleValue::new("json")),
+            Self::Full => Some(PossibleValue::new("full")),
+        }
+    }
+}
+
+impl Display for LogFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json => write!(f, "json"),
+            Self::Full => write!(f, "full"),
+        }
     }
 }
 

--- a/crates/dojo/test-utils/src/sequencer.rs
+++ b/crates/dojo/test-utils/src/sequencer.rs
@@ -118,7 +118,7 @@ pub fn get_default_test_config(sequencing: SequencingConfig) -> Config {
     chain.genesis.sequencer_address = *DEFAULT_SEQUENCER_ADDRESS;
 
     let rpc = RpcConfig {
-        allowed_origins: None,
+        cors_domain: None,
         port: 0,
         addr: DEFAULT_RPC_ADDR,
         max_connections: DEFAULT_RPC_MAX_CONNECTIONS,

--- a/crates/katana/node-bindings/src/lib.rs
+++ b/crates/katana/node-bindings/src/lib.rs
@@ -427,7 +427,7 @@ impl Katana {
 
         // In the case where port 0 is set, we will need to extract the actual port number
         // from the logs.
-        let mut port = self.http_port.unwrap_or(5050);
+        let mut port = self.http_port.unwrap_or(0);
         cmd.arg("--http.port").arg(port.to_string());
 
         if self.no_mining {

--- a/crates/katana/node-bindings/src/lib.rs
+++ b/crates/katana/node-bindings/src/lib.rs
@@ -176,20 +176,21 @@ pub struct Katana {
     json_log: bool,
     block_time: Option<u64>,
     db_dir: Option<PathBuf>,
-    rpc_url: Option<String>,
+    l1_provider: Option<String>,
     fork_block_number: Option<u64>,
     messaging: Option<PathBuf>,
 
     // Metrics options
-    metrics: Option<String>,
+    metrics_addr: Option<SocketAddr>,
+    metrics_port: Option<u16>,
 
     // Server options
-    port: Option<u16>,
-    host: Option<String>,
-    max_connections: Option<u64>,
-    allowed_origins: Option<String>,
+    http_addr: Option<SocketAddr>,
+    http_port: Option<u16>,
+    rpc_max_connections: Option<u64>,
+    http_cors_domain: Option<String>,
 
-    // Starknet options
+    // Dev options
     seed: Option<u64>,
     accounts: Option<u16>,
     disable_fee: bool,
@@ -253,7 +254,7 @@ impl Katana {
 
     /// Sets the port which will be used when the `katana` instance is launched.
     pub fn port<T: Into<u16>>(mut self, port: T) -> Self {
-        self.port = Some(port.into());
+        self.http_port = Some(port.into());
         self
     }
 
@@ -271,8 +272,8 @@ impl Katana {
     }
 
     /// Sets the RPC URL to fork the network from.
-    pub fn rpc_url<T: Into<String>>(mut self, rpc_url: T) -> Self {
-        self.rpc_url = Some(rpc_url.into());
+    pub fn l1_provider<T: Into<String>>(mut self, rpc_url: T) -> Self {
+        self.l1_provider = Some(rpc_url.into());
         self
     }
 
@@ -301,27 +302,33 @@ impl Katana {
         self
     }
 
-    /// Enables Prometheus metrics and sets the socket address.
-    pub fn metrics<T: Into<String>>(mut self, metrics: T) -> Self {
-        self.metrics = Some(metrics.into());
+    /// Enables Prometheus metrics and sets the metrics server address.
+    pub fn metrics_addr<T: Into<SocketAddr>>(mut self, addr: T) -> Self {
+        self.metrics_addr = Some(addr.into());
+        self
+    }
+
+    /// Enables Prometheus metrics and sets the metrics server port.
+    pub fn metrics_port<T: Into<u16>>(mut self, port: T) -> Self {
+        self.metrics_port = Some(port.into());
         self
     }
 
     /// Sets the host IP address the server will listen on.
-    pub fn host<T: Into<String>>(mut self, host: T) -> Self {
-        self.host = Some(host.into());
+    pub fn http_addr<T: Into<SocketAddr>>(mut self, addr: T) -> Self {
+        self.http_addr = Some(addr.into());
         self
     }
 
     /// Sets the maximum number of concurrent connections allowed.
-    pub const fn max_connections(mut self, max_connections: u64) -> Self {
-        self.max_connections = Some(max_connections);
+    pub const fn rpc_max_connections(mut self, max_connections: u64) -> Self {
+        self.rpc_max_connections = Some(max_connections);
         self
     }
 
     /// Enables the CORS layer and sets the allowed origins, separated by commas.
-    pub fn allowed_origins<T: Into<String>>(mut self, allowed_origins: T) -> Self {
-        self.allowed_origins = Some(allowed_origins.into());
+    pub fn http_cors_domain<T: Into<String>>(mut self, allowed_origins: T) -> Self {
+        self.http_cors_domain = Some(allowed_origins.into());
         self
     }
 
@@ -414,8 +421,14 @@ impl Katana {
         let mut cmd = self.program.as_ref().map_or_else(|| Command::new("katana"), Command::new);
         cmd.stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::inherit());
 
-        let mut port = self.port.unwrap_or(0);
-        cmd.arg("--port").arg(port.to_string());
+        if let Some(host) = self.http_addr {
+            cmd.arg("--http.addr").arg(host.to_string());
+        }
+
+        // In the case where port 0 is set, we will need to extract the actual port number
+        // from the logs.
+        let mut port = self.http_port.unwrap_or(5050);
+        cmd.arg("--http.port").arg(port.to_string());
 
         if self.no_mining {
             cmd.arg("--no-mining");
@@ -428,56 +441,92 @@ impl Katana {
         if let Some(db_dir) = self.db_dir {
             cmd.arg("--db-dir").arg(db_dir);
         }
-        if let Some(rpc_url) = self.rpc_url {
-            cmd.arg("--rpc-url").arg(rpc_url);
+
+        if let Some(url) = self.l1_provider {
+            cmd.arg("--l1.provider").arg(url);
         }
+
+        // Need to make sure that the `--dev` is not being set twice.
+        let mut is_dev = false;
 
         if self.dev {
             cmd.arg("--dev");
+            is_dev = true;
+        }
+
+        if let Some(seed) = self.seed {
+            if !is_dev {
+                cmd.arg("--dev");
+                is_dev = true;
+            }
+
+            cmd.arg("--dev.seed").arg(seed.to_string());
+        }
+
+        if let Some(accounts) = self.accounts {
+            if !is_dev {
+                cmd.arg("--dev");
+                is_dev = true;
+            }
+
+            cmd.arg("--dev.accounts").arg(accounts.to_string());
+        }
+
+        if self.disable_fee {
+            if !is_dev {
+                cmd.arg("--dev");
+                is_dev = true;
+            }
+
+            cmd.arg("--dev.no-fee");
+        }
+
+        if self.disable_validate {
+            if !is_dev {
+                cmd.arg("--dev");
+            }
+
+            cmd.arg("--dev.no-account-validation");
         }
 
         if self.json_log {
-            cmd.arg("--json-log");
+            cmd.args(["--log.format", "json"]);
         }
 
         if let Some(fork_block_number) = self.fork_block_number {
-            cmd.arg("--fork-block-number").arg(fork_block_number.to_string());
+            cmd.args(["--fork", "--fork.block"]).arg(fork_block_number.to_string());
         }
 
         if let Some(messaging) = self.messaging {
             cmd.arg("--messaging").arg(messaging);
         }
 
-        if let Some(metrics) = self.metrics {
-            cmd.arg("--metrics").arg(metrics);
+        // Need to make sure that the `--metrics` is not being set twice.
+        let mut metrics_enabled = false;
+
+        if let Some(addr) = self.metrics_addr {
+            if !metrics_enabled {
+                cmd.arg("--metrics");
+                metrics_enabled = true;
+            }
+
+            cmd.arg("--metrics.addr").arg(addr.to_string());
         }
 
-        if let Some(host) = self.host {
-            cmd.arg("--host").arg(host);
+        if let Some(port) = self.metrics_port {
+            if !metrics_enabled {
+                cmd.arg("--metrics");
+            }
+
+            cmd.arg("--metrics.port").arg(port.to_string());
         }
 
-        if let Some(max_connections) = self.max_connections {
-            cmd.arg("--max-connections").arg(max_connections.to_string());
+        if let Some(max_connections) = self.rpc_max_connections {
+            cmd.arg("--rpc.max-connections").arg(max_connections.to_string());
         }
 
-        if let Some(allowed_origins) = self.allowed_origins {
-            cmd.arg("--allowed-origins").arg(allowed_origins);
-        }
-
-        if let Some(seed) = self.seed {
-            cmd.arg("--seed").arg(seed.to_string());
-        }
-
-        if let Some(accounts) = self.accounts {
-            cmd.arg("--accounts").arg(accounts.to_string());
-        }
-
-        if self.disable_fee {
-            cmd.arg("--disable-fee");
-        }
-
-        if self.disable_validate {
-            cmd.arg("--disable-validate");
+        if let Some(allowed_origins) = self.http_cors_domain {
+            cmd.arg("--http.corsdomain").arg(allowed_origins);
         }
 
         if let Some(chain_id) = self.chain_id {

--- a/crates/katana/node/src/config/dev.rs
+++ b/crates/katana/node/src/config/dev.rs
@@ -1,3 +1,7 @@
+use katana_core::constants::{
+    DEFAULT_ETH_L1_DATA_GAS_PRICE, DEFAULT_ETH_L1_GAS_PRICE, DEFAULT_STRK_L1_DATA_GAS_PRICE,
+    DEFAULT_STRK_L1_GAS_PRICE,
+};
 use katana_primitives::block::GasPrices;
 
 /// Development configuration.
@@ -34,6 +38,18 @@ pub struct DevConfig {
 pub struct FixedL1GasPriceConfig {
     pub gas_price: GasPrices,
     pub data_gas_price: GasPrices,
+}
+
+impl std::default::Default for FixedL1GasPriceConfig {
+    fn default() -> Self {
+        Self {
+            gas_price: GasPrices { eth: DEFAULT_ETH_L1_GAS_PRICE, strk: DEFAULT_STRK_L1_GAS_PRICE },
+            data_gas_price: GasPrices {
+                eth: DEFAULT_ETH_L1_DATA_GAS_PRICE,
+                strk: DEFAULT_STRK_L1_DATA_GAS_PRICE,
+            },
+        }
+    }
 }
 
 impl std::default::Default for DevConfig {

--- a/crates/katana/node/src/config/metrics.rs
+++ b/crates/katana/node/src/config/metrics.rs
@@ -1,8 +1,22 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+/// Metrics server default address.
+pub const DEFAULT_METRICS_ADDR: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+/// Metrics server default port.
+pub const DEFAULT_METRICS_PORT: u16 = 9100;
 
 /// Node metrics configurations.
 #[derive(Debug, Clone)]
 pub struct MetricsConfig {
     /// The address to bind the metrics server to.
-    pub addr: SocketAddr,
+    pub addr: IpAddr,
+    /// The port to bind the metrics server to.
+    pub port: u16,
+}
+
+impl MetricsConfig {
+    /// Returns the [`SocketAddr`] for the metrics server.
+    pub fn socket_addr(&self) -> SocketAddr {
+        SocketAddr::new(self.addr, self.port)
+    }
 }

--- a/crates/katana/node/src/config/rpc.rs
+++ b/crates/katana/node/src/config/rpc.rs
@@ -23,8 +23,8 @@ pub struct RpcConfig {
     pub addr: IpAddr,
     pub port: u16,
     pub max_connections: u32,
-    pub allowed_origins: Option<Vec<String>>,
     pub apis: HashSet<ApiKind>,
+    pub cors_domain: Option<Vec<String>>,
 }
 
 impl RpcConfig {
@@ -37,7 +37,7 @@ impl RpcConfig {
 impl Default for RpcConfig {
     fn default() -> Self {
         Self {
-            allowed_origins: None,
+            cors_domain: None,
             addr: DEFAULT_RPC_ADDR,
             port: DEFAULT_RPC_PORT,
             max_connections: DEFAULT_RPC_MAX_CONNECTIONS,

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -313,20 +313,19 @@ pub async fn spawn<EF: ExecutorFactory>(
             .allow_methods([Method::POST, Method::GET])
             .allow_headers([hyper::header::CONTENT_TYPE, "argent-client".parse().unwrap(), "argent-version".parse().unwrap()]);
 
-    let cors =
-        config.allowed_origins.clone().map(|allowed_origins| match allowed_origins.as_slice() {
-            [origin] if origin == "*" => cors.allow_origin(AllowOrigin::mirror_request()),
-            origins => cors.allow_origin(
-                origins
-                    .iter()
-                    .map(|o| {
-                        let _ = o.parse::<Uri>().expect("Invalid URI");
+    let cors = config.cors_domain.clone().map(|allowed_origins| match allowed_origins.as_slice() {
+        [origin] if origin == "*" => cors.allow_origin(AllowOrigin::mirror_request()),
+        origins => cors.allow_origin(
+            origins
+                .iter()
+                .map(|o| {
+                    let _ = o.parse::<Uri>().expect("Invalid URI");
 
-                        o.parse().expect("Invalid origin")
-                    })
-                    .collect::<Vec<_>>(),
-            ),
-        });
+                    o.parse().expect("Invalid origin")
+                })
+                .collect::<Vec<_>>(),
+        ),
+    });
 
     let middleware = tower::ServiceBuilder::new()
         .option_layer(cors)

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -107,6 +107,7 @@ impl Node {
 
         // TODO: maybe move this to the build stage
         if let Some(ref cfg) = self.metrics_config {
+            let addr = cfg.socket_addr();
             let mut reports: Vec<Box<dyn Report>> = Vec::new();
 
             if let Some(ref db) = self.db {
@@ -116,8 +117,8 @@ impl Node {
             let exporter = PrometheusRecorder::current().expect("qed; should exist at this point");
             let server = MetricsServer::new(exporter).with_process_metrics().with_reports(reports);
 
-            self.task_manager.task_spawner().build_task().spawn(server.start(cfg.addr));
-            info!(addr = %cfg.addr, "Metrics server started.");
+            self.task_manager.task_spawner().build_task().spawn(server.start(addr));
+            info!(%addr, "Metrics server started.");
         }
 
         let pool = self.pool.clone();

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -16,12 +16,12 @@ use config::{Config, SequencingConfig};
 use dojo_metrics::exporters::prometheus::PrometheusRecorder;
 use dojo_metrics::{Report, Server as MetricsServer};
 use hyper::{Method, Uri};
+use jsonrpsee::RpcModule;
 use jsonrpsee::server::middleware::proxy_get_request::ProxyGetRequestLayer;
 use jsonrpsee::server::{AllowHosts, ServerBuilder, ServerHandle};
-use jsonrpsee::RpcModule;
+use katana_core::backend::Backend;
 use katana_core::backend::gas_oracle::L1GasOracle;
 use katana_core::backend::storage::Blockchain;
-use katana_core::backend::Backend;
 use katana_core::constants::{
     DEFAULT_ETH_L1_DATA_GAS_PRICE, DEFAULT_ETH_L1_GAS_PRICE, DEFAULT_STRK_L1_DATA_GAS_PRICE,
     DEFAULT_STRK_L1_GAS_PRICE,
@@ -32,17 +32,17 @@ use katana_core::service::messaging::MessagingConfig;
 use katana_db::mdbx::DbEnv;
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::{ExecutionFlags, ExecutorFactory};
-use katana_pipeline::{stage, Pipeline};
+use katana_pipeline::{Pipeline, stage};
+use katana_pool::TxPool;
 use katana_pool::ordering::FiFo;
 use katana_pool::validation::stateful::TxValidator;
-use katana_pool::TxPool;
 use katana_primitives::block::GasPrices;
 use katana_primitives::env::{CfgEnv, FeeTokenAddressses};
 use katana_rpc::dev::DevApi;
 use katana_rpc::metrics::RpcServerMetrics;
 use katana_rpc::saya::SayaApi;
-use katana_rpc::starknet::forking::ForkedClient;
 use katana_rpc::starknet::StarknetApi;
+use katana_rpc::starknet::forking::ForkedClient;
 use katana_rpc::torii::ToriiApi;
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::saya::SayaApiServer;

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -16,12 +16,12 @@ use config::{Config, SequencingConfig};
 use dojo_metrics::exporters::prometheus::PrometheusRecorder;
 use dojo_metrics::{Report, Server as MetricsServer};
 use hyper::{Method, Uri};
-use jsonrpsee::RpcModule;
 use jsonrpsee::server::middleware::proxy_get_request::ProxyGetRequestLayer;
 use jsonrpsee::server::{AllowHosts, ServerBuilder, ServerHandle};
-use katana_core::backend::Backend;
+use jsonrpsee::RpcModule;
 use katana_core::backend::gas_oracle::L1GasOracle;
 use katana_core::backend::storage::Blockchain;
+use katana_core::backend::Backend;
 use katana_core::constants::{
     DEFAULT_ETH_L1_DATA_GAS_PRICE, DEFAULT_ETH_L1_GAS_PRICE, DEFAULT_STRK_L1_DATA_GAS_PRICE,
     DEFAULT_STRK_L1_GAS_PRICE,
@@ -32,17 +32,17 @@ use katana_core::service::messaging::MessagingConfig;
 use katana_db::mdbx::DbEnv;
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::{ExecutionFlags, ExecutorFactory};
-use katana_pipeline::{Pipeline, stage};
-use katana_pool::TxPool;
+use katana_pipeline::{stage, Pipeline};
 use katana_pool::ordering::FiFo;
 use katana_pool::validation::stateful::TxValidator;
+use katana_pool::TxPool;
 use katana_primitives::block::GasPrices;
 use katana_primitives::env::{CfgEnv, FeeTokenAddressses};
 use katana_rpc::dev::DevApi;
 use katana_rpc::metrics::RpcServerMetrics;
 use katana_rpc::saya::SayaApi;
-use katana_rpc::starknet::StarknetApi;
 use katana_rpc::starknet::forking::ForkedClient;
+use katana_rpc::starknet::StarknetApi;
 use katana_rpc::torii::ToriiApi;
 use katana_rpc_api::dev::DevApiServer;
 use katana_rpc_api::saya::SayaApiServer;

--- a/crates/katana/runner/src/lib.rs
+++ b/crates/katana/runner/src/lib.rs
@@ -121,7 +121,7 @@ impl KatanaRunner {
             .port(port)
             .accounts(n_accounts)
             .json_log(true)
-            .max_connections(10000)
+            .rpc_max_connections(10000)
             .dev(config.dev)
             .fee(!config.disable_fee);
 


### PR DESCRIPTION
new/rename katana cli args

## Motivation

standardize the cli arguments names, categorized the arguments based on their scope, and makes it more flexible to add new arguments later.

## Changes 

1. JSON log format

Removed `--json-log` and introduce a more generic argument, `--log.format`, with possible values: json, full. Doing `--log.format json` is the equivalent of `--json-log`.

2. Metrics 

Currently, `--metrics` is used to specify the address of the metrics server, but now we split the argument into 3 parts:

- `--metrics`: To enable metrics collection. Right now, whether you specify the flag or not, metrics will still be collected. This is a required flag if you want to start the metrics server.
- `--metrics.addr`: Metrics server address.
- `--metrics.port`: Metrics server port.

3. RPC Server

- `--http.addr`: RPC HTTP server address. Replacing `--host`.
- `--http.port`: RPC HTTP server port. Replacing `--port`.
- `--http.corsdomain`: RPC HTTP server allowed cors domain. Replacing `--allowed-origins`.
- `--rpc.max-connections`: Maximum number of concurrent connections allowed for all servers.

4. Dev

- `--dev`: Now this flag must be enabled to use any of the flags below.
- `--dev.seed`: Replacing `--seed`.
- `--dev.accounts`: Replacing `--accounts`.
- `--dev.no-fee`: Replacing `--disable-fee`.
- `--dev.no-account-validation`: Replacing `--disable-validation`.

5. Gas Price Oracle

- `--gpo.l1-eth-gas-price`: Replacing `--l1-eth-gas-price`.
- `--gpo.l1-strk-gas-price`: Replacing `--l1-str-gas-price`. 
- `--gpo.l1-eth-data-gas-price`: Replacing `--l1-eth-data-gas-price`.
- `--gpo.l1-strk-data-gas-price`: Replacing `--l1-strk-data-gas-price`. 

6. Forking

- `--fork.provider`: Replacing `--rpc-url`.

## Preview

```console
A fast and lightweight local Starknet development sequencer.

Usage: katana [OPTIONS] [COMMAND]

Commands:
  completions  Generate shell completion file for specified shell
  db           Database utilities
  help         Print this message or the help of the given subcommand(s)

Options:
      --silent                     Don't print anything on startup
      --no-mining                  Disable auto and interval mining, and mine on demand instead via an endpoint
  -b, --block-time <MILLISECONDS>  Block time in milliseconds for interval mining
      --db-dir <PATH>              Directory path of the database to initialize from
      --messaging <PATH>           Configure the messaging with an other chain
  -h, --help                       Print help (see more with '--help')
  -V, --version                    Print version

Logging options:
      --log.format <FORMAT>  Log format to use [default: full] [possible values: json, full]

Metrics options:
      --metrics                 Enable metrics
      --metrics.addr <ADDRESS>  The metrics will be served at the given address [default: 127.0.0.1]
      --metrics.port <PORT>     The metrics will be served at the given port [default: 9100]

Server options:
      --http.addr <ADDRESS>
          HTTP-RPC server listening interface [default: 127.0.0.1]
      --http.port <PORT>
          HTTP-RPC server listening port [default: 5050]
      --http.corsdomain <HTTP_CORS_DOMAIN>
          Comma separated list of domains from which to accept cross origin requests
      --rpc.max-connections <COUNT>
          Maximum number of concurrent connections allowed [default: 100]

Environment options:
      --chain-id <CHAIN_ID>
          The chain ID
      --validate-max-steps <VALIDATE_MAX_STEPS>
          The maximum number of steps available for the account validation logic
      --invoke-max-steps <INVOKE_MAX_STEPS>
          The maximum number of steps available for the account execution logic
      --genesis <GENESIS>


Gas Price Oracle Options:
      --gpo.l1-eth-gas-price <WEI>        The L1 ETH gas price. (denominated in wei)
      --gpo.l1-strk-gas-price <FRI>       The L1 STRK gas price. (denominated in fri)
      --gpo.l1-eth-data-gas-price <WEI>   The L1 ETH data gas price. (denominated in wei)
      --gpo.l1-strk-data-gas-price <FRI>  The L1 STRK data gas price. (denominated in fri)

Forking options:
      --fork.provider <URL>  The RPC URL of the network to fork from
      --fork.block <BLOCK>   Fork the network at a specific block id, can either be a hash (0x-prefixed) or a block number

Development options:
      --dev                        Enable development mode
      --dev.seed <SEED>            Specify the seed for randomness of accounts to be predeployed [default: 0]
      --dev.accounts <NUM>         Number of pre-funded accounts to generate [default: 10]
      --dev.no-fee                 Disable charging fee when executing transactions
      --dev.no-account-validation  Disable account validation when executing transactions
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new configuration options for metrics and development settings.
	- Added support for structured logging formats with `LogFormat` enum.
	- Enhanced metrics server configuration with default values.

- **Bug Fixes**
	- Updated CORS configuration to use `cors_domain` for improved clarity.

- **Chores**
	- Modified CI workflow to reflect updated command-line parameters for the `katana` binary. 

These changes enhance the overall functionality and clarity of the Katana CLI, improving user experience and configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->