### PR TITLE
refactor(torii-libp2p): always use is_valid_signature

### DIFF
--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -37,8 +37,8 @@ use crate::errors::Error;
 mod events;
 
 use crate::server::events::ServerEvent;
-use crate::typed_data::{encode_type, parse_value_to_ty, PrimitiveType, TypedData};
-use crate::types::{Message, Signature};
+use crate::typed_data::{parse_value_to_ty, PrimitiveType, TypedData};
+use crate::types::Message;
 
 pub(crate) const LOG_TARGET: &str = "torii::relay::server";
 
@@ -414,51 +414,24 @@ async fn validate_signature<P: Provider + Sync>(
     provider: &P,
     entity_identity: Felt,
     message: &TypedData,
-    signature: &Signature,
+    signature: &[Felt],
 ) -> Result<bool, Error> {
     let message_hash = message.encode(entity_identity)?;
 
-    match signature {
-        Signature::Account(signature) => {
-            let mut calldata = vec![message_hash, Felt::from(signature.len())];
-            calldata.extend(signature);
-            provider
-                .call(
-                    FunctionCall {
-                        contract_address: entity_identity,
-                        entry_point_selector: get_selector_from_name("is_valid_signature").unwrap(),
-                        calldata,
-                    },
-                    BlockId::Tag(BlockTag::Pending),
-                )
-                .await
-                .map_err(Error::ProviderError)
-                .map(|res| res[0] != Felt::ZERO)
-        }
-        Signature::Session(signature) => {
-            let mut calldata = vec![
-                Felt::ONE,
-                get_selector_from_name(&encode_type(&message.primary_type, &message.types)?)
-                    .map_err(|e| Error::InvalidMessageError(e.to_string()))?,
-                message_hash,
-                signature.len().into(),
-            ];
-            calldata.extend(signature);
-            provider
-                .call(
-                    FunctionCall {
-                        contract_address: entity_identity,
-                        entry_point_selector: get_selector_from_name("is_session_sigature_valid")
-                            .unwrap(),
-                        calldata,
-                    },
-                    BlockId::Tag(BlockTag::Pending),
-                )
-                .await
-                .map_err(Error::ProviderError)
-                .map(|res| res[0] != Felt::ZERO)
-        }
-    }
+    let mut calldata = vec![message_hash, Felt::from(signature.len())];
+    calldata.extend(signature);
+    provider
+        .call(
+            FunctionCall {
+                contract_address: entity_identity,
+                entry_point_selector: get_selector_from_name("is_valid_signature").unwrap(),
+                calldata,
+            },
+            BlockId::Tag(BlockTag::Pending),
+        )
+        .await
+        .map_err(Error::ProviderError)
+        .map(|res| res[0] != Felt::ZERO)
 }
 
 fn ty_keys(ty: &Ty) -> Result<Vec<Felt>, Error> {

--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -693,10 +693,7 @@ mod test {
 
         client
             .command_sender
-            .publish(Message {
-                message: typed_data,
-                signature: vec![signature.r, signature.s],
-            })
+            .publish(Message { message: typed_data, signature: vec![signature.r, signature.s] })
             .await?;
 
         sleep(std::time::Duration::from_secs(2)).await;

--- a/crates/torii/libp2p/src/tests.rs
+++ b/crates/torii/libp2p/src/tests.rs
@@ -546,7 +546,7 @@ mod test {
 
         use crate::server::Relay;
         use crate::typed_data::{Domain, Field, SimpleField, TypedData};
-        use crate::types::{Message, Signature};
+        use crate::types::Message;
 
         let _ = tracing_subscriber::fmt()
             .with_env_filter("torii::relay::client=debug,torii::relay::server=debug")
@@ -695,7 +695,7 @@ mod test {
             .command_sender
             .publish(Message {
                 message: typed_data,
-                signature: Signature::Account(vec![signature.r, signature.s]),
+                signature: vec![signature.r, signature.s],
             })
             .await?;
 

--- a/crates/torii/libp2p/src/types.rs
+++ b/crates/torii/libp2p/src/types.rs
@@ -4,13 +4,7 @@ use starknet::core::types::Felt;
 use crate::typed_data::TypedData;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Signature {
-    Account(Vec<Felt>),
-    Session(Vec<Felt>),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub message: TypedData,
-    pub signature: Signature,
+    pub signature: Vec<Felt>,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified signature validation process by using a vector format for signatures.
	- Enhanced maintainability through a consistent calldata structure for signature validation.

- **Bug Fixes**
	- Improved error handling during message deserialization, validation, and database operations.

- **Refactor**
	- Removed the `Signature` enum, streamlining the `Message` struct to use a vector for signatures.
	- Updated test suite to reflect changes in signature handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->