### PR TITLE
fix(katana-cli): ensure compilation without server feature

### DIFF
--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use alloy_primitives::U256;
-use anyhow::{bail, Context, Result};
+#[cfg(feature = "server")]
+use anyhow::bail;
+use anyhow::{Context, Result};
 use clap::Parser;
 use katana_core::constants::DEFAULT_SEQUENCER_ADDRESS;
 use katana_core::service::messaging::MessagingConfig;
@@ -13,7 +15,9 @@ use katana_node::config::dev::{DevConfig, FixedL1GasPriceConfig};
 use katana_node::config::execution::ExecutionConfig;
 use katana_node::config::fork::ForkingConfig;
 use katana_node::config::metrics::MetricsConfig;
-use katana_node::config::rpc::{RpcConfig, RpcModuleKind, RpcModulesList};
+use katana_node::config::rpc::RpcConfig;
+#[cfg(feature = "server")]
+use katana_node::config::rpc::{RpcModuleKind, RpcModulesList};
 use katana_node::config::{Config, SequencingConfig};
 use katana_primitives::chain_spec::{self, ChainSpec};
 use katana_primitives::genesis::allocation::DevAllocationsGenerator;
@@ -197,24 +201,24 @@ impl NodeArgs {
     }
 
     fn rpc_config(&self) -> Result<RpcConfig> {
-        let modules = if let Some(modules) = &self.server.http_modules {
-            // TODO: This check should be handled in the `katana-node` level. Right now if you
-            // instantiate katana programmatically, you can still add the dev module without
-            // enabling dev mode.
-            //
-            // We only allow the `dev` module in dev mode (ie `--dev` flag)
-            if !self.development.dev && modules.contains(&RpcModuleKind::Dev) {
-                bail!("The `dev` module can only be enabled in dev mode (ie `--dev` flag)")
-            }
-
-            modules.clone()
-        } else {
-            // Expose the default modules if none is specified.
-            RpcModulesList::default()
-        };
-
         #[cfg(feature = "server")]
         {
+            let modules = if let Some(modules) = &self.server.http_modules {
+                // TODO: This check should be handled in the `katana-node` level. Right now if you
+                // instantiate katana programmatically, you can still add the dev module without
+                // enabling dev mode.
+                //
+                // We only allow the `dev` module in dev mode (ie `--dev` flag)
+                if !self.development.dev && modules.contains(&RpcModuleKind::Dev) {
+                    bail!("The `dev` module can only be enabled in dev mode (ie `--dev` flag)")
+                }
+
+                modules.clone()
+            } else {
+                // Expose the default modules if none is specified.
+                RpcModulesList::default()
+            };
+
             Ok(RpcConfig {
                 apis: modules,
                 port: self.server.http_port,
@@ -228,7 +232,7 @@ impl NodeArgs {
 
         #[cfg(not(feature = "server"))]
         {
-            Ok(RpcConfig { apis, ..Default::default() })
+            Ok(RpcConfig::default())
         }
     }
 

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -7,11 +7,14 @@
 //!
 //! Currently, the merge is made at the top level of the commands.
 
+#[cfg(feature = "server")]
 use std::net::IpAddr;
 
 use clap::Args;
 use katana_node::config::execution::{DEFAULT_INVOCATION_MAX_STEPS, DEFAULT_VALIDATION_MAX_STEPS};
+#[cfg(feature = "server")]
 use katana_node::config::metrics::{DEFAULT_METRICS_ADDR, DEFAULT_METRICS_PORT};
+#[cfg(feature = "server")]
 use katana_node::config::rpc::{RpcModulesList, DEFAULT_RPC_MAX_PROOF_KEYS};
 #[cfg(feature = "server")]
 use katana_node::config::rpc::{
@@ -21,14 +24,14 @@ use katana_node::config::rpc::{
 use katana_primitives::block::BlockHashOrNumber;
 use katana_primitives::chain::ChainId;
 use katana_primitives::genesis::Genesis;
+#[cfg(feature = "server")]
 use katana_rpc::cors::HeaderValue;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::utils::{
-    deserialize_cors_origins, parse_block_hash_or_number, parse_genesis, serialize_cors_origins,
-    LogFormat,
-};
+#[cfg(feature = "server")]
+use crate::utils::{deserialize_cors_origins, serialize_cors_origins};
+use crate::utils::{parse_block_hash_or_number, parse_genesis, LogFormat};
 
 const DEFAULT_DEV_SEED: &str = "0";
 const DEFAULT_DEV_ACCOUNTS: u16 = 10;


### PR DESCRIPTION
This PR ensures the compilation without the `server` feature can happen (mostly used in Slot CLI currently).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added optional server configuration with support for metrics and HTTP-RPC server settings
  - Introduced configurable options for server address, port, CORS origins, and connection limits

- **Improvements**
  - Enhanced modularity of CLI configuration
  - Added flexible feature flagging for server-related functionality

- **Configuration**
  - New options for customizing metrics and server behavior
  - Default settings provided for easy setup and deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->