### PR TITLE
fix(torii-core): client negative i128 conversion

### DIFF
--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -270,11 +270,10 @@ pub fn map_row_to_ty(
                     let value = row.try_get::<String, &str>(column_name)?;
                     let hex_str = value.trim_start_matches("0x");
 
-                    if !hex_str.is_empty() {
-                        primitive.set_i128(Some(
-                            i128::from_str_radix(hex_str, 16).map_err(ParseError::ParseIntError)?,
-                        ))?;
-                    }
+                    primitive.set_i128(Some(
+                        u128::from_str_radix(&hex_str, 16).map_err(ParseError::ParseIntError)?
+                            as i128,
+                    ))?;
                 }
                 Primitive::U8(_) => {
                     let value = row.try_get::<u8, &str>(column_name)?;

--- a/crates/torii/core/src/model.rs
+++ b/crates/torii/core/src/model.rs
@@ -271,7 +271,7 @@ pub fn map_row_to_ty(
                     let hex_str = value.trim_start_matches("0x");
 
                     primitive.set_i128(Some(
-                        u128::from_str_radix(&hex_str, 16).map_err(ParseError::ParseIntError)?
+                        u128::from_str_radix(hex_str, 16).map_err(ParseError::ParseIntError)?
                             as i128,
                     ))?;
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of hexadecimal string conversion to the `I128` primitive type, enhancing data population from SQLite rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->