### PR TITLE
feat: introduce updated at field in top level torii query

### DIFF
--- a/crates/torii/core/src/error.rs
+++ b/crates/torii/core/src/error.rs
@@ -51,4 +51,6 @@ pub enum QueryError {
     SqliteJoinLimit,
     #[error("Invalid namespaced model: {0}")]
     InvalidNamespacedModel(String),
+    #[error("Invalid timestamp: {0}. Expected valid number of seconds since unix epoch.")]
+    InvalidTimestamp(u64),
 }

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -184,7 +184,7 @@ pub fn build_sql_query(
         ));
 
         if internal_updated_at > 0 {
-            internal_updated_at_clause.push(format!("[{model_table}].internal_updated_at > ?"));
+            internal_updated_at_clause.push(format!("[{model_table}].internal_updated_at >= ?"));
         }
 
         // Collect columns with table prefix

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -116,6 +116,7 @@ impl ModelReader<Error> for ModelSQLReader {
 }
 
 /// Creates a query that fetches all models and their nested data.
+#[allow(clippy::too_many_arguments)]
 pub fn build_sql_query(
     schemas: &Vec<Ty>,
     table_name: &str,

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -184,8 +184,7 @@ pub fn build_sql_query(
         ));
 
         if internal_updated_at > 0 {
-            internal_updated_at_clause
-                .push(format!("[{model_table}].internal_updated_at > {}", internal_updated_at));
+            internal_updated_at_clause.push(format!("[{model_table}].internal_updated_at > ?"));
         }
 
         // Collect columns with table prefix

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -517,7 +517,8 @@ mod tests {
         )
         .unwrap();
 
