### PR TITLE
fix(katana): invalid trie path conversion 

### DIFF
--- a/crates/katana/rpc/rpc/Cargo.toml
+++ b/crates/katana/rpc/rpc/Cargo.toml
@@ -7,11 +7,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-anyhow.workspace = true
-dojo-metrics.workspace = true
-futures.workspace = true
-http.workspace = true
-jsonrpsee = { workspace = true, features = [ "server" ] }
 katana-core.workspace = true
 katana-executor.workspace = true
 katana-pool.workspace = true
@@ -21,6 +16,12 @@ katana-rpc-api.workspace = true
 katana-rpc-types.workspace = true
 katana-rpc-types-builder.workspace = true
 katana-tasks.workspace = true
+
+anyhow.workspace = true
+dojo-metrics.workspace = true
+futures.workspace = true
+http.workspace = true
+jsonrpsee = { workspace = true, features = [ "server" ] }
 metrics.workspace = true
 serde_json.workspace = true
 starknet.workspace = true
@@ -32,6 +33,11 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+katana-cairo.workspace = true
+katana-node.workspace = true
+katana-rpc-api = { workspace = true, features = [ "client" ] }
+katana-trie.workspace = true
+
 alloy = { git = "https://github.com/alloy-rs/alloy", features = [ "contract", "network", "node-bindings", "provider-http", "providers", "signer-local" ] }
 alloy-primitives = { workspace = true, features = [ "serde" ] }
 assert_matches.workspace = true
@@ -40,10 +46,6 @@ dojo-test-utils.workspace = true
 dojo-utils.workspace = true
 indexmap.workspace = true
 jsonrpsee = { workspace = true, features = [ "client" ] }
-katana-cairo.workspace = true
-katana-node.workspace = true
-katana-rpc-api = { workspace = true, features = [ "client" ] }
-katana-trie.workspace = true
 num-traits.workspace = true
 rand.workspace = true
 rstest.workspace = true

--- a/crates/katana/rpc/rpc/tests/proofs.rs
+++ b/crates/katana/rpc/rpc/tests/proofs.rs
@@ -6,17 +6,15 @@ use jsonrpsee::http_client::HttpClientBuilder;
 use katana_node::config::rpc::DEFAULT_RPC_MAX_PROOF_KEYS;
 use katana_node::config::SequencingConfig;
 use katana_primitives::block::BlockIdOrTag;
-use katana_primitives::class::ClassHash;
-use katana_primitives::hash::StarkHash;
-use katana_primitives::{hash, Felt};
+use katana_primitives::class::{ClassHash, CompiledClassHash};
+use katana_primitives::Felt;
 use katana_rpc_api::starknet::StarknetApiClient;
-use katana_rpc_types::trie::GetStorageProofResponse;
-use katana_trie::bitvec::view::AsBits;
-use katana_trie::bonsai::BitVec;
-use katana_trie::MultiProof;
-use starknet::accounts::Account;
+use katana_trie::{compute_classes_trie_value, ClassesMultiProof, MultiProof};
+use starknet::accounts::{Account, ConnectedAccount, SingleOwnerAccount};
 use starknet::core::types::BlockTag;
-use starknet::macros::short_string;
+use starknet::providers::jsonrpc::HttpTransport;
+use starknet::providers::JsonRpcClient;
+use starknet::signers::LocalWallet;
 
 mod common;
 
