### PR TITLE
fix(torii): ensure correct serde of args in config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15320,6 +15320,7 @@ dependencies = [
  "camino",
  "chrono",
  "clap",
+ "clap_complete",
  "clap_config",
  "ctrlc",
  "dojo-metrics",

--- a/bin/torii/Cargo.toml
+++ b/bin/torii/Cargo.toml
@@ -12,6 +12,7 @@ base64.workspace = true
 camino.workspace = true
 chrono.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 ctrlc = { version = "3.4", features = [ "termination" ] }
 dojo-metrics.workspace = true
 dojo-types.workspace = true

--- a/bin/torii/src/cli.rs
+++ b/bin/torii/src/cli.rs
@@ -1,0 +1,14 @@
+//! CLI for Torii.
+//!
+//! Use a `Cli` struct to parse the CLI arguments
+//! and to have flexibility in the future to add more commands
+//! that may not start Torii directly.
+use clap::Parser;
+use torii_cli::ToriiArgs;
+
+#[derive(Parser)]
+#[command(name = "torii", author, version, about, long_about = None)]
+pub struct Cli {
+    #[command(flatten)]
+    pub args: ToriiArgs,
+}

--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 
 use camino::Utf8PathBuf;
 use clap::Parser;
+use cli::Cli;
 use dojo_metrics::exporters::prometheus::PrometheusRecorder;
 use dojo_world::contracts::world::WorldContractReader;
 use sqlx::sqlite::{
@@ -30,7 +31,6 @@ use tempfile::{NamedTempFile, TempDir};
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::Sender;
 use tokio_stream::StreamExt;
-use torii_cli::ToriiArgs;
 use torii_core::engine::{Engine, EngineConfig, IndexingFlags, Processors};
 use torii_core::executor::Executor;
 use torii_core::processors::store_transaction::StoreTransactionProcessor;
@@ -46,9 +46,11 @@ use url::{form_urlencoded, Url};
 
 pub(crate) const LOG_TARGET: &str = "torii::cli";
 
+mod cli;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let mut args = ToriiArgs::parse().with_config_file()?;
+    let mut args = Cli::parse().args.with_config_file()?;
 
     let world_address = if let Some(world_address) = args.world_address {
         world_address
@@ -56,7 +58,6 @@ async fn main() -> anyhow::Result<()> {
         return Err(anyhow::anyhow!("Please specify a world address."));
     };
 
-    // let mut contracts = parse_erc_contracts(&args.contracts)?;
     args.indexing.contracts.push(Contract { address: world_address, r#type: ContractType::WORLD });
 
     let filter_layer = EnvFilter::try_from_default_env()

--- a/crates/torii/cli/src/args.rs
+++ b/crates/torii/cli/src/args.rs
@@ -14,7 +14,7 @@ pub const DEFAULT_RPC_URL: &str = "http://0.0.0.0:5050";
 
 /// Dojo World Indexer
 #[derive(Parser, Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[command(name = "torii", author, version, about, long_about = None)]
+#[command(name = "torii", author, about, long_about = None)]
 #[command(next_help_heading = "Torii general options")]
 pub struct ToriiArgs {
     /// The world to index

--- a/crates/torii/core/src/types.rs
+++ b/crates/torii/core/src/types.rs
@@ -156,6 +156,12 @@ pub enum ContractType {
     ERC721,
 }
 
+impl std::fmt::Display for Contract {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{:#x}", self.r#type, self.address)
+    }
+}
+
 impl FromStr for ContractType {
     type Err = anyhow::Error;
 


### PR DESCRIPTION
# Description

This PR ensures that the serialized contracts in a config files are actually compliant with the expected format.

Also, the version of Torii is now removed from the `ToriiArgs` to be used at the binary level. This helps re-using the `torii/cli` crates without having `version` conflicting with the binary importing the crate.