### PR TITLE
feat(katana): classes trie hash

### DIFF
--- a/crates/katana/rpc/rpc/tests/proofs.rs
+++ b/crates/katana/rpc/rpc/tests/proofs.rs
@@ -122,7 +122,7 @@ async fn genesis_states() {
 
     let classes_proof = MultiProof::from(proofs.classes_proof.nodes);
     let classes_tree_root = proofs.global_roots.classes_tree_root;
-    let classes_verification_result = katana_trie::verify_proof::<hash::Pedersen>(
+    let classes_verification_result = katana_trie::verify_proof::<hash::Poseidon>(
         &classes_proof,
         classes_tree_root,
         genesis_classes,

--- a/crates/katana/storage/db/src/trie/mod.rs
+++ b/crates/katana/storage/db/src/trie/mod.rs
@@ -388,7 +388,7 @@ fn to_db_key(key: &DatabaseKey<'_>) -> models::trie::TrieDatabaseKey {
 
 #[cfg(test)]
 mod tests {
-    use katana_primitives::hash::{Pedersen, StarkHash};
+    use katana_primitives::hash::{Pedersen, Poseidon, StarkHash};
     use katana_primitives::{felt, hash};
     use katana_trie::{verify_proof, ClassesTrie, CommitId};
     use starknet::macros::short_string;
@@ -447,7 +447,7 @@ mod tests {
 
             let proofs0 = snapshot0.multiproof(vec![felt!("0x9999")]);
             let verify_result0 =
-                verify_proof::<Pedersen>(&proofs0, snapshot_root0, vec![felt!("0x9999")]);
+                verify_proof::<Poseidon>(&proofs0, snapshot_root0, vec![felt!("0x9999")]);
 
             let value =
                 hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &felt!("0xdead"));
@@ -464,7 +464,7 @@ mod tests {
 
             let proofs1 = snapshot1.multiproof(vec![felt!("0x6969")]);
             let verify_result1 =
-                verify_proof::<Pedersen>(&proofs1, snapshot_root1, vec![felt!("0x6969")]);
+                verify_proof::<Poseidon>(&proofs1, snapshot_root1, vec![felt!("0x6969")]);
 
             let value =
                 hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &felt!("0x80085"));
@@ -475,7 +475,7 @@ mod tests {
             let root = trie.root();
             let proofs = trie.multiproof(vec![felt!("0x6969"), felt!("0x9999")]);
             let result =
-                verify_proof::<Pedersen>(&proofs, root, vec![felt!("0x6969"), felt!("0x9999")]);
+                verify_proof::<Poseidon>(&proofs, root, vec![felt!("0x6969"), felt!("0x9999")]);
 
             let value0 =
                 hash::Poseidon::hash(&short_string!("CONTRACT_CLASS_LEAF_V0"), &felt!("0x80085"));

--- a/crates/katana/storage/db/src/trie/mod.rs
+++ b/crates/katana/storage/db/src/trie/mod.rs
@@ -388,7 +388,7 @@ fn to_db_key(key: &DatabaseKey<'_>) -> models::trie::TrieDatabaseKey {
 
 #[cfg(test)]
 mod tests {
-    use katana_primitives::hash::{Pedersen, Poseidon, StarkHash};
+    use katana_primitives::hash::{Poseidon, StarkHash};
     use katana_primitives::{felt, hash};
     use katana_trie::{verify_proof, ClassesTrie, CommitId};
     use starknet::macros::short_string;

--- a/crates/katana/trie/src/classes.rs
+++ b/crates/katana/trie/src/classes.rs
@@ -1,10 +1,9 @@
 use bonsai_trie::{BonsaiDatabase, BonsaiPersistentDatabase, MultiProof};
 use katana_primitives::block::BlockNumber;
 use katana_primitives::class::{ClassHash, CompiledClassHash};
-use katana_primitives::hash::Pedersen;
+use katana_primitives::hash::{Poseidon, StarkHash};
 use katana_primitives::Felt;
 use starknet::macros::short_string;
-use starknet_types_core::hash::{Poseidon, StarkHash};
 
 use crate::id::CommitId;
 
@@ -15,7 +14,7 @@ impl ClassesMultiProof {
     // TODO: maybe perform results check in this method as well. make it accept the compiled class
     // hashes
     pub fn verify(&self, root: Felt, class_hashes: Vec<ClassHash>) -> Vec<Felt> {
-        crate::verify_proof::<Pedersen>(&self.0, root, class_hashes)
+        crate::verify_proof::<Poseidon>(&self.0, root, class_hashes)
     }
 }
 
@@ -27,7 +26,7 @@ impl From<MultiProof> for ClassesMultiProof {
 
 #[derive(Debug)]
 pub struct ClassesTrie<DB: BonsaiDatabase> {
-    trie: crate::BonsaiTrie<DB, Pedersen>,
+    trie: crate::BonsaiTrie<DB, Poseidon>,
 }
 
 //////////////////////////////////////////////////////////////


### PR DESCRIPTION
It was set to Pedersen based on the [Starknet docs](https://docs.starknet.io/architecture-and-concepts/network-architecture/starknet-state/#merkle_patricia_trie) but Pathfinder is using [Poseidon](https://github.com/glihm/pathfinder/blob/fc2d3f8da66638492bc1b2c9b5c22ca1b9be01ff/crates/merkle-tree/src/contract.rs#L28-L38). Based on my experience, it's better to just follow what Pathfinder is doing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- None

- **Bug Fixes**
	- None

- **Refactor**
	- Updated hashing algorithm from Pedersen to Poseidon in proof verification processes across multiple components
	- Modified trie and proof verification implementations to use Poseidon hash function

- **Tests**
	- Updated test cases to reflect the new hashing algorithm in proof verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->