### PR TITLE
refactor(katana-rpc): remove some components dependency from starknet rpc handler

### DIFF
--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -32,7 +32,6 @@ use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_executor::{ExecutionFlags, ExecutorFactory};
 use katana_pipeline::stage::Sequencing;
 use katana_pool::ordering::FiFo;
-use katana_pool::validation::stateful::TxValidator;
 use katana_pool::TxPool;
 use katana_primitives::block::GasPrices;
 use katana_primitives::env::{CfgEnv, FeeTokenAddressses};
@@ -119,7 +118,6 @@ impl Node {
         let pool = self.pool.clone();
         let backend = self.backend.clone();
         let block_producer = self.block_producer.clone();
-        let validator = self.block_producer.validator().clone();
 
         // --- build and run sequencing task
 
@@ -138,7 +136,7 @@ impl Node {
             .name("Sequencing")
             .spawn(sequencing.into_future());
 
-        let node_components = (pool, backend, block_producer, validator, self.forked_client.take());
+        let node_components = (pool, backend, block_producer, self.forked_client.take());
         let rpc = spawn(node_components, self.config.rpc.clone()).await?;
 
         Ok(LaunchedNode { node: self, rpc })
@@ -250,16 +248,10 @@ pub async fn build(mut config: Config) -> Result<Node> {
 
 // Moved from `katana_rpc` crate
 pub async fn spawn<EF: ExecutorFactory>(
-    node_components: (
-        TxPool,
-        Arc<Backend<EF>>,
-        BlockProducer<EF>,
-        TxValidator,
-        Option<ForkedClient>,
-    ),
+    node_components: (TxPool, Arc<Backend<EF>>, BlockProducer<EF>, Option<ForkedClient>),
     config: RpcConfig,
 ) -> Result<RpcServer> {
-    let (pool, backend, block_producer, validator, forked_client) = node_components;
+    let (pool, backend, block_producer, forked_client) = node_components;
 
     let mut methods = RpcModule::new(());
     methods.register_method("health", |_, _| Ok(serde_json::json!({ "health": true })))?;
@@ -272,12 +264,11 @@ pub async fn spawn<EF: ExecutorFactory>(
                 backend.clone(),
                 pool.clone(),
                 block_producer.clone(),
-                validator,
                 client,
                 cfg,
             )
         } else {
-            StarknetApi::new(backend.clone(), pool.clone(), block_producer.clone(), validator, cfg)
+            StarknetApi::new(backend.clone(), pool.clone(), Some(block_producer.clone()), cfg)
         };
 
         methods.merge(StarknetApiServer::into_rpc(server.clone()))?;

--- a/crates/katana/rpc/rpc/src/starknet/config.rs
+++ b/crates/katana/rpc/rpc/src/starknet/config.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Clone)]
+pub struct StarknetApiConfig {
+    /// The max chunk size that can be served from the `getEvents` method.
+    ///
+    /// If `None`, the maximum chunk size is bounded by [`u64::MAX`].
+    pub max_event_page_size: Option<u64>,
+}


### PR DESCRIPTION
the idea is to make the `StarknetApi` struct not depend on components that are not shared in a full and sequencer node configuration.

this is just a small refactor for now and still doesn't unblock anything just yet.

