### PR TITLE
feat: add keepalive to Torii client gRPC connections

### DIFF
--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -1,7 +1,6 @@
 pub mod error;
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use dojo_types::WorldMetadata;
 use dojo_world::contracts::WorldContractReader;
@@ -42,10 +41,8 @@ impl Client {
         rpc_url: String,
         relay_url: String,
         world: Felt,
-        keepalive: Option<Duration>,
     ) -> Result<Self, Error> {
-        let mut grpc_client =
-            torii_grpc::client::WorldClient::new(torii_url, world, keepalive).await?;
+        let mut grpc_client = torii_grpc::client::WorldClient::new(torii_url, world).await?;
 
         let relay_client = torii_relay::client::RelayClient::new(relay_url)?;
 

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use dojo_types::WorldMetadata;
 use dojo_world::contracts::WorldContractReader;
@@ -41,8 +42,10 @@ impl Client {
         rpc_url: String,
         relay_url: String,
         world: Felt,
+        keepalive: Option<Duration>,
     ) -> Result<Self, Error> {
-        let mut grpc_client = torii_grpc::client::WorldClient::new(torii_url, world).await?;
+        let mut grpc_client =
+            torii_grpc::client::WorldClient::new(torii_url, world, keepalive).await?;
 
         let relay_client = torii_relay::client::RelayClient::new(relay_url)?;
 

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -1,5 +1,6 @@
 //! Client implementation for the gRPC service.
 use std::num::ParseIntError;
+use std::time::Duration;
 
 use futures_util::stream::MapOk;
 use futures_util::{Stream, StreamExt, TryStreamExt};
@@ -49,9 +50,14 @@ pub struct WorldClient {
 
 impl WorldClient {
     #[cfg(not(target_arch = "wasm32"))]
-    pub async fn new(dst: String, world_address: Felt) -> Result<Self, Error> {
-        let endpoint =
-            Endpoint::from_shared(dst.clone()).map_err(|e| Error::Endpoint(e.to_string()))?;
+    pub async fn new(
+        dst: String,
+        world_address: Felt,
+        keepalive: Option<Duration>,
+    ) -> Result<Self, Error> {
+        let endpoint = Endpoint::from_shared(dst.clone())
+            .map_err(|e| Error::Endpoint(e.to_string()))?
+            .tcp_keepalive(keepalive);
         let channel = endpoint.connect().await.map_err(Error::Transport)?;
         Ok(Self {
             _world_address: world_address,

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -51,9 +51,11 @@ pub struct WorldClient {
 impl WorldClient {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn new(dst: String, world_address: Felt) -> Result<Self, Error> {
+        const KEEPALIVE_TIME: u64 = 60;
+
         let endpoint = Endpoint::from_shared(dst.clone())
             .map_err(|e| Error::Endpoint(e.to_string()))?
-            .tcp_keepalive(Some(Duration::from_secs(30)));
+            .tcp_keepalive(Some(Duration::from_secs(KEEPALIVE_TIME)));
         let channel = endpoint.connect().await.map_err(Error::Transport)?;
         Ok(Self {
             _world_address: world_address,

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -50,14 +50,10 @@ pub struct WorldClient {
 
 impl WorldClient {
     #[cfg(not(target_arch = "wasm32"))]
-    pub async fn new(
-        dst: String,
-        world_address: Felt,
-        keepalive: Option<Duration>,
-    ) -> Result<Self, Error> {
+    pub async fn new(dst: String, world_address: Felt) -> Result<Self, Error> {
         let endpoint = Endpoint::from_shared(dst.clone())
             .map_err(|e| Error::Endpoint(e.to_string()))?
-            .tcp_keepalive(keepalive);
+            .tcp_keepalive(Some(Duration::from_secs(30)));
         let channel = endpoint.connect().await.map_err(Error::Transport)?;
         Ok(Self {
             _world_address: world_address,


### PR DESCRIPTION
# Description

Allows grpc subscriptions to survive network issues by introducing a keepalive parameter, the `Some` value represents the delay between keepalive checks between the grpc client and server. 

## Tests

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `keepalive` parameter for enhanced TCP keepalive configuration in the gRPC client.
  
- **Bug Fixes**
	- Preserved existing functionality while adding new features, ensuring stability of the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->