@@ -74,14 +72,96 @@ async fn proofs_limit() {
 
 #[tokio::test]
 async fn classes_proofs() {
-    let sequencer =
-        TestSequencer::start(get_default_test_config(SequencingConfig::default())).await;
+    let cfg = get_default_test_config(SequencingConfig::default());
 
-    let provider = sequencer.provider();
+    let sequencer = TestSequencer::start(cfg).await;
     let account = sequencer.account();
 
-    let path: PathBuf = PathBuf::from("tests/test_data/cairo1_contract.json");
-    let (contract, compiled_class_hash) = common::prepare_contract_declaration_params(&path)
+    let (class_hash1, compiled_class_hash1) =
+        declare(&account, "tests/test_data/cairo1_contract.json").await;
+    let (class_hash2, compiled_class_hash2) =
+        declare(&account, "tests/test_data/cairo_l1_msg_contract.json").await;
+    let (class_hash3, compiled_class_hash3) =
+        declare(&account, "tests/test_data/test_sierra_contract.json").await;
+
+    // We need to use the jsonrpsee client because `starknet-rs` doesn't yet support RPC 0.8.0
+    let client = HttpClientBuilder::default().build(sequencer.url()).unwrap();
+
+    {
+        let class_hash = class_hash1;
+        let trie_entry = compute_classes_trie_value(compiled_class_hash1);
+
+        let proofs = client
+            .get_storage_proof(BlockIdOrTag::Number(1), Some(vec![class_hash]), None, None)
+            .await
+            .expect("failed to get storage proof");
+
+        let results = ClassesMultiProof::from(MultiProof::from(proofs.classes_proof.nodes))
+            .verify(proofs.global_roots.classes_tree_root, vec![class_hash]);
+
+        assert_eq!(vec![trie_entry], results);
+    }
+
+    {
+        let class_hash = class_hash2;
+        let trie_entry = compute_classes_trie_value(compiled_class_hash2);
+
+        let proofs = client
+            .get_storage_proof(BlockIdOrTag::Number(2), Some(vec![class_hash]), None, None)
+            .await
+            .expect("failed to get storage proof");
+
+        let results = ClassesMultiProof::from(MultiProof::from(proofs.classes_proof.nodes))
+            .verify(proofs.global_roots.classes_tree_root, vec![class_hash]);
+
+        assert_eq!(vec![trie_entry], results);
+    }
+
+    {
+        let class_hash = class_hash3;
+        let trie_entry = compute_classes_trie_value(compiled_class_hash3);
+
+        let proofs = client
+            .get_storage_proof(BlockIdOrTag::Number(3), Some(vec![class_hash]), None, None)
+            .await
+            .expect("failed to get storage proof");
+
+        let results = ClassesMultiProof::from(MultiProof::from(proofs.classes_proof.nodes))
+            .verify(proofs.global_roots.classes_tree_root, vec![class_hash]);
+
+        assert_eq!(vec![trie_entry], results);
+    }
+
+    {
+        let class_hashes = vec![class_hash1, class_hash2, class_hash3];
+        let trie_entries = vec![
+            compute_classes_trie_value(compiled_class_hash1),
+            compute_classes_trie_value(compiled_class_hash2),
+            compute_classes_trie_value(compiled_class_hash3),
+        ];
+
+        let proofs = client
+            .get_storage_proof(
+                BlockIdOrTag::Tag(BlockTag::Latest),
+                Some(class_hashes.clone()),
+                None,
+                None,
+            )
+            .await
+            .expect("failed to get storage proof");
+
+        let results = ClassesMultiProof::from(MultiProof::from(proofs.classes_proof.nodes))
+            .verify(proofs.global_roots.classes_tree_root, class_hashes.clone());
+
+        assert_eq!(trie_entries, results);
+    }
+}
+
+async fn declare(
+    account: &SingleOwnerAccount<JsonRpcClient<HttpTransport>, LocalWallet>,
+    path: impl Into<PathBuf>,
+) -> (ClassHash, CompiledClassHash) {
+    let (contract, compiled_class_hash) = common::prepare_contract_declaration_params(&path.into())
         .expect("failed to prepare class declaration params");
 
     let class_hash = contract.class_hash();
@@ -91,29 +171,9 @@ async fn classes_proofs() {
         .await
         .expect("failed to send declare tx");
 
-    dojo_utils::TransactionWaiter::new(res.transaction_hash, &provider)
+    dojo_utils::TransactionWaiter::new(res.transaction_hash, account.provider())
         .await
         .expect("failed to wait on tx");
 
-    // We need to use the jsonrpsee client because `starknet-rs` doesn't yet support RPC 0.8.0
-    let client = HttpClientBuilder::default().build(sequencer.url()).unwrap();
-
-    let GetStorageProofResponse { global_roots, classes_proof, .. } = client
-        .get_storage_proof(BlockIdOrTag::Tag(BlockTag::Latest), Some(vec![class_hash]), None, None)
-        .await
-        .expect("failed to get storage proof");
-
-    let key: BitVec = class_hash.to_bytes_be().as_bits()[5..].to_owned();
-    let value =
-        hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &compiled_class_hash);
-
-    let classes_proof = MultiProof::from(classes_proof.nodes);
-
-    // the returned data is the list of values corresponds to the [key]
-    let results = classes_proof
-        .verify_proof::<hash::Pedersen>(global_roots.classes_tree_root, [key], 251)
-        .collect::<Result<Vec<_>, _>>()
-        .expect("failed to verify proofs");
-
-    assert_eq!(vec![value], results);
+    (class_hash, compiled_class_hash)
 }

--- a/crates/katana/rpc/rpc/tests/test_data/test_sierra_contract.json
+++ b/crates/katana/rpc/rpc/tests/test_data/test_sierra_contract.json
@@ -1,0 +1,1 @@
+../../../../contracts/build/account_with_dummy_validate.sierra.json


### PR DESCRIPTION
We didn't preserve the `Path` semantics when it is being converted from RPC types to internal types from `bonsai-trie`. 