### PR TITLE
fix(dojo-lang): verify constructor args to follow dojo rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4135,7 +4135,7 @@ dependencies = [
 [[package]]
 name = "create-output-dir"
 version = "1.0.0"
-source = "git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373#f67331d99bca24c13ad56af6752b93f23e5ac373"
+source = "git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc#b5ab351aa9b52dcf27a397021d84a423afd016dc"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.0",
@@ -4852,7 +4852,7 @@ dependencies = [
 [[package]]
 name = "dojo-lang"
 version = "1.0.12"
-source = "git+https://github.com/dojoengine/dojo?rev=b4bf759aca2765e2236e27e748468e44cbc77718#b4bf759aca2765e2236e27e748468e44cbc77718"
+source = "git+https://github.com/dojoengine/dojo?rev=99bdd37c1aeb6d75028c32d4039916b97cb3a438#99bdd37c1aeb6d75028c32d4039916b97cb3a438"
 dependencies = [
  "anyhow",
  "cairo-lang-defs",
@@ -4862,7 +4862,7 @@ dependencies = [
  "cairo-lang-semantic",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "dojo-types 1.0.12 (git+https://github.com/dojoengine/dojo?rev=b4bf759aca2765e2236e27e748468e44cbc77718)",
+ "dojo-types 1.0.12 (git+https://github.com/dojoengine/dojo?rev=99bdd37c1aeb6d75028c32d4039916b97cb3a438)",
  "itertools 0.12.1",
  "serde",
  "smol_str",
@@ -4943,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "dojo-types"
 version = "1.0.12"
-source = "git+https://github.com/dojoengine/dojo?rev=b4bf759aca2765e2236e27e748468e44cbc77718#b4bf759aca2765e2236e27e748468e44cbc77718"
+source = "git+https://github.com/dojoengine/dojo?rev=99bdd37c1aeb6d75028c32d4039916b97cb3a438#99bdd37c1aeb6d75028c32d4039916b97cb3a438"
 dependencies = [
  "anyhow",
  "cainome 0.4.11",
@@ -13125,7 +13125,7 @@ dependencies = [
 [[package]]
 name = "scarb"
 version = "2.9.2"
-source = "git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373#f67331d99bca24c13ad56af6752b93f23e5ac373"
+source = "git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc#b5ab351aa9b52dcf27a397021d84a423afd016dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13157,7 +13157,7 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "directories",
- "dojo-lang 1.0.12 (git+https://github.com/dojoengine/dojo?rev=b4bf759aca2765e2236e27e748468e44cbc77718)",
+ "dojo-lang 1.0.12 (git+https://github.com/dojoengine/dojo?rev=99bdd37c1aeb6d75028c32d4039916b97cb3a438)",
  "dunce",
  "flate2",
  "fs4",
@@ -13178,9 +13178,9 @@ dependencies = [
  "redb",
  "reqwest 0.11.27",
  "scarb-build-metadata",
- "scarb-metadata 1.13.0 (git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373)",
- "scarb-proc-macro-server-types 0.1.0 (git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373)",
- "scarb-stable-hash 1.0.0 (git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373)",
+ "scarb-metadata 1.13.0 (git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc)",
+ "scarb-proc-macro-server-types 0.1.0 (git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc)",
+ "scarb-stable-hash 1.0.0 (git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc)",
  "scarb-ui",
  "semver 1.0.23",
  "serde",
@@ -13210,7 +13210,7 @@ dependencies = [
 [[package]]
 name = "scarb-build-metadata"
 version = "2.9.2"
-source = "git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373#f67331d99bca24c13ad56af6752b93f23e5ac373"
+source = "git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc#b5ab351aa9b52dcf27a397021d84a423afd016dc"
 dependencies = [
  "cargo_metadata",
 ]
@@ -13231,7 +13231,7 @@ dependencies = [
 [[package]]
 name = "scarb-metadata"
 version = "1.13.0"
-source = "git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373#f67331d99bca24c13ad56af6752b93f23e5ac373"
+source = "git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc#b5ab351aa9b52dcf27a397021d84a423afd016dc"
 dependencies = [
  "camino",
  "derive_builder",
@@ -13255,7 +13255,7 @@ dependencies = [
 [[package]]
 name = "scarb-proc-macro-server-types"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373#f67331d99bca24c13ad56af6752b93f23e5ac373"
+source = "git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc#b5ab351aa9b52dcf27a397021d84a423afd016dc"
 dependencies = [
  "cairo-lang-macro",
  "serde",
@@ -13275,7 +13275,7 @@ dependencies = [
 [[package]]
 name = "scarb-stable-hash"
 version = "1.0.0"
-source = "git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373#f67331d99bca24c13ad56af6752b93f23e5ac373"
+source = "git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc#b5ab351aa9b52dcf27a397021d84a423afd016dc"
 dependencies = [
  "data-encoding",
  "xxhash-rust",
@@ -13284,14 +13284,14 @@ dependencies = [
 [[package]]
 name = "scarb-ui"
 version = "0.1.5"
-source = "git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373#f67331d99bca24c13ad56af6752b93f23e5ac373"
+source = "git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc#b5ab351aa9b52dcf27a397021d84a423afd016dc"
 dependencies = [
  "anyhow",
  "camino",
  "clap",
  "console",
  "indicatif",
- "scarb-metadata 1.13.0 (git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373)",
+ "scarb-metadata 1.13.0 (git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc)",
  "serde",
  "serde_json",
  "tracing-core",
@@ -14079,7 +14079,7 @@ dependencies = [
  "notify",
  "reqwest 0.11.27",
  "scarb",
- "scarb-metadata 1.13.0 (git+https://github.com/dojoengine/scarb?rev=f67331d99bca24c13ad56af6752b93f23e5ac373)",
+ "scarb-metadata 1.13.0 (git+https://github.com/dojoengine/scarb?rev=b5ab351aa9b52dcf27a397021d84a423afd016dc)",
  "scarb-ui",
  "semver 1.0.23",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,9 +212,9 @@ rpassword = "7.2.0"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 salsa = "0.16.1"
-scarb = { git = "https://github.com/dojoengine/scarb", rev = "f67331d99bca24c13ad56af6752b93f23e5ac373" }
-scarb-metadata = { git = "https://github.com/dojoengine/scarb", rev = "f67331d99bca24c13ad56af6752b93f23e5ac373" }
-scarb-ui = { git = "https://github.com/dojoengine/scarb", rev = "f67331d99bca24c13ad56af6752b93f23e5ac373" }
+scarb = { git = "https://github.com/dojoengine/scarb", rev = "b5ab351aa9b52dcf27a397021d84a423afd016dc" }
+scarb-metadata = { git = "https://github.com/dojoengine/scarb", rev = "b5ab351aa9b52dcf27a397021d84a423afd016dc" }
+scarb-ui = { git = "https://github.com/dojoengine/scarb", rev = "b5ab351aa9b52dcf27a397021d84a423afd016dc" }
 semver = "1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }

--- a/crates/dojo/lang/src/attribute_macros/contract.rs
+++ b/crates/dojo/lang/src/attribute_macros/contract.rs
@@ -175,11 +175,10 @@ impl DojoContract {
         if !is_valid_constructor_params(&params_str) {
             self.diagnostics.push(PluginDiagnostic {
                 stable_ptr: fn_ast.stable_ptr().untyped(),
-                message: format!(
-                    "The constructor must have exactly one parameter, which is `ref self: \
-                     ContractState`. Add a `dojo_init` function instead if you need to initialize \
-                     the contract with parameters."
-                ),
+                message: "The constructor must have exactly one parameter, which is `ref self: \
+                          ContractState`. Add a `dojo_init` function instead if you need to \
+                          initialize the contract with parameters."
+                    .to_string(),
                 severity: Severity::Error,
             });
         }
@@ -394,5 +393,26 @@ fn is_valid_constructor_params(params: &str) -> bool {
         return false;
     }
 
-    frags.first().unwrap().starts_with("ref self: ContractState")
+    frags.first().unwrap().contains("ref self: ContractState")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_constructor_params_ok() {
+        assert!(is_valid_constructor_params("ref self: ContractState"));
+        assert!(is_valid_constructor_params("ref self: ContractState "));
+        assert!(is_valid_constructor_params(" ref self: ContractState"));
+    }
+
+    #[test]
+    fn test_is_valid_constructor_params_not_ok() {
+        assert!(!is_valid_constructor_params(""));
+        assert!(!is_valid_constructor_params("self: ContractState"));
+        assert!(!is_valid_constructor_params("ref self: OtherState"));
+        assert!(!is_valid_constructor_params("ref self: ContractState, other: felt252"));
+        assert!(!is_valid_constructor_params("other: felt252"));
+    }
 }

--- a/crates/dojo/lang/src/attribute_macros/contract.rs
+++ b/crates/dojo/lang/src/attribute_macros/contract.rs
@@ -172,6 +172,17 @@ impl DojoContract {
         let fn_decl = fn_ast.declaration(db);
 
         let params_str = self.params_to_str(db, fn_decl.signature(db).parameters(db));
+        if !is_valid_constructor_params(&params_str) {
+            self.diagnostics.push(PluginDiagnostic {
+                stable_ptr: fn_ast.stable_ptr().untyped(),
+                message: format!(
+                    "The constructor must have exactly one parameter, which is `ref self: \
+                     ContractState`. Add a `dojo_init` function instead if you need to initialize \
+                     the contract with parameters."
+                ),
+                severity: Severity::Error,
+            });
+        }
 
         let declaration_node = RewriteNode::Mapped {
             node: Box::new(RewriteNode::Text(format!(
@@ -371,4 +382,17 @@ impl DojoContract {
 
         params.join(", ")
     }
+}
+
+/// Checks if the constructor parameters are valid.
+/// We only allow one parameter for the constructor, which is the contract state,
+/// since `dojo_init` is called by the world after every resource has been deployed.
+fn is_valid_constructor_params(params: &str) -> bool {
+    let frags = params.split(",").collect::<Vec<_>>();
+
+    if frags.len() != 1 {
+        return false;
+    }
+
+    frags.first().unwrap().starts_with("ref self: ContractState")
 }


### PR DESCRIPTION
Dojo contracts are always deployed with an empty calldata for constructor. This is done as such for two reasons:
1. Deterministic addresses, since calldata of the constructor impacts the computed address.
2. All the contract can be first deployed, and then the initialization can be ordered with the guarantee that all resources are already deployed.

This PR aims at ensuring the user is warned in case that a custom constructor is used. This is something possible, and some logic may be done in the constructor in some specific cases.

However, the recommended way to initialize a contract is adding the `dojo_init` function, which ensures that all models and permissions are already done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `scarb`, `scarb-metadata`, and `scarb-ui` dependencies to a new commit hash.

- **Code Improvements**
	- Added validation for constructor parameters in contract implementation.
	- Introduced stricter checks for constructor method definitions.
	- Added a test module to verify the correctness of the new validation function.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->