### PR TITLE
refactor(katana): store genesis in `ChainSpec` as its JSON repr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8491,6 +8491,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet 0.12.0",
+ "tempfile",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8490,6 +8490,7 @@ dependencies = [
  "lazy_static",
  "serde",
  "serde_json",
+ "similar-asserts",
  "starknet 0.12.0",
  "tempfile",
  "url",

--- a/crates/katana/chain-spec/Cargo.toml
+++ b/crates/katana/chain-spec/Cargo.toml
@@ -17,6 +17,7 @@ starknet.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+similar-asserts.workspace = true
 tempfile.workspace = true
 
 [features]

--- a/crates/katana/chain-spec/Cargo.toml
+++ b/crates/katana/chain-spec/Cargo.toml
@@ -16,5 +16,8 @@ serde_json.workspace = true
 starknet.workspace = true
 url.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [features]
 controller = [ "katana-primitives/controller" ]

--- a/crates/katana/chain-spec/src/lib.rs
+++ b/crates/katana/chain-spec/src/lib.rs
@@ -388,12 +388,7 @@ mod tests {
         // Load the ChainSpec back from the file
         let loaded_chainspec = ChainSpec::load(temp.path()).unwrap();
 
-        // Assert that the loaded ChainSpec matches the original
-        assert_eq!(chainspec.id, loaded_chainspec.id);
-        assert_eq!(chainspec.version, loaded_chainspec.version);
-        assert_eq!(chainspec.settlement, loaded_chainspec.settlement);
-        assert_eq!(chainspec.fee_contracts, loaded_chainspec.fee_contracts);
-        assert_eq!(chainspec.genesis, loaded_chainspec.genesis);
+        similar_asserts::assert_eq!(chainspec, loaded_chainspec);
     }
 
     #[test]
@@ -505,22 +500,7 @@ mod tests {
         let actual_block = chain_spec.block();
         let actual_state_updates = chain_spec.state_updates();
 
-        // assert individual fields of the block
-
-        assert_eq!(actual_block.header.number, expected_block.header.number);
-        assert_eq!(actual_block.header.timestamp, expected_block.header.timestamp);
-        assert_eq!(actual_block.header.parent_hash, expected_block.header.parent_hash);
-        assert_eq!(actual_block.header.sequencer_address, expected_block.header.sequencer_address);
-        assert_eq!(actual_block.header.l1_gas_prices, expected_block.header.l1_gas_prices);
-        assert_eq!(
-            actual_block.header.l1_data_gas_prices,
-            expected_block.header.l1_data_gas_prices
-        );
-        assert_eq!(actual_block.header.l1_da_mode, expected_block.header.l1_da_mode);
-        assert_eq!(actual_block.header.protocol_version, expected_block.header.protocol_version);
-        assert_eq!(actual_block.header.transaction_count, expected_block.header.transaction_count);
-        assert_eq!(actual_block.header.events_count, expected_block.header.events_count);
-        assert_eq!(actual_block.body, expected_block.body);
+        similar_asserts::assert_eq!(actual_block, expected_block);
 
         if cfg!(feature = "controller") {
             assert!(actual_state_updates.classes.len() == 4);

--- a/crates/katana/chain-spec/src/lib.rs
+++ b/crates/katana/chain-spec/src/lib.rs
@@ -10,21 +10,21 @@ use katana_primitives::chain::ChainId;
 use katana_primitives::class::ClassHash;
 use katana_primitives::contract::ContractAddress;
 use katana_primitives::da::L1DataAvailabilityMode;
-use katana_primitives::genesis::Genesis;
 use katana_primitives::genesis::allocation::{DevAllocationsGenerator, GenesisAllocation};
 use katana_primitives::genesis::constant::{
-    DEFAULT_ACCOUNT_CLASS_PUBKEY_STORAGE_SLOT, DEFAULT_ETH_FEE_TOKEN_ADDRESS,
-    DEFAULT_LEGACY_ERC20_CLASS, DEFAULT_LEGACY_ERC20_CLASS_HASH, DEFAULT_LEGACY_UDC_CLASS,
-    DEFAULT_LEGACY_UDC_CLASS_HASH, DEFAULT_LEGACY_UDC_COMPILED_CLASS_HASH,
-    DEFAULT_PREFUNDED_ACCOUNT_BALANCE, DEFAULT_STRK_FEE_TOKEN_ADDRESS, DEFAULT_UDC_ADDRESS,
-    ERC20_DECIMAL_STORAGE_SLOT, ERC20_NAME_STORAGE_SLOT, ERC20_SYMBOL_STORAGE_SLOT,
-    ERC20_TOTAL_SUPPLY_STORAGE_SLOT, get_fee_token_balance_base_storage_address,
+    get_fee_token_balance_base_storage_address, DEFAULT_ACCOUNT_CLASS_PUBKEY_STORAGE_SLOT,
+    DEFAULT_ETH_FEE_TOKEN_ADDRESS, DEFAULT_LEGACY_ERC20_CLASS, DEFAULT_LEGACY_ERC20_CLASS_HASH,
+    DEFAULT_LEGACY_UDC_CLASS, DEFAULT_LEGACY_UDC_CLASS_HASH,
+    DEFAULT_LEGACY_UDC_COMPILED_CLASS_HASH, DEFAULT_PREFUNDED_ACCOUNT_BALANCE,
+    DEFAULT_STRK_FEE_TOKEN_ADDRESS, DEFAULT_UDC_ADDRESS, ERC20_DECIMAL_STORAGE_SLOT,
+    ERC20_NAME_STORAGE_SLOT, ERC20_SYMBOL_STORAGE_SLOT, ERC20_TOTAL_SUPPLY_STORAGE_SLOT,
 };
 use katana_primitives::genesis::json::GenesisJson;
+use katana_primitives::genesis::Genesis;
 use katana_primitives::state::StateUpdatesWithClasses;
 use katana_primitives::utils::split_u256;
-use katana_primitives::version::{CURRENT_STARKNET_VERSION, ProtocolVersion};
-use katana_primitives::{Felt, eth};
+use katana_primitives::version::{ProtocolVersion, CURRENT_STARKNET_VERSION};
+use katana_primitives::{eth, Felt};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use starknet::core::utils::cairo_short_string_to_felt;
@@ -360,7 +360,6 @@ mod tests {
     use katana_primitives::address;
     use katana_primitives::block::{Block, GasPrices, Header};
     use katana_primitives::da::L1DataAvailabilityMode;
-    use katana_primitives::genesis::GenesisClass;
     use katana_primitives::genesis::allocation::{
         GenesisAccount, GenesisAccountAlloc, GenesisContractAlloc,
     };
@@ -372,6 +371,7 @@ mod tests {
         DEFAULT_LEGACY_ERC20_CLASS, DEFAULT_LEGACY_ERC20_COMPILED_CLASS_HASH,
         DEFAULT_LEGACY_UDC_CLASS, DEFAULT_LEGACY_UDC_COMPILED_CLASS_HASH,
     };
+    use katana_primitives::genesis::GenesisClass;
     use katana_primitives::version::CURRENT_STARKNET_VERSION;
     use starknet::macros::felt;
 
@@ -396,23 +396,35 @@ mod tests {
         // setup initial states to test
 
         let classes = BTreeMap::from([
-            (DEFAULT_LEGACY_UDC_CLASS_HASH, GenesisClass {
-                class: DEFAULT_LEGACY_UDC_CLASS.clone().into(),
-                compiled_class_hash: DEFAULT_LEGACY_UDC_COMPILED_CLASS_HASH,
-            }),
-            (DEFAULT_LEGACY_ERC20_CLASS_HASH, GenesisClass {
-                class: DEFAULT_LEGACY_ERC20_CLASS.clone().into(),
-                compiled_class_hash: DEFAULT_LEGACY_ERC20_COMPILED_CLASS_HASH,
-            }),
-            (DEFAULT_ACCOUNT_CLASS_HASH, GenesisClass {
-                compiled_class_hash: DEFAULT_ACCOUNT_COMPILED_CLASS_HASH,
-                class: DEFAULT_ACCOUNT_CLASS.clone().into(),
-            }),
+            (
+                DEFAULT_LEGACY_UDC_CLASS_HASH,
+                GenesisClass {
+                    class: DEFAULT_LEGACY_UDC_CLASS.clone().into(),
+                    compiled_class_hash: DEFAULT_LEGACY_UDC_COMPILED_CLASS_HASH,
+                },
+            ),
+            (
+                DEFAULT_LEGACY_ERC20_CLASS_HASH,
+                GenesisClass {
+                    class: DEFAULT_LEGACY_ERC20_CLASS.clone().into(),
+                    compiled_class_hash: DEFAULT_LEGACY_ERC20_COMPILED_CLASS_HASH,
+                },
+            ),
+            (
+                DEFAULT_ACCOUNT_CLASS_HASH,
+                GenesisClass {
+                    compiled_class_hash: DEFAULT_ACCOUNT_COMPILED_CLASS_HASH,
+                    class: DEFAULT_ACCOUNT_CLASS.clone().into(),
+                },
+            ),
             #[cfg(feature = "controller")]
-            (CONTROLLER_CLASS_HASH, GenesisClass {
-                compiled_class_hash: CONTROLLER_CLASS_HASH,
-                class: CONTROLLER_ACCOUNT_CLASS.clone().into(),
-            }),
+            (
+                CONTROLLER_CLASS_HASH,
+                GenesisClass {
+                    compiled_class_hash: CONTROLLER_CLASS_HASH,
+                    class: CONTROLLER_ACCOUNT_CLASS.clone().into(),
+                },
+            ),
         ]);
 
         let allocations = [

--- a/crates/katana/primitives/src/class.rs
+++ b/crates/katana/primitives/src/class.rs
@@ -28,6 +28,10 @@ pub enum ContractClassCompilationError {
     SierraCompilation(#[from] StarknetSierraCompilationError),
 }
 
+// NOTE:
+// Ideally, we can implement this enum as an untagged `serde` enum, so that we can deserialize from
+// the raw JSON class artifact directly into this (ie
+// `serde_json::from_str::<ContractClass>(json)`). But that is not possible due to a limitation with untagged enums derivation (see https://github.com/serde-rs/serde/pull/2781).
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]

--- a/crates/katana/primitives/src/genesis/json.rs
+++ b/crates/katana/primitives/src/genesis/json.rs
@@ -807,8 +807,13 @@ mod tests {
             (
                 CONTROLLER_CLASS_HASH,
                 GenesisClass {
-                    compiled_class_hash: CONTROLLER_CLASS_HASH,
                     class: CONTROLLER_ACCOUNT_CLASS.clone().into(),
+                    compiled_class_hash: CONTROLLER_ACCOUNT_CLASS
+                        .clone()
+                        .compile()
+                        .unwrap()
+                        .class_hash()
+                        .unwrap(),
                 },
             ),
         ]);
@@ -998,7 +1003,12 @@ mod tests {
                 CONTROLLER_CLASS_HASH,
                 GenesisClass {
                     class: CONTROLLER_ACCOUNT_CLASS.clone().into(),
-                    compiled_class_hash: CONTROLLER_CLASS_HASH,
+                    compiled_class_hash: CONTROLLER_ACCOUNT_CLASS
+                        .clone()
+                        .compile()
+                        .unwrap()
+                        .class_hash()
+                        .unwrap(),
                 },
             ),
         ]);

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -40,7 +40,6 @@ impl core::fmt::Debug for GenesisClass {
 }
 
 /// Genesis block configuration.
-#[serde_with::serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Genesis {
     /// The genesis block parent hash.

--- a/crates/katana/primitives/src/genesis/mod.rs
+++ b/crates/katana/primitives/src/genesis/mod.rs
@@ -127,7 +127,12 @@ impl Default for Genesis {
             (
                 CONTROLLER_CLASS_HASH,
                 GenesisClass {
-                    compiled_class_hash: CONTROLLER_CLASS_HASH,
+                    compiled_class_hash: CONTROLLER_ACCOUNT_CLASS
+                        .clone()
+                        .compile()
+                        .expect("failed to compile")
+                        .class_hash()
+                        .expect("failed to compute class hash"),
                     class: CONTROLLER_ACCOUNT_CLASS.clone().into(),
                 },
             ),


### PR DESCRIPTION
To allow specifying the genesis file in the chain spec file in its JSON format. Basically, in the same format as if when the genesis file is passed using `--genesis`. The JSON repr is a more user facing format compared to its internal counterpart (ie `Genesis`). 