### PR TITLE
fix(katana): genesis deprecated declared classes in state updates

### DIFF
--- a/crates/katana/core/Cargo.toml
+++ b/crates/katana/core/Cargo.toml
@@ -28,7 +28,6 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 starknet.workspace = true
-starknet-crypto.workspace = true
 starknet-types-core.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
@@ -37,6 +36,7 @@ url.workspace = true
 
 alloy-primitives = { workspace = true, features = [ "serde" ] }
 alloy-sol-types = { workspace = true, default-features = false, features = [ "json" ] }
+starknet-crypto = { workspace = true, optional = true }
 
 alloy-contract = { workspace = true, default-features = false }
 alloy-network = { workspace = true, default-features = false }
@@ -50,4 +50,4 @@ hex.workspace = true
 tempfile.workspace = true
 
 [features]
-starknet-messaging = [  ]
+starknet-messaging = [ "dep:starknet-crypto" ]

--- a/crates/katana/primitives/src/chain_spec.rs
+++ b/crates/katana/primitives/src/chain_spec.rs
@@ -80,7 +80,12 @@ impl ChainSpec {
         for (class_hash, class) in &self.genesis.classes {
             let class_hash = *class_hash;
 
-            states.state_updates.declared_classes.insert(class_hash, class.compiled_class_hash);
+            if class.class.is_legacy() {
+                states.state_updates.deprecated_declared_classes.insert(class_hash);
+            } else {
+                states.state_updates.declared_classes.insert(class_hash, class.compiled_class_hash);
+            }
+
             states.classes.insert(class_hash, class.class.as_ref().clone());
         }
 
@@ -412,7 +417,7 @@ mod tests {
         assert_eq!(
             actual_state_updates
                 .state_updates
-                .declared_classes
+                .deprecated_declared_classes
                 .get(&DEFAULT_LEGACY_ERC20_CLASS_HASH),
             Some(&DEFAULT_LEGACY_ERC20_COMPILED_CLASS_HASH),
         );
@@ -444,7 +449,10 @@ mod tests {
         );
 
         assert_eq!(
-            actual_state_updates.state_updates.declared_classes.get(&DEFAULT_LEGACY_UDC_CLASS_HASH),
+            actual_state_updates
+                .state_updates
+                .deprecated_declared_classes
+                .get(&DEFAULT_LEGACY_UDC_CLASS_HASH),
             Some(&DEFAULT_LEGACY_UDC_COMPILED_CLASS_HASH),
             "The default universal deployer class should be declared"
         );

--- a/crates/katana/primitives/src/class.rs
+++ b/crates/katana/primitives/src/class.rs
@@ -57,13 +57,6 @@ impl ContractClass {
         }
     }
 
-    /// Checks if this contract class is a Sierra class.
-    ///
-    /// Returns `true` if the contract class is a Sierra class, `false` otherwise.
-    pub fn is_class(&self) -> bool {
-        matches!(self, Self::Class(_))
-    }
-
     /// Checks if this contract class is a Cairo 0 legacy class.
     ///
     /// Returns `true` if the contract class is a legacy class, `false` otherwise.

--- a/crates/katana/primitives/src/class.rs
+++ b/crates/katana/primitives/src/class.rs
@@ -57,20 +57,18 @@ impl ContractClass {
         }
     }
 
-    /// Returns the class as a Sierra class, if any.
-    pub fn as_class(&self) -> Option<&SierraContractClass> {
-        match self {
-            Self::Class(class) => Some(class),
-            _ => None,
-        }
+    /// Checks if this contract class is a Sierra class.
+    ///
+    /// Returns `true` if the contract class is a Sierra class, `false` otherwise.
+    pub fn is_class(&self) -> bool {
+        matches!(self, Self::Class(_))
     }
 
-    /// Returns the class as a legacy class, if any.
-    pub fn as_legacy(&self) -> Option<&LegacyContractClass> {
-        match self {
-            Self::Legacy(class) => Some(class),
-            _ => None,
-        }
+    /// Checks if this contract class is a Cairo 0 legacy class.
+    ///
+    /// Returns `true` if the contract class is a legacy class, `false` otherwise.
+    pub fn is_legacy(&self) -> bool {
+        matches!(self, Self::Legacy(_))
     }
 }
 

--- a/crates/katana/storage/provider/src/providers/db/mod.rs
+++ b/crates/katana/storage/provider/src/providers/db/mod.rs
@@ -702,6 +702,11 @@ impl<Db: Database> BlockWriter for DbProvider<Db> {
                 db_tx.put::<tables::ClassDeclarations>(block_number, class_hash)?
             }
 
+            for class_hash in states.state_updates.deprecated_declared_classes {
+                db_tx.put::<tables::ClassDeclarationBlock>(class_hash, block_number)?;
+                db_tx.put::<tables::ClassDeclarations>(block_number, class_hash)?
+            }
+
             for (class_hash, class) in states.classes {
                 // generate the compiled class
                 let compiled = class.clone().compile()?;


### PR DESCRIPTION
Put legacy classes in the correct mappings in the `StateUpdates` struct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced class management with support for deprecated and legacy classes.
  - Added method to check if a class was declared before a specific block.

- **Refactor**
  - Simplified contract class type checking methods.
  - Improved handling of state updates for class declarations.

- **Bug Fixes**
  - Updated database insertion logic to accommodate deprecated class declarations.
  
- **Chores**
  - Added optional dependency on `starknet-crypto` and updated feature requirements for `starknet-messaging`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->