### PR TITLE
feat(torii-client): retrieve controllers from client

### DIFF
--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -18,7 +18,7 @@ use torii_grpc::proto::world::{
     RetrieveTokensResponse,
 };
 use torii_grpc::types::schema::Entity;
-use torii_grpc::types::{EntityKeysClause, Event, EventQuery, Query, Token, TokenBalance};
+use torii_grpc::types::{Controller, EntityKeysClause, Event, EventQuery, Query, Token, TokenBalance};
 use torii_relay::client::EventLoop;
 use torii_relay::types::Message;
 
@@ -88,6 +88,14 @@ impl Client {
     /// Returns a read lock on the World metadata that the client is connected to.
     pub fn metadata(&self) -> RwLockReadGuard<'_, WorldMetadata> {
         self.metadata.read()
+    }
+
+    /// Retrieves controllers matching contract addresses.
+    pub async fn controllers(&self, contract_addresses: Vec<Felt>) -> Result<Vec<Controller>, Error> {
+        let mut grpc_client = self.inner.write().await;
+        let RetrieveControllersResponse { controllers } =
+            grpc_client.retrieve_controllers(contract_addresses).await?;
+        Ok(controllers.into_iter().map(TryInto::try_into).collect::<Result<Vec<Controller>, _>>()?)
     }
 
     /// Retrieves tokens matching contract addresses.

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -18,7 +18,9 @@ use torii_grpc::proto::world::{
     RetrieveTokensResponse,
 };
 use torii_grpc::types::schema::Entity;
-use torii_grpc::types::{Controller, EntityKeysClause, Event, EventQuery, Query, Token, TokenBalance};
+use torii_grpc::types::{
+    Controller, EntityKeysClause, Event, EventQuery, Query, Token, TokenBalance,
+};
 use torii_relay::client::EventLoop;
 use torii_relay::types::Message;
 
@@ -91,11 +93,17 @@ impl Client {
     }
 
     /// Retrieves controllers matching contract addresses.
