### PR TITLE
fix: add explicit edition for test cairo contracts across the repo

### DIFF
--- a/bin/sozo/tests/test_data/invalid_cairo_version/Scarb.toml
+++ b/bin/sozo/tests/test_data/invalid_cairo_version/Scarb.toml
@@ -2,3 +2,4 @@
 cairo-version = "1.2.0"
 name = "sozo_test"
 version = "0.3.1-rc7"
+edition = "2023_01"

--- a/crates/benches/contracts/Scarb.toml
+++ b/crates/benches/contracts/Scarb.toml
@@ -2,6 +2,7 @@
 cairo-version = "=2.9.1"
 name = "benches"
 version = "1.0.0-rc.0"
+edition = "2023_01"
 
 [[target.starknet-contract]]
 build-external-contracts = ["dojo::world::world_contract::world"]

--- a/crates/katana/contracts/messaging/cairo/Scarb.toml
+++ b/crates/katana/contracts/messaging/cairo/Scarb.toml
@@ -1,6 +1,7 @@
 [package]
 name = "katana_messaging"
 version.workspace = true
+edition = "2023_01"
 
 [dependencies]
 starknet.workspace = true

--- a/crates/katana/contracts/messaging/cairo/src/appchain_messaging.cairo
+++ b/crates/katana/contracts/messaging/cairo/src/appchain_messaging.cairo
@@ -238,10 +238,11 @@ mod appchain_messaging {
             selector: felt252,
             payload: Span<felt252>
         ) -> (felt252, felt252) {
+            let from_address = starknet::get_caller_address();
             let nonce = self.sn_to_appc_nonce.read() + 1;
             self.sn_to_appc_nonce.write(nonce);
 
-            let msg_hash = compute_hash_sn_to_appc(nonce, to_address, selector, payload);
+            let msg_hash = compute_hash_sn_to_appc(from_address, to_address, selector, payload, nonce);
 
             self
                 .emit(


### PR DESCRIPTION
Currently, building with `sozo` generates those warnings:
<img width="763" alt="image" src="https://github.com/user-attachments/assets/51556d8f-418e-4718-a6dd-29d97c10e16f" />

Seems to be caused by Scarb scanning the whole repository.
This PR aims at removing those warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `edition = "2023_01"` to configuration files in multiple projects
	- Updated message sending logic in appchain messaging contract to correctly capture sender's address

- **Bug Fixes**
	- Corrected message hash computation in `send_message_to_appchain` function to use the correct sender address

<!-- end of auto-generated comment: release notes by coderabbit.ai -->