### PR TITLE
fix: fix graphql playground URL

### DIFF
--- a/crates/torii/graphql/src/server.rs
+++ b/crates/torii/graphql/src/server.rs
@@ -48,20 +48,21 @@ fn graphql_filter(
         },
     );
 
+    // If an external URL is provided, we are expecting the GraphQL endpoint to be given.
+    // Hence, we don't have to append "/graphql" to the URL.
     let (graphql_endpoint, subscription_endpoint) = if let Some(external_url) = external_url {
-        let mut graphql_url = external_url;
-        graphql_url.set_path("graphql");
-
+        let graphql_url = external_url;
         let mut websocket_url = graphql_url.clone();
-        websocket_url.set_path("ws");
+        websocket_url.set_path(&format!("{}/ws", websocket_url.path()));
         let _ = websocket_url.set_scheme(match websocket_url.scheme() {
             "https" => "wss",
             "http" => "ws",
             _ => panic!("Invalid URL scheme - must be http or https"),
         });
-
-        (graphql_url.path().to_string(), websocket_url.to_string())
+        (graphql_url.to_string(), websocket_url.to_string())
     } else {
+        // Otherwise, we are running the GraphQL server locally and we need to
+        // append "/graphql" to the URL.
         ("graphql".to_string(), "graphql/ws".to_string())
     };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved URL handling for GraphQL and WebSocket endpoints, allowing direct use of external URLs without appending additional paths.
	- Enhanced clarity and correctness in URL construction for both external and local server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->