### PR TITLE
feat: remove `starknet-messaging` feature

### DIFF
--- a/bin/katana/Cargo.toml
+++ b/bin/katana/Cargo.toml
@@ -45,4 +45,3 @@ default = [ "jemalloc", "katana-cli/slot" ]
 
 init-custom-settlement-chain = [  ]
 jemalloc = [  ]
-starknet-messaging = [ "katana-cli/starknet-messaging" ]

--- a/crates/katana/cli/Cargo.toml
+++ b/crates/katana/cli/Cargo.toml
@@ -37,4 +37,3 @@ starknet.workspace = true
 default = [ "server", "slot" ]
 server = [  ]
 slot = [ "dep:katana-slot-controller", "katana-chain-spec/controller" ]
-starknet-messaging = [ "katana-node/starknet-messaging" ]

--- a/crates/katana/contracts/messaging/README.md
+++ b/crates/katana/contracts/messaging/README.md
@@ -121,10 +121,7 @@ How to run the scripts:
 
 ```bash
    # From installed Katana.
-   katana --messaging crates/katana/contracts/messaging/l3.messaging.json -p 6060`
-
-   # Dev mode
-   cargo run --bin katana --features "starknet-messaging" -- --messaging crates/katana/contracts/messaging/l3.messaging.json -p 6060
+   katana --messaging crates/katana/contracts/messaging/l3.messaging.json -p 6060
 ```
 
 - Open an other terminal and `cd ~/dojo/crates/katana/core/contracts/messaging`.

--- a/crates/katana/core/Cargo.toml
+++ b/crates/katana/core/Cargo.toml
@@ -38,7 +38,7 @@ url.workspace = true
 
 alloy-primitives = { workspace = true, features = [ "serde" ] }
 alloy-sol-types = { workspace = true, default-features = false, features = [ "json" ] }
-starknet-crypto = { workspace = true, optional = true }
+starknet-crypto.workspace = true
 
 alloy-contract = { workspace = true, default-features = false }
 alloy-network = { workspace = true, default-features = false }
@@ -55,9 +55,6 @@ rand.workspace = true
 rstest.workspace = true
 tempfile.workspace = true
 pprof.workspace = true
-
-[features]
-starknet-messaging = [ "dep:starknet-crypto" ]
 
 [[bench]]
 name = "commit"

--- a/crates/katana/core/src/service/messaging/mod.rs
+++ b/crates/katana/core/src/service/messaging/mod.rs
@@ -17,7 +17,7 @@
 //! updates on Ethereum, since the process of proving and verifying of state updates, and then
 //! posting in on the settlement layer are not yet present in Katana.
 //!
-//! Katana also has a `starknet-messaging` feature, where an opiniated implementation of L2 <-> L3
+//! Katana also has starknet messaging built-in, where an opiniated implementation of L2 <-> L3
 //! messaging is implemented using Starknet as settlement chain.
 //!
 //! With this feature, Katana also has the capability to directly send `invoke` transactions to a
@@ -34,7 +34,6 @@
 
 mod ethereum;
 mod service;
-#[cfg(feature = "starknet-messaging")]
 mod starknet;
 
 use std::future::Future;
@@ -55,12 +54,10 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, info, trace};
 
 pub use self::service::{MessagingOutcome, MessagingService};
-#[cfg(feature = "starknet-messaging")]
 use self::starknet::StarknetMessaging;
 
 pub(crate) const LOG_TARGET: &str = "messaging";
 pub(crate) const CONFIG_CHAIN_ETHEREUM: &str = "ethereum";
-#[cfg(feature = "starknet-messaging")]
 pub(crate) const CONFIG_CHAIN_STARKNET: &str = "starknet";
 
 type MessengerResult<T> = Result<T, Error>;
@@ -170,7 +167,6 @@ pub trait Messenger {
 #[derive(Debug)]
 pub enum MessengerMode {
     Ethereum(EthereumMessaging),
-    #[cfg(feature = "starknet-messaging")]
     Starknet(StarknetMessaging),
 }
 
@@ -188,7 +184,6 @@ impl MessengerMode {
                 }
             },
 
-            #[cfg(feature = "starknet-messaging")]
             CONFIG_CHAIN_STARKNET => match StarknetMessaging::new(config).await {
                 Ok(m_sn) => {
                     info!(target: LOG_TARGET, "Messaging enabled [Starknet].");

--- a/crates/katana/core/src/service/messaging/service.rs
+++ b/crates/katana/core/src/service/messaging/service.rs
@@ -100,7 +100,6 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
                 Ok((block_num, txs_count))
             }
 
-            #[cfg(feature = "starknet-messaging")]
             MessengerMode::Starknet(inner) => {
                 let (block_num, txs) =
                     inner.gather_messages(from_block, max_block, backend.chain_spec.id()).await?;
@@ -146,7 +145,6 @@ impl<EF: ExecutorFactory> MessagingService<EF> {
                     Ok(Some((block_num, hashes.len())))
                 }
 
-                #[cfg(feature = "starknet-messaging")]
                 MessengerMode::Starknet(inner) => {
                     let hashes = inner.send_messages(&messages).await.map(|hashes| {
                         hashes.iter().map(|h| format!("{h:#x}")).collect::<Vec<_>>()

--- a/crates/katana/node/Cargo.toml
+++ b/crates/katana/node/Cargo.toml
@@ -50,7 +50,6 @@ vergen = { version = "9.0.0", features = [ "build", "cargo", "emit_and_set" ] }
 vergen-gitcl = { version = "1.0.0", features = [ "build", "cargo", "rustc", "si" ] }
 
 [features]
-starknet-messaging = [ "katana-core/starknet-messaging" ]
 # experimental feature to test katana full node mode
 full-node = [ "dep:katana-feeder-gateway", "dep:katana-provider", "dep:tokio" ]
 


### PR DESCRIPTION
`starknet-messaging` feature was added as an initial work to explore appchains on katana.
Now that appchains are unlocked, this feature is by default included in Katana.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the legacy Starknet messaging support to streamline the messaging functionality.
- **Documentation**
	- Updated command-line instructions for starting messaging. Users should now launch messaging with the simplified command syntax (e.g., using "katana --messaging …") without legacy feature flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->