-        let expected_query = "SELECT entities.id, entities.keys, [Test-Position].[player] as \
+        let expected_query =
+            "SELECT entities.id, entities.keys, [Test-Position].[player] as \
              \"Test-Position.player\", [Test-Position].[vec.x] as \"Test-Position.vec.x\", \
              [Test-Position].[vec.y] as \"Test-Position.vec.y\", \
              [Test-Position].[test_everything] as \"Test-Position.test_everything\", \

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -76,6 +76,7 @@ message Query {
     bool dont_include_hashed_keys = 4;
     repeated OrderBy order_by = 5;
     repeated string entity_models = 6;
+	uint64 internal_updated_at = 7;
 }
 
 message EventQuery {

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -229,6 +229,7 @@ impl DojoWorld {
         dont_include_hashed_keys: bool,
         order_by: Option<&str>,
         entity_models: Vec<String>,
+        internal_updated_at: u64,
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
         self.query_by_hashed_keys(
             table,
@@ -240,6 +241,7 @@ impl DojoWorld {
             dont_include_hashed_keys,
             order_by,
             entity_models,
+            internal_updated_at,
         )
         .await
     }
@@ -266,6 +268,7 @@ impl DojoWorld {
         dont_include_hashed_keys: bool,
         order_by: Option<&str>,
         entity_models: Vec<String>,
+        internal_updated_at: u64,
     ) -> Result<Vec<proto::types::Entity>, Error> {
         let entity_models =
             entity_models.iter().map(|tag| compute_selector_from_tag(tag)).collect::<Vec<Felt>>();
@@ -354,9 +357,11 @@ impl DojoWorld {
                 order_by,
                 None,
                 None,
+                internal_updated_at,
             )?;
 
-            let rows = sqlx::query(&entity_query).bind(models_str).fetch_all(&mut *tx).await?;
+            let query = sqlx::query(&entity_query).bind(models_str);
+            let rows = query.fetch_all(&mut *tx).await?;
             let schemas = Arc::new(schemas);
 
             let group_entities: Result<Vec<_>, Error> = rows
@@ -430,6 +435,7 @@ impl DojoWorld {
         dont_include_hashed_keys: bool,
         order_by: Option<&str>,
         entity_models: Vec<String>,
+        internal_updated_at: u64,
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
         // TODO: use prepared statement for where clause
         let filter_ids = match hashed_keys {
@@ -510,6 +516,7 @@ impl DojoWorld {
                 dont_include_hashed_keys,
                 order_by,
                 entity_models,
+                internal_updated_at,
             )
             .await?;
         Ok((entities, total_count))
@@ -527,6 +534,7 @@ impl DojoWorld {
         dont_include_hashed_keys: bool,
         order_by: Option<&str>,
         entity_models: Vec<String>,
+        internal_updated_at: u64,
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
         let keys_pattern = build_keys_pattern(keys_clause)?;
 
@@ -655,6 +663,7 @@ impl DojoWorld {
                 dont_include_hashed_keys,
                 order_by,
                 entity_models,
+                internal_updated_at,
             )
             .await?;
         Ok((entities, total_count))
@@ -699,6 +708,7 @@ impl DojoWorld {
         dont_include_hashed_keys: bool,
         order_by: Option<&str>,
         entity_models: Vec<String>,
+        internal_updated_at: u64,
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
         let entity_models =
             entity_models.iter().map(|model| compute_selector_from_tag(model)).collect::<Vec<_>>();
@@ -765,6 +775,7 @@ impl DojoWorld {
             order_by,
             limit,
             offset,
+            internal_updated_at,
         )?;
 
         let total_count = sqlx::query_scalar(&count_query)
@@ -798,6 +809,7 @@ impl DojoWorld {
         dont_include_hashed_keys: bool,
         order_by: Option<&str>,
         entity_models: Vec<String>,
+        internal_updated_at: u64,
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
         let (where_clause, having_clause, join_clause, bind_values) =
             build_composite_clause(table, model_relation_table, &composite)?;
@@ -868,6 +880,7 @@ impl DojoWorld {
                 dont_include_hashed_keys,
                 order_by,
                 entity_models,
+                internal_updated_at,
             )
             .await?;
         Ok((entities, total_count))
@@ -1036,6 +1049,7 @@ impl DojoWorld {
                     query.dont_include_hashed_keys,
                     order_by,
                     query.entity_models,
+                    query.internal_updated_at,
                 )
                 .await?
             }
@@ -1059,6 +1073,7 @@ impl DojoWorld {
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
+                            query.internal_updated_at,
                         )
                         .await?
                     }
@@ -1073,6 +1088,7 @@ impl DojoWorld {
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
+                            query.internal_updated_at,
                         )
                         .await?
                     }
@@ -1087,6 +1103,7 @@ impl DojoWorld {
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
+                            query.internal_updated_at,
                         )
                         .await?
                     }
@@ -1101,6 +1118,7 @@ impl DojoWorld {
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
+                            query.internal_updated_at,
                         )
                         .await?
                     }

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -260,6 +260,7 @@ impl DojoWorld {
         row_events.iter().map(map_row_to_event).collect()
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn fetch_entities(
         &self,
         table: &str,

--- a/crates/torii/grpc/src/server/tests/entities_test.rs
+++ b/crates/torii/grpc/src/server/tests/entities_test.rs
@@ -143,6 +143,7 @@ async fn test_entities_queries(sequencer: &RunnerCtx) {
             false,
             None,
             vec![],
+            0,
         )
         .await
         .unwrap()

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -105,7 +105,11 @@ pub struct Query {
     pub offset: u32,
     pub dont_include_hashed_keys: bool,
     pub order_by: Vec<OrderBy>,
+    /// If the array is not empty, only the given models are retrieved.
+    /// All entities that don't have a model in the array are excluded.
     pub entity_models: Vec<String>,
+    /// The internal updated at timestamp in seconds (unix timestamp) from which entities are
+    /// retrieved (inclusive). Use 0 to retrieve all entities.
     pub internal_updated_at: u64,
 }
 

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -106,6 +106,7 @@ pub struct Query {
     pub dont_include_hashed_keys: bool,
     pub order_by: Vec<OrderBy>,
     pub entity_models: Vec<String>,
+    pub internal_updated_at: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
@@ -271,6 +272,7 @@ impl From<Query> for proto::types::Query {
             dont_include_hashed_keys: value.dont_include_hashed_keys,
             order_by: value.order_by.into_iter().map(|o| o.into()).collect(),
             entity_models: value.entity_models,
+            internal_updated_at: value.internal_updated_at,
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new field `internal_updated_at` for tracking updates in the `Query` message.
	- Enhanced query capabilities to filter results based on the `internal_updated_at` timestamp.
	- Added a new field `entity_models` to specify which models should be retrieved.

- **Bug Fixes**
	- Added error handling for invalid timestamps with the new `InvalidTimestamp` variant in the `QueryError` enum.

- **Documentation**
	- Updated method signatures to reflect the addition of the `internal_updated_at` parameter across various functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->