-    pub async fn controllers(&self, contract_addresses: Vec<Felt>) -> Result<Vec<Controller>, Error> {
+    pub async fn controllers(
+        &self,
+        contract_addresses: Vec<Felt>,
+    ) -> Result<Vec<Controller>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveControllersResponse { controllers } =
             grpc_client.retrieve_controllers(contract_addresses).await?;
-        Ok(controllers.into_iter().map(TryInto::try_into).collect::<Result<Vec<Controller>, _>>()?)
+        Ok(controllers
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<Controller>, _>>()?)
     }
 
     /// Retrieves tokens matching contract addresses.

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -14,8 +14,8 @@ use torii_grpc::client::{
     EntityUpdateStreaming, EventUpdateStreaming, IndexerUpdateStreaming, TokenBalanceStreaming,
 };
 use torii_grpc::proto::world::{
-    RetrieveEntitiesResponse, RetrieveEventsResponse, RetrieveTokenBalancesResponse,
-    RetrieveTokensResponse,
+    RetrieveControllersResponse, RetrieveEntitiesResponse, RetrieveEventsResponse,
+    RetrieveTokenBalancesResponse, RetrieveTokensResponse,
 };
 use torii_grpc::types::schema::Entity;
 use torii_grpc::types::{

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -10,15 +10,7 @@ use tonic::codec::CompressionEncoding;
 use tonic::transport::Endpoint;
 
 use crate::proto::world::{
-    world_client, RetrieveControllersRequest, RetrieveEntitiesRequest, RetrieveEntitiesResponse,
-    RetrieveEventMessagesRequest, RetrieveEventsRequest, RetrieveEventsResponse,
-    RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse, RetrieveTokensRequest,
-    RetrieveTokensResponse, SubscribeEntitiesRequest, SubscribeEntityResponse,
-    SubscribeEventMessagesRequest, SubscribeEventsRequest, SubscribeEventsResponse,
-    SubscribeIndexerRequest, SubscribeIndexerResponse, SubscribeModelsRequest,
-    SubscribeModelsResponse, SubscribeTokenBalancesResponse, UpdateEntitiesSubscriptionRequest,
-    UpdateEventMessagesSubscriptionRequest, UpdateTokenBalancesSubscriptionRequest,
-    WorldMetadataRequest,
+    world_client, RetrieveControllersRequest, RetrieveControllersResponse, RetrieveEntitiesRequest, RetrieveEntitiesResponse, RetrieveEventMessagesRequest, RetrieveEventsRequest, RetrieveEventsResponse, RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse, RetrieveTokensRequest, RetrieveTokensResponse, SubscribeEntitiesRequest, SubscribeEntityResponse, SubscribeEventMessagesRequest, SubscribeEventsRequest, SubscribeEventsResponse, SubscribeIndexerRequest, SubscribeIndexerResponse, SubscribeModelsRequest, SubscribeModelsResponse, SubscribeTokenBalancesResponse, UpdateEntitiesSubscriptionRequest, UpdateEventMessagesSubscriptionRequest, UpdateTokenBalancesSubscriptionRequest, WorldMetadataRequest
 };
 use crate::types::schema::{Entity, SchemaError};
 use crate::types::{
@@ -100,7 +92,12 @@ impl WorldClient {
         contract_addresses: Vec<Felt>,
     ) -> Result<RetrieveControllersResponse, Error> {
         self.inner
-            .retrieve_controllers(RetrieveControllersRequest { contract_addresses })
+            .retrieve_controllers(RetrieveControllersRequest {
+                contract_addresses: contract_addresses
+                    .into_iter()
+                    .map(|c| c.to_bytes_be().to_vec())
+                    .collect(),
+            })
             .await
             .map_err(Error::Grpc)
             .map(|res| res.into_inner())

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -10,7 +10,15 @@ use tonic::codec::CompressionEncoding;
 use tonic::transport::Endpoint;
 
 use crate::proto::world::{
-    world_client, RetrieveControllersRequest, RetrieveControllersResponse, RetrieveEntitiesRequest, RetrieveEntitiesResponse, RetrieveEventMessagesRequest, RetrieveEventsRequest, RetrieveEventsResponse, RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse, RetrieveTokensRequest, RetrieveTokensResponse, SubscribeEntitiesRequest, SubscribeEntityResponse, SubscribeEventMessagesRequest, SubscribeEventsRequest, SubscribeEventsResponse, SubscribeIndexerRequest, SubscribeIndexerResponse, SubscribeModelsRequest, SubscribeModelsResponse, SubscribeTokenBalancesResponse, UpdateEntitiesSubscriptionRequest, UpdateEventMessagesSubscriptionRequest, UpdateTokenBalancesSubscriptionRequest, WorldMetadataRequest
+    world_client, RetrieveControllersRequest, RetrieveControllersResponse, RetrieveEntitiesRequest,
+    RetrieveEntitiesResponse, RetrieveEventMessagesRequest, RetrieveEventsRequest,
+    RetrieveEventsResponse, RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse,
+    RetrieveTokensRequest, RetrieveTokensResponse, SubscribeEntitiesRequest,
+    SubscribeEntityResponse, SubscribeEventMessagesRequest, SubscribeEventsRequest,
+    SubscribeEventsResponse, SubscribeIndexerRequest, SubscribeIndexerResponse,
+    SubscribeModelsRequest, SubscribeModelsResponse, SubscribeTokenBalancesResponse,
+    UpdateEntitiesSubscriptionRequest, UpdateEventMessagesSubscriptionRequest,
+    UpdateTokenBalancesSubscriptionRequest, WorldMetadataRequest,
 };
 use crate::types::schema::{Entity, SchemaError};
 use crate::types::{

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -10,13 +10,13 @@ use tonic::codec::CompressionEncoding;
 use tonic::transport::Endpoint;
 
 use crate::proto::world::{
-    world_client, RetrieveEntitiesRequest, RetrieveEntitiesResponse, RetrieveEventMessagesRequest,
-    RetrieveEventsRequest, RetrieveEventsResponse, RetrieveTokenBalancesRequest,
-    RetrieveTokenBalancesResponse, RetrieveTokensRequest, RetrieveTokensResponse,
-    SubscribeEntitiesRequest, SubscribeEntityResponse, SubscribeEventMessagesRequest,
-    SubscribeEventsRequest, SubscribeEventsResponse, SubscribeIndexerRequest,
-    SubscribeIndexerResponse, SubscribeModelsRequest, SubscribeModelsResponse,
-    SubscribeTokenBalancesResponse, UpdateEntitiesSubscriptionRequest,
+    world_client, RetrieveControllersRequest, RetrieveEntitiesRequest, RetrieveEntitiesResponse,
+    RetrieveEventMessagesRequest, RetrieveEventsRequest, RetrieveEventsResponse,
+    RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse, RetrieveTokensRequest,
+    RetrieveTokensResponse, SubscribeEntitiesRequest, SubscribeEntityResponse,
+    SubscribeEventMessagesRequest, SubscribeEventsRequest, SubscribeEventsResponse,
+    SubscribeIndexerRequest, SubscribeIndexerResponse, SubscribeModelsRequest,
+    SubscribeModelsResponse, SubscribeTokenBalancesResponse, UpdateEntitiesSubscriptionRequest,
     UpdateEventMessagesSubscriptionRequest, UpdateTokenBalancesSubscriptionRequest,
     WorldMetadataRequest,
 };
@@ -93,6 +93,17 @@ impl WorldClient {
                     .ok_or(Error::Schema(SchemaError::MissingExpectedData("metadata".to_string())))
             })
             .and_then(|metadata| metadata.try_into().map_err(Error::ParseStr))
+    }
+
+    pub async fn retrieve_controllers(
+        &mut self,
+        contract_addresses: Vec<Felt>,
+    ) -> Result<RetrieveControllersResponse, Error> {
+        self.inner
+            .retrieve_controllers(RetrieveControllersRequest { contract_addresses })
+            .await
+            .map_err(Error::Grpc)
+            .map(|res| res.into_inner())
     }
 
     pub async fn retrieve_tokens(

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -19,6 +19,24 @@ use crate::proto::{self};
 pub mod schema;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
+pub struct Controller {
+    pub address: Felt,
+    pub username: String,
+    pub deployed_at: u64,
+}
+
+impl TryFrom<proto::types::Controller> for Controller {
+    type Error = SchemaError;
+    fn try_from(value: proto::types::Controller) -> Result<Self, Self::Error> {
+        Ok(Self {
+            address: Felt::from_bytes_be_slice(&value.address),
+            username: value.username,
+            deployed_at: value.deployed_at_timestamp,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
 pub struct Token {
     pub contract_address: Felt,
     pub name: String,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled retrieval of controller details based on specified contract addresses.
	- Introduced a new, structured representation for controller data that includes address, username, and deployment time.
	- Added an asynchronous method to retrieve controllers from the client interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->