### PR TITLE
feat(katana): chain config management tool

### DIFF
--- a/bin/katana/src/cli/config.rs
+++ b/bin/katana/src/cli/config.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use clap::Args;
+use katana_chain_spec::rollup::file::ChainConfigDir;
+use katana_primitives::chain::ChainId;
+
+#[derive(Debug, Args)]
+pub struct ConfigArgs {
+    /// The chain id.
+    #[arg(value_parser = ChainId::parse)]
+    chain: ChainId,
+}
+
+impl ConfigArgs {
+    pub fn execute(self) -> Result<()> {
+        let cs = ChainConfigDir::open(&self.chain)?;
+        let path = cs.config_path();
+        let config = std::fs::read_to_string(&path)?;
+        println!("File: {}\n\n{config}", path.display());
+        Ok(())
+    }
+}

--- a/bin/katana/src/cli/mod.rs
+++ b/bin/katana/src/cli/mod.rs
@@ -4,6 +4,7 @@ use clap_complete::Shell;
 use katana_cli::NodeArgs;
 use katana_node::version::VERSION;
 
+mod config;
 mod db;
 mod init;
 
@@ -24,6 +25,7 @@ impl Cli {
                 Commands::Completions(args) => args.execute(),
                 Commands::Db(args) => args.execute(),
                 Commands::Init(args) => args.execute(),
+                Commands::Config(args) => args.execute(),
             };
         }
 
@@ -33,8 +35,11 @@ impl Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    #[command(about = "Initialize chain", hide = true)]
+    #[command(about = "Initialize chain")]
     Init(init::InitArgs),
+
+    #[command(about = "Chain configuration utilities")]
+    Config(config::ConfigArgs),
 
     #[command(about = "Database utilities")]
     Db(db::DbArgs),


### PR DESCRIPTION
New subcommand:

`katana config`

for managing chain configuration files created by `katana init`. Currently, all it does is just displaying the config file.

```
$ katana config fartchain
File: /Users/kariy/Library/Application Support/katana/0x66617274636861696e/config.toml

[id]
Id = "0x66617274636861696e"

[fee-contract]
strk = "0x2e7442625bab778683501c0eadbc1ea17b3535da040a12ac7d281066e915eea"

[settlement.starknet]
rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
account = "0x4ac0264c73207f9bc7b12801500324be647a8c2fc56964f8e1945ca993006a7"
core_contract = "0x3c5a55d09400e9e79d34535a48499ae87fbb1b17538ac6b5c093863445dfdc8"

[settlement.starknet.id]
Named = "Sepolia"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new configuration command to retrieve and display chain configuration details
	- Enhanced CLI with configuration management capabilities for different chain IDs

- **Improvements**
	- Improved error handling for configuration file operations
	- Made initialization command more visible in the command-line interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->