### PR TITLE
refactor(katana): dont run sequencing task inside of pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8419,7 +8419,7 @@ dependencies = [
 
 [[package]]
 name = "katana-feeder-gateway"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "katana-primitives",
  "katana-rpc-types",


### PR DESCRIPTION
the pipeline is meant for syncing purposes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified sequencing task instantiation for improved performance.
	- Introduced a new method for executing sequencing tasks, enhancing asynchronous operations.
  
- **Bug Fixes**
	- Updated error logging context for better clarity during sequencing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->