### PR TITLE
feat(torii): retrieve controllers & usernames graphql and grpc

### DIFF
--- a/crates/torii/graphql/src/constants.rs
+++ b/crates/torii/graphql/src/constants.rs
@@ -9,6 +9,7 @@ pub const EVENT_MESSAGE_TABLE: &str = "event_messages";
 pub const MODEL_TABLE: &str = "models";
 pub const TRANSACTION_TABLE: &str = "transactions";
 pub const METADATA_TABLE: &str = "metadata";
+pub const CONTROLLER_TABLE: &str = "controllers";
 
 pub const ID_COLUMN: &str = "id";
 pub const EVENT_ID_COLUMN: &str = "event_id";
@@ -64,3 +65,6 @@ pub const TOKEN_TRANSFER_NAME: (&str, &str) = ("", "tokenTransfers");
 pub const ORDER_DIR_TYPE_NAME: &str = "OrderDirection";
 pub const ORDER_ASC: &str = "ASC";
 pub const ORDER_DESC: &str = "DESC";
+
+pub const CONTROLLER_TYPE_NAME: &str = "World__Controller";
+pub const CONTROLLER_NAMES: (&str, &str) = ("controller", "controllers");

--- a/crates/torii/graphql/src/mapping.rs
+++ b/crates/torii/graphql/src/mapping.rs
@@ -177,4 +177,13 @@ lazy_static! {
         (Name::new("imagePath"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
     ]);
 
+    pub static ref CONTROLLER_MAPPING: TypeMapping = IndexMap::from([
+        (Name::new("id"), TypeData::Simple(TypeRef::named(TypeRef::ID))),
+        (Name::new("username"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("address"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (
+            Name::new("deployedAt"),
+            TypeData::Simple(TypeRef::named_nn(GraphqlType::DateTime.to_string())),
+        ),
+    ]);
 }

--- a/crates/torii/graphql/src/object/controller.rs
+++ b/crates/torii/graphql/src/object/controller.rs
@@ -1,9 +1,7 @@
 use async_graphql::dynamic::Field;
 
 use super::{BasicObject, ResolvableObject, TypeMapping};
-use crate::constants::{
-    CONTROLLER_NAMES, CONTROLLER_TABLE, CONTROLLER_TYPE_NAME, ID_COLUMN,
-};
+use crate::constants::{CONTROLLER_NAMES, CONTROLLER_TABLE, CONTROLLER_TYPE_NAME, ID_COLUMN};
 use crate::mapping::CONTROLLER_MAPPING;
 use crate::object::{resolve_many, resolve_one};
 
@@ -44,4 +42,4 @@ impl ResolvableObject for ControllerObject {
 
         vec![resolve_one, resolve_many]
     }
-} 
+}

--- a/crates/torii/graphql/src/object/controller.rs
+++ b/crates/torii/graphql/src/object/controller.rs
@@ -1,0 +1,47 @@
+use async_graphql::dynamic::Field;
+
+use super::{BasicObject, ResolvableObject, TypeMapping};
+use crate::constants::{
+    CONTROLLER_NAMES, CONTROLLER_TABLE, CONTROLLER_TYPE_NAME, ID_COLUMN,
+};
+use crate::mapping::CONTROLLER_MAPPING;
+use crate::object::{resolve_many, resolve_one};
+
+#[derive(Debug)]
+pub struct ControllerObject;
+
+impl BasicObject for ControllerObject {
+    fn name(&self) -> (&str, &str) {
+        CONTROLLER_NAMES
+    }
+
+    fn type_name(&self) -> &str {
+        CONTROLLER_TYPE_NAME
+    }
+
+    fn type_mapping(&self) -> &TypeMapping {
+        &CONTROLLER_MAPPING
+    }
+}
+
+impl ResolvableObject for ControllerObject {
+    fn resolvers(&self) -> Vec<Field> {
+        let resolve_one = resolve_one(
+            CONTROLLER_TABLE,
+            ID_COLUMN,
+            self.name().0,
+            self.type_name(),
+            self.type_mapping(),
+        );
+
+        let resolve_many = resolve_many(
+            CONTROLLER_TABLE,
+            ID_COLUMN,
+            self.name().1,
+            self.type_name(),
+            self.type_mapping(),
+        );
+
+        vec![resolve_one, resolve_many]
+    }
+} 

--- a/crates/torii/graphql/src/object/mod.rs
+++ b/crates/torii/graphql/src/object/mod.rs
@@ -1,4 +1,5 @@
 pub mod connection;
+pub mod controller;
 pub mod entity;
 pub mod erc;
 pub mod event;
@@ -8,7 +9,6 @@ pub mod metadata;
 pub mod model;
 pub mod model_data;
 pub mod transaction;
-pub mod controller;
 
 use async_graphql::dynamic::{
     Enum, Field, FieldFuture, FieldValue, InputObject, InputValue, Object, SubscriptionField,

--- a/crates/torii/graphql/src/object/mod.rs
+++ b/crates/torii/graphql/src/object/mod.rs
@@ -8,6 +8,7 @@ pub mod metadata;
 pub mod model;
 pub mod model_data;
 pub mod transaction;
+pub mod controller;
 
 use async_graphql::dynamic::{
     Enum, Field, FieldFuture, FieldValue, InputObject, InputValue, Object, SubscriptionField,

--- a/crates/torii/graphql/src/schema.rs
+++ b/crates/torii/graphql/src/schema.rs
@@ -13,6 +13,7 @@ use super::utils;
 use crate::constants::{
     ERC20_TYPE_NAME, ERC721_TYPE_NAME, QUERY_TYPE_NAME, SUBSCRIPTION_TYPE_NAME, TOKEN_TYPE_NAME,
 };
+use crate::object::controller::ControllerObject;
 use crate::object::erc::erc_token::{Erc20TokenObject, Erc721TokenObject};
 use crate::object::erc::token_balance::ErcBalanceObject;
 use crate::object::erc::token_transfer::ErcTransferObject;
@@ -121,6 +122,7 @@ async fn build_objects(pool: &SqlitePool) -> Result<(Vec<ObjectVariant>, Vec<Uni
         ObjectVariant::Resolvable(Box::new(TransactionObject)),
         ObjectVariant::Resolvable(Box::new(ErcBalanceObject)),
         ObjectVariant::Resolvable(Box::new(ErcTransferObject)),
+        ObjectVariant::Resolvable(Box::new(ControllerObject)),
         ObjectVariant::Basic(Box::new(SocialObject)),
         ObjectVariant::Basic(Box::new(ContentObject)),
         ObjectVariant::Basic(Box::new(PageInfoObject)),

--- a/crates/torii/grpc/proto/types.proto
+++ b/crates/torii/grpc/proto/types.proto
@@ -186,3 +186,9 @@ enum OrderDirection {
     ASC = 0;
     DESC = 1;
 }
+
+message Controller {
+    bytes address = 1;
+    string username = 2;
+    uint64 deployed_at_timestamp = 3;
+}

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -54,6 +54,17 @@ service World {
 
     // Retrieve token balances
     rpc RetrieveTokenBalances (RetrieveTokenBalancesRequest) returns (RetrieveTokenBalancesResponse);
+
+    // Retrieve controllers
+    rpc RetrieveControllers (RetrieveControllersRequest) returns (RetrieveControllersResponse);
+}
+
+message RetrieveControllersRequest {
+    repeated bytes contract_addresses = 1;
+}
+
+message RetrieveControllersResponse {
+    repeated types.Controller controllers = 1;
 }
 
 // A request to update a token balance subscription

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -1057,7 +1057,7 @@ impl DojoWorld {
             )
         };
 
-        let mut db_query = sqlx::query_as::<_, (String, String, u64)>(&query);
+        let mut db_query = sqlx::query_as::<_, (String, String, DateTime<Utc>)>(&query);
         for address in &contract_addresses {
             db_query = db_query.bind(format!("{:#x}", address));
         }
@@ -1069,7 +1069,7 @@ impl DojoWorld {
             .map(|(address, username, deployed_at)| proto::types::Controller {
                 address: address.parse::<Felt>().unwrap().to_bytes_be().to_vec(),
                 username,
-                deployed_at_timestamp: deployed_at,
+                deployed_at_timestamp: deployed_at.timestamp() as u64,
             })
             .collect();
 

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -56,12 +56,13 @@ use crate::proto::types::member_value::ValueType;
 use crate::proto::types::LogicalOperator;
 use crate::proto::world::world_server::WorldServer;
 use crate::proto::world::{
-    RetrieveEntitiesStreamingResponse, RetrieveEventMessagesRequest, RetrieveTokenBalancesRequest,
-    RetrieveTokenBalancesResponse, RetrieveTokensRequest, RetrieveTokensResponse,
-    SubscribeEntitiesRequest, SubscribeEntityResponse, SubscribeEventMessagesRequest,
-    SubscribeEventsResponse, SubscribeIndexerRequest, SubscribeIndexerResponse,
-    SubscribeTokenBalancesResponse, UpdateEventMessagesSubscriptionRequest,
-    UpdateTokenBalancesSubscriptionRequest, WorldMetadataRequest, WorldMetadataResponse,
+    RetrieveControllersRequest, RetrieveControllersResponse, RetrieveEntitiesStreamingResponse,
+    RetrieveEventMessagesRequest, RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse,
+    RetrieveTokensRequest, RetrieveTokensResponse, SubscribeEntitiesRequest,
+    SubscribeEntityResponse, SubscribeEventMessagesRequest, SubscribeEventsResponse,
+    SubscribeIndexerRequest, SubscribeIndexerResponse, SubscribeTokenBalancesResponse,
+    UpdateEventMessagesSubscriptionRequest, UpdateTokenBalancesSubscriptionRequest,
+    WorldMetadataRequest, WorldMetadataResponse,
 };
 use crate::proto::{self};
 use crate::types::schema::SchemaError;
@@ -1042,6 +1043,38 @@ impl DojoWorld {
             .add_subscriber(clause.into_iter().map(|keys| keys.into()).collect())
             .await
     }
+
+    async fn retrieve_controllers(
+        &self,
+        contract_addresses: Vec<Felt>,
+    ) -> Result<proto::world::RetrieveControllersResponse, Error> {
+        let query = if contract_addresses.is_empty() {
+            "SELECT address, username, deployed_at FROM controllers".to_string()
+        } else {
+            format!(
+                "SELECT address, username, deployed_at FROM controllers WHERE address IN ({})",
+                contract_addresses.iter().map(|_| "?".to_string()).collect::<Vec<_>>().join(", ")
+            )
+        };
+
+        let mut db_query = sqlx::query_as::<_, (String, String, u64)>(&query);
+        for address in &contract_addresses {
+            db_query = db_query.bind(format!("{:#x}", address));
+        }
+
+        let rows = db_query.fetch_all(&self.pool).await?;
+
+        let controllers = rows
+            .into_iter()
+            .map(|(address, username, deployed_at)| proto::types::Controller {
+                address: address.parse::<Felt>().unwrap().to_bytes_be().to_vec(),
+                username,
+                deployed_at_timestamp: deployed_at,
+            })
+            .collect();
+
+        Ok(RetrieveControllersResponse { controllers })
+    }
 }
 
 fn process_event_field(data: &str) -> Result<Vec<Vec<u8>>, Error> {
@@ -1269,6 +1302,23 @@ impl proto::world::world_server::World for DojoWorld {
         })?);
 
         Ok(Response::new(WorldMetadataResponse { metadata }))
+    }
+
+    async fn retrieve_controllers(
+        &self,
+        request: Request<RetrieveControllersRequest>,
+    ) -> Result<Response<RetrieveControllersResponse>, Status> {
+        let RetrieveControllersRequest { contract_addresses } = request.into_inner();
+        let contract_addresses = contract_addresses
+            .iter()
+            .map(|address| Felt::from_bytes_be_slice(address))
+            .collect::<Vec<_>>();
+
+        let controllers = self
+            .retrieve_controllers(contract_addresses)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(controllers))
     }
 
     async fn retrieve_tokens(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new message type `Controller` to capture essential details like address, username, and deployment timestamp.
  - Added a new API endpoint to retrieve controller information based on provided contract addresses, enhancing data access capabilities.
  - Expanded GraphQL schema with a new `ControllerObject` for handling controller-related queries.
  - Introduced a new module for controller functionalities within the GraphQL interface.
  - Added new constants and mappings related to the `Controller` entity for improved structure and access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->