### PR TITLE
fix: enable dev api automatically with dev flag

### DIFF
--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -216,7 +216,14 @@ impl NodeArgs {
                 modules.clone()
             } else {
                 // Expose the default modules if none is specified.
-                RpcModulesList::default()
+                let mut modules = RpcModulesList::default();
+
+                // Ensures the `--dev` flag enabled the dev module.
+                if self.development.dev {
+                    modules.add(RpcModuleKind::Dev);
+                }
+
+                modules
             };
 
             Ok(RpcConfig {
@@ -672,5 +679,13 @@ chain_id.Named = "Mainnet"
             err.to_string()
                 .contains("The `dev` module can only be enabled in dev mode (ie `--dev` flag)")
         );
+    }
+
+    #[test]
+    fn test_dev_api_enabled() {
+        let args = NodeArgs::parse_from(["katana", "--dev"]);
+        let config = args.config().unwrap();
+
+        assert!(config.rpc.apis.contains(&RpcModuleKind::Dev));
     }
 }

--- a/crates/katana/rpc/rpc/tests/dev.rs
+++ b/crates/katana/rpc/rpc/tests/dev.rs
@@ -99,6 +99,16 @@ async fn test_increase_next_block_timestamp() {
     );
 }
 
+#[tokio::test]
+async fn test_dev_api_enabled() {
+    let sequencer = create_test_sequencer().await;
+
+    let client = HttpClientBuilder::default().build(sequencer.url()).unwrap();
+
+    let accounts = client.predeployed_accounts().await.unwrap();
+    assert!(!accounts.is_empty(), "predeployed accounts should not be empty");
+}
+
 // #[tokio::test]
 // async fn test_set_storage_at_on_instant_mode() {
 //     let sequencer = create_test_sequencer().await;


### PR DESCRIPTION
Ensures the `--dev` flag enabled the `DevApi` for Katana.

This was a design choice where `--dev` could enable some dev features without actually exposing the `DevApi`.

However, in the current of Katana, it's more convenient to have the `DevApi` enables as soon as `--dev` is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced RPC configuration control to conditionally include development modules
- **Tests**
  - Added test to verify development API functionality and predeployed account availability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->