### PR TITLE
chore(katana): hide init subcommand for now

### DIFF
--- a/bin/katana/src/cli/mod.rs
+++ b/bin/katana/src/cli/mod.rs
@@ -33,7 +33,7 @@ impl Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    #[command(about = "Initialize chain")]
+    #[command(about = "Initialize chain", hide = true)]
     Init(init::InitArgs),
 
     #[command(about = "Database utilities")]


### PR DESCRIPTION
it's not exactly useful for now, will unhide once `katana` can consume the generated config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CLI command visibility settings
	- Modified `Init` command to be hidden from help output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->