### PR TITLE
feat(sozo): split hash command into 'hash compute' and 'hash find'

### DIFF
--- a/bin/sozo/src/commands/hash.rs
+++ b/bin/sozo/src/commands/hash.rs
@@ -213,11 +213,7 @@ impl HashArgs {
             }
         }
 
-        if hash_found {
-            Ok(())
-        } else {
-            bail!("No resource matches the provided hash.")
-        }
+        if hash_found { Ok(()) } else { bail!("No resource matches the provided hash.") }
     }
 
     pub fn run(&self, config: &Config) -> Result<()> {

--- a/bin/sozo/src/commands/mod.rs
+++ b/bin/sozo/src/commands/mod.rs
@@ -112,7 +112,7 @@ pub fn run(command: Commands, config: &Config) -> Result<()> {
         Commands::Clean(args) => args.run(config),
         Commands::Call(args) => args.run(config),
         Commands::Test(args) => args.run(config),
-        Commands::Hash(args) => args.run().map(|_| ()),
+        Commands::Hash(args) => args.run(config).map(|_| ()),
         Commands::Init(args) => args.run(config),
         Commands::Model(args) => args.run(config),
         Commands::Events(args) => args.run(config),


### PR DESCRIPTION
# Description

This PR splits the existing `sozo hash` command into 2 subcommands:
- `sozo hash compute` which does the same thing than the actual `sozo hash` command,
- `sozo hash find` which:
     + reads namespaces and resource names from the project configuration (manifest and profile configuration) or from the command-line through `--namespaces` and `--resources` options,
     + compute namespace hashes, resource name hashes and resource tag hashes to find a match with the provided hash. 

## Related issue

https://github.com/dojoengine/dojo/issues/2850

## Tests

- [ ] Yes
- [X] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

- [ ] README.md
- [X] [Dojo Book](https://github.com/dojoengine/book) https://github.com/dojoengine/book/pull/377
- [ ] No documentation needed

## Checklist

- [X] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [X] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [X] I've commented my code
- [X] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced hash command functionality with new search capabilities.
	- Added ability to find hashes across namespaces and resources.
	- Introduced a more flexible command structure for hash operations.

- **Refactor**
	- Restructured hash command implementation.
	- Updated command execution to ensure proper configuration context is passed during hash operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->