### PR TITLE
feat(katana): automatically close block if resources limit reached

### DIFF
--- a/crates/dojo/test-utils/src/sequencer.rs
+++ b/crates/dojo/test-utils/src/sequencer.rs
@@ -6,6 +6,7 @@ use katana_core::constants::DEFAULT_SEQUENCER_ADDRESS;
 use katana_executor::implementation::blockifier::BlockifierFactory;
 use katana_node::config::dev::DevConfig;
 use katana_node::config::rpc::{RpcConfig, DEFAULT_RPC_ADDR};
+use katana_node::config::sequencing::SequencingConfig;
 pub use katana_node::config::*;
 use katana_node::LaunchedNode;
 use katana_primitives::chain::ChainId;

--- a/crates/katana/chain-spec/src/rollup/utils.rs
+++ b/crates/katana/chain-spec/src/rollup/utils.rs
@@ -336,7 +336,7 @@ mod tests {
 
     use alloy_primitives::U256;
     use katana_executor::implementation::blockifier::BlockifierFactory;
-    use katana_executor::ExecutorFactory;
+    use katana_executor::{BlockLimits, ExecutorFactory};
     use katana_primitives::chain::ChainId;
     use katana_primitives::contract::Nonce;
     use katana_primitives::env::CfgEnv;
@@ -386,6 +386,7 @@ mod tests {
                 ..Default::default()
             },
             Default::default(),
+            BlockLimits::max(),
         )
     }
 

--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -19,7 +19,8 @@ use katana_node::config::metrics::MetricsConfig;
 use katana_node::config::rpc::RpcConfig;
 #[cfg(feature = "server")]
 use katana_node::config::rpc::{RpcModuleKind, RpcModulesList};
-use katana_node::config::{Config, SequencingConfig};
+use katana_node::config::sequencing::SequencingConfig;
+use katana_node::config::Config;
 use katana_primitives::chain::ChainId;
 use katana_primitives::genesis::allocation::DevAllocationsGenerator;
 use katana_primitives::genesis::constant::DEFAULT_PREFUNDED_ACCOUNT_BALANCE;
@@ -57,6 +58,10 @@ pub struct NodeArgs {
     #[arg(short, long)]
     #[arg(value_name = "MILLISECONDS")]
     pub block_time: Option<u64>,
+
+    #[arg(long = "sequencing.block-max-cairo-steps")]
+    #[arg(value_name = "TOTAL")]
+    pub block_cairo_steps_limit: Option<u64>,
 
     /// Directory path of the database to initialize from.
     ///
@@ -187,7 +192,11 @@ impl NodeArgs {
     }
 
     fn sequencer_config(&self) -> SequencingConfig {
-        SequencingConfig { block_time: self.block_time, no_mining: self.no_mining }
+        SequencingConfig {
+            block_time: self.block_time,
+            no_mining: self.no_mining,
+            block_cairo_steps_limit: self.block_cairo_steps_limit,
+        }
     }
 
     fn rpc_config(&self) -> Result<RpcConfig> {

--- a/crates/katana/core/tests/backend.rs
+++ b/crates/katana/core/tests/backend.rs
@@ -5,6 +5,7 @@ use katana_core::backend::gas_oracle::GasOracle;
 use katana_core::backend::storage::{Blockchain, Database};
 use katana_core::backend::Backend;
 use katana_executor::implementation::blockifier::BlockifierFactory;
+use katana_executor::BlockLimits;
 use katana_primitives::chain::ChainId;
 use katana_primitives::env::CfgEnv;
 use katana_primitives::felt;
@@ -25,6 +26,7 @@ fn executor(chain_spec: &ChainSpec) -> BlockifierFactory {
             ..Default::default()
         },
         Default::default(),
+        BlockLimits::max(),
     )
 }
 

--- a/crates/katana/executor/benches/concurrent.rs
+++ b/crates/katana/executor/benches/concurrent.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkGroup, Criterion};
 use katana_executor::implementation::blockifier::BlockifierFactory;
