### PR TITLE
ci: add constraints on jobs to start based on linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest-4-cores
+    needs: [fmt, cairofmt]
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
 
   ensure-wasm:
     runs-on: ubuntu-latest
+    needs: [fmt, cairofmt]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.0.9
     steps:
@@ -154,6 +155,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest-4-cores
+    needs: [fmt, cairofmt]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.0.9
     steps:
@@ -172,6 +174,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    needs: [fmt, cairofmt]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.0.9
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow configuration to improve job dependency management
	- Ensured specific jobs now run only after formatting checks are completed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->