### PR TITLE
ci(docker): add missing ca-certificates and SSL certs copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim as builder
 
-RUN apt-get update && apt install -y git libtool automake autoconf make tini
+RUN apt-get update && apt install -y git libtool automake autoconf make tini ca-certificates
 
 RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && cd curtailer \
@@ -15,6 +15,8 @@ RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && curtail --version
 
 FROM debian:bookworm-slim as base
+
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 
 COPY --from=builder /usr/bin/tini /tini
 ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
# Description

Ensure ca-certificates are installed and copied to the base image to support secure HTTPS connections where required.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [x] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
	- Enhanced SSL certificate handling in the container build process
	- Improved container security by properly copying SSL certificates between build stages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->