### PR TITLE
refactor(katana): return error as default for state commitment provider 

### DIFF
--- a/crates/katana/executor/src/implementation/blockifier/state.rs
+++ b/crates/katana/executor/src/implementation/blockifier/state.rs
@@ -92,8 +92,6 @@ impl<S: StateDb> Clone for CachedState<S> {
     }
 }
 
-// type DeclaredClass = (CompiledClass, ContractClass);
-
 #[derive(Debug)]
 pub(super) struct CachedStateInner<S: StateReader> {
     pub(super) inner: cached_state::CachedState<S>,
@@ -238,47 +236,9 @@ impl<S: StateDb> StateReader for CachedState<S> {
     }
 }
 
-impl<S: StateDb> StateProofProvider for CachedState<S> {
-    fn class_multiproof(
-        &self,
-        classes: Vec<class::ClassHash>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        let _ = classes;
-        unimplemented!("not supported in executor's state")
-    }
+impl<S: StateDb> StateProofProvider for CachedState<S> {}
 
-    fn contract_multiproof(
-        &self,
-        addresses: Vec<katana_primitives::ContractAddress>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        let _ = addresses;
-        unimplemented!("not supported in executor's state")
-    }
-
-    fn storage_multiproof(
-        &self,
-        address: katana_primitives::ContractAddress,
-        key: Vec<katana_primitives::contract::StorageKey>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        let _ = address;
-        let _ = key;
-        unimplemented!("not supported in executor's state")
-    }
-}
-
-impl<S: StateDb> StateRootProvider for CachedState<S> {
-    fn classes_root(&self) -> ProviderResult<Felt> {
-        unimplemented!("not supported in executor's state")
-    }
-
-    fn contracts_root(&self) -> ProviderResult<Felt> {
-        unimplemented!("not supported in executor's state")
-    }
-
-    fn storage_root(&self, _: katana_primitives::ContractAddress) -> ProviderResult<Option<Felt>> {
-        unimplemented!("not supported in executor's state")
-    }
-}
+impl<S: StateDb> StateRootProvider for CachedState<S> {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/katana/storage/provider/src/error.rs
+++ b/crates/katana/storage/provider/src/error.rs
@@ -96,6 +96,12 @@ pub enum ProviderError {
         storage_key: StorageKey,
     },
 
+    #[error("State proof not supported")]
+    StateProofNotSupported,
+
+    #[error("State root not found")]
+    StateRootNotFound,
+
     #[error(transparent)]
     ContractClassCompilation(#[from] ContractClassCompilationError),
 
@@ -110,6 +116,6 @@ pub enum ProviderError {
     ForkedBackend(#[from] crate::providers::fork::backend::BackendError),
 
     /// Any error that is not covered by the other variants.
-    #[error("soemthing went wrong: {0}")]
+    #[error("Something went wrong: {0}")]
     Other(String),
 }

--- a/crates/katana/storage/provider/src/providers/fork/state.rs
+++ b/crates/katana/storage/provider/src/providers/fork/state.rs
@@ -102,40 +102,8 @@ impl ContractClassProvider for ForkedStateDb {
     }
 }
 
-impl StateProofProvider for ForkedStateDb {
-    fn class_multiproof(&self, _: Vec<ClassHash>) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-
-    fn contract_multiproof(
-        &self,
-        _: Vec<ContractAddress>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-
-    fn storage_multiproof(
-        &self,
-        _: ContractAddress,
-        _: Vec<StorageKey>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-}
-
-impl StateRootProvider for ForkedStateDb {
-    fn classes_root(&self) -> ProviderResult<katana_primitives::Felt> {
-        Ok(katana_primitives::Felt::ZERO)
-    }
-
-    fn contracts_root(&self) -> ProviderResult<katana_primitives::Felt> {
-        Ok(katana_primitives::Felt::ZERO)
-    }
-
-    fn storage_root(&self, _: ContractAddress) -> ProviderResult<Option<katana_primitives::Felt>> {
-        Ok(Some(katana_primitives::Felt::ZERO))
-    }
-}
+impl StateProofProvider for ForkedStateDb {}
+impl StateRootProvider for ForkedStateDb {}
 
 #[derive(Debug)]
 pub(super) struct LatestStateProvider(pub(super) Arc<ForkedStateDb>);
@@ -178,40 +146,8 @@ impl ContractClassProvider for LatestStateProvider {
     }
 }
 
-impl StateProofProvider for LatestStateProvider {
-    fn class_multiproof(&self, _: Vec<ClassHash>) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-
-    fn contract_multiproof(
-        &self,
-        _: Vec<ContractAddress>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-
-    fn storage_multiproof(
-        &self,
-        _: ContractAddress,
-        _: Vec<StorageKey>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-}
-
-impl StateRootProvider for LatestStateProvider {
-    fn classes_root(&self) -> ProviderResult<katana_primitives::Felt> {
-        Ok(katana_primitives::Felt::ZERO)
-    }
-
-    fn contracts_root(&self) -> ProviderResult<katana_primitives::Felt> {
-        Ok(katana_primitives::Felt::ZERO)
-    }
-
-    fn storage_root(&self, _: ContractAddress) -> ProviderResult<Option<katana_primitives::Felt>> {
-        Ok(Some(katana_primitives::Felt::ZERO))
-    }
-}
+impl StateProofProvider for LatestStateProvider {}
+impl StateRootProvider for LatestStateProvider {}
 
 impl StateProvider for ForkedSnapshot {
     fn nonce(&self, address: ContractAddress) -> ProviderResult<Option<Nonce>> {
@@ -285,40 +221,8 @@ impl ContractClassProvider for ForkedSnapshot {
     }
 }
 
-impl StateProofProvider for ForkedSnapshot {
-    fn class_multiproof(&self, _: Vec<ClassHash>) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-
-    fn contract_multiproof(
-        &self,
-        _: Vec<ContractAddress>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-
-    fn storage_multiproof(
-        &self,
-        _: ContractAddress,
-        _: Vec<StorageKey>,
-    ) -> ProviderResult<katana_trie::MultiProof> {
-        Ok(katana_trie::MultiProof(Default::default()))
-    }
-}
-
-impl StateRootProvider for ForkedSnapshot {
-    fn classes_root(&self) -> ProviderResult<katana_primitives::Felt> {
-        Ok(katana_primitives::Felt::ZERO)
-    }
-
-    fn contracts_root(&self) -> ProviderResult<katana_primitives::Felt> {
-        Ok(katana_primitives::Felt::ZERO)
-    }
-
-    fn storage_root(&self, _: ContractAddress) -> ProviderResult<Option<katana_primitives::Felt>> {
-        Ok(Some(katana_primitives::Felt::ZERO))
-    }
-}
+impl StateProofProvider for ForkedSnapshot {}
+impl StateRootProvider for ForkedSnapshot {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/katana/storage/provider/src/traits/state.rs
+++ b/crates/katana/storage/provider/src/traits/state.rs
@@ -7,6 +7,7 @@ use starknet::macros::short_string;
 use starknet_types_core::hash::StarkHash;
 
 use super::contract::ContractClassProvider;
+use crate::error::ProviderError;
 use crate::ProviderResult;
 
 #[auto_impl::auto_impl(&, Box, Arc)]
@@ -22,13 +23,20 @@ pub trait StateRootProvider: Send + Sync {
     }
 
     /// Retrieves the root of the classes trie.
-    fn classes_root(&self) -> ProviderResult<Felt>;
+    fn classes_root(&self) -> ProviderResult<Felt> {
+        Err(ProviderError::StateRootNotFound)
+    }
 
     /// Retrieves the root of the contracts trie.
-    fn contracts_root(&self) -> ProviderResult<Felt>;
+    fn contracts_root(&self) -> ProviderResult<Felt> {
+        Err(ProviderError::StateRootNotFound)
+    }
 
     /// Retrieves the root of a contract's storage trie.
-    fn storage_root(&self, contract: ContractAddress) -> ProviderResult<Option<Felt>>;
+    fn storage_root(&self, contract: ContractAddress) -> ProviderResult<Option<Felt>> {
+        let _ = contract;
+        Ok(None)
+    }
 }
 
 #[auto_impl::auto_impl(&, Box, Arc)]
@@ -91,9 +99,19 @@ pub trait StateProofProvider: Send + Sync {
         &self,
         address: ContractAddress,
         key: Vec<StorageKey>,
-    ) -> ProviderResult<MultiProof>;
+    ) -> ProviderResult<MultiProof> {
+        let _ = address;
+        let _ = key;
+        Err(ProviderError::StateProofNotSupported)
+    }
 
-    fn contract_multiproof(&self, addresses: Vec<ContractAddress>) -> ProviderResult<MultiProof>;
+    fn contract_multiproof(&self, addresses: Vec<ContractAddress>) -> ProviderResult<MultiProof> {
+        let _ = addresses;
+        Err(ProviderError::StateProofNotSupported)
+    }
 
-    fn class_multiproof(&self, classes: Vec<ClassHash>) -> ProviderResult<MultiProof>;
+    fn class_multiproof(&self, classes: Vec<ClassHash>) -> ProviderResult<MultiProof> {
+        let _ = classes;
+        Err(ProviderError::StateProofNotSupported)
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - None

- **Bug Fixes**
  - Corrected a minor typo in error message

- **Refactor**
  - Simplified state proof and root handling across multiple components
  - Updated error handling for state root and proof operations

- **Chores**
  - Removed unsupported multiproof and state root retrieval methods
  - Added default error responses for state proof and root operations

The changes primarily focus on streamlining state management interfaces and improving error handling in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->