### PR TITLE
feat: apply semver to tag versions

### DIFF
--- a/crates/dojo/core-cairo-test/Scarb.lock
+++ b/crates/dojo/core-cairo-test/Scarb.lock
@@ -3,7 +3,7 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "1.0.0-rc.0"
+version = "1.0.10"
 dependencies = [
  "dojo_plugin",
 ]


### PR DESCRIPTION
This PR adds semver behavior for the usage of dojo versions, since we can't use `scarbs.xyz` yet.