### PR TITLE
ci(docker): sync dojo base image with build

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -42,4 +42,3 @@ WORKDIR /
 COPY --from=builder /app/target/release/katana /app/artifacts/
 COPY --from=builder /app/target/release/torii /app/artifacts/
 COPY --from=builder /app/target/release/sozo /app/artifacts/
-COPY --from=builder /app/target/release/saya /app/artifacts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && make install \
     && curtail --version
 
-FROM debian:bookworm-slim as base
+FROM debian:buster-slim as base
 
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim as builder
+FROM debian:buster-slim as builder
 
 RUN apt-get update && apt install -y git libtool automake autoconf make tini ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as builder
+FROM ubuntu:24.04 as builder
 
 RUN apt-get update && apt install -y git libtool automake autoconf make tini ca-certificates
 
@@ -14,7 +14,7 @@ RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && make install \
     && curtail --version
 
-FROM debian:buster-slim as base
+FROM ubuntu:24.04 as base
 
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated base Docker image from Debian Bookworm to Debian Buster for the build process.
	- Removed the inclusion of the `saya` binary from the final Docker image artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->