### PR TITLE
refactor(torii-grpc): chunk schema joins to avoid sqlite join limit

### DIFF
--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -398,9 +398,10 @@ pub fn map_row_to_ty(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_entities(
     pool: &Pool<sqlx::Sqlite>,
-    schemas: &Vec<Ty>,
+    schemas: &[Ty],
     table_name: &str,
     model_relation_table: &str,
     entity_relation_column: &str,

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -470,7 +470,8 @@ pub async fn fetch_entities(
         for model in chunk {
             let model_table = model.name();
             joins.push(format!(
-                "LEFT JOIN [{model_table}] ON {table_name}.id = [{model_table}].{entity_relation_column}"
+                "LEFT JOIN [{model_table}] ON {table_name}.id = \
+                 [{model_table}].{entity_relation_column}"
             ));
             collect_columns(&model_table, "", model, &mut selections);
         }
@@ -484,7 +485,8 @@ pub async fn fetch_entities(
 
         // Build count query
         let count_query = format!(
-            "SELECT COUNT(*) FROM (SELECT {}.id, group_concat({}.model_id) as model_ids FROM [{}] {} {} GROUP BY {}.id {})",
+            "SELECT COUNT(*) FROM (SELECT {}.id, group_concat({}.model_id) as model_ids FROM [{}] \
+             {} {} GROUP BY {}.id {})",
             table_name,
             model_relation_table,
             table_name,
@@ -504,10 +506,8 @@ pub async fn fetch_entities(
 
         if chunk_count > 0 {
             // Build main query
-            let mut query = format!(
-                "SELECT {} FROM [{}] {}",
-                selections_clause, table_name, joins_clause
-            );
+            let mut query =
+                format!("SELECT {} FROM [{}] {}", selections_clause, table_name, joins_clause);
 
             if let Some(where_clause) = where_clause {
                 query += &format!(" WHERE {}", where_clause);

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -312,11 +312,8 @@ impl DojoWorld {
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
         let where_clause = match &hashed_keys {
             Some(hashed_keys) => {
-                let ids = hashed_keys
-                    .hashed_keys
-                    .iter()
-                    .map(|_| "{table}.id = ?")
-                    .collect::<Vec<_>>();
+                let ids =
+                    hashed_keys.hashed_keys.iter().map(|_| "{table}.id = ?").collect::<Vec<_>>();
                 format!(
                     "{} {}",
                     ids.join(" OR "),
@@ -348,10 +345,8 @@ impl DojoWorld {
             bind_values.push(entity_updated_after);
         }
 
-        let entity_models = entity_models
-            .iter()
-            .map(|model| compute_selector_from_tag(model))
-            .collect::<Vec<_>>();
+        let entity_models =
+            entity_models.iter().map(|model| compute_selector_from_tag(model)).collect::<Vec<_>>();
         let schemas = self
             .model_cache
             .models(&entity_models)
@@ -414,7 +409,8 @@ impl DojoWorld {
             limit,
             offset,
             bind_values,
-        ).await?;
+        )
+        .await?;
 
         let entities = rows
             .iter()
@@ -454,10 +450,8 @@ impl DojoWorld {
             bind_values.push(entity_updated_after);
         }
 
-        let entity_models = entity_models
-            .iter()
-            .map(|model| compute_selector_from_tag(model))
-            .collect::<Vec<_>>();
+        let entity_models =
+            entity_models.iter().map(|model| compute_selector_from_tag(model)).collect::<Vec<_>>();
         let schemas = self
             .model_cache
             .models(&entity_models)
@@ -520,7 +514,8 @@ impl DojoWorld {
             limit,
             offset,
             bind_values,
-        ).await?;
+        )
+        .await?;
 
         let entities = rows
             .iter()
@@ -571,10 +566,8 @@ impl DojoWorld {
         entity_models: Vec<String>,
         entity_updated_after: Option<String>,
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
-        let entity_models = entity_models
-            .iter()
-            .map(|model| compute_selector_from_tag(model))
-            .collect::<Vec<_>>();
+        let entity_models =
+            entity_models.iter().map(|model| compute_selector_from_tag(model)).collect::<Vec<_>>();
         let comparison_operator = ComparisonOperator::from_repr(member_clause.operator as usize)
             .expect("invalid comparison operator");
 
@@ -700,13 +693,11 @@ impl DojoWorld {
         entity_models: Vec<String>,
         entity_updated_after: Option<String>,
     ) -> Result<(Vec<proto::types::Entity>, u32), Error> {
-        let (where_clause, bind_values) = 
+        let (where_clause, bind_values) =
             build_composite_clause(table, &composite, entity_updated_after)?;
 
-        let entity_models = entity_models
-            .iter()
-            .map(|model| compute_selector_from_tag(model))
-            .collect::<Vec<_>>();
+        let entity_models =
+            entity_models.iter().map(|model| compute_selector_from_tag(model)).collect::<Vec<_>>();
         let schemas = self
             .model_cache
             .models(&entity_models)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous function for fetching entities from the database with support for pagination and filtering.
- **Bug Fixes**
	- Enhanced error handling for SQL operations and improved clarity in error responses for missing query arguments.
- **Refactor**
	- Streamlined the logic for building SQL queries by centralizing query execution and management of bind values.
	- Improved readability and maintainability of the `query_by_keys` and `query_by_hashed_keys` methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->