### PR TITLE
feat(katana-rpc-types): untagged enum

### DIFF
--- a/crates/katana/rpc/rpc-types/src/trie.rs
+++ b/crates/katana/rpc/rpc-types/src/trie.rs
@@ -25,6 +25,7 @@ pub struct GlobalRoots {
 
 /// Node in the Merkle-Patricia trie.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum MerkleNode {
     /// Represents a path to the highest non-zero descendant node.
     Edge {


### PR DESCRIPTION
The default implementation of `serde` for enum is to tag it based on the variant name. But the RPC specs doesn't require a tag.

https://github.com/starkware-libs/starknet-specs/blob/c94df2c5866e11c866abd3d234b0d5df681073c3/api/starknet_api_openrpc.json#L3699-L3710