### PR TITLE
feat: Improve bindgen types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_cbor_2",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "sha2 0.10.8",
  "starknet 0.12.0",
  "starknet-crypto 0.7.2",
@@ -2448,10 +2448,36 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720)",
- "cainome-cairo-serde-derive",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720)",
  "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720)",
  "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720)",
  "cainome-rs-macro 0.1.0 (git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720)",
+ "camino",
+ "clap",
+ "clap_complete",
+ "convert_case 0.6.0",
+ "serde",
+ "serde_json",
+ "starknet 0.12.0",
+ "starknet-types-core",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "cainome"
+version = "0.4.8"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-rs-macro 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
  "camino",
  "clap",
  "clap_complete",
@@ -2479,11 +2505,34 @@ dependencies = [
 [[package]]
 name = "cainome-cairo-serde"
 version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+dependencies = [
+ "num-bigint",
+ "serde",
+ "serde_with 3.11.0",
+ "starknet 0.12.0",
+ "thiserror",
+]
+
+[[package]]
+name = "cainome-cairo-serde"
+version = "0.1.0"
 source = "git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720#5c2616c273faca7700d2ba565503fcefb5b9d720"
 dependencies = [
  "serde",
  "starknet 0.12.0",
  "thiserror",
+]
+
+[[package]]
+name = "cainome-cairo-serde-derive"
+version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "unzip-n",
 ]
 
 [[package]]