-use katana_executor::{ExecutionFlags, ExecutorFactory};
+use katana_executor::{BlockLimits, ExecutionFlags, ExecutorFactory};
 use katana_primitives::env::{BlockEnv, CfgEnv};
 use katana_primitives::transaction::ExecutableTxWithHash;
 use katana_provider::test_utils;
@@ -44,7 +44,7 @@ fn blockifier(
     (block_env, cfg_env): (BlockEnv, CfgEnv),
     tx: ExecutableTxWithHash,
 ) {
-    let factory = Arc::new(BlockifierFactory::new(cfg_env, flags.clone()));
+    let factory = Arc::new(BlockifierFactory::new(cfg_env, flags.clone(), BlockLimits::max()));
 
     group.bench_function("Blockifier.1", |b| {
         b.iter_batched(

--- a/crates/katana/executor/benches/execution.rs
+++ b/crates/katana/executor/benches/execution.rs
@@ -49,7 +49,9 @@ fn blockifier(
 
                 (state, &block_context, execution_flags, tx.clone())
             },
-            |(mut state, block_context, flags, tx)| transact(&mut state, block_context, flags, tx),
+            |(mut state, block_context, flags, tx)| {
+                transact(&mut state, block_context, flags, tx, None)
+            },
             BatchSize::SmallInput,
         )
     });

--- a/crates/katana/executor/src/abstraction/error.rs
+++ b/crates/katana/executor/src/abstraction/error.rs
@@ -4,7 +4,13 @@ use katana_primitives::Felt;
 
 /// Errors that can be returned by the executor.
 #[derive(Debug, thiserror::Error)]
-pub enum ExecutorError {}
+pub enum ExecutorError {
+    #[error("Limits exhausted")]
+    LimitsExhausted,
+
+    #[error(transparent)]
+    Other(Box<dyn core::error::Error + Send + Sync + 'static>),
+}
 
 /// Errors that can occur during the transaction execution.
 #[derive(Debug, Clone, thiserror::Error)]

--- a/crates/katana/executor/src/abstraction/executor.rs
+++ b/crates/katana/executor/src/abstraction/executor.rs
@@ -5,6 +5,7 @@ use katana_primitives::transaction::{ExecutableTxWithHash, TxWithHash};
 use katana_primitives::Felt;
 use katana_provider::traits::state::StateProvider;
 
+use super::ExecutorError;
 use crate::{
     EntryPointCall, ExecutionError, ExecutionFlags, ExecutionOutput, ExecutionResult,
     ExecutorResult, ResultAndStates,
@@ -38,10 +39,11 @@ pub trait BlockExecutor<'a>: ExecutorExt + Send + Sync + core::fmt::Debug {
     /// Executes the given block.
     fn execute_block(&mut self, block: ExecutableBlock) -> ExecutorResult<()>;
 
+    /// Execute transactions and returns the total number of transactions that was executed.
     fn execute_transactions(
         &mut self,
         transactions: Vec<ExecutableTxWithHash>,
-    ) -> ExecutorResult<()>;
+    ) -> ExecutorResult<(usize, Option<ExecutorError>)>;
 
     /// Takes the output state of the executor.
     fn take_execution_output(&mut self) -> ExecutorResult<ExecutionOutput>;

--- a/crates/katana/executor/src/abstraction/mod.rs
+++ b/crates/katana/executor/src/abstraction/mod.rs
@@ -17,6 +17,19 @@ use katana_trie::MultiProof;
 
 pub type ExecutorResult<T> = Result<T, error::ExecutorError>;
 
+/// See <https://docs.starknet.io/chain-info/#current_limits>.
+#[derive(Debug, Clone, Default)]
+pub struct BlockLimits {
+    /// The maximum number of Cairo steps that can be completed within each block.
+    pub cairo_steps: u64,
+}
+
+impl BlockLimits {
+    pub fn max() -> Self {
+        Self { cairo_steps: u64::MAX }
+    }
+}
+
 /// Transaction execution simulation flags.
 ///
 /// These flags can be used to control the behavior of the transaction execution, such as skipping

--- a/crates/katana/executor/src/implementation/blockifier/error.rs
+++ b/crates/katana/executor/src/implementation/blockifier/error.rs
@@ -1,3 +1,4 @@
+use blockifier::blockifier::transaction_executor::TransactionExecutorError;
 use blockifier::execution::errors::{EntryPointExecutionError, PreExecutionError};
 use blockifier::execution::execution_utils::format_panic_data;
 use blockifier::state::errors::StateError;
@@ -6,7 +7,7 @@ use blockifier::transaction::errors::{
 };
 
 use crate::implementation::blockifier::utils::to_address;
-use crate::ExecutionError;
+use crate::{ExecutionError, ExecutorError};
 
 impl From<TransactionExecutionError> for ExecutionError {
     fn from(error: TransactionExecutionError) -> Self {
@@ -97,6 +98,16 @@ impl From<StateError> for ExecutionError {
         match error {
             StateError::UndeclaredClassHash(hash) => Self::UndeclaredClass(hash.0),
             e => Self::Other(e.to_string()),
+        }
+    }
+}
+
+impl From<TransactionExecutorError> for ExecutorError {
+    fn from(value: TransactionExecutorError) -> Self {
+        match value {
+            TransactionExecutorError::BlockFull => Self::LimitsExhausted,
+            TransactionExecutorError::StateError(e) => Self::Other(e.into()),
+            TransactionExecutorError::TransactionExecutionError(e) => Self::Other(e.into()),
         }
     }
 }

--- a/crates/katana/executor/src/implementation/noop.rs
+++ b/crates/katana/executor/src/implementation/noop.rs
@@ -102,8 +102,7 @@ impl<'a> BlockExecutor<'a> for NoopExecutor {
         &mut self,
         transactions: Vec<ExecutableTxWithHash>,
     ) -> ExecutorResult<(usize, Option<ExecutorError>)> {
-        let _ = transactions;
-        Ok((0, None))
+        Ok((transactions.len(), None))
     }
 
     fn take_execution_output(&mut self) -> ExecutorResult<ExecutionOutput> {

--- a/crates/katana/executor/src/implementation/noop.rs
+++ b/crates/katana/executor/src/implementation/noop.rs
@@ -13,7 +13,7 @@ use crate::abstraction::{
     BlockExecutor, EntryPointCall, ExecutionFlags, ExecutionOutput, ExecutionResult, ExecutorExt,
     ExecutorFactory, ExecutorResult, ResultAndStates,
 };
-use crate::ExecutionError;
+use crate::{ExecutionError, ExecutorError};
 
 /// A no-op executor factory. Creates an executor that does nothing.
 #[derive(Debug, Default)]
@@ -101,9 +101,9 @@ impl<'a> BlockExecutor<'a> for NoopExecutor {
     fn execute_transactions(
         &mut self,
         transactions: Vec<ExecutableTxWithHash>,
-    ) -> ExecutorResult<()> {
+    ) -> ExecutorResult<(usize, Option<ExecutorError>)> {
         let _ = transactions;
-        Ok(())
+        Ok((0, None))
     }
 
     fn take_execution_output(&mut self) -> ExecutorResult<ExecutionOutput> {

--- a/crates/katana/executor/tests/fixtures/mod.rs
+++ b/crates/katana/executor/tests/fixtures/mod.rs
@@ -266,12 +266,12 @@ pub fn executor_factory<EF: ExecutorFactory>(
 #[cfg(feature = "blockifier")]
 pub mod blockifier {
     use katana_executor::implementation::blockifier::BlockifierFactory;
-    use katana_executor::ExecutionFlags;
+    use katana_executor::{BlockLimits, ExecutionFlags};
 
     use super::{cfg, flags, CfgEnv};
 
     #[rstest::fixture]
     pub fn factory(cfg: CfgEnv, #[with(true)] flags: ExecutionFlags) -> BlockifierFactory {
-        BlockifierFactory::new(cfg, flags)
+        BlockifierFactory::new(cfg, flags, BlockLimits::max())
     }
 }

--- a/crates/katana/node/src/config/mod.rs
+++ b/crates/katana/node/src/config/mod.rs
@@ -6,6 +6,7 @@ pub mod execution;
 pub mod fork;
 pub mod metrics;
 pub mod rpc;
+pub mod sequencing;
 
 use db::DbConfig;
 use dev::DevConfig;
@@ -15,6 +16,7 @@ use katana_chain_spec::ChainSpec;
 use katana_core::service::messaging::MessagingConfig;
 use metrics::MetricsConfig;
 use rpc::RpcConfig;
+use sequencing::SequencingConfig;
 
 /// Node configurations.
 ///
@@ -47,16 +49,4 @@ pub struct Config {
 
     /// Development options.
     pub dev: DevConfig,
-}
-
-/// Configurations related to block production.
-#[derive(Debug, Clone, Default)]
-pub struct SequencingConfig {
-    /// The time in milliseconds for a block to be produced.
-    pub block_time: Option<u64>,
-
-    /// Disable automatic block production.
-    ///
-    /// Allowing block to only be produced manually.
-    pub no_mining: bool,
 }

--- a/crates/katana/node/src/config/sequencing.rs
+++ b/crates/katana/node/src/config/sequencing.rs
@@ -1,0 +1,29 @@
+use katana_executor::BlockLimits;
+
+/// Configurations related to block production.
+#[derive(Debug, Clone, Default)]
+pub struct SequencingConfig {
+    /// The time in milliseconds for a block to be produced.
+    pub block_time: Option<u64>,
+
+    /// Disable automatic block production.
+    ///
+    /// Allowing block to only be produced manually.
+    pub no_mining: bool,
+
+    /// The maximum number of Cairo steps in a block.
+    //
+    /// The block will automatically be closed when the accumulated Cairo steps across all the
+    /// transactions has reached this limit.
+    ///
+    /// NOTE: This only affect interval block production.
+    ///
+    /// See <https://docs.starknet.io/chain-info/#current_limits>.
+    pub block_cairo_steps_limit: Option<u64>,
+}
+
+impl SequencingConfig {
+    pub fn block_limits(&self) -> BlockLimits {
+        BlockLimits { cairo_steps: self.block_cairo_steps_limit.unwrap_or(u64::MAX) }
+    }
+}

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -182,7 +182,11 @@ pub async fn build(mut config: Config) -> Result<Node> {
         .with_account_validation(config.dev.account_validation)
         .with_fee(config.dev.fee);
 
-    let executor_factory = Arc::new(BlockifierFactory::new(cfg_env, execution_flags));
+    let executor_factory = Arc::new(BlockifierFactory::new(
+        cfg_env,
+        execution_flags,
+        config.sequencing.block_limits(),
+    ));
 
     // --- build backend
 

--- a/crates/katana/rpc/rpc/tests/dev.rs
+++ b/crates/katana/rpc/rpc/tests/dev.rs
@@ -1,5 +1,5 @@
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
-use katana_node::config::SequencingConfig;
+use katana_node::config::sequencing::SequencingConfig;
 use katana_provider::traits::block::{BlockNumberProvider, BlockProvider};
 use katana_provider::traits::env::BlockEnvProvider;
 use katana_rpc_api::dev::DevApiClient;

--- a/crates/katana/rpc/rpc/tests/forking.rs
+++ b/crates/katana/rpc/rpc/tests/forking.rs
@@ -3,7 +3,7 @@ use assert_matches::assert_matches;
 use cainome::rs::abigen_legacy;
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use katana_node::config::fork::ForkingConfig;
-use katana_node::config::SequencingConfig;
+use katana_node::config::sequencing::SequencingConfig;
 use katana_primitives::block::{BlockHash, BlockHashOrNumber, BlockIdOrTag, BlockNumber, BlockTag};
 use katana_primitives::chain::NamedChainId;
 use katana_primitives::event::MaybeForkedContinuationToken;

--- a/crates/katana/rpc/rpc/tests/messaging.rs
+++ b/crates/katana/rpc/rpc/tests/messaging.rs
@@ -11,7 +11,7 @@ use cainome::rs::abigen;
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use dojo_utils::TransactionWaiter;
 use katana_core::service::messaging::MessagingConfig;
-use katana_node::config::SequencingConfig;
+use katana_node::config::sequencing::SequencingConfig;
 use katana_primitives::felt;
 use katana_primitives::utils::transaction::{
     compute_l1_handler_tx_hash, compute_l1_to_l2_message_hash, compute_l2_to_l1_message_hash,

--- a/crates/katana/rpc/rpc/tests/proofs.rs
+++ b/crates/katana/rpc/rpc/tests/proofs.rs
@@ -5,7 +5,7 @@ use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use jsonrpsee::http_client::HttpClientBuilder;
 use katana_chain_spec::ChainSpec;
 use katana_node::config::rpc::DEFAULT_RPC_MAX_PROOF_KEYS;
-use katana_node::config::SequencingConfig;
+use katana_node::config::sequencing::SequencingConfig;
 use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::contract::{StorageKey, StorageValue};

--- a/crates/katana/rpc/rpc/tests/saya.rs
+++ b/crates/katana/rpc/rpc/tests/saya.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use dojo_utils::TransactionWaiter;
 use jsonrpsee::http_client::HttpClientBuilder;
-use katana_node::config::SequencingConfig;
+use katana_node::config::sequencing::SequencingConfig;
 use katana_primitives::block::{BlockIdOrTag, BlockTag};
 use katana_rpc_api::dev::DevApiClient;
 use katana_rpc_api::saya::SayaApiClient;

--- a/crates/katana/rpc/rpc/tests/starknet.rs
+++ b/crates/katana/rpc/rpc/tests/starknet.rs
@@ -9,7 +9,7 @@ use common::split_felt;
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use indexmap::IndexSet;
 use jsonrpsee::http_client::HttpClientBuilder;
-use katana_node::config::SequencingConfig;
+use katana_node::config::sequencing::SequencingConfig;
 use katana_primitives::event::ContinuationToken;
 use katana_primitives::genesis::constant::{
     DEFAULT_ACCOUNT_CLASS_HASH, DEFAULT_ETH_FEE_TOKEN_ADDRESS, DEFAULT_PREFUNDED_ACCOUNT_BALANCE,

--- a/crates/katana/rpc/rpc/tests/torii.rs
+++ b/crates/katana/rpc/rpc/tests/torii.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use dojo_utils::TransactionWaiter;
 use jsonrpsee::http_client::HttpClientBuilder;
-use katana_node::config::SequencingConfig;
+use katana_node::config::sequencing::SequencingConfig;
 use katana_rpc_api::dev::DevApiClient;
 use katana_rpc_api::starknet::StarknetApiClient;
 use katana_rpc_api::torii::ToriiApiClient;


### PR DESCRIPTION
Add resource limit parameter for interval block mining. Blocks will now be prompted to close when the total execution resources of their transactions reaches this configurable threshold. Configure via the new `--sequencing.block-max-cairo-steps` CLI argument.

---

Transactions that have been queued to the block producer, but is unable to be included in the current block due to the resources limit, will be pushed to the next block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line option for setting a maximum limit on Cairo steps per block, giving users more granular control over block production.
	- Added enhanced sequencing configuration settings that allow customization of block timing and mining behavior.

- **Enhancements**
	- Improved transaction handling by better managing block capacity and error reporting during block production.
	- Streamlined configuration integration to provide more reliable and adaptive block execution across the system.
	- Enhanced clarity and efficiency in testing logic for block production.
	- Added a new error handling mechanism for transaction execution, providing more detailed feedback on execution outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->