### PR TITLE
feat(sozo): add sozo `dev` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5364,6 +5364,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7457,6 +7466,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8518,6 +8547,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9477,6 +9526,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -9793,6 +9843,34 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.6.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7393c226621f817964ffb3dc5704f9509e107a8b024b489cc2c1b217378785df"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -13254,6 +13332,7 @@ dependencies = [
  "itertools 0.12.1",
  "katana-rpc-api",
  "katana-runner",
+ "notify",
  "reqwest 0.11.27",
  "scarb",
  "scarb-ui",

--- a/bin/sozo/Cargo.toml
+++ b/bin/sozo/Cargo.toml
@@ -29,6 +29,7 @@ dojo-utils.workspace = true
 dojo-world.workspace = true
 itertools.workspace = true
 katana-rpc-api.workspace = true
+notify = "7.0.0"
 tabled = { version = "0.16.0", features = [ "ansi" ] }
 scarb.workspace = true
 scarb-ui.workspace = true

--- a/bin/sozo/src/commands/build.rs
+++ b/bin/sozo/src/commands/build.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 
 use crate::commands::check_package_dojo_version;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct BuildArgs {
     #[arg(long)]
     #[arg(help = "Generate Typescript bindings.")]

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -19,19 +19,19 @@ use super::options::transaction::TransactionOptions;
 use super::options::world::WorldOptions;
 use crate::utils;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct MigrateArgs {
     #[command(flatten)]
-    transaction: TransactionOptions,
+    pub transaction: TransactionOptions,
 
     #[command(flatten)]
-    world: WorldOptions,
+    pub world: WorldOptions,
 
     #[command(flatten)]
-    starknet: StarknetOptions,
+    pub starknet: StarknetOptions,
 
     #[command(flatten)]
-    account: AccountOptions,
+    pub account: AccountOptions,
 }
 
 impl MigrateArgs {

--- a/bin/sozo/src/commands/mod.rs
+++ b/bin/sozo/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod auth;
 pub(crate) mod build;
 pub(crate) mod call;
 pub(crate) mod clean;
+pub(crate) mod dev;
 pub(crate) mod events;
 pub(crate) mod execute;
 pub(crate) mod hash;
@@ -24,6 +25,7 @@ pub(crate) mod test;
 use build::BuildArgs;
 use call::CallArgs;
 use clean::CleanArgs;
+use dev::DevArgs;
 use execute::ExecuteArgs;
 use hash::HashArgs;
 use init::InitArgs;
@@ -37,7 +39,9 @@ pub enum Commands {
     #[command(about = "Grant or revoke a contract permission to write to a resource")]
     Auth(Box<AuthArgs>),
     #[command(about = "Build the world, generating the necessary artifacts for deployment")]
-    Build(BuildArgs),
+    Build(Box<BuildArgs>),
+    #[command(about = "Build and migrate the world every time a file changes")]
+    Dev(Box<DevArgs>),
     #[command(about = "Run a migration, declaring and deploying contracts as necessary to update \
                        the world")]
     Migrate(Box<MigrateArgs>),
@@ -67,6 +71,7 @@ impl fmt::Display for Commands {
             Commands::Auth(_) => write!(f, "Auth"),
             Commands::Build(_) => write!(f, "Build"),
             Commands::Clean(_) => write!(f, "Clean"),
+            Commands::Dev(_) => write!(f, "Dev"),
             Commands::Execute(_) => write!(f, "Execute"),
             Commands::Inspect(_) => write!(f, "Inspect"),
             Commands::Migrate(_) => write!(f, "Migrate"),
@@ -91,6 +96,7 @@ pub fn run(command: Commands, config: &Config) -> Result<()> {
     match command {
         Commands::Auth(args) => args.run(config),
         Commands::Build(args) => args.run(config),
+        Commands::Dev(args) => args.run(config),
         Commands::Migrate(args) => args.run(config),
         Commands::Execute(args) => args.run(config),
         Commands::Inspect(args) => args.run(config),

--- a/examples/simple/src/lib.cairo
+++ b/examples/simple/src/lib.cairo
@@ -41,13 +41,13 @@ pub mod c1 {
     use super::{MyInterface, M, E, EH, MValue};
     use dojo::model::{ModelStorage, ModelValueStorage, Model};
     use dojo::event::EventStorage;
-  
+
     fn dojo_init(self: @ContractState, v: felt252) {
         let m = M { k: 0, v, };
 
         let mut world = self.world_default();
         world.write_model(@m);
-    }      
+    }
 
     #[abi(embed_v0)]
     impl MyInterfaceImpl of MyInterface<ContractState> {

--- a/examples/simple/src/lib.cairo
+++ b/examples/simple/src/lib.cairo
@@ -41,13 +41,13 @@ pub mod c1 {
     use super::{MyInterface, M, E, EH, MValue};
     use dojo::model::{ModelStorage, ModelValueStorage, Model};
     use dojo::event::EventStorage;
-
+  
     fn dojo_init(self: @ContractState, v: felt252) {
         let m = M { k: 0, v, };
 
         let mut world = self.world_default();
         world.write_model(@m);
-    }
+    }      
 
     #[abi(embed_v0)]
     impl MyInterfaceImpl of MyInterface<ContractState> {


### PR DESCRIPTION
Add `sozo dev` command which now supports regenerating the bindings on the fly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `Dev` command for enhanced development workflows, allowing automatic builds and migrations on file changes.
  - Expanded configuration options for development commands with new fields in `DevArgs`.
  - Added public visibility to the fields in `MigrateArgs`, improving accessibility.

- **Improvements**
  - Enhanced responsiveness in the development command with refined error handling and a debounce mechanism for rebuilds.
  - Enabled cloning of `BuildArgs` and `MigrateArgs` for improved usability.

- **Bug Fixes**
  - Adjusted argument handling in the `Build` command for better functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->