@@ -2501,6 +2550,19 @@ dependencies = [
 name = "cainome-parser"
 version = "0.1.0"
 source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.2#4e3924fb82b7299d56d3619aa5d7b9863f581e0a"
+dependencies = [
+ "convert_case 0.6.0",
+ "quote",
+ "serde_json",
+ "starknet 0.12.0",
+ "syn 2.0.77",
+ "thiserror",
+]
+
+[[package]]
+name = "cainome-parser"
+version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
 dependencies = [
  "convert_case 0.6.0",
  "quote",
@@ -2531,6 +2593,24 @@ dependencies = [
  "anyhow",
  "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
  "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
+ "camino",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet 0.12.0",
+ "syn 2.0.77",
+ "thiserror",
+]
+
+[[package]]
+name = "cainome-rs"
+version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
  "camino",
  "prettyplease",
  "proc-macro2",
@@ -2568,6 +2648,24 @@ dependencies = [
  "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
  "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
  "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet 0.12.0",
+ "syn 2.0.77",
+ "thiserror",
+]
+
+[[package]]
+name = "cainome-rs-macro"
+version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3812,7 +3910,7 @@ dependencies = [
  "ed25519-dalek",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "starknet-types-core",
 ]
 
@@ -4715,7 +4813,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "camino",
  "chrono",
  "convert_case 0.6.0",
@@ -4767,7 +4865,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "smol_str",
  "starknet 0.12.0",
  "starknet-crypto 0.7.2",
@@ -4872,7 +4970,7 @@ name = "dojo-types"
 version = "1.0.2"
 dependencies = [
  "anyhow",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "crypto-bigint",
  "hex",
  "itertools 0.12.1",
@@ -4911,7 +5009,7 @@ version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "cairo-lang-starknet-classes",
  "dojo-types 1.0.2",
  "hex",
@@ -4921,7 +5019,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "starknet 0.12.0",
  "starknet-crypto 0.7.2",
  "thiserror",
@@ -4936,7 +5034,7 @@ name = "dojo-world-abigen"
 version = "1.0.2"
 dependencies = [
  "anyhow",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "camino",
@@ -8282,7 +8380,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "assert_matches",
- "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720)",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
  "clap",
  "console",
  "dojo-utils",
@@ -8522,7 +8620,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_pythonic",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "similar-asserts",
  "starknet 0.12.0",
  "starknet-crypto 0.7.2",
@@ -8566,7 +8664,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "assert_matches",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "dojo-metrics",
  "dojo-test-utils",
  "dojo-utils",
@@ -8631,7 +8729,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_pythonic",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "similar-asserts",
  "starknet 0.12.0",
  "thiserror",
@@ -12760,7 +12858,7 @@ dependencies = [
  "num-traits 0.2.19",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "starknet 0.12.0",
  "thiserror",
  "tokio",
@@ -13274,9 +13372,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -13286,7 +13384,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.9.0",
+ "serde_with_macros 3.11.0",
  "time",
 ]
 
@@ -13304,9 +13402,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -13662,7 +13760,7 @@ version = "1.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "cairo-lang-compiler",
  "cairo-lang-filesystem",
  "cairo-lang-project",
@@ -13714,7 +13812,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "async-trait",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "colored",
  "colored_json",
  "dojo-test-utils",
@@ -13728,7 +13826,7 @@ dependencies = [
  "scarb",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "sozo-scarbext",
  "sozo-walnut",
  "spinoff",
@@ -14133,7 +14231,7 @@ checksum = "bd6ee5762d24c4f06ab7e9406550925df406712e73719bd2de905c879c674a87"
 dependencies = [
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "starknet-accounts 0.11.0",
  "starknet-core 0.12.0",
  "starknet-providers 0.12.0",
@@ -14172,7 +14270,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_pythonic",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "sha3",
  "starknet-crypto 0.7.2",
  "starknet-types-core",
@@ -14335,7 +14433,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_with 3.9.0",
+ "serde_with 3.11.0",
  "starknet-core 0.12.0",
  "thiserror",
  "url",
@@ -15416,7 +15514,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bitflags 2.6.0",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "chrono",
  "crypto-bigint",
  "data-url",
@@ -15491,7 +15589,7 @@ dependencies = [
 name = "torii-grpc"
 version = "1.0.2"
 dependencies = [
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "camino",
  "crypto-bigint",
  "dojo-test-utils",
@@ -15539,7 +15637,7 @@ name = "torii-relay"
 version = "1.0.2"
 dependencies = [
  "anyhow",
- "cainome 0.4.6",
+ "cainome 0.4.8",
  "chrono",
  "crypto-bigint",
  "dojo-types 1.0.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,15 +2469,15 @@ dependencies = [
 [[package]]
 name = "cainome"
 version = "0.4.8"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.10#6fefd8bf4370c77d8834d18a2ae3c59d3a5e8dd5"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
- "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
- "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
- "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
- "cainome-rs-macro 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "cainome-rs-macro 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
  "camino",
  "clap",
  "clap_complete",
@@ -2495,17 +2495,7 @@ dependencies = [
 [[package]]
 name = "cainome-cairo-serde"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.2#4e3924fb82b7299d56d3619aa5d7b9863f581e0a"
-dependencies = [
- "serde",
- "starknet 0.12.0",
- "thiserror",
-]
-
-[[package]]
-name = "cainome-cairo-serde"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.10#6fefd8bf4370c77d8834d18a2ae3c59d3a5e8dd5"
 dependencies = [
  "num-bigint",
  "serde",
@@ -2517,6 +2507,16 @@ dependencies = [
 [[package]]
 name = "cainome-cairo-serde"
 version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.2#4e3924fb82b7299d56d3619aa5d7b9863f581e0a"
+dependencies = [
+ "serde",
+ "starknet 0.12.0",
+ "thiserror",
+]
+
+[[package]]
+name = "cainome-cairo-serde"
+version = "0.1.0"
 source = "git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720#5c2616c273faca7700d2ba565503fcefb5b9d720"
 dependencies = [
  "serde",
@@ -2527,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "cainome-cairo-serde-derive"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.10#6fefd8bf4370c77d8834d18a2ae3c59d3a5e8dd5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2544,6 +2544,19 @@ dependencies = [
  "quote",
  "syn 2.0.77",
  "unzip-n",
+]
+
+[[package]]
+name = "cainome-parser"
+version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.10#6fefd8bf4370c77d8834d18a2ae3c59d3a5e8dd5"
+dependencies = [
+ "convert_case 0.6.0",
+ "quote",
+ "serde_json",
+ "starknet 0.12.0",
+ "syn 2.0.77",
+ "thiserror",
 ]
 
 [[package]]
@@ -2562,7 +2575,7 @@ dependencies = [
 [[package]]
 name = "cainome-parser"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+source = "git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720#5c2616c273faca7700d2ba565503fcefb5b9d720"
 dependencies = [
  "convert_case 0.6.0",
  "quote",
@@ -2573,11 +2586,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cainome-parser"
+name = "cainome-rs"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?rev=5c2616c273faca7700d2ba565503fcefb5b9d720#5c2616c273faca7700d2ba565503fcefb5b9d720"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.10#6fefd8bf4370c77d8834d18a2ae3c59d3a5e8dd5"
 dependencies = [
- "convert_case 0.6.0",
+ "anyhow",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "camino",
+ "prettyplease",
+ "proc-macro2",
  "quote",
  "serde_json",
  "starknet 0.12.0",
@@ -2593,24 +2611,6 @@ dependencies = [
  "anyhow",
  "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
  "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
- "camino",
- "prettyplease",
- "proc-macro2",
- "quote",
- "serde_json",
- "starknet 0.12.0",
- "syn 2.0.77",
- "thiserror",
-]
-
-[[package]]
-name = "cainome-rs"
-version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
-dependencies = [
- "anyhow",
- "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
- "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
  "camino",
  "prettyplease",
  "proc-macro2",
@@ -2642,12 +2642,12 @@ dependencies = [
 [[package]]
 name = "cainome-rs-macro"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.2#4e3924fb82b7299d56d3619aa5d7b9863f581e0a"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.10#6fefd8bf4370c77d8834d18a2ae3c59d3a5e8dd5"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
- "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
- "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
+ "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2660,12 +2660,12 @@ dependencies = [
 [[package]]
 name = "cainome-rs-macro"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.8#53f989af513adc30c5576898c4a586bb3cd71d63"
+source = "git+https://github.com/cartridge-gg/cainome?tag=v0.4.2#4e3924fb82b7299d56d3619aa5d7b9863f581e0a"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
- "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
- "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
+ "cainome-parser 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
+ "cainome-rs 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.2)",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -8380,7 +8380,7 @@ dependencies = [
  "alloy-primitives",
  "anyhow",
  "assert_matches",
- "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.8)",
+ "cainome-cairo-serde 0.1.0 (git+https://github.com/cartridge-gg/cainome?tag=v0.4.10)",
  "clap",
  "console",
  "dojo-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ debug = true
 inherits = "release"
 
 [workspace.dependencies]
-cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "5c2616c273faca7700d2ba565503fcefb5b9d720", features = [ "abigen-rs" ] }
-cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", rev = "5c2616c273faca7700d2ba565503fcefb5b9d720" }
+cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.8", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.8" }
 dojo-utils = { path = "crates/dojo/utils" }
 
 # metrics
@@ -210,7 +210,7 @@ scarb-ui = { git = "https://github.com/dojoengine/scarb", rev = "7eac49b3e61236c
 semver = "1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
-serde_with = "3.9.0"
+serde_with = "3.11.0"
 similar-asserts = "1.5.0"
 smol_str = { version = "0.2.0", features = [ "serde" ] }
 spinoff = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ debug = true
 inherits = "release"
 
 [workspace.dependencies]
-cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.8", features = [ "abigen-rs" ] }
-cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.8" }
+cainome = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.10", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", tag = "v0.4.10" }
 dojo-utils = { path = "crates/dojo/utils" }
 
 # metrics

--- a/crates/dojo/bindgen/src/plugins/mod.rs
+++ b/crates/dojo/bindgen/src/plugins/mod.rs
@@ -74,6 +74,15 @@ impl Buffer {
         }
     }
 
+    /// Inserts string at the specified index.
+    ///
+    /// * `s` - The string to insert.
+    /// * `pos` - The position to insert the string at.
+    /// * `idx` - The index of the string to insert at.
+    pub fn insert_at_index(&mut self, s: String, idx: usize) {
+        self.0.insert(idx, s);
+    }
+
     /// Finds position of the given string in the inner vec.
     ///
     /// * `pos` - The string to search for.

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
@@ -22,3 +22,12 @@ pub(crate) const CAIRO_OPTION_TYPE_PATH: &str = "core::option::Option";
 pub(crate) const SN_IMPORT_SEARCH: &str = "} from 'starknet';";
 pub(crate) const CAIRO_OPTION_TOKEN: &str = "CairoOption,";
 pub(crate) const CAIRO_ENUM_TOKEN: &str = "CairoCustomEnum,";
+
+pub(crate) const REMOVE_FIELD_ORDER_TYPE_DEF: &str = "type RemoveFieldOrder<T> = T extends object
+  ? Omit<
+      {
+        [K in keyof T]: T[K] extends object ? RemoveFieldOrder<T[K]> : T[K];
+      },
+      'fieldOrder'
+    >
+  : T;";

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
@@ -14,3 +14,11 @@ pub const CAIRO_BOOL: &str = "bool";
 pub const JS_BOOLEAN: &str = "boolean";
 pub const JS_STRING: &str = "string";
 pub const JS_BIGNUMBERISH: &str = "BigNumberish";
+
+pub(crate) const BIGNUMNERISH_IMPORT: &str = "import type { BigNumberish } from 'starknet';\n";
+pub(crate) const CAIRO_OPTION_IMPORT: &str = "import type { CairoOption } from 'starknet';\n";
+pub(crate) const CAIRO_ENUM_IMPORT: &str = "import type { CairoCustomEnum } from 'starknet';\n";
+pub(crate) const CAIRO_OPTION_TYPE_PATH: &str = "core::option::Option";
+pub(crate) const SN_IMPORT_SEARCH: &str = "} from 'starknet';";
+pub(crate) const CAIRO_OPTION_TOKEN: &str = "CairoOption,";
+pub(crate) const CAIRO_ENUM_TOKEN: &str = "CairoCustomEnum,";

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/enum.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/enum.rs
@@ -1,9 +1,34 @@
 use cainome::parser::tokens::{Composite, CompositeType};
 
 use crate::error::BindgenResult;
+use crate::plugins::typescript::generator::JsType;
 use crate::plugins::{BindgenModelGenerator, Buffer};
 
+use super::constants::{CAIRO_ENUM_IMPORT, CAIRO_ENUM_TOKEN, SN_IMPORT_SEARCH};
+use super::token_is_custom_enum;
+
+const CAIRO_ENUM_TYPE_IMPL: &str = "export type TypedCairoEnum<T> = CairoCustomEnum & {\n\tvariant: { [K in keyof T]: T[K] | undefined };\n\tunwrap(): T[keyof T];\n}\n";
+
 pub(crate) struct TsEnumGenerator;
+
+impl TsEnumGenerator {
+    fn check_import(&self, token: &Composite, buffer: &mut Buffer) {
+        // type is Enum with type variants, need to import CairoEnum
+        // if enum has at least one inner that is a composite type
+        if token_is_custom_enum(token) {
+            if !buffer.has(SN_IMPORT_SEARCH) {
+                buffer.push(CAIRO_ENUM_IMPORT.to_owned());
+            } else if !buffer.has(CAIRO_ENUM_TOKEN) {
+                // If 'starknet' import is present, we add CairoEnum to the imported types
+                buffer.insert_after(format!(" {CAIRO_ENUM_TOKEN}"), SN_IMPORT_SEARCH, "{", 1);
+            }
+        }
+        if !buffer.has(CAIRO_ENUM_TYPE_IMPL) {
+            let pos = buffer.pos(SN_IMPORT_SEARCH).unwrap();
+            buffer.insert_at_index(CAIRO_ENUM_TYPE_IMPL.to_owned(), pos + 1);
+        }
+    }
+}
 
 impl BindgenModelGenerator for TsEnumGenerator {
     fn generate(&self, token: &Composite, buffer: &mut Buffer) -> BindgenResult<String> {
@@ -11,21 +36,41 @@ impl BindgenModelGenerator for TsEnumGenerator {
             return Ok(String::new());
         }
 
-        let gen = format!(
-            "// Type definition for `{path}` enum
+        let gen = if token_is_custom_enum(token) {
+            self.check_import(token, buffer);
+            format!(
+                "// Type definition for `{path}` enum
+export type {name} = {{
+{variants}
+}}
+export type {name}Enum = TypedCairoEnum<{name}>;
+",
+                path = token.type_path,
+                name = token.type_name(),
+                variants = token
+                    .inners
+                    .iter()
+                    .map(|inner| { format!("\t{}: {};", inner.name, JsType::from(&inner.token)) })
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            )
+        } else {
+            format!(
+                "// Type definition for `{path}` enum
 export enum {name} {{
 {variants}
 }}
 ",
-            path = token.type_path,
-            name = token.type_name(),
-            variants = token
-                .inners
-                .iter()
-                .map(|inner| format!("\t{},", inner.name))
-                .collect::<Vec<String>>()
-                .join("\n")
-        );
+                path = token.type_path,
+                name = token.type_name(),
+                variants = token
+                    .inners
+                    .iter()
+                    .map(|inner| format!("\t{},", inner.name))
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            )
+        };
 
         if buffer.has(&gen) {
             return Ok(String::new());

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/enum.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/enum.rs
@@ -1,13 +1,14 @@
 use cainome::parser::tokens::{Composite, CompositeType};
 
+use super::constants::{CAIRO_ENUM_IMPORT, CAIRO_ENUM_TOKEN, SN_IMPORT_SEARCH};
+use super::token_is_custom_enum;
 use crate::error::BindgenResult;
 use crate::plugins::typescript::generator::JsType;
 use crate::plugins::{BindgenModelGenerator, Buffer};
 
-use super::constants::{CAIRO_ENUM_IMPORT, CAIRO_ENUM_TOKEN, SN_IMPORT_SEARCH};
-use super::token_is_custom_enum;
-
-const CAIRO_ENUM_TYPE_IMPL: &str = "export type TypedCairoEnum<T> = CairoCustomEnum & {\n\tvariant: { [K in keyof T]: T[K] | undefined };\n\tunwrap(): T[keyof T];\n}\n";
+const CAIRO_ENUM_TYPE_IMPL: &str = "export type TypedCairoEnum<T> = CairoCustomEnum & \
+                                    {\n\tvariant: { [K in keyof T]: T[K] | undefined \
+                                    };\n\tunwrap(): T[keyof T];\n}\n";
 
 pub(crate) struct TsEnumGenerator;
 

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/function.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/function.rs
@@ -88,11 +88,12 @@ impl TsFunctionGenerator {
             .fold(inputs, |mut acc, input| {
                 let prefix = match &input.1 {
                     Token::Composite(t) => {
-                        if t.r#type == CompositeType::Enum
-                            || (t.r#type == CompositeType::Struct
-                                && !t.type_path.starts_with("core"))
-                        {
+                        if t.r#type == CompositeType::Enum {
                             "models."
+                        } else if t.r#type == CompositeType::Struct
+                            && !t.type_path.starts_with("core")
+                        {
+                            "models.Input"
                         } else {
                             ""
                         }

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
@@ -1,12 +1,31 @@
-use cainome::parser::tokens::{Composite, CompositeType};
+use cainome::parser::tokens::{Composite, CompositeType, Token};
 
-use super::JsType;
+use super::constants::{BIGNUMNERISH_IMPORT, CAIRO_OPTION_IMPORT, SN_IMPORT_SEARCH};
+use super::{token_is_option, JsType};
 use crate::error::BindgenResult;
+use crate::plugins::typescript::generator::constants::CAIRO_OPTION_TOKEN;
 use crate::plugins::{BindgenModelGenerator, Buffer};
 
-const BIGNUMNERISH_IMPORT: &str = "import type { BigNumberish } from 'starknet';";
-
 pub(crate) struct TsInterfaceGenerator;
+impl TsInterfaceGenerator {
+    fn check_import(&self, token: &Composite, buffer: &mut Buffer) {
+        // only search for end part of the import, as we append the other imports afterward
+        if !buffer.has("BigNumberish } from 'starknet';") {
+            buffer.push(BIGNUMNERISH_IMPORT.to_owned());
+        }
+
+        // type is Option, need to import CairoOption
+        if token_is_option(token) {
+            // we directly add import if 'starknet' import is not present
+            if !buffer.has(SN_IMPORT_SEARCH) {
+                buffer.push(CAIRO_OPTION_IMPORT.to_owned());
+            } else if !buffer.has(CAIRO_OPTION_TOKEN) {
+                // If 'starknet' import is present, we add CairoOption to the imported types
+                buffer.insert_after(format!(" {CAIRO_OPTION_TOKEN}"), SN_IMPORT_SEARCH, "{", 1);
+            }
+        }
+    }
+}
 
 impl BindgenModelGenerator for TsInterfaceGenerator {
     fn generate(&self, token: &Composite, buffer: &mut Buffer) -> BindgenResult<String> {
@@ -14,9 +33,7 @@ impl BindgenModelGenerator for TsInterfaceGenerator {
             return Ok(String::new());
         }
 
-        if !buffer.has(BIGNUMNERISH_IMPORT) {
-            buffer.push(BIGNUMNERISH_IMPORT.to_owned());
-        }
+        self.check_import(token, buffer);
 
         Ok(format!(
             "// Type definition for `{path}` struct
@@ -30,7 +47,15 @@ export interface {name} {{
             fields = token
                 .inners
                 .iter()
-                .map(|inner| { format!("\t{}: {};", inner.name, JsType::from(&inner.token)) })
+                .map(|inner| {
+                    if let Token::Composite(composite) = &inner.token {
+                        if token_is_option(composite) {
+                            self.check_import(composite, buffer);
+                        }
+                    }
+
+                    format!("\t{}: {};", inner.name, JsType::from(&inner.token))
+                })
                 .collect::<Vec<String>>()
                 .join("\n")
         ))
@@ -93,6 +118,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_check_import() {
+        let mut buff = Buffer::new();
+        let writer = TsInterfaceGenerator;
+        let token = create_test_struct_token();
+        writer.check_import(&token, &mut buff);
+        assert_eq!(1, buff.len());
+        let option = create_option_token();
+        writer.check_import(&option, &mut buff);
+        assert_eq!(1, buff.len());
+        let custom_enum = create_custom_enum_token();
+        writer.check_import(&custom_enum, &mut buff);
+        assert_eq!(1, buff.len());
+    }
+
     fn create_test_struct_token() -> Composite {
         Composite {
             type_path: "core::test::TestStruct".to_owned(),
@@ -118,6 +158,59 @@ mod tests {
             ],
             generic_args: vec![],
             r#type: CompositeType::Struct,
+            is_event: false,
+            alias: None,
+        }
+    }
+
+    fn create_option_token() -> Composite {
+        Composite {
+            type_path: "core::option::Option<core::felt252>".to_owned(),
+            inners: vec![CompositeInner {
+                index: 0,
+                name: "value".to_owned(),
+                kind: CompositeInnerKind::Key,
+                token: Token::CoreBasic(CoreBasic { type_path: "core::felt252".to_owned() }),
+            }],
+            generic_args: vec![],
+            r#type: CompositeType::Struct,
+            is_event: false,
+            alias: None,
+        }
+    }
+    fn create_custom_enum_token() -> Composite {
+        Composite {
+            type_path: "core::test::CustomEnum".to_owned(),
+            inners: vec![
+                CompositeInner {
+                    index: 0,
+                    name: "Variant1".to_owned(),
+                    kind: CompositeInnerKind::NotUsed,
+                    token: Token::CoreBasic(CoreBasic { type_path: "core::felt252".to_owned() }),
+                },
+                CompositeInner {
+                    index: 1,
+                    name: "Variant2".to_owned(),
+                    kind: CompositeInnerKind::NotUsed,
+                    token: Token::Composite(Composite {
+                        type_path: "core::test::NestedStruct".to_owned(),
+                        inners: vec![CompositeInner {
+                            index: 0,
+                            name: "nested_field".to_owned(),
+                            kind: CompositeInnerKind::Key,
+                            token: Token::CoreBasic(CoreBasic {
+                                type_path: "core::felt252".to_owned(),
+                            }),
+                        }],
+                        generic_args: vec![],
+                        r#type: CompositeType::Struct,
+                        is_event: false,
+                        alias: None,
+                    }),
+                },
+            ],
+            generic_args: vec![],
+            r#type: CompositeType::Enum,
             is_event: false,
             alias: None,
         }

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
@@ -1,6 +1,8 @@
 use cainome::parser::tokens::{Composite, CompositeType, Token};
 
-use super::constants::{BIGNUMNERISH_IMPORT, CAIRO_OPTION_IMPORT, SN_IMPORT_SEARCH};
+use super::constants::{
+    BIGNUMNERISH_IMPORT, CAIRO_OPTION_IMPORT, REMOVE_FIELD_ORDER_TYPE_DEF, SN_IMPORT_SEARCH,
+};
 use super::{token_is_option, JsType};
 use crate::error::BindgenResult;
 use crate::plugins::typescript::generator::constants::CAIRO_OPTION_TOKEN;
@@ -25,6 +27,12 @@ impl TsInterfaceGenerator {
             }
         }
     }
+
+    fn add_input_type(&self, buffer: &mut Buffer) {
+        if !buffer.has(REMOVE_FIELD_ORDER_TYPE_DEF) {
+            buffer.push(REMOVE_FIELD_ORDER_TYPE_DEF.to_owned());
+        }
+    }
 }
 
 impl BindgenModelGenerator for TsInterfaceGenerator {
@@ -34,6 +42,7 @@ impl BindgenModelGenerator for TsInterfaceGenerator {
         }
 
         self.check_import(token, buffer);
+        self.add_input_type(buffer);
 
         Ok(format!(
             "// Type definition for `{path}` struct
@@ -41,6 +50,7 @@ export interface {name} {{
 \tfieldOrder: string[];
 {fields}
 }}
+export type Input{name} = RemoveFieldOrder<{name}>;
 ",
             path = token.type_path,
             name = token.type_name(),
@@ -114,7 +124,7 @@ mod tests {
             result,
             "// Type definition for `core::test::TestStruct` struct\nexport interface TestStruct \
              {\n\tfieldOrder: string[];\n\tfield1: BigNumberish;\n\tfield2: \
-             BigNumberish;\n\tfield3: BigNumberish;\n}\n"
+             BigNumberish;\n\tfield3: BigNumberish;\n}\nexport type InputTestStruct = RemoveFieldOrder<TestStruct>;\n"
         );
     }
 

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
@@ -40,6 +40,11 @@ impl BindgenModelGenerator for TsInterfaceGenerator {
         if token.r#type != CompositeType::Struct || token.inners.is_empty() {
             return Ok(String::new());
         }
+        if buffer
+            .has(format!("// Type definition for `{path}` struct", path = token.type_path).as_str())
+        {
+            return Ok(String::new());
+        }
 
         self.check_import(token, buffer);
         self.add_input_type(buffer);
@@ -124,7 +129,8 @@ mod tests {
             result,
             "// Type definition for `core::test::TestStruct` struct\nexport interface TestStruct \
              {\n\tfieldOrder: string[];\n\tfield1: BigNumberish;\n\tfield2: \
-             BigNumberish;\n\tfield3: BigNumberish;\n}\nexport type InputTestStruct = RemoveFieldOrder<TestStruct>;\n"
+             BigNumberish;\n\tfield3: BigNumberish;\n}\nexport type InputTestStruct = \
+             RemoveFieldOrder<TestStruct>;\n"
         );
     }
 

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
@@ -87,7 +87,7 @@ impl TsSchemaGenerator {
             return;
         }
 
-        buffer.insert_after(gen, const_type, ",", 1);
+        buffer.insert_after(gen, const_type, ",", 2);
     }
 
     /// Check if namespace is defined in schema

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
@@ -26,8 +26,8 @@ impl TsSchemaGenerator {
         let schema_type = "export interface SchemaType extends ISchemaType";
         if !buffer.has(schema_type) {
             buffer.push(format!(
-                "export interface SchemaType extends ISchemaType {{\n\t{ns}: \
-                 {{\n\t\t{}: {},\n\t}},\n}}",
+                "export interface SchemaType extends ISchemaType {{\n\t{ns}: {{\n\t\t{}: \
+                 {},\n\t}},\n}}",
                 type_name, type_name
             ));
             return;
@@ -64,8 +64,7 @@ impl TsSchemaGenerator {
         let const_type = "export const schema: SchemaType";
         if !buffer.has(const_type) {
             buffer.push(format!(
-                "export const schema: SchemaType = {{\n\t{ns}: {{\n\t\t{}: \
-                 {},\n\t}},\n}};",
+                "export const schema: SchemaType = {{\n\t{ns}: {{\n\t\t{}: {},\n\t}},\n}};",
                 type_name,
                 generate_type_init(token)
             ));
@@ -203,14 +202,16 @@ mod tests {
         generator.handle_schema_type(&token_3, &mut buffer);
         assert_eq!(
             "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
-             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: {\n\t\tPlayer: Player,\n\t},\n}",
+             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: \
+             {\n\t\tPlayer: Player,\n\t},\n}",
             buffer[0]
         );
         let token_4 = create_test_struct_token("Position", "combat");
         generator.handle_schema_type(&token_4, &mut buffer);
         assert_eq!(
             "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
-             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: {\n\t\tPlayer: Player,\n\t\tPosition: Position,\n\t},\n}",
+             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: \
+             {\n\t\tPlayer: Player,\n\t\tPosition: Position,\n\t},\n}",
             buffer[0]
         );
     }
@@ -251,7 +252,9 @@ mod tests {
              {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
              0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
              {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: \
+             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
         );
 
         let token_4 = create_test_struct_token("Position", "combat");
@@ -263,7 +266,11 @@ mod tests {
              {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
              0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
              {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tPosition: {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: \
+             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tPosition: {\n\t\t\tfieldOrder: \
+             ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: \
+             0,\n\t\t},\n\t},\n};"
         );
     }
 

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
@@ -12,21 +12,32 @@ pub(crate) struct TsSchemaGenerator {}
 impl TsSchemaGenerator {
     /// Import only needs to be present once
     fn import_schema_type(&self, buffer: &mut Buffer) {
-        if !buffer.has("import type { SchemaType }") {
-            buffer.insert(0, "import type { SchemaType } from \"@dojoengine/sdk\";\n".to_owned());
+        if !buffer.has("import type { SchemaType as ISchemaType }") {
+            buffer.insert(
+                0,
+                "import type { SchemaType as ISchemaType } from \"@dojoengine/sdk\";\n".to_owned(),
+            );
         }
     }
 
     /// Generates the type definition for the schema
     fn handle_schema_type(&self, token: &Composite, buffer: &mut Buffer) {
-        let (ns, namespace, type_name) = get_namespace_and_path(token);
-        let schema_type = format!("export interface {namespace}SchemaType extends SchemaType");
-        if !buffer.has(&schema_type) {
+        let (ns, _namespace, type_name) = get_namespace_and_path(token);
+        let schema_type = "export interface SchemaType extends ISchemaType";
+        if !buffer.has(schema_type) {
             buffer.push(format!(
-                "export interface {namespace}SchemaType extends SchemaType {{\n\t{ns}: \
+                "export interface SchemaType extends ISchemaType {{\n\t{ns}: \
                  {{\n\t\t{}: {},\n\t}},\n}}",
                 type_name, type_name
             ));
+            return;
+        }
+
+        // check if namespace is defined in interface. if not, add it.
+        // next, find where namespace was defined in interface and add property to it.
+        if !self.namespace_is_defined(buffer, &ns) {
+            let gen = format!("\n\t{ns}: {{\n\t\t{type_name}: {type_name},\n\t}},");
+            buffer.insert_after(gen, schema_type, ",", 1);
             return;
         }
 
@@ -36,25 +47,37 @@ impl TsSchemaGenerator {
             return;
         }
 
-        // fastest way to add a field to the interface is to search for the n-1 `,` and add the
+        let ns_def = format!("\n\t{ns}: {{\n\t\t");
+
+        // fastest way to add a field to the interface is to search for the n-1
+        // `,` and add the
         // field directly after it.
         // to improve this logic, we would need to either have some kind of code parsing.
         // we could otherwise have some intermediate representation that we pass to this generator
         // function.
-        buffer.insert_after(gen, &schema_type, ",", 2);
+        buffer.insert_after(gen, &ns_def, ",", 2);
     }
 
     /// Generates the default values for the schema
     fn handle_schema_const(&self, token: &Composite, buffer: &mut Buffer) {
-        let (ns, namespace, type_name) = get_namespace_and_path(token);
-        let const_type = format!("export const schema: {namespace}SchemaType");
-        if !buffer.has(&const_type) {
+        let (ns, _namespace, type_name) = get_namespace_and_path(token);
+        let const_type = "export const schema: SchemaType";
+        if !buffer.has(const_type) {
             buffer.push(format!(
-                "export const schema: {namespace}SchemaType = {{\n\t{ns}: {{\n\t\t{}: \
+                "export const schema: SchemaType = {{\n\t{ns}: {{\n\t\t{}: \
                  {},\n\t}},\n}};",
                 type_name,
                 generate_type_init(token)
             ));
+            return;
+        }
+
+        // check if namespace is defined in interface. if not, add it.
+        // next, find where namespace was defined in interface and add property to it.
+        if !self.namespace_is_defined(buffer, &ns) {
+            let gen =
+                format!("\n\t{ns}: {{\n\t\t{}: {},\n\t}},", type_name, generate_type_init(token));
+            buffer.insert_after(gen, const_type, ",", 1);
             return;
         }
 
@@ -63,7 +86,13 @@ impl TsSchemaGenerator {
         if buffer.has(&gen) {
             return;
         }
-        buffer.insert_after(gen, &const_type, ",", 2);
+
+        buffer.insert_after(gen, const_type, ",", 1);
+    }
+
+    /// Check if namespace is defined in schema
+    fn namespace_is_defined(&self, buffer: &mut Buffer, ns: &str) -> bool {
+        buffer.has(format!("\n\t{ns}: {{\n\t\t").as_str())
     }
 }
 
@@ -74,12 +103,12 @@ impl BindgenModelGenerator for TsSchemaGenerator {
         }
         self.import_schema_type(buffer);
 
-        // in buffer search for interface named {pascal_case(namespace)}SchemaType extends
-        // SchemaType
+        // in buffer search for interface named SchemaType extends
+        // ISchemaType
         // this should be hold in a buffer item
         self.handle_schema_type(token, buffer);
 
-        // in buffer search for const schema: InterfaceName =  named
+        // in buffer search for const schema: SchemaType =  named
         // {pascal_case(namespace)}SchemaType extends SchemaType
         // this should be hold in a buffer item
         self.handle_schema_const(token, buffer);
@@ -122,11 +151,14 @@ mod tests {
         let generator = TsSchemaGenerator {};
         let mut buffer = Buffer::new();
 
-        let token = create_test_struct_token("TestStruct");
+        let token = create_test_struct_token("TestStruct", "onchain_dash");
         let _result = generator.generate(&token, &mut buffer);
 
         // token is not empty, we should have an import
-        assert_eq!("import type { SchemaType } from \"@dojoengine/sdk\";\n", buffer[0]);
+        assert_eq!(
+            "import type { SchemaType as ISchemaType } from \"@dojoengine/sdk\";\n",
+            buffer[0]
+        );
     }
 
     /// NOTE: For the following tests, we assume that the `enum.rs` and `interface.rs` generators
@@ -136,10 +168,10 @@ mod tests {
         let generator = TsSchemaGenerator {};
         let mut buffer = Buffer::new();
 
-        let token = create_test_struct_token("TestStruct");
+        let token = create_test_struct_token("TestStruct", "onchain_dash");
         let _result = generator.generate(&token, &mut buffer);
         assert_eq!(
-            "export interface OnchainDashSchemaType extends SchemaType {\n\tonchain_dash: \
+            "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
              {\n\t\tTestStruct: TestStruct,\n\t},\n}",
             buffer[1]
         );
@@ -150,21 +182,35 @@ mod tests {
         let generator = TsSchemaGenerator {};
         let mut buffer = Buffer::new();
 
-        let token = create_test_struct_token("TestStruct");
+        let token = create_test_struct_token("TestStruct", "onchain_dash");
         generator.handle_schema_type(&token, &mut buffer);
 
         assert_ne!(0, buffer.len());
         assert_eq!(
-            "export interface OnchainDashSchemaType extends SchemaType {\n\tonchain_dash: \
+            "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
              {\n\t\tTestStruct: TestStruct,\n\t},\n}",
             buffer[0]
         );
 
-        let token_2 = create_test_struct_token("AvailableTheme");
+        let token_2 = create_test_struct_token("AvailableTheme", "onchain_dash");
         generator.handle_schema_type(&token_2, &mut buffer);
         assert_eq!(
-            "export interface OnchainDashSchemaType extends SchemaType {\n\tonchain_dash: \
+            "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
              {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n}",
+            buffer[0]
+        );
+        let token_3 = create_test_struct_token("Player", "combat");
+        generator.handle_schema_type(&token_3, &mut buffer);
+        assert_eq!(
+            "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
+             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: {\n\t\tPlayer: Player,\n\t},\n}",
+            buffer[0]
+        );
+        let token_4 = create_test_struct_token("Position", "combat");
+        generator.handle_schema_type(&token_4, &mut buffer);
+        assert_eq!(
+            "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
+             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: {\n\t\tPlayer: Player,\n\t\tPosition: Position,\n\t},\n}",
             buffer[0]
         );
     }
@@ -173,27 +219,51 @@ mod tests {
     fn test_handle_schema_const() {
         let generator = TsSchemaGenerator {};
         let mut buffer = Buffer::new();
-        let token = create_test_struct_token("TestStruct");
+        let token = create_test_struct_token("TestStruct", "onchain_dash");
 
         generator.handle_schema_const(&token, &mut buffer);
         assert_eq!(buffer.len(), 1);
         assert_eq!(
             buffer[0],
-            "export const schema: OnchainDashSchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
+            "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
              {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
              0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
         );
 
-        let token_2 = create_test_struct_token("AvailableTheme");
+        let token_2 = create_test_struct_token("AvailableTheme", "onchain_dash");
         generator.handle_schema_const(&token_2, &mut buffer);
         assert_eq!(buffer.len(), 1);
         assert_eq!(
             buffer[0],
-            "export const schema: OnchainDashSchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
+            "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
              {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
              0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
              {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
              0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
+        );
+
+        let token_3 = create_test_struct_token("Player", "combat");
+        generator.handle_schema_const(&token_3, &mut buffer);
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(
+            buffer[0],
+            "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
+             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
+             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
+        );
+
+        let token_4 = create_test_struct_token("Position", "combat");
+        generator.handle_schema_const(&token_4, &mut buffer);
+        assert_eq!(buffer.len(), 1);
+        assert_eq!(
+            buffer[0],
+            "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
+             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
+             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
+             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tPosition: {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
         );
     }
 
@@ -201,14 +271,14 @@ mod tests {
     fn test_handle_nested_struct() {
         let generator = TsSchemaGenerator {};
         let mut buffer = Buffer::new();
-        let nested_struct = create_test_nested_struct_token("TestNestedStruct");
+        let nested_struct = create_test_nested_struct_token("TestNestedStruct", "onchain_dash");
         let _res = generator.generate(&nested_struct, &mut buffer);
         assert_eq!(buffer.len(), 3);
     }
 
-    fn create_test_struct_token(name: &str) -> Composite {
+    fn create_test_struct_token(name: &str, namespace: &str) -> Composite {
         Composite {
-            type_path: format!("onchain_dash::{name}"),
+            type_path: format!("{namespace}::{name}"),
             inners: vec![
                 CompositeInner {
                     index: 0,
@@ -236,18 +306,18 @@ mod tests {
         }
     }
 
-    pub fn create_test_nested_struct_token(name: &str) -> Composite {
+    pub fn create_test_nested_struct_token(name: &str, namespace: &str) -> Composite {
         Composite {
-            type_path: format!("onchain_dash::{name}"),
+            type_path: format!("{namespace}::{name}"),
             inners: vec![
                 CompositeInner {
                     index: 0,
                     name: "field1".to_owned(),
                     kind: CompositeInnerKind::Key,
                     token: Token::Array(cainome::parser::tokens::Array {
-                        type_path: "core::array::Array::<onchain_dah::Direction>".to_owned(),
+                        type_path: format!("core::array::Array::<{namespace}::Direction>"),
                         inner: Box::new(Token::Composite(Composite {
-                            type_path: "onchain_dah::Direction".to_owned(),
+                            type_path: format!("{namespace}::Direction"),
                             inners: vec![
                                 CompositeInner {
                                     index: 0,
@@ -302,7 +372,7 @@ mod tests {
                     index: 1,
                     name: "field2".to_owned(),
                     kind: CompositeInnerKind::Key,
-                    token: Token::Composite(create_test_struct_token("Position")),
+                    token: Token::Composite(create_test_struct_token("Position", namespace)),
                 },
             ],
             generic_args: vec![],

--- a/crates/dojo/bindgen/src/plugins/typescript/writer.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/writer.rs
@@ -51,6 +51,9 @@ impl BindgenWriter for TsFileWriter {
             .iter()
             .fold(Buffer::new(), |mut acc, g| {
                 composites.iter().for_each(|c| {
+                    // println!("Generating code for model {}", c.type_path);
+                    // println!("{:#?}", c);
+                    // println!("=====================");
                     match g.generate(c, &mut acc) {
                         Ok(code) => {
                             if !code.is_empty() {


### PR DESCRIPTION
# Description
Long awaited PR is finally there. Mainly solves #2715 


## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [x] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to insert strings at specific indices within the `Buffer` struct.
	- Introduced new constants for TypeScript imports related to Cairo and StarkNet.
	- Enhanced TypeScript enum generation with conditional imports and type definitions.
	- Improved handling of TypeScript schema types and namespaces.

- **Bug Fixes**
	- Updated dependency versions for improved stability and compatibility.

- **Tests**
	- Expanded test coverage for new functionalities in TypeScript generation and import handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->