### PR TITLE
fix(torii/graphql): wait to query db after getting broker update

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -290,6 +290,8 @@ async fn spawn_rebuilding_graphql_server(
         // Break the loop if there are no more events
         if broker.next().await.is_none() {
             break;
+        } else {
+            tokio::time::sleep(Duration::from_secs(1)).await;
         }
     }
 }


### PR DESCRIPTION
since we now use a separate `readonly` pool we need to wait for sometime for db changes to have been written before reading the db.

fix: #2747
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Introduced a delay in event processing to reduce server load during high-frequency event checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->