### PR TITLE
fix(katana-rpc-types): proofs types serde

### DIFF
--- a/crates/katana/rpc/rpc-types/src/trie.rs
+++ b/crates/katana/rpc/rpc-types/src/trie.rs
@@ -77,6 +77,7 @@ pub struct GetStorageProofResponse {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ClassesProof {
     pub nodes: Nodes,
 }
@@ -101,9 +102,11 @@ pub struct ContractLeafData {
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct ContractStorageProofs {
     pub nodes: Vec<Nodes>,
 }
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NodeWithHash {
     pub node_hash: Felt,


### PR DESCRIPTION
it should be an array instead of object https://github.com/starkware-libs/starknet-specs/blob/c94df2c5866e11c866abd3d234b0d5df681073c3/api/starknet_api_openrpc.json#L975-L1010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced serialization and deserialization of proof-related structs by adding `#[serde(transparent)]` attribute
	- Simplified JSON representation for `ClassesProof`, `ContractStorageProofs`, and `Nodes` structs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->