### PR TITLE
feat(katana): remove support for initializing custom settlement chain 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8453,6 +8453,7 @@ dependencies = [
  "shellexpand",
  "spinoff",
  "starknet 0.12.0",
+ "strum_macros 0.25.3",
  "thiserror 1.0.63",
  "tokio",
  "toml 0.8.19",

--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -28,6 +28,7 @@ serde.workspace = true
 shellexpand = "3.1.0"
 spinoff.workspace = true
 starknet.workspace = true
+strum_macros.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
@@ -41,5 +42,6 @@ starknet.workspace = true
 [features]
 default = [ "jemalloc", "katana-cli/slot" ]
 
+init-custom-settlement-chain = [  ]
 jemalloc = [  ]
 starknet-messaging = [ "katana-cli/starknet-messaging" ]


### PR DESCRIPTION
We can't support custom chain for now as we're relying heavily on the Atlantic service for setting the proofs and currently it is limited to only Starknet Sepolia.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for selecting settlement chain during initialization
	- Introduced Sepolia as a default settlement chain option
	- Enabled optional custom settlement chain configuration

- **Improvements**
	- Enhanced initialization workflow with more flexible chain selection
	- Simplified RPC URL configuration process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->