### PR TITLE
refactor(torii-graphql): move away from external url

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -278,8 +278,7 @@ async fn spawn_rebuilding_graphql_server(
 
     loop {
         let shutdown_rx = shutdown_tx.subscribe();
-        let (new_addr, new_server) =
-            torii_graphql::server::new(shutdown_rx, &pool).await;
+        let (new_addr, new_server) = torii_graphql::server::new(shutdown_rx, &pool).await;
 
         tokio::spawn(new_server);
 

--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -42,7 +42,7 @@ use torii_core::types::{Contract, ContractType, Model};
 use torii_server::proxy::Proxy;
 use tracing::{error, info};
 use tracing_subscriber::{fmt, EnvFilter};
-use url::{form_urlencoded, Url};
+use url::form_urlencoded;
 
 pub(crate) const LOG_TARGET: &str = "torii::cli";
 
@@ -220,7 +220,6 @@ async fn main() -> anyhow::Result<()> {
     let graphql_server = spawn_rebuilding_graphql_server(
         shutdown_tx.clone(),
         readonly_pool.into(),
-        args.external_url,
         proxy_server.clone(),
     );
 
@@ -273,7 +272,6 @@ async fn main() -> anyhow::Result<()> {
 async fn spawn_rebuilding_graphql_server(
     shutdown_tx: Sender<()>,
     pool: Arc<SqlitePool>,
-    external_url: Option<Url>,
     proxy_server: Arc<Proxy>,
 ) {
     let mut broker = SimpleBroker::<Model>::subscribe();
@@ -281,7 +279,7 @@ async fn spawn_rebuilding_graphql_server(
     loop {
         let shutdown_rx = shutdown_tx.subscribe();
         let (new_addr, new_server) =
-            torii_graphql::server::new(shutdown_rx, &pool, external_url.clone()).await;
+            torii_graphql::server::new(shutdown_rx, &pool).await;
 
         tokio::spawn(new_server);
 

--- a/crates/torii/cli/src/args.rs
+++ b/crates/torii/cli/src/args.rs
@@ -35,11 +35,6 @@ pub struct ToriiArgs {
     )]
     pub db_dir: Option<PathBuf>,
 
-    /// The external url of the server, used for configuring the GraphQL Playground in a hosted
-    /// environment
-    #[arg(long, value_parser = parse_url, help = "The external url of the server, used for configuring the GraphQL Playground in a hosted environment.")]
-    pub external_url: Option<Url>,
-
     /// Open World Explorer on the browser.
     #[arg(long, help = "Open World Explorer on the browser.")]
     pub explorer: bool,
@@ -95,10 +90,6 @@ impl ToriiArgs {
 
         if self.db_dir.is_none() {
             self.db_dir = config.db_dir;
-        }
-
-        if self.external_url.is_none() {
-            self.external_url = config.external_url;
         }
 
         // Currently the comparison it's only at the top level.
@@ -164,7 +155,6 @@ impl TryFrom<ToriiArgs> for ToriiArgsConfig {
         config.rpc =
             if args.rpc == Url::parse(DEFAULT_RPC_URL).unwrap() { None } else { Some(args.rpc) };
         config.db_dir = args.db_dir;
-        config.external_url = args.external_url;
         config.explorer = Some(args.explorer);
 
         // Only include the following options if they are not the default.

--- a/crates/torii/graphql/src/server.rs
+++ b/crates/torii/graphql/src/server.rs
@@ -50,7 +50,7 @@ fn graphql_filter(
             GraphiQLSource::build()
                 .subscription_endpoint("/ws")
                 // we patch the generated source to use the current URL instead of the origin
-                // for hsoted services like SLOT
+                // for hosted services like SLOT
                 .finish().replace("new URL(endpoint, window.location.origin);", "new URL(window.location.href.trimEnd('/') + endpoint)"),
         )
     });

--- a/crates/torii/graphql/src/server.rs
+++ b/crates/torii/graphql/src/server.rs
@@ -8,7 +8,6 @@ use async_graphql_warp::graphql_subscription;
 use serde_json::json;
 use sqlx::{Pool, Sqlite};
 use tokio::sync::broadcast::Receiver;
-use url::Url;
 use warp::{Filter, Rejection, Reply};
 
 use super::schema::build_schema;
@@ -18,13 +17,12 @@ use crate::query::data::count_rows;
 pub async fn new(
     mut shutdown_rx: Receiver<()>,
     pool: &Pool<Sqlite>,
-    external_url: Option<Url>,
 ) -> (SocketAddr, impl Future<Output = ()> + 'static) {
     let schema = build_schema(pool).await.unwrap();
     let mut conn = pool.acquire().await.unwrap();
     let num_models = count_rows(&mut conn, MODEL_TABLE, &None, &None).await.unwrap();
 
-    let routes = graphql_filter(schema, external_url, num_models == 0);
+    let routes = graphql_filter(schema, num_models == 0);
     warp::serve(routes).bind_with_graceful_shutdown(([127, 0, 0, 1], 0), async move {
         shutdown_rx.recv().await.ok();
     })
@@ -32,7 +30,6 @@ pub async fn new(
 
 fn graphql_filter(
     schema: Schema,
-    external_url: Option<Url>,
     is_empty: bool,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     let graphql_post = async_graphql_warp::graphql(schema.clone()).and_then(
@@ -48,30 +45,13 @@ fn graphql_filter(
         },
     );
 
-    // If an external URL is provided, we are expecting the GraphQL endpoint to be given.
-    // Hence, we don't have to append "/graphql" to the URL.
-    let (graphql_endpoint, subscription_endpoint) = if let Some(external_url) = external_url {
-        let graphql_url = external_url;
-        let mut websocket_url = graphql_url.clone();
-        websocket_url.set_path(&format!("{}/ws", websocket_url.path()));
-        let _ = websocket_url.set_scheme(match websocket_url.scheme() {
-            "https" => "wss",
-            "http" => "ws",
-            _ => panic!("Invalid URL scheme - must be http or https"),
-        });
-        (graphql_url.to_string(), websocket_url.to_string())
-    } else {
-        // Otherwise, we are running the GraphQL server locally and we need to
-        // append "/graphql" to the URL.
-        ("graphql".to_string(), "graphql/ws".to_string())
-    };
-
     let playground_filter = warp::path("graphql").map(move || {
         warp::reply::html(
             GraphiQLSource::build()
-                .endpoint(&graphql_endpoint)
-                .subscription_endpoint(&subscription_endpoint)
-                .finish(),
+                .subscription_endpoint("graphql/ws")
+                // we patch the generated source to use the current URL instead of the origin
+                // for hsoted services like SLOT
+                .finish().replace("window.location.origin", "window.location.href"),
         )
     });
 

--- a/crates/torii/graphql/src/server.rs
+++ b/crates/torii/graphql/src/server.rs
@@ -48,10 +48,10 @@ fn graphql_filter(
     let playground_filter = warp::path("graphql").map(move || {
         warp::reply::html(
             GraphiQLSource::build()
-                .subscription_endpoint("graphql/ws")
+                .subscription_endpoint("/ws")
                 // we patch the generated source to use the current URL instead of the origin
                 // for hsoted services like SLOT
-                .finish().replace("window.location.origin", "window.location.href"),
+                .finish().replace("new URL(endpoint, window.location.origin);", "new URL(window.location.href.trimEnd('/') + endpoint)"),
         )
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Streamlined configuration by removing the `external_url` option from CLI arguments and server setup.

- **Bug Fixes**
  - Improved error handling in the main function regarding the `world_address` specification.

- **Refactor**
  - Simplified function signatures and overall code organization for better readability and maintainability. 
  - Removed unused parameters and imports, enhancing code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->