### PR TITLE
feat(torii): add eth address to ty and remove usize

### DIFF
--- a/crates/dojo/types/src/primitive.rs
+++ b/crates/dojo/types/src/primitive.rs
@@ -141,7 +141,7 @@ impl Primitive {
     set_primitive!(set_class_hash, ClassHash, Felt);
     set_primitive!(set_contract_address, ContractAddress, Felt);
     set_primitive!(set_eth_address, EthAddress, Felt);
-    
+
     pub fn to_numeric(&self) -> usize {
         match self {
             Primitive::Bool(_) => 0,
@@ -507,10 +507,7 @@ mod tests {
                 vec![Felt::from(123456789u128)],
                 Primitive::ContractAddress(Some(Felt::from(123456789))),
             ),
-            (
-                vec![Felt::from(123456789u128)],
-                Primitive::EthAddress(Some(Felt::from(123456789))),
-            ),
+            (vec![Felt::from(123456789u128)], Primitive::EthAddress(Some(Felt::from(123456789)))),
         ];
 
         for (serialized, expected) in test_cases {

--- a/crates/dojo/types/src/primitive.rs
+++ b/crates/dojo/types/src/primitive.rs
@@ -38,13 +38,14 @@ pub enum Primitive {
     U64(Option<u64>),
     U128(Option<u128>),
     U256(Option<U256>),
-    USize(Option<u32>),
     Bool(Option<bool>),
     Felt252(Option<Felt>),
     #[strum(serialize = "ClassHash")]
     ClassHash(Option<Felt>),
     #[strum(serialize = "ContractAddress")]
     ContractAddress(Option<Felt>),
+    #[strum(serialize = "EthAddress")]
+    EthAddress(Option<Felt>),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -118,11 +119,11 @@ impl Primitive {
     as_primitive!(as_u64, U64, u64);
     as_primitive!(as_u128, U128, u128);
     as_primitive!(as_u256, U256, U256);
-    as_primitive!(as_usize, USize, u32);
     as_primitive!(as_bool, Bool, bool);
     as_primitive!(as_felt252, Felt252, Felt);
     as_primitive!(as_class_hash, ClassHash, Felt);
     as_primitive!(as_contract_address, ContractAddress, Felt);
+    as_primitive!(as_eth_address, EthAddress, Felt);
 
     set_primitive!(set_i8, I8, i8);
     set_primitive!(set_i16, I16, i16);
@@ -135,30 +136,30 @@ impl Primitive {
     set_primitive!(set_u64, U64, u64);
     set_primitive!(set_u128, U128, u128);
     set_primitive!(set_u256, U256, U256);
-    set_primitive!(set_usize, USize, u32);
     set_primitive!(set_bool, Bool, bool);
     set_primitive!(set_felt252, Felt252, Felt);
     set_primitive!(set_class_hash, ClassHash, Felt);
     set_primitive!(set_contract_address, ContractAddress, Felt);
-
+    set_primitive!(set_eth_address, EthAddress, Felt);
+    
     pub fn to_numeric(&self) -> usize {
         match self {
-            Primitive::U8(_) => 0,
-            Primitive::U16(_) => 1,
-            Primitive::U32(_) => 2,
-            Primitive::U64(_) => 3,
-            Primitive::U128(_) => 4,
-            Primitive::U256(_) => 5,
-            Primitive::USize(_) => 6,
-            Primitive::Bool(_) => 7,
-            Primitive::Felt252(_) => 8,
-            Primitive::ClassHash(_) => 9,
-            Primitive::ContractAddress(_) => 10,
-            Primitive::I8(_) => 11,
-            Primitive::I16(_) => 12,
-            Primitive::I32(_) => 13,
-            Primitive::I64(_) => 14,
-            Primitive::I128(_) => 15,
+            Primitive::Bool(_) => 0,
+            Primitive::U8(_) => 1,
+            Primitive::U16(_) => 2,
+            Primitive::U32(_) => 3,
+            Primitive::U64(_) => 4,
+            Primitive::U128(_) => 5,
+            Primitive::U256(_) => 6,
+            Primitive::I8(_) => 7,
+            Primitive::I16(_) => 8,
+            Primitive::I32(_) => 9,
+            Primitive::I64(_) => 10,
+            Primitive::I128(_) => 11,
+            Primitive::Felt252(_) => 12,
+            Primitive::ClassHash(_) => 13,
+            Primitive::ContractAddress(_) => 14,
+            Primitive::EthAddress(_) => 15,
         }
     }
 
@@ -176,7 +177,6 @@ impl Primitive {
             | Primitive::U8(_)
             | Primitive::U16(_)
             | Primitive::U32(_)
-            | Primitive::USize(_)
             | Primitive::Bool(_) => SqlType::Integer,
 
             // u64 cannot fit into a i64, so we use text
@@ -186,7 +186,8 @@ impl Primitive {
             | Primitive::U256(_)
             | Primitive::ContractAddress(_)
             | Primitive::ClassHash(_)
-            | Primitive::Felt252(_) => SqlType::Text,
+            | Primitive::Felt252(_)
+            | Primitive::EthAddress(_) => SqlType::Text,
         }
     }
 
@@ -201,7 +202,6 @@ impl Primitive {
             Primitive::U8(u8) => format!("{}", u8.unwrap_or_default()),
             Primitive::U16(u16) => format!("{}", u16.unwrap_or_default()),
             Primitive::U32(u32) => format!("{}", u32.unwrap_or_default()),
-            Primitive::USize(u32) => format!("{}", u32.unwrap_or_default()),
             Primitive::Bool(bool) => format!("{}", bool.unwrap_or_default() as i32),
 
             // Hex string
@@ -211,7 +211,7 @@ impl Primitive {
             Primitive::Felt252(felt) => format!("0x{:064x}", felt.unwrap_or_default()),
             Primitive::U128(u128) => format!("0x{:064x}", u128.unwrap_or_default()),
             Primitive::U64(u64) => format!("0x{:064x}", u64.unwrap_or_default()),
-
+            Primitive::EthAddress(felt) => format!("0x{:064x}", felt.unwrap_or_default()),
             Primitive::U256(u256) => format!("0x{:064x}", u256.unwrap_or_default()),
         }
     }
@@ -311,14 +311,6 @@ impl Primitive {
                 *value = Some(U256::from_be_bytes(bytes));
             }
 
-            Primitive::USize(ref mut value) => {
-                let felt = felts.remove(0);
-                *value = Some(felt.to_u32().ok_or_else(|| PrimitiveError::ValueOutOfRange {
-                    r#type: type_name::<u32>(),
-                    value: felt,
-                })?);
-            }
-
             Primitive::Bool(ref mut value) => {
                 let raw = felts.remove(0);
                 *value = Some(raw == Felt::ONE);
@@ -333,6 +325,10 @@ impl Primitive {
             }
 
             Primitive::Felt252(ref mut value) => {
+                *value = Some(felts.remove(0));
+            }
+
+            Primitive::EthAddress(ref mut value) => {
                 *value = Some(felts.remove(0));
             }
         }
@@ -386,9 +382,6 @@ impl Primitive {
                     Ok(vec![value0, value1])
                 })
                 .unwrap_or(Err(PrimitiveError::MissingFieldElement)),
-            Primitive::USize(value) => value
-                .map(|v| Ok(vec![Felt::from(v)]))
-                .unwrap_or(Err(PrimitiveError::MissingFieldElement)),
             Primitive::Bool(value) => value
                 .map(|v| Ok(vec![if v { Felt::ONE } else { Felt::ZERO }]))
                 .unwrap_or(Err(PrimitiveError::MissingFieldElement)),
@@ -399,6 +392,9 @@ impl Primitive {
                 value.map(|v| Ok(vec![v])).unwrap_or(Err(PrimitiveError::MissingFieldElement))
             }
             Primitive::Felt252(value) => {
+                value.map(|v| Ok(vec![v])).unwrap_or(Err(PrimitiveError::MissingFieldElement))
+            }
+            Primitive::EthAddress(value) => {
                 value.map(|v| Ok(vec![v])).unwrap_or(Err(PrimitiveError::MissingFieldElement))
             }
         }
@@ -471,9 +467,6 @@ mod tests {
         let mut primitive = Primitive::U256(None);
         primitive.set_u256(Some(U256::from(1u128))).unwrap();
         assert_eq!(primitive.as_u256(), Some(U256::from(1u128)));
-        let mut primitive = Primitive::USize(None);
-        primitive.set_usize(Some(1u32)).unwrap();
-        assert_eq!(primitive.as_usize(), Some(1u32));
         let mut primitive = Primitive::Bool(None);
         primitive.set_bool(Some(true)).unwrap();
         assert_eq!(primitive.as_bool(), Some(true));
@@ -486,6 +479,9 @@ mod tests {
         let mut primitive = Primitive::ContractAddress(None);
         primitive.set_contract_address(Some(Felt::from(1u128))).unwrap();
         assert_eq!(primitive.as_contract_address(), Some(Felt::from(1u128)));
+        let mut primitive = Primitive::EthAddress(None);
+        primitive.set_eth_address(Some(Felt::from(1u128))).unwrap();
+        assert_eq!(primitive.as_eth_address(), Some(Felt::from(1u128)));
     }
 
     #[test]
@@ -504,13 +500,16 @@ mod tests {
             (vec![Felt::from(100000u32)], Primitive::U32(Some(100000))),
             (vec![Felt::from(1000000000u64)], Primitive::U64(Some(1000000000))),
             (vec![Felt::from(1000000000000000000u128)], Primitive::U128(Some(1000000000000000000))),
-            (vec![Felt::from(42u32)], Primitive::USize(Some(42))),
             (vec![Felt::from(1u8)], Primitive::Bool(Some(true))),
             (vec![Felt::from(123456789u128)], Primitive::Felt252(Some(Felt::from(123456789)))),
             (vec![Felt::from(987654321u128)], Primitive::ClassHash(Some(Felt::from(987654321)))),
             (
                 vec![Felt::from(123456789u128)],
                 Primitive::ContractAddress(Some(Felt::from(123456789))),
+            ),
+            (
+                vec![Felt::from(123456789u128)],
+                Primitive::EthAddress(Some(Felt::from(123456789))),
             ),
         ];
 

--- a/crates/dojo/types/src/schema.rs
+++ b/crates/dojo/types/src/schema.rs
@@ -349,7 +349,6 @@ impl Ty {
                 Primitive::U32(Some(v)) => Ok(json!(*v)),
                 Primitive::U64(Some(v)) => Ok(json!(v.to_string())),
                 Primitive::U128(Some(v)) => Ok(json!(v.to_string())),
-                Primitive::USize(Some(v)) => Ok(json!(*v)),
                 Primitive::U256(Some(v)) => {
                     let bytes = v.to_be_bytes();
                     let high = u128::from_be_bytes(bytes[..16].try_into().unwrap());
@@ -362,6 +361,7 @@ impl Ty {
                 Primitive::Felt252(Some(v)) => Ok(json!(format!("{:#x}", v))),
                 Primitive::ClassHash(Some(v)) => Ok(json!(format!("{:#x}", v))),
                 Primitive::ContractAddress(Some(v)) => Ok(json!(format!("{:#x}", v))),
+                Primitive::EthAddress(Some(v)) => Ok(json!(format!("{:#x}", v))),
                 _ => Err(PrimitiveError::MissingFieldElement),
             },
             Ty::Struct(s) => {
@@ -448,11 +448,6 @@ impl Ty {
                         *v = s.parse().ok();
                     }
                 }
-                Primitive::USize(v) => {
-                    if let JsonValue::Number(n) = value {
-                        *v = n.as_u64().map(|n| n as u32);
-                    }
-                }
                 Primitive::U256(v) => {
                     if let JsonValue::Object(obj) = value {
                         if let (Some(JsonValue::String(high)), Some(JsonValue::String(low))) =
@@ -479,6 +474,11 @@ impl Ty {
                     }
                 }
                 Primitive::ContractAddress(v) => {
+                    if let JsonValue::String(s) = value {
+                        *v = Felt::from_str(&s).ok();
+                    }
+                }
+                Primitive::EthAddress(v) => {
                     if let JsonValue::String(s) = value {
                         *v = Felt::from_str(&s).ok();
                     }
@@ -719,11 +719,6 @@ fn format_member(m: &Member) -> String {
                     str.push_str(&format!(" = {}", value));
                 }
             }
-            Primitive::USize(value) => {
-                if let Some(value) = value {
-                    str.push_str(&format!(" = {}", value));
-                }
-            }
             Primitive::Bool(value) => {
                 if let Some(value) = value {
                     str.push_str(&format!(" = {}", value));
@@ -740,6 +735,11 @@ fn format_member(m: &Member) -> String {
                 }
             }
             Primitive::ContractAddress(value) => {
+                if let Some(value) = value {
+                    str.push_str(&format!(" = {:#x}", value));
+                }
+            }
+            Primitive::EthAddress(value) => {
                 if let Some(value) = value {
                     str.push_str(&format!(" = {:#x}", value));
                 }

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -192,11 +192,11 @@ fn get_name_from_schema(schema: &Ty) -> String {
             Primitive::U64(_) => "u64".to_string(),
             Primitive::U128(_) => "u128".to_string(),
             Primitive::U256(_) => "u256".to_string(),
-            Primitive::USize(_) => "usize".to_string(),
             Primitive::Bool(_) => "bool".to_string(),
             Primitive::Felt252(_) => "felt252".to_string(),
             Primitive::ClassHash(_) => "ClassHash".to_string(),
             Primitive::ContractAddress(_) => "ContractAddress".to_string(),
+            Primitive::EthAddress(_) => "EthAddress".to_string(),
         },
         Ty::Tuple(t) => {
             format!("({})", t.iter().map(get_name_from_schema).collect::<Vec<_>>().join(", "))

--- a/crates/torii/grpc/proto/schema.proto
+++ b/crates/torii/grpc/proto/schema.proto
@@ -25,11 +25,11 @@ message Primitive {
         uint64 u64 = 9;
         bytes u128 = 10;
         bytes u256 = 11;
-        uint32 usize = 12;
-        bool bool = 13;
-        bytes felt252 = 14;
-        bytes class_hash = 15;
-        bytes contract_address = 16;
+        bool bool = 12;
+        bytes felt252 = 13;
+        bytes class_hash = 14;
+        bytes contract_address = 15;
+        bytes eth_address = 16;
     }
 }
 

--- a/crates/torii/grpc/src/types/schema.rs
+++ b/crates/torii/grpc/src/types/schema.rs
@@ -165,7 +165,6 @@ impl TryFrom<proto::types::Primitive> for Primitive {
             proto::types::primitive::PrimitiveType::U128(bytes) => Primitive::U128(Some(
                 u128::from_be_bytes(bytes.as_slice().try_into().map_err(SchemaError::FromSlice)?),
             )),
-            proto::types::primitive::PrimitiveType::Usize(int) => Primitive::USize(Some(*int)),
             proto::types::primitive::PrimitiveType::Felt252(felt) => {
                 Primitive::Felt252(Some(Felt::from_bytes_be_slice(felt.as_slice())))
             }
@@ -174,6 +173,9 @@ impl TryFrom<proto::types::Primitive> for Primitive {
             }
             proto::types::primitive::PrimitiveType::ContractAddress(felt) => {
                 Primitive::ContractAddress(Some(Felt::from_bytes_be_slice(felt.as_slice())))
+            }
+            proto::types::primitive::PrimitiveType::EthAddress(felt) => {
+                Primitive::EthAddress(Some(Felt::from_bytes_be_slice(felt.as_slice())))
             }
             proto::types::primitive::PrimitiveType::U256(bytes) => Primitive::U256(Some(
                 U256::from_be_bytes(bytes.as_slice().try_into().map_err(SchemaError::FromSlice)?),
@@ -220,9 +222,6 @@ impl From<Primitive> for proto::types::Primitive {
             Primitive::U128(u128) => proto::types::primitive::PrimitiveType::U128(
                 u128.unwrap_or_default().to_be_bytes().to_vec(),
             ),
-            Primitive::USize(usize) => {
-                proto::types::primitive::PrimitiveType::Usize(usize.unwrap_or_default())
-            }
             Primitive::Felt252(felt) => proto::types::primitive::PrimitiveType::Felt252(
                 felt.unwrap_or_default().to_bytes_be().to_vec(),
             ),
@@ -234,6 +233,9 @@ impl From<Primitive> for proto::types::Primitive {
                     felt.unwrap_or_default().to_bytes_be().to_vec(),
                 )
             }
+            Primitive::EthAddress(felt) => proto::types::primitive::PrimitiveType::EthAddress(
+                felt.unwrap_or_default().to_bytes_be().to_vec(),
+            ),
             Primitive::U256(u256) => proto::types::primitive::PrimitiveType::U256(
                 u256.unwrap_or_default().to_be_bytes().to_vec(),
             ),

--- a/crates/torii/sqlite/src/model.rs
+++ b/crates/torii/sqlite/src/model.rs
@@ -315,10 +315,6 @@ pub fn map_row_to_ty(
                         primitive.set_u256(Some(U256::from_be_hex(hex_str)))?;
                     }
                 }
-                Primitive::USize(_) => {
-                    let value = row.try_get::<u32, &str>(column_name)?;
-                    primitive.set_usize(Some(value))?;
-                }
                 Primitive::Bool(_) => {
                     let value = row.try_get::<bool, &str>(column_name)?;
                     primitive.set_bool(Some(value))?;
@@ -343,6 +339,14 @@ pub fn map_row_to_ty(
                     let value = row.try_get::<String, &str>(column_name)?;
                     if !value.is_empty() {
                         primitive.set_contract_address(Some(
+                            Felt::from_str(&value).map_err(ParseError::FromStr)?,
+                        ))?;
+                    }
+                }
+                Primitive::EthAddress(_) => {
+                    let value = row.try_get::<String, &str>(column_name)?;
+                    if !value.is_empty() {
+                        primitive.set_eth_address(Some(
                             Felt::from_str(&value).map_err(ParseError::FromStr)?,
                         ))?;
                     }

--- a/crates/torii/typed-data/src/test.rs
+++ b/crates/torii/typed-data/src/test.rs
@@ -24,11 +24,6 @@ fn test_parse_primitive_to_ty() {
     parse_value_to_ty(&value, &mut ty).unwrap();
     assert_eq!(ty, Ty::Primitive(Primitive::U32(Some(1))));
 
-    let mut ty = Ty::Primitive(Primitive::USize(None));
-    let value = PrimitiveType::Number(Number::from(1u64));
-    parse_value_to_ty(&value, &mut ty).unwrap();
-    assert_eq!(ty, Ty::Primitive(Primitive::USize(Some(1))));
-
     let mut ty = Ty::Primitive(Primitive::U64(None));
     let value = PrimitiveType::Number(Number::from(1u64));
     parse_value_to_ty(&value, &mut ty).unwrap();
@@ -67,6 +62,11 @@ fn test_parse_primitive_to_ty() {
     parse_value_to_ty(&value, &mut ty).unwrap();
     assert_eq!(ty, Ty::Primitive(Primitive::ContractAddress(Some(Felt::ONE))));
 
+    let mut ty = Ty::Primitive(Primitive::EthAddress(None));
+    let value = PrimitiveType::String("1".to_string());
+    parse_value_to_ty(&value, &mut ty).unwrap();
+    assert_eq!(ty, Ty::Primitive(Primitive::EthAddress(Some(Felt::ONE))));
+
     let mut ty = Ty::Primitive(Primitive::Bool(None));
     let value = PrimitiveType::Bool(true);
     parse_value_to_ty(&value, &mut ty).unwrap();
@@ -90,10 +90,6 @@ fn test_map_ty_to_primitive() {
     assert_eq!(value, map_ty_to_primitive(&ty).unwrap());
 
     let ty = Ty::Primitive(Primitive::U32(Some(1)));
-    let value = PrimitiveType::Number(Number::from(1u64));
-    assert_eq!(value, map_ty_to_primitive(&ty).unwrap());
-
-    let ty = Ty::Primitive(Primitive::USize(Some(1)));
     let value = PrimitiveType::Number(Number::from(1u64));
     assert_eq!(value, map_ty_to_primitive(&ty).unwrap());
 
@@ -125,6 +121,10 @@ fn test_map_ty_to_primitive() {
     assert_eq!(value, map_ty_to_primitive(&ty).unwrap());
 
     let ty = Ty::Primitive(Primitive::ContractAddress(Some(Felt::ONE)));
+    let value = PrimitiveType::String("1".to_string());
+    assert_eq!(value, map_ty_to_primitive(&ty).unwrap());
+
+    let ty = Ty::Primitive(Primitive::EthAddress(Some(Felt::ONE)));
     let value = PrimitiveType::String("1".to_string());
     assert_eq!(value, map_ty_to_primitive(&ty).unwrap());
 

--- a/crates/torii/typed-data/src/typed_data.rs
+++ b/crates/torii/typed-data/src/typed_data.rs
@@ -552,9 +552,6 @@ pub fn parse_value_to_ty(value: &PrimitiveType, ty: &mut Ty) -> Result<(), Error
                 Primitive::U64(ref mut u64) => {
                     *u64 = Some(number.as_u64().unwrap());
                 }
-                Primitive::USize(ref mut usize) => {
-                    *usize = Some(number.as_u64().unwrap() as u32);
-                }
                 _ => {
                     return Err(Error::InvalidType(format!(
                         "Invalid number type for {}",
@@ -601,9 +598,6 @@ pub fn parse_value_to_ty(value: &PrimitiveType, ty: &mut Ty) -> Result<(), Error
                 Primitive::U128(v) => {
                     *v = Some(from_str!(string, u128)?);
                 }
-                Primitive::USize(v) => {
-                    *v = Some(from_str!(string, u32)?);
-                }
                 Primitive::Felt252(v) => {
                     *v = Some(Felt::from_str(string).unwrap());
                 }
@@ -611,6 +605,9 @@ pub fn parse_value_to_ty(value: &PrimitiveType, ty: &mut Ty) -> Result<(), Error
                     *v = Some(Felt::from_str(string).unwrap());
                 }
                 Primitive::ContractAddress(v) => {
+                    *v = Some(Felt::from_str(string).unwrap());
+                }
+                Primitive::EthAddress(v) => {
                     *v = Some(Felt::from_str(string).unwrap());
                 }
                 Primitive::Bool(v) => {
@@ -674,7 +671,6 @@ pub fn map_ty_to_primitive(ty: &Ty) -> Result<PrimitiveType, Error> {
             Primitive::U32(n) => Ok(PrimitiveType::Number(Number::from(n.unwrap_or(0)))),
             Primitive::U64(n) => Ok(PrimitiveType::String((n.unwrap_or(0)).to_string())),
             Primitive::U128(n) => Ok(PrimitiveType::String((n.unwrap_or(0)).to_string())),
-            Primitive::USize(n) => Ok(PrimitiveType::Number(Number::from(n.unwrap_or(0)))),
             Primitive::Felt252(f) => {
                 Ok(PrimitiveType::String((f.unwrap_or(Felt::ZERO)).to_string()))
             }
@@ -683,6 +679,9 @@ pub fn map_ty_to_primitive(ty: &Ty) -> Result<PrimitiveType, Error> {
             }
             Primitive::ContractAddress(c) => {
                 Ok(PrimitiveType::String((c.unwrap_or(Felt::ZERO)).to_string()))
+            }
+            Primitive::EthAddress(e) => {
+                Ok(PrimitiveType::String((e.unwrap_or(Felt::ZERO)).to_string()))
             }
             Primitive::U256(u256) => {
                 let mut object = IndexMap::new();
@@ -714,7 +713,6 @@ fn map_ty_type(types: &mut IndexMap<String, Vec<Field>>, name: &str, ty: Ty) -> 
             | Primitive::U16(_)
             | Primitive::U32(_)
             | Primitive::U64(_)
-            | Primitive::USize(_)
             | Primitive::U128(_) => Field::SimpleType(SimpleField {
                 name: name.to_string(),
                 r#type: "u128".to_string(),
@@ -738,6 +736,10 @@ fn map_ty_type(types: &mut IndexMap<String, Vec<Field>>, name: &str, ty: Ty) -> 
             Primitive::ContractAddress(_) => Field::SimpleType(SimpleField {
                 name: name.to_string(),
                 r#type: "ContractAddress".to_string(),
+            }),
+            Primitive::EthAddress(_) => Field::SimpleType(SimpleField {
+                name: name.to_string(),
+                r#type: "EthAddress".to_string(),
             }),
         },
         Ty::Array(array) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced support for Ethereum address handling, including improved conversion, serialization, and integration with storage operations.
  - Added a new `EthAddress` variant to the `Primitive` enum, replacing the previous `USize` variant.

- **Bug Fixes**
  - Removed references to the `USize` type across various functionalities, ensuring consistent handling of primitive types.

- **Tests**
  - Updated test suites to validate the new Ethereum address functionality, removing all references to the `USize` type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->