### PR TITLE
fix(torii-grpc-server): adjust regex to support variable len correctly

### DIFF
--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -1161,7 +1161,7 @@ fn build_keys_pattern(clause: &proto::types::KeysClause) -> Result<String, Error
     let mut keys_pattern = format!("^{}", keys.join("/"));
 
     if clause.pattern_matching == proto::types::PatternMatching::VariableLen as i32 {
-        keys_pattern += &format!("/({})*", KEY_PATTERN);
+        keys_pattern += &format!("(/{})*", KEY_PATTERN);
     }
     keys_pattern += "/$";
 


### PR DESCRIPTION
Use correct regex to have `VariableLen` correctly retrieving the entities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced methods for subscribing to indexers, models, entities, and event messages in the DojoWorld service.
- **Improvements**
	- Enhanced error handling for entity and event retrieval methods.
	- Optimized SQL query building logic for better performance and clarity.
- **Bug Fixes**
	- Improved handling of optional parameters in query methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->