### PR TITLE
feat(torii): add world block and instrument queries

### DIFF
--- a/bin/torii/src/main.rs
+++ b/bin/torii/src/main.rs
@@ -164,6 +164,7 @@ async fn main() -> anyhow::Result<()> {
                 historical_events: args.events.historical.into_iter().collect(),
                 namespaces: args.indexing.namespaces.into_iter().collect(),
             },
+            world_block: args.indexing.world_block,
         },
         shutdown_tx.clone(),
         Some(block_tx),

--- a/crates/torii/cli/src/options.rs
+++ b/crates/torii/cli/src/options.rs
@@ -157,6 +157,19 @@ pub struct IndexingOptions {
     )]
     #[serde(default)]
     pub namespaces: Vec<String>,
+
+    /// The block number to start indexing the world from.
+    ///
+    /// Warning: In the current implementation, this will break the indexing of tokens, if any.
+    /// Since the tokens require the chain to be indexed from the beginning, to ensure correct
+    /// balance updates.
+    #[arg(
+        long = "indexing.world_block",
+        help = "The block number to start indexing from.",
+        default_value_t = 0
+    )]
+    #[serde(default)]
+    pub world_block: u64,
 }
 
 impl Default for IndexingOptions {
@@ -170,6 +183,7 @@ impl Default for IndexingOptions {
             polling_interval: DEFAULT_POLLING_INTERVAL,
             max_concurrent_tasks: DEFAULT_MAX_CONCURRENT_TASKS,
             namespaces: vec![],
+            world_block: 0,
         }
     }
 }
@@ -207,6 +221,10 @@ impl IndexingOptions {
 
             if self.namespaces.is_empty() {
                 self.namespaces = other.namespaces.clone();
+            }
+
+            if self.world_block == 0 {
+                self.world_block = other.world_block;
             }
         }
     }

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -148,6 +148,7 @@ pub struct EngineConfig {
     pub max_concurrent_tasks: usize,
     pub flags: IndexingFlags,
     pub event_processor_config: EventProcessorConfig,
+    pub world_block: u64,
 }
 
 impl Default for EngineConfig {
@@ -159,6 +160,7 @@ impl Default for EngineConfig {
             max_concurrent_tasks: 100,
             flags: IndexingFlags::empty(),
             event_processor_config: EventProcessorConfig::default(),
+            world_block: 0,
         }
     }
 }
@@ -323,7 +325,7 @@ impl<P: Provider + Send + Sync + std::fmt::Debug + 'static> Engine<P> {
     pub async fn fetch_data(&mut self, cursors: &Cursors) -> Result<FetchDataResult> {
         let latest_block = self.provider.block_hash_and_number().await?;
 
-        let from = cursors.head.unwrap_or(948000);
+        let from = cursors.head.unwrap_or(self.config.world_block);
         let total_remaining_blocks = latest_block.block_number - from;
         let blocks_to_process = total_remaining_blocks.min(self.config.blocks_chunk_size);
         let to = from + blocks_to_process;

--- a/crates/torii/core/src/engine.rs
+++ b/crates/torii/core/src/engine.rs
@@ -323,7 +323,7 @@ impl<P: Provider + Send + Sync + std::fmt::Debug + 'static> Engine<P> {
     pub async fn fetch_data(&mut self, cursors: &Cursors) -> Result<FetchDataResult> {
         let latest_block = self.provider.block_hash_and_number().await?;
 
-        let from = cursors.head.unwrap_or(0);
+        let from = cursors.head.unwrap_or(948000);
         let total_remaining_blocks = latest_block.block_number - from;
         let blocks_to_process = total_remaining_blocks.min(self.config.blocks_chunk_size);
         let to = from + blocks_to_process;

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -332,7 +332,7 @@ impl DojoWorld {
                 None,
             )?;
 
-            let rows = sqlx::query(&entity_query).bind(&models_str).fetch_all(&mut *tx).await?;
+            let rows = sqlx::query(&entity_query).bind(models_str).fetch_all(&mut *tx).await?;
             let schemas = Arc::new(schemas);
 
             let group_entities: Result<Vec<_>, Error> = rows

--- a/eternum.toml
+++ b/eternum.toml
@@ -3,12 +3,12 @@ rpc = "https://api.cartridge.gg/x/starknet/mainnet"
 explorer = false
 
 [indexing]
-world_block = 948000
+world_block = 947500
 events_chunk_size = 1024
 blocks_chunk_size = 1024000
 pending = true
 polling_interval = 500
 max_concurrent_tasks = 100
 transactions = false
-contracts = ["ERC721:0x57675b9c0bd62b096a2e15502a37b290fa766ead21c33eda42993e48a714b80", "ERC721:0x7ae27a31bb6526e3de9cf02f081f6ce0615ac12a6d7b85ee58b8ad7947a2809", "ERC20:0x124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49"]
+contracts = ["ERC721:0x57675b9c0bd62b096a2e15502a37b290fa766ead21c33eda42993e48a714b80"]
 namespaces = []

--- a/eternum.toml
+++ b/eternum.toml
@@ -3,6 +3,7 @@ rpc = "https://api.cartridge.gg/x/starknet/mainnet"
 explorer = false
 
 [indexing]
+world_block = 948000
 events_chunk_size = 1024
 blocks_chunk_size = 1024000
 pending = true

--- a/eternum.toml
+++ b/eternum.toml
@@ -1,0 +1,13 @@
+world_address = "0x6a9e4c6f0799160ea8ddc43ff982a5f83d7f633e9732ce42701de1288ff705f"
+rpc = "https://api.cartridge.gg/x/starknet/mainnet"
+explorer = false
+
+[indexing]
+events_chunk_size = 1024
+blocks_chunk_size = 1024000
+pending = true
+polling_interval = 500
+max_concurrent_tasks = 100
+transactions = false
+contracts = ["ERC721:0x57675b9c0bd62b096a2e15502a37b290fa766ead21c33eda42993e48a714b80", "ERC721:0x7ae27a31bb6526e3de9cf02f081f6ce0615ac12a6d7b85ee58b8ad7947a2809", "ERC20:0x124aeb495b947201f5fac96fd1138e326ad86195b98df6dec9009158a533b49"]
+namespaces = []


### PR DESCRIPTION
Run with `RUST_LOG=torii_grpc::server=debug,info cargo run --bin torii -- --db-dir=./eternum.db --config=eternum.toml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration file `eternum.toml` with various settings for blockchain applications, including parameters for data processing and transaction management.
	- Enhanced logging capabilities in the `fetch_entities` method to provide detailed insights into execution flow and performance metrics.
	- Added a new field `world_block` to configuration settings, allowing for customizable indexing starting points.
	- Added a `world_block` field to the `IndexingOptions` struct for specifying the starting block number for indexing.

- **Bug Fixes**
	- Adjusted the default starting point for data fetching, potentially improving data processing efficiency.

- **Refactor**
	- Refactored the `fetch_entities` method for improved clarity and maintainability, while preserving existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->