### PR TITLE
feat(torii-grpc): IN operator for comparison

### DIFF
--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -120,7 +120,12 @@ message MemberValue {
     oneof value_type {
         Primitive primitive = 1;
         string string = 2;
+        MemberValueList list = 3;
     }
+}
+
+message MemberValueList {
+    repeated MemberValue values = 1;
 }
 
 message MemberClause {
@@ -152,6 +157,8 @@ enum ComparisonOperator {
     GTE = 3;
     LT = 4;
     LTE = 5;
+    IN = 6;
+    NOT_IN = 7;
 }
 
 message Token {

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -796,7 +796,7 @@ impl DojoWorld {
                         .collect::<Result<Vec<String>, Error>>()?
                         .join(", ")
                 )),
-                None => return Err(QueryError::MissingParam("value_type".into()).into()),
+                None => Err(QueryError::MissingParam("value_type".into()).into()),
             }
         }
 
@@ -1408,7 +1408,7 @@ fn build_composite_clause(
                                 .collect::<Result<Vec<String>, Error>>()?
                                 .join(", ")
                         )),
-                        None => return Err(QueryError::MissingParam("value_type".into()).into()),
+                        None => Err(QueryError::MissingParam("value_type".into()).into()),
                     }
                 }
                 let value = prepare_comparison(&value, &mut bind_values)?;

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -844,8 +844,10 @@ impl DojoWorld {
             &member_clause.value.clone().ok_or(QueryError::MissingParam("value".into()))?,
             &mut bind_values,
         )?;
-        let mut where_clause =
-            format!("[{}].[{}] {comparison_operator} {value}", member_clause.model, member_clause.member);
+        let mut where_clause = format!(
+            "[{}].[{}] {comparison_operator} {value}",
+            member_clause.model, member_clause.member
+        );
         if entity_updated_after.is_some() {
             where_clause += &format!(" AND {table}.updated_at >= ?");
         }

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -187,6 +187,8 @@ pub enum ComparisonOperator {
     Gte,
     Lt,
     Lte,
+    In,
+    NotIn,
 }
 
 impl fmt::Display for ComparisonOperator {
@@ -198,6 +200,8 @@ impl fmt::Display for ComparisonOperator {
             ComparisonOperator::Lte => write!(f, "<="),
             ComparisonOperator::Neq => write!(f, "!="),
             ComparisonOperator::Eq => write!(f, "="),
+            ComparisonOperator::In => write!(f, "IN"),
+            ComparisonOperator::NotIn => write!(f, "NOT IN"),
         }
     }
 }
@@ -211,6 +215,8 @@ impl From<proto::types::ComparisonOperator> for ComparisonOperator {
             proto::types::ComparisonOperator::Lt => ComparisonOperator::Lt,
             proto::types::ComparisonOperator::Lte => ComparisonOperator::Lte,
             proto::types::ComparisonOperator::Neq => ComparisonOperator::Neq,
+            proto::types::ComparisonOperator::In => ComparisonOperator::In,
+            proto::types::ComparisonOperator::NotIn => ComparisonOperator::NotIn,
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced query capabilities for member comparisons with the addition of `IN` and `NOT_IN` comparison types.
	- Introduced a new `MemberValueList` message for handling lists of member values.
- **Bug Fixes**
	- Improved error handling across various methods for better robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->