### PR TITLE
fix: use bookworm-slim to check execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: debian:bookworm-slim
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use a different base Docker image for CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->