### PR TITLE
refactor(katana): pending block provider

### DIFF
--- a/crates/katana/core/src/backend/mod.rs
+++ b/crates/katana/core/src/backend/mod.rs
@@ -32,7 +32,7 @@ use crate::utils::get_current_timestamp;
 pub(crate) const LOG_TARGET: &str = "katana::core::backend";
 
 #[derive(Debug)]
-pub struct Backend<EF: ExecutorFactory> {
+pub struct Backend<EF> {
     pub chain_spec: Arc<ChainSpec>,
     /// stores all block related data in memory
     pub blockchain: Blockchain,

--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -707,10 +707,7 @@ impl<EF: ExecutorFactory> Stream for InstantBlockProducer<EF> {
     }
 }
 
-impl<EF> PendingBlockProvider for BlockProducer<EF>
-where
-    EF: ExecutorFactory,
-{
+impl<EF: ExecutorFactory> PendingBlockProvider for BlockProducer<EF> {
     fn pending_block(&self) -> ProviderResult<()> {
         match &*self.producer.read() {
             BlockProducerMode::Instant(bp) => bp.pending_block(),
@@ -785,10 +782,7 @@ where
     }
 }
 
-impl<EF> PendingBlockProvider for InstantBlockProducer<EF>
-where
-    EF: ExecutorFactory,
-{
+impl<EF: ExecutorFactory> PendingBlockProvider for InstantBlockProducer<EF> {
     fn pending_transaction(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
         self.backend.blockchain.provider().transaction_by_hash(hash)
     }
@@ -815,7 +809,7 @@ where
         &self,
         hash: TxHash,
     ) -> ProviderResult<Option<TransactionStatus>> {
-        if let Some(receipt) = self.backend.blockchain.provider().receipt_by_hash(hash)? {
+        if let Some(receipt) = dbg!(self.backend.blockchain.provider().receipt_by_hash(hash)?) {
             if receipt.is_reverted() {
                 Ok(Some(TransactionStatus::AcceptedOnL2(TransactionExecutionStatus::Reverted)))
             } else {
@@ -846,28 +840,27 @@ where
     }
 }
 
-impl<EF> PendingBlockProvider for IntervalBlockProducer<EF>
-where
-    EF: ExecutorFactory,
-{
+impl<EF: ExecutorFactory> PendingBlockProvider for IntervalBlockProducer<EF> {
     fn pending_transaction(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
-        let transaction = self
-            .executor()
-            .read()
-            .transactions()
-            .iter()
-            .find_map(|(tx, _)| if tx.hash == hash { Some(tx.clone()) } else { None });
+        let transaction = self.executor().read().transactions().iter().find_map(|(tx, _)| {
+            if tx.hash == hash {
+                Some(tx.clone())
+            } else {
+                None
+            }
+        });
 
         Ok(transaction)
     }
 
     fn pending_receipt(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
-        let receipt = self
-            .executor()
-            .read()
-            .transactions()
-            .iter()
-            .find_map(|(tx, res)| if tx.hash == hash { res.receipt().cloned() } else { None });
+        let receipt = self.executor().read().transactions().iter().find_map(|(tx, res)| {
+            if tx.hash == hash {
+                res.receipt().cloned()
+            } else {
+                None
+            }
+        });
 
         Ok(receipt)
     }

--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -792,14 +792,15 @@ impl<EF: ExecutorFactory> PendingBlockProvider for InstantBlockProducer<EF> {
     }
 
     fn pending_block_env(&self) -> ProviderResult<BlockEnv> {
-        // In instant mining mode, we don't have a notion of 'pending' block as a block is mined instantly
-        // when a valid transaction is submitted. So we need to mimic how a new block env is created in
-        // interval mining mode.
+        // In instant mining mode, we don't have a notion of 'pending' block as a block is mined
+        // instantly when a valid transaction is submitted. So we need to mimic how a new
+        // block env is created in interval mining mode.
         //
-        // It is important that we update the block env here especially for the block timestamp. Because if
-        // a fee estimate is requested using the pending block in instant mode, and the timestamp is NOT
-        // UPDATED, it will be estimated using the block timestamp of the last mined block. This is not ideal
-        // as the fee estimate should be based on the block timestamp of the block that the transaction may
+        // It is important that we update the block env here especially for the block timestamp.
+        // Because if a fee estimate is requested using the pending block in instant mode,
+        // and the timestamp is NOT UPDATED, it will be estimated using the block timestamp
+        // of the last mined block. This is not ideal as the fee estimate should be based on
+        // the block timestamp of the block that the transaction may
 
         let num = self.backend.blockchain.provider().latest_number()?;
         let env = self.backend.blockchain.provider().block_env_at(num.into())?;
@@ -855,25 +856,23 @@ impl<EF: ExecutorFactory> PendingBlockProvider for InstantBlockProducer<EF> {
 
 impl<EF: ExecutorFactory> PendingBlockProvider for IntervalBlockProducer<EF> {
     fn pending_transaction(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>> {
-        let transaction = self.executor().read().transactions().iter().find_map(|(tx, _)| {
-            if tx.hash == hash {
-                Some(tx.clone())
-            } else {
-                None
-            }
-        });
+        let transaction = self
+            .executor()
+            .read()
+            .transactions()
+            .iter()
+            .find_map(|(tx, _)| if tx.hash == hash { Some(tx.clone()) } else { None });
 
         Ok(transaction)
     }
 
     fn pending_receipt(&self, hash: TxHash) -> ProviderResult<Option<Receipt>> {
-        let receipt = self.executor().read().transactions().iter().find_map(|(tx, res)| {
-            if tx.hash == hash {
-                res.receipt().cloned()
-            } else {
-                None
-            }
-        });
+        let receipt = self
+            .executor()
+            .read()
+            .transactions()
+            .iter()
+            .find_map(|(tx, res)| if tx.hash == hash { res.receipt().cloned() } else { None });
 
         Ok(receipt)
     }

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -279,7 +279,7 @@ pub async fn spawn<EF: ExecutorFactory>(
                 cfg,
             )
         } else {
-            StarknetApi::new(backend.clone(), pool.clone(), Some(block_producer.clone()), cfg)
+            StarknetApi::new(backend.clone(), pool.clone(), block_producer.clone(), cfg)
         };
 
         methods.merge(StarknetApiServer::into_rpc(server.clone()))?;

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -3,8 +3,7 @@
 use std::sync::Arc;
 
 use katana_core::backend::Backend;
-use katana_core::service::block_producer::{BlockProducer, BlockProducerMode, PendingExecutor};
-use katana_executor::{ExecutionResult, ExecutorFactory};
+use katana_executor::ExecutorFactory;
 use katana_pool::{TransactionPool, TxPool};
 use katana_primitives::block::{
     BlockHash, BlockHashOrNumber, BlockIdOrTag, BlockNumber, BlockTag, FinalityStatus,
@@ -63,68 +62,64 @@ type StarknetApiResult<T> = Result<T, StarknetApiError>;
 /// [write](katana_rpc_api::starknet::StarknetWriteApi), and
 /// [trace](katana_rpc_api::starknet::StarknetTraceApi) APIs.
 #[allow(missing_debug_implementations)]
-pub struct StarknetApi<EF>
-where
-    EF: ExecutorFactory,
-{
-    inner: Arc<StarknetApiInner<EF>>,
+pub struct StarknetApi<EF, P> {
+    inner: Arc<StarknetApiInner<EF, P>>,
 }
 
-struct StarknetApiInner<EF>
-where
-    EF: ExecutorFactory,
-{
+struct StarknetApiInner<EF, P> {
     pool: TxPool,
     backend: Arc<Backend<EF>>,
     forked_client: Option<ForkedClient>,
     blocking_task_pool: BlockingTaskPool,
-    block_producer: Option<BlockProducer<EF>>,
+    // block_producer: Option<BlockProducer<EF>>,
+    pending_provider: Option<P>,
     config: StarknetApiConfig,
 }
 
-impl<EF> StarknetApi<EF>
+impl<EF, P> StarknetApi<EF, P>
 where
     EF: ExecutorFactory,
+    P: PendingBlockProvider,
 {
     pub fn new(
         backend: Arc<Backend<EF>>,
         pool: TxPool,
-        block_producer: Option<BlockProducer<EF>>,
+        pending_provider: P,
         config: StarknetApiConfig,
     ) -> Self {
-        Self::new_inner(backend, pool, block_producer, None, config)
+        Self::new_inner(backend, pool, Some(pending_provider), None, config)
     }
 
     pub fn new_forked(
         backend: Arc<Backend<EF>>,
         pool: TxPool,
-        block_producer: BlockProducer<EF>,
+        pending_provider: P,
         forked_client: ForkedClient,
         config: StarknetApiConfig,
     ) -> Self {
-        Self::new_inner(backend, pool, Some(block_producer), Some(forked_client), config)
+        Self::new_inner(backend, pool, Some(pending_provider), Some(forked_client), config)
     }
 
     fn new_inner(
         backend: Arc<Backend<EF>>,
         pool: TxPool,
-        block_producer: Option<BlockProducer<EF>>,
+        pending_provider: Option<P>,
         forked_client: Option<ForkedClient>,
         config: StarknetApiConfig,
     ) -> Self {
         let blocking_task_pool =
             BlockingTaskPool::new().expect("failed to create blocking task pool");
 
-        let inner = StarknetApiInner {
-            pool,
-            backend,
-            block_producer,
-            blocking_task_pool,
-            forked_client,
-            config,
-        };
-
-        Self { inner: Arc::new(inner) }
+        Self {
+            inner: Arc::new(StarknetApiInner {
+                pool,
+                config,
+                backend,
+                forked_client,
+                pending_provider,
+                blocking_task_pool,
+            }),
+        }
     }
 
     async fn on_cpu_blocking_task<F, T>(&self, func: F) -> T
@@ -186,17 +181,17 @@ where
         Ok(estimates)
     }
 
-    fn pending_provider(&self) -> Option<Box<dyn PendingBlockProvider>> {
-        todo!()
+    fn pending_provider(&self) -> Option<&P> {
+        self.inner.pending_provider.as_ref()
     }
 
     /// Returns the pending state if the sequencer is running in _interval_ mode. Otherwise `None`.
-    fn pending_executor(&self) -> Option<PendingExecutor> {
-        self.inner.block_producer.as_ref().and_then(|bp| match &*bp.producer.read() {
-            BlockProducerMode::Instant(_) => None,
-            BlockProducerMode::Interval(producer) => Some(producer.executor()),
-        })
-    }
+    // fn pending_executor(&self) -> Option<PendingExecutor> {
+    //     self.inner.block_producer.as_ref().and_then(|bp| match &*bp.producer.read() {
+    //         BlockProducerMode::Instant(_) => None,
+    //         BlockProducerMode::Interval(producer) => Some(producer.executor()),
+    //     })
+    // }
 
     fn state(&self, block_id: &BlockIdOrTag) -> StarknetApiResult<Box<dyn StateProvider>> {
         let provider = self.inner.backend.blockchain.provider();
@@ -402,13 +397,11 @@ where
             .on_io_blocking_task(move |this| {
                 // TEMP: have to handle pending tag independently for now
                 let tx = if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                    let Some(executor) = this.pending_executor() else {
+                    let Some(provider) = this.pending_provider() else {
                         return Err(StarknetApiError::BlockNotFound);
                     };
 
-                    let executor = executor.read();
-                    let pending_txs = executor.transactions();
-                    pending_txs.get(index as usize).map(|(tx, _)| tx.clone())
+                    provider.pending_transactions()?.get(index as usize).cloned()
                 } else {
                     let provider = &this.inner.backend.blockchain.provider();
 
@@ -456,7 +449,7 @@ where
                         // })
 
                         this.pending_provider()
-                            .map(|pv| pv.pending_transaction(hash))
+                            .and_then(|pv| pv.pending_transaction(hash).transpose())
                             .transpose()?
                             .map(Tx::from)
                     }
@@ -493,8 +486,8 @@ where
                         //     // Find the transaction in the pending block that matches the hash
                         //     executor.read().transactions().iter().find_map(|(tx, res)| {
                         //         if tx.hash == hash {
-                        //             // If the transaction is found, only return the receipt if it's
-                        //             // successful
+                        //             // If the transaction is found, only return the receipt if
+                        // it's             // successful
                         //             match res {
                         //                 ExecutionResult::Success { receipt, .. } => {
                         //                     Some(receipt.clone())
@@ -509,7 +502,7 @@ where
 
                         let receipt = this
                             .pending_provider()
-                            .map(|pv| pv.pending_receipt(hash))
+                            .and_then(|pv| pv.pending_receipt(hash).transpose())
                             .transpose()?;
 
                         if let Some(receipt) = receipt {
@@ -573,31 +566,8 @@ where
                 }
 
                 // seach in the pending block if the transaction is not found
-                if let Some(pending_executor) = this.pending_executor() {
-                    let pending_executor = pending_executor.read();
-                    let pending_txs = pending_executor.transactions();
-                    let (_, res) = pending_txs
-                        .iter()
-                        .find(|(tx, _)| tx.hash == hash)
-                        .ok_or(StarknetApiError::TxnHashNotFound)?;
-
-                    // TODO: should impl From<ExecutionResult> for TransactionStatus
-                    let status = match res {
-                        ExecutionResult::Failed { .. } => TransactionStatus::Rejected,
-                        ExecutionResult::Success { receipt, .. } => {
-                            if receipt.is_reverted() {
-                                TransactionStatus::AcceptedOnL2(
-                                    TransactionExecutionStatus::Reverted,
-                                )
-                            } else {
-                                TransactionStatus::AcceptedOnL2(
-                                    TransactionExecutionStatus::Succeeded,
-                                )
-                            }
-                        }
-                    };
-
-                    Ok(Some(status))
+                if let Some(provider) = this.pending_provider() {
+                    Ok(provider.pending_transaction_status(hash)?)
                 } else {
                     // Err(StarknetApiError::TxnHashNotFound)
                     Ok(None)
@@ -624,8 +594,8 @@ where
                 let provider = this.inner.backend.blockchain.provider();
 
                 if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                    if let Some(executor) = this.pending_executor() {
-                        let block_env = executor.read().block_env();
+                    if let Some(pending_provider) = this.pending_provider() {
+                        let block_env = pending_provider.pending_block_env()?;
                         let latest_hash = provider.latest_hash()?;
 
                         let l1_gas_prices = block_env.l1_gas_prices.clone();
@@ -647,14 +617,7 @@ where
 
                         // A block should only include successful transactions, we filter out the
                         // failed ones (didn't pass validation stage).
-                        let transactions = executor
-                            .read()
-                            .transactions()
-                            .iter()
-                            .filter(|(_, receipt)| receipt.is_success())
-                            .map(|(tx, _)| tx.clone())
-                            .collect::<Vec<_>>();
-
+                        let transactions = pending_provider.pending_transactions()?;
                         let block = PendingBlockWithTxs::new(header, transactions);
                         return Ok(Some(MaybePendingBlockWithTxs::Pending(block)));
                     }
@@ -690,8 +653,8 @@ where
                 let provider = this.inner.backend.blockchain.provider();
 
                 if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                    if let Some(executor) = this.pending_executor() {
-                        let block_env = executor.read().block_env();
+                    if let Some(pending_provider) = this.pending_provider() {
+                        let block_env = pending_provider.pending_block_env()?;
                         let latest_hash = provider.latest_hash()?;
 
                         let l1_gas_prices = block_env.l1_gas_prices.clone();
@@ -708,19 +671,11 @@ where
                             protocol_version: this.inner.backend.chain_spec.version.clone(),
                         };
 
-                        let receipts = executor
-                            .read()
-                            .transactions()
-                            .iter()
-                            .filter_map(|(tx, result)| match result {
-                                ExecutionResult::Success { receipt, .. } => {
-                                    Some((tx.clone(), receipt.clone()))
-                                }
-                                ExecutionResult::Failed { .. } => None,
-                            })
-                            .collect::<Vec<_>>();
+                        let transactions = pending_provider.pending_transactions()?;
+                        let receipts = pending_provider.pending_receipts()?;
+                        let tx_receipt_pairs = transactions.into_iter().zip(receipts.into_iter());
 
-                        let block = PendingBlockWithReceipts::new(header, receipts.into_iter());
+                        let block = PendingBlockWithReceipts::new(header, tx_receipt_pairs);
                         return Ok(Some(MaybePendingBlockWithReceipts::Pending(block)));
                     }
                 }
@@ -755,8 +710,8 @@ where
                 let provider = this.inner.backend.blockchain.provider();
 
                 if BlockIdOrTag::Tag(BlockTag::Pending) == block_id {
-                    if let Some(executor) = this.pending_executor() {
-                        let block_env = executor.read().block_env();
+                    if let Some(pending_provider) = this.pending_provider() {
+                        let block_env = pending_provider.pending_block_env()?;
                         let latest_hash = provider.latest_hash().map_err(StarknetApiError::from)?;
 
                         let l1_gas_prices = block_env.l1_gas_prices.clone();
@@ -778,15 +733,13 @@ where
 
                         // A block should only include successful transactions, we filter out the
                         // failed ones (didn't pass validation stage).
-                        let transactions = executor
-                            .read()
-                            .transactions()
-                            .iter()
-                            .filter(|(_, receipt)| receipt.is_success())
-                            .map(|(tx, _)| tx.hash)
+                        let hashes = pending_provider
+                            .pending_transactions()?
+                            .into_iter()
+                            .map(|tx| tx.hash)
                             .collect::<Vec<_>>();
 
-                        let block = PendingBlockWithTxHashes::new(header, transactions);
+                        let block = PendingBlockWithTxHashes::new(header, hashes);
                         return Ok(Some(MaybePendingBlockWithTxHashes::Pending(block)));
                     }
                 }
@@ -1070,9 +1023,9 @@ where
                     return Ok(EventsPage { events, continuation_token });
                 }
 
-                if let Some(executor) = self.pending_executor() {
+                if let Some(provider) = self.pending_provider() {
                     let cursor = utils::events::fetch_pending_events(
-                        &executor,
+                        provider,
                         &filter,
                         chunk_size,
                         cursor,
@@ -1089,10 +1042,10 @@ where
             }
 
             (EventBlockId::Pending, EventBlockId::Pending) => {
-                if let Some(executor) = self.pending_executor() {
+                if let Some(provider) = self.pending_provider() {
                     let cursor = continuation_token.and_then(|t| t.to_token().map(|t| t.into()));
                     let new_cursor = utils::events::fetch_pending_events(
-                        &executor,
+                        provider,
                         &filter,
                         chunk_size,
                         cursor,
@@ -1157,10 +1110,7 @@ where
     }
 }
 
-impl<EF> Clone for StarknetApi<EF>
-where
-    EF: ExecutorFactory,
-{
+impl<EF, P> Clone for StarknetApi<EF, P> {
     fn clone(&self) -> Self {
         Self { inner: Arc::clone(&self.inner) }
     }

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -3,6 +3,7 @@ use katana_executor::{EntryPointCall, ExecutorFactory};
 use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash, TxHash};
 use katana_primitives::Felt;
+use katana_provider::traits::pending::PendingBlockProvider;
 use katana_rpc_api::starknet::StarknetApiServer;
 use katana_rpc_types::block::{
     BlockHashAndNumber, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
@@ -21,7 +22,11 @@ use starknet::core::types::TransactionStatus;
 use super::StarknetApi;
 
 #[async_trait]
-impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
+impl<EF, P> StarknetApiServer for StarknetApi<EF, P>
+where
+    EF: ExecutorFactory,
+    P: PendingBlockProvider,
+{
     async fn chain_id(&self) -> RpcResult<FeltAsHex> {
         Ok(self.inner.backend.chain_spec.id.id().into())
     }

--- a/crates/katana/rpc/rpc/src/starknet/write.rs
+++ b/crates/katana/rpc/rpc/src/starknet/write.rs
@@ -2,6 +2,7 @@ use jsonrpsee::core::{async_trait, RpcResult};
 use katana_executor::ExecutorFactory;
 use katana_pool::TransactionPool;
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash};
+use katana_provider::traits::pending::PendingBlockProvider;
 use katana_rpc_api::starknet::StarknetWriteApiServer;
 use katana_rpc_types::error::starknet::StarknetApiError;
 use katana_rpc_types::transaction::{
@@ -11,7 +12,11 @@ use katana_rpc_types::transaction::{
 
 use super::StarknetApi;
 
-impl<EF: ExecutorFactory> StarknetApi<EF> {
+impl<EF, P> StarknetApi<EF, P>
+where
+    EF: ExecutorFactory,
+    P: PendingBlockProvider,
+{
     async fn add_invoke_transaction_impl(
         &self,
         tx: BroadcastedInvokeTx,
@@ -74,7 +79,11 @@ impl<EF: ExecutorFactory> StarknetApi<EF> {
 }
 
 #[async_trait]
-impl<EF: ExecutorFactory> StarknetWriteApiServer for StarknetApi<EF> {
+impl<EF, P> StarknetWriteApiServer for StarknetApi<EF, P>
+where
+    EF: ExecutorFactory,
+    P: PendingBlockProvider,
+{
     async fn add_invoke_transaction(
         &self,
         invoke_transaction: BroadcastedInvokeTx,

--- a/crates/katana/rpc/rpc/src/utils/events.rs
+++ b/crates/katana/rpc/rpc/src/utils/events.rs
@@ -86,15 +86,12 @@ impl PartialCursor {
 }
 
 pub fn fetch_pending_events(
-    // pending_executor: &PendingExecutor,
     pending_provider: &impl PendingBlockProvider,
     filter: &Filter,
     chunk_size: u64,
     cursor: Option<Cursor>,
     buffer: &mut Vec<EmittedEvent>,
 ) -> EventQueryResult<Cursor> {
-    // let pending_block = pending_executor.read();
-
     let block_env = pending_provider.pending_block_env()?;
     let txs = pending_provider.pending_transactions()?;
     let receipts = pending_provider.pending_receipts()?;

--- a/crates/katana/storage/provider/src/traits/mod.rs
+++ b/crates/katana/storage/provider/src/traits/mod.rs
@@ -5,6 +5,7 @@
 pub mod block;
 pub mod contract;
 pub mod env;
+pub mod pending;
 pub mod stage;
 pub mod state;
 pub mod state_update;

--- a/crates/katana/storage/provider/src/traits/pending.rs
+++ b/crates/katana/storage/provider/src/traits/pending.rs
@@ -1,0 +1,26 @@
+use katana_primitives::{
+    env::BlockEnv,
+    receipt::Receipt,
+    transaction::{TxHash, TxWithHash},
+};
+
+use crate::ProviderResult;
+
+use super::state::StateProvider;
+
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait PendingBlockProvider: Send + Sync {
+    fn pending_block_env(&self) -> ProviderResult<BlockEnv>;
+
+    fn pending_transactions(&self) -> ProviderResult<Vec<TxWithHash>>;
+
+    fn pending_receipts(&self) -> ProviderResult<Vec<Receipt>>;
+
+    fn pending_transaction(&self, hash: TxHash) -> ProviderResult<TxWithHash>;
+
+    fn pending_receipt(&self, hash: TxHash) -> ProviderResult<Receipt>;
+
+    fn pending_transaction_status(&self, hash: TxHash) -> ProviderResult<()>;
+
+    fn pending_state(&self) -> ProviderResult<Box<dyn StateProvider>>;
+}

--- a/crates/katana/storage/provider/src/traits/pending.rs
+++ b/crates/katana/storage/provider/src/traits/pending.rs
@@ -1,26 +1,32 @@
-use katana_primitives::{
-    env::BlockEnv,
-    receipt::Receipt,
-    transaction::{TxHash, TxWithHash},
-};
-
-use crate::ProviderResult;
+use katana_primitives::env::BlockEnv;
+use katana_primitives::receipt::Receipt;
+use katana_primitives::trace::TxExecInfo;
+use katana_primitives::transaction::{TxHash, TxWithHash};
+use starknet::core::types::TransactionStatus;
 
 use super::state::StateProvider;
+use crate::ProviderResult;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
-pub trait PendingBlockProvider: Send + Sync {
+pub trait PendingBlockProvider: Send + Sync + 'static {
     fn pending_block_env(&self) -> ProviderResult<BlockEnv>;
+
+    fn pending_block(&self) -> ProviderResult<()>;
 
     fn pending_transactions(&self) -> ProviderResult<Vec<TxWithHash>>;
 
     fn pending_receipts(&self) -> ProviderResult<Vec<Receipt>>;
 
-    fn pending_transaction(&self, hash: TxHash) -> ProviderResult<TxWithHash>;
+    fn pending_transaction(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>>;
 
-    fn pending_receipt(&self, hash: TxHash) -> ProviderResult<Receipt>;
+    fn pending_receipt(&self, hash: TxHash) -> ProviderResult<Option<Receipt>>;
 
-    fn pending_transaction_status(&self, hash: TxHash) -> ProviderResult<()>;
+    fn pending_transaction_trace(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>>;
+
+    fn pending_transaction_traces(&self) -> ProviderResult<Vec<TxExecInfo>>;
+
+    fn pending_transaction_status(&self, hash: TxHash)
+    -> ProviderResult<Option<TransactionStatus>>;
 
     fn pending_state(&self) -> ProviderResult<Box<dyn StateProvider>>;
 }

--- a/crates/katana/storage/provider/src/traits/pending.rs
+++ b/crates/katana/storage/provider/src/traits/pending.rs
@@ -8,11 +8,10 @@ use super::state::StateProvider;
 use crate::ProviderResult;
 
 /// A provider for pending block data ie., header, transactions, receipts, traces (if any).
-//
-// In the context of a full node, where the node doesn't produce the blocks itself, how it can provide
-// the pending block data could be from a remote sequencer or feeder gateway. But, if the node itself
-// is a sequencer, it can provide the pending block data from its own local state. So, the main motivation
-// for this trait is to provide a common interface for both cases.
+// In the context of a full node, where the node doesn't produce the blocks itself, how it can
+// provide the pending block data could be from a remote sequencer or feeder gateway. But, if the
+// node itself is a sequencer, it can provide the pending block data from its own local state. So,
+// the main motivation for this trait is to provide a common interface for both cases.
 //
 // TODO: Maybe more to rpc crate as this is mainly gonna be used in the rpc side.
 #[auto_impl::auto_impl(&, Box, Arc)]
@@ -40,7 +39,7 @@ pub trait PendingBlockProvider: Send + Sync + 'static {
     fn pending_transaction_trace(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>>;
 
     fn pending_transaction_status(&self, hash: TxHash)
-        -> ProviderResult<Option<TransactionStatus>>;
+    -> ProviderResult<Option<TransactionStatus>>;
 
     /// Returns a [`StateProvider`] for the pending state.
     fn pending_state(&self) -> ProviderResult<Box<dyn StateProvider>>;

--- a/crates/katana/storage/provider/src/traits/pending.rs
+++ b/crates/katana/storage/provider/src/traits/pending.rs
@@ -7,26 +7,41 @@ use starknet::core::types::TransactionStatus;
 use super::state::StateProvider;
 use crate::ProviderResult;
 
+/// A provider for pending block data ie., header, transactions, receipts, traces (if any).
+//
+// In the context of a full node, where the node doesn't produce the blocks itself, how it can provide
+// the pending block data could be from a remote sequencer or feeder gateway. But, if the node itself
+// is a sequencer, it can provide the pending block data from its own local state. So, the main motivation
+// for this trait is to provide a common interface for both cases.
+//
+// TODO: Maybe more to rpc crate as this is mainly gonna be used in the rpc side.
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait PendingBlockProvider: Send + Sync + 'static {
     fn pending_block_env(&self) -> ProviderResult<BlockEnv>;
 
     fn pending_block(&self) -> ProviderResult<()>;
 
+    /// Returns all the transactions that are currently in the pending block.
     fn pending_transactions(&self) -> ProviderResult<Vec<TxWithHash>>;
 
+    /// Returns all the receipts that are currently in the pending block.
     fn pending_receipts(&self) -> ProviderResult<Vec<Receipt>>;
 
-    fn pending_transaction(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>>;
-
-    fn pending_receipt(&self, hash: TxHash) -> ProviderResult<Option<Receipt>>;
-
-    fn pending_transaction_trace(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>>;
-
+    /// Returns all the transaction traces that are currently in the pending block.
     fn pending_transaction_traces(&self) -> ProviderResult<Vec<TxExecInfo>>;
 
-    fn pending_transaction_status(&self, hash: TxHash)
-    -> ProviderResult<Option<TransactionStatus>>;
+    /// Returns a transaction in the pending block by its hash.
+    fn pending_transaction(&self, hash: TxHash) -> ProviderResult<Option<TxWithHash>>;
 
+    /// Returns a receipt in the pending block by its hash.
+    fn pending_receipt(&self, hash: TxHash) -> ProviderResult<Option<Receipt>>;
+
+    /// Returns a transaction trace in the pending block by its hash.
+    fn pending_transaction_trace(&self, hash: TxHash) -> ProviderResult<Option<TxExecInfo>>;
+
+    fn pending_transaction_status(&self, hash: TxHash)
+        -> ProviderResult<Option<TransactionStatus>>;
+
+    /// Returns a [`StateProvider`] for the pending state.
     fn pending_state(&self) -> ProviderResult<Box<dyn StateProvider>>;
 }


### PR DESCRIPTION
The motivation is to abstract how pending block data is being fetched in the rpc server. This is to support having different source for where the pending block will be provided from. Right now in sequencing mode, the pending block will be provided by the block producer's state. But in the case for a full node, where block production doesn't happen locally, the pending block information needs to be fetched from the feeder gateway (as right now we want to support syncing from fgw). ref #2724 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced the `PendingBlockProvider` trait to enhance functionality related to pending blocks, allowing access to pending transactions, receipts, and their statuses.
	- Updated the `StarknetApi` to utilize the new `PendingBlockProvider`, improving interaction with pending transactions.
	- Added new methods for retrieving pending block data, enhancing the API's capabilities.
	- Expanded the `BlockProducer` with methods for accessing pending transactions and their statuses.
	- Added a new `pending` module to encapsulate related functionalities in the storage provider.

- **Bug Fixes**
	- Streamlined the fetching of pending events, improving clarity and functionality.

- **Documentation**
	- Updated documentation for the new `PendingBlockProvider` trait and its methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->