### PR TITLE
fix: cli args for torii and katana with serde default

### DIFF
--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -25,6 +25,7 @@ use crate::utils::{parse_block_hash_or_number, parse_genesis, LogFormat};
 const DEFAULT_DEV_SEED: &str = "0";
 const DEFAULT_DEV_ACCOUNTS: u16 = 10;
 
+#[cfg(feature = "server")]
 #[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
 #[command(next_help_heading = "Metrics options")]
 pub struct MetricsOptions {
@@ -33,18 +34,21 @@ pub struct MetricsOptions {
     /// For now, metrics will still be collected even if this flag is not set. This only
     /// controls whether the metrics server is started or not.
     #[arg(long)]
+    #[serde(default)]
     pub metrics: bool,
 
     /// The metrics will be served at the given address.
     #[arg(requires = "metrics")]
     #[arg(long = "metrics.addr", value_name = "ADDRESS")]
     #[arg(default_value_t = DEFAULT_METRICS_ADDR)]
+    #[serde(default = "default_metrics_addr")]
     pub metrics_addr: IpAddr,
 
     /// The metrics will be served at the given port.
     #[arg(requires = "metrics")]
     #[arg(long = "metrics.port", value_name = "PORT")]
     #[arg(default_value_t = DEFAULT_METRICS_PORT)]
+    #[serde(default = "default_metrics_port")]
     pub metrics_port: u16,
 }
 
@@ -77,6 +81,7 @@ pub struct ServerOptions {
     /// Comma separated list of domains from which to accept cross origin requests.
     #[arg(long = "http.cors_origins")]
     #[arg(value_delimiter = ',')]
+    #[serde(default)]
     pub http_cors_origins: Option<Vec<String>>,
 
     /// Maximum number of concurrent connections allowed.
@@ -133,6 +138,7 @@ pub struct EnvironmentOptions {
     /// ASCII values. It must be a valid Cairo short string.
     #[arg(long)]
     #[arg(value_parser = ChainId::parse)]
+    #[serde(default)]
     pub chain_id: Option<ChainId>,
 
     /// The maximum number of steps available for the account validation logic.
@@ -348,4 +354,14 @@ fn default_http_port() -> u16 {
 #[cfg(feature = "server")]
 fn default_max_connections() -> u32 {
     DEFAULT_RPC_MAX_CONNECTIONS
+}
+
+#[cfg(feature = "server")]
+fn default_metrics_addr() -> IpAddr {
+    DEFAULT_METRICS_ADDR
+}
+
+#[cfg(feature = "server")]
+fn default_metrics_port() -> u16 {
+    DEFAULT_METRICS_PORT
 }

--- a/crates/torii/cli/src/args.rs
+++ b/crates/torii/cli/src/args.rs
@@ -108,9 +108,7 @@ impl ToriiArgs {
             self.explorer = config.explorer.unwrap_or_default();
         }
 
-        if self.indexing == IndexingOptions::default() {
-            self.indexing = config.indexing.unwrap_or_default();
-        }
+        self.indexing.merge(config.indexing.as_ref());
 
         if self.events == EventsOptions::default() {
             self.events = config.events.unwrap_or_default();
@@ -206,7 +204,10 @@ mod test {
         world_address = "0x1234"
         rpc = "http://0.0.0.0:5050"
         db_dir = "/tmp/torii-test"
-        
+
+        [indexing]
+        transactions = false
+
         [events]
         raw = true
         historical = [
@@ -231,6 +232,8 @@ mod test {
             "false",
             "--events.historical",
             "a-A",
+            "--indexing.transactions",
+            "true",
             "--config",
             path_str.as_str(),
         ];
@@ -243,6 +246,7 @@ mod test {
         assert!(!torii_args.events.raw);
         assert_eq!(torii_args.events.historical, vec!["a-A".to_string()]);
         assert_eq!(torii_args.server, ServerOptions::default());
+        assert!(torii_args.indexing.transactions);
     }
 
     #[test]

--- a/crates/torii/cli/src/options.rs
+++ b/crates/torii/cli/src/options.rs
@@ -60,6 +60,7 @@ pub struct RelayOptions {
         help = "Path to a local identity key file. If not specified, a new identity will be \
                 generated."
     )]
+    #[serde(default)]
     pub local_key_path: Option<String>,
 
     /// Path to a local certificate file. If not specified, a new certificate will be generated
@@ -70,6 +71,7 @@ pub struct RelayOptions {
         help = "Path to a local certificate file. If not specified, a new certificate will be \
                 generated for WebRTC connections."
     )]
+    #[serde(default)]
     pub cert_path: Option<String>,
 }
 
@@ -100,6 +102,7 @@ pub struct IndexingOptions {
 
     /// Enable indexing pending blocks
     #[arg(long = "indexing.pending", action = ArgAction::Set, default_value_t = true, help = "Whether or not to index pending blocks.")]
+    #[serde(default)]
     pub pending: bool,
 
     /// Polling interval in ms
@@ -127,6 +130,7 @@ pub struct IndexingOptions {
         default_value_t = false,
         help = "Whether or not to index world transactions and keep them in the database."
     )]
+    #[serde(default)]
     pub transactions: bool,
 
     /// ERC contract addresses to index
@@ -137,6 +141,7 @@ pub struct IndexingOptions {
         help = "ERC contract addresses to index. You may only specify ERC20 or ERC721 contracts."
     )]
     #[serde(deserialize_with = "deserialize_contracts")]
+    #[serde(default)]
     pub contracts: Vec<Contract>,
 
     /// Namespaces to index
@@ -146,6 +151,7 @@ pub struct IndexingOptions {
         help = "The namespaces of the world that torii should index. If empty, all namespaces \
                 will be indexed."
     )]
+    #[serde(default)]
     pub namespaces: Vec<String>,
 }
 
@@ -164,11 +170,50 @@ impl Default for IndexingOptions {
     }
 }
 
