### PR TITLE
refactor(katana): remove starknet version from chainspec

### DIFF
--- a/crates/katana/chain-spec/src/lib.rs
+++ b/crates/katana/chain-spec/src/lib.rs
@@ -23,7 +23,7 @@ use katana_primitives::genesis::json::GenesisJson;
 use katana_primitives::genesis::Genesis;
 use katana_primitives::state::StateUpdatesWithClasses;
 use katana_primitives::utils::split_u256;
-use katana_primitives::version::{ProtocolVersion, CURRENT_STARKNET_VERSION};
+use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::{eth, Felt};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -42,9 +42,6 @@ pub struct ChainSpec {
 
     /// The chain fee token contract.
     pub fee_contracts: FeeContracts,
-
-    // TODO: Maybe remove? Doesn't seem like this should belong here.
-    pub version: ProtocolVersion,
 
     /// The chain's settlement layer configurations.
     ///
@@ -112,13 +109,7 @@ impl ChainSpec {
         let genesis_json: GenesisJson = serde_json::from_reader(BufReader::new(file))?;
         let genesis = Genesis::try_from(genesis_json)?;
 
-        Ok(Self {
-            genesis,
-            id: cs.id,
-            version: cs.version,
-            settlement: cs.settlement,
-            fee_contracts: cs.fee_contracts,
-        })
+        Ok(Self { genesis, id: cs.id, settlement: cs.settlement, fee_contracts: cs.fee_contracts })
     }
 
     pub fn store<P: AsRef<Path>>(self, path: P) -> anyhow::Result<()> {
@@ -128,7 +119,6 @@ impl ChainSpec {
 
         let stored = ChainSpecFile {
             id: self.id,
-            version: self.version,
             genesis: genesis_path,
             settlement: self.settlement,
             fee_contracts: self.fee_contracts,
@@ -146,7 +136,7 @@ impl ChainSpec {
     pub fn block(&self) -> Block {
         let header = Header {
             state_diff_length: 0,
-            protocol_version: self.version.clone(),
+            protocol_version: CURRENT_STARKNET_VERSION,
             number: self.genesis.number,
             timestamp: self.genesis.timestamp,
             events_count: 0,
@@ -214,7 +204,6 @@ impl Default for ChainSpec {
 struct ChainSpecFile {
     id: ChainId,
     fee_contracts: FeeContracts,
-    version: ProtocolVersion,
     #[serde(skip_serializing_if = "Option::is_none")]
     settlement: Option<SettlementLayer>,
     genesis: PathBuf,
@@ -246,7 +235,6 @@ lazy_static! {
             genesis,
             fee_contracts,
             settlement: None,
-            version: CURRENT_STARKNET_VERSION,
         }
     };
 }
@@ -468,7 +456,6 @@ mod tests {
         ];
         let chain_spec = ChainSpec {
             id: ChainId::SEPOLIA,
-            version: CURRENT_STARKNET_VERSION,
             genesis: Genesis {
                 classes,
                 allocations: BTreeMap::from(allocations.clone()),

--- a/crates/katana/core/src/backend/mod.rs
+++ b/crates/katana/core/src/backend/mod.rs
@@ -11,6 +11,7 @@ use katana_primitives::env::BlockEnv;
 use katana_primitives::receipt::{Event, ReceiptWithTxHash};
 use katana_primitives::state::{compute_state_diff_hash, StateUpdates};
 use katana_primitives::transaction::{TxHash, TxWithHash};
+use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::Felt;
 use katana_provider::traits::block::{BlockHashProvider, BlockWriter};
 use katana_provider::traits::trie::TrieWriter;
@@ -138,7 +139,7 @@ impl<EF: ExecutorFactory> Backend<EF> {
             parent_hash,
             number: block_env.number,
             timestamp: block_env.timestamp,
-            protocol_version: self.chain_spec.version.clone(),
+            protocol_version: CURRENT_STARKNET_VERSION,
             sequencer_address: block_env.sequencer_address,
             l1_gas_prices: block_env.l1_gas_prices,
             l1_data_gas_prices: block_env.l1_data_gas_prices,

--- a/crates/katana/core/src/backend/storage.rs
+++ b/crates/katana/core/src/backend/storage.rs
@@ -9,7 +9,6 @@ use katana_primitives::block::{
 use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::hash::{self, StarkHash};
 use katana_primitives::state::StateUpdatesWithClasses;
-use katana_primitives::version::ProtocolVersion;
 use katana_provider::providers::db::DbProvider;
 use katana_provider::providers::fork::ForkedProvider;
 use katana_provider::traits::block::{BlockProvider, BlockWriter};
@@ -160,7 +159,6 @@ impl Blockchain {
         let block_num = forked_block.block_number;
 
         chain.id = chain_id.into();
-        chain.version = ProtocolVersion::parse(&forked_block.starknet_version)?;
 
         // adjust the genesis to match the forked block
         chain.genesis.timestamp = forked_block.timestamp;

--- a/crates/katana/core/src/service/block_producer.rs
+++ b/crates/katana/core/src/service/block_producer.rs
@@ -15,6 +15,7 @@ use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::receipt::Receipt;
 use katana_primitives::trace::TxExecInfo;
 use katana_primitives::transaction::{ExecutableTxWithHash, TxHash, TxWithHash};
+use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_provider::error::ProviderError;
 use katana_provider::traits::block::{BlockHashProvider, BlockNumberProvider};
 use katana_provider::traits::env::BlockEnvProvider;
@@ -578,7 +579,7 @@ impl<EF: ExecutorFactory> InstantBlockProducer<EF> {
                 parent_hash,
                 number: block_env.number,
                 timestamp: block_env.timestamp,
-                protocol_version: backend.chain_spec.version.clone(),
+                protocol_version: CURRENT_STARKNET_VERSION,
                 sequencer_address: block_env.sequencer_address,
                 l1_da_mode: L1DataAvailabilityMode::Calldata,
                 l1_gas_prices: block_env.l1_gas_prices.clone(),

--- a/crates/katana/rpc/rpc/src/starknet/mod.rs
+++ b/crates/katana/rpc/rpc/src/starknet/mod.rs
@@ -16,6 +16,7 @@ use katana_primitives::da::L1DataAvailabilityMode;
 use katana_primitives::env::BlockEnv;
 use katana_primitives::event::MaybeForkedContinuationToken;
 use katana_primitives::transaction::{ExecutableTxWithHash, TxHash, TxWithHash};
+use katana_primitives::version::CURRENT_STARKNET_VERSION;
 use katana_primitives::Felt;
 use katana_provider::error::ProviderError;
 use katana_provider::traits::block::{BlockHashProvider, BlockIdReader, BlockNumberProvider};
@@ -613,7 +614,7 @@ where
                             parent_hash: latest_hash,
                             timestamp: block_env.timestamp,
                             sequencer_address: block_env.sequencer_address,
-                            protocol_version: this.inner.backend.chain_spec.version.clone(),
+                            protocol_version: CURRENT_STARKNET_VERSION,
                         };
 
                         // TODO(kariy): create a method that can perform this filtering for us
@@ -679,7 +680,7 @@ where
                             timestamp: block_env.timestamp,
                             l1_da_mode: L1DataAvailabilityMode::Calldata,
                             sequencer_address: block_env.sequencer_address,
-                            protocol_version: this.inner.backend.chain_spec.version.clone(),
+                            protocol_version: CURRENT_STARKNET_VERSION,
                         };
 
                         let receipts = executor
@@ -743,7 +744,7 @@ where
                             number: block_env.number,
                             parent_hash: latest_hash,
                             timestamp: block_env.timestamp,
-                            protocol_version: this.inner.backend.chain_spec.version.clone(),
+                            protocol_version: CURRENT_STARKNET_VERSION,
                             sequencer_address: block_env.sequencer_address,
                         };
 


### PR DESCRIPTION
The protocol version isn't exactly being used (for what it's meant to be) except for putting it into the block header when building blocks. So, semantically it does nothing, and also it doesn't make sense to include it in the chain spec anyway. For now, we're removing it and replace all of its references with a constant.

