### PR TITLE
feat(torii-grpc): add list to member value enum for usage in sdk

### DIFF
--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -151,6 +151,7 @@ pub enum PatternMatching {
 pub enum MemberValue {
     Primitive(Primitive),
     String(String),
+    List(Vec<MemberValue>),
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
@@ -418,6 +419,9 @@ impl From<MemberValue> for member_value::ValueType {
                 member_value::ValueType::Primitive(primitive.into())
             }
             MemberValue::String(string) => member_value::ValueType::String(string),
+            MemberValue::List(list) => member_value::ValueType::List(proto::types::MemberValueList {
+                values: list.into_iter().map(|v| proto::types::MemberValue { value_type: Some(v.into()) }).collect(),
+            }),
         }
     }
 }

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -419,9 +419,14 @@ impl From<MemberValue> for member_value::ValueType {
                 member_value::ValueType::Primitive(primitive.into())
             }
             MemberValue::String(string) => member_value::ValueType::String(string),
-            MemberValue::List(list) => member_value::ValueType::List(proto::types::MemberValueList {
-                values: list.into_iter().map(|v| proto::types::MemberValue { value_type: Some(v.into()) }).collect(),
-            }),
+            MemberValue::List(list) => {
+                member_value::ValueType::List(proto::types::MemberValueList {
+                    values: list
+                        .into_iter()
+                        .map(|v| proto::types::MemberValue { value_type: Some(v.into()) })
+                        .collect(),
+                })
+            }
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `List` variant to enhance the `MemberValue` type, allowing for a collection of `MemberValue` items.
  
- **Bug Fixes**
  - Updated conversion methods to accommodate the new `List` variant, ensuring proper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->