+impl IndexingOptions {
+    pub fn merge(&mut self, other: Option<&Self>) {
+        if let Some(other) = other {
+            if self.events_chunk_size == DEFAULT_EVENTS_CHUNK_SIZE {
+                self.events_chunk_size = other.events_chunk_size;
+            }
+
+            if self.blocks_chunk_size == DEFAULT_BLOCKS_CHUNK_SIZE {
+                self.blocks_chunk_size = other.blocks_chunk_size;
+            }
+
+            if !self.pending {
+                self.pending = other.pending;
+            }
+
+            if self.polling_interval == DEFAULT_POLLING_INTERVAL {
+                self.polling_interval = other.polling_interval;
+            }
+
+            if self.max_concurrent_tasks == DEFAULT_MAX_CONCURRENT_TASKS {
+                self.max_concurrent_tasks = other.max_concurrent_tasks;
+            }
+
+            if !self.transactions {
+                self.transactions = other.transactions;
+            }
+
+            if self.contracts.is_empty() {
+                self.contracts = other.contracts.clone();
+            }
+
+            if self.namespaces.is_empty() {
+                self.namespaces = other.namespaces.clone();
+            }
+        }
+    }
+}
+
 #[derive(Debug, clap::Args, Clone, Serialize, Deserialize, PartialEq)]
 #[command(next_help_heading = "Events indexing options")]
 pub struct EventsOptions {
     /// Whether or not to index raw events
     #[arg(long = "events.raw", action = ArgAction::Set, default_value_t = true, help = "Whether or not to index raw events.")]
+    #[serde(default)]
     pub raw: bool,
 
     /// Event messages that are going to be treated as historical
@@ -178,6 +223,7 @@ pub struct EventsOptions {
         value_delimiter = ',',
         help = "Event messages that are going to be treated as historical during indexing."
     )]
+    #[serde(default)]
     pub historical: Vec<String>,
 }
 
@@ -205,6 +251,7 @@ pub struct ServerOptions {
     /// Comma separated list of domains from which to accept cross origin requests.
     #[arg(long = "http.cors_origins")]
     #[arg(value_delimiter = ',')]
+    #[serde(default)]
     pub http_cors_origins: Option<Vec<String>>,
 }
 
@@ -222,6 +269,7 @@ pub struct MetricsOptions {
     /// For now, metrics will still be collected even if this flag is not set. This only
     /// controls whether the metrics server is started or not.
     #[arg(long)]
+    #[serde(default)]
     pub metrics: bool,
 
     /// The metrics will be served at the given address.


### PR DESCRIPTION
This PR will ensure the configuration files can only contain part of the fields, which will imply default value for the others.