### PR TITLE
feat(katana): allow specifying multiple values w/o wrapping in quotes

### DIFF
--- a/bin/katana/src/cli/init/slot.rs
+++ b/bin/katana/src/cli/init/slot.rs
@@ -36,7 +36,7 @@ pub struct SlotArgs {
     ///
     /// where the total number of pairs determine how many paymaster accounts will be created.
     #[arg(requires_all = ["id", "slot"])]
-    #[arg(long = "slot.paymasters", value_delimiter = ' ')]
+    #[arg(long = "slot.paymasters", value_delimiter = ' ', num_args = 1..)]
     pub paymaster_accounts: Option<Vec<PaymasterAccountArgs>>,
 }
 
@@ -188,8 +188,9 @@ mod tests {
             "--id",
             "--slot",
             "--slot.paymasters",
-            // Must be in one argument because the shell splits the argument otherwise.
-            "0x1,0x2 0x1,0x3 0x1,0x4",
+            "0x1,0x2",
+            "0x1,0x3",
+            "0x1,0x4",
         ]);
 
         let paymasters = slot.paymaster_accounts.unwrap();

--- a/bin/katana/src/cli/init/slot.rs
+++ b/bin/katana/src/cli/init/slot.rs
@@ -21,22 +21,19 @@ pub struct SlotArgs {
     /// Specify the number of paymaster accounts to create.
     ///
     /// This argument accepts a list of values, where each value is a pair of public key and salt
-    /// separated by a comma. If more than one pair is provided, the double quotes are required to
-    /// prevent the shell from prematurely splitting the argument.
+    /// separated by a comma.
     ///
     /// For example:
     ///
-    /// ```
-    /// --slot.paymasters 0x1,0x2
-    /// ```
+    /// 0x1,0x2
     ///
-    /// ```
-    /// --slot.paymasters "0x1,0x2 0x3,0x4 0x5,0x6"
-    /// ```
+    /// multiple values can be provided by separating them with spaces:
+    ///
+    /// 0x1,0x2 0x3,0x4 0x5,0x6
     ///
     /// where the total number of pairs determine how many paymaster accounts will be created.
     #[arg(requires_all = ["id", "slot"])]
-    #[arg(long = "slot.paymasters", value_delimiter = ' ', num_args = 1..)]
+    #[arg(long = "slot.paymasters", num_args = 1..)]
     pub paymaster_accounts: Option<Vec<PaymasterAccountArgs>>,
 }
 


### PR DESCRIPTION
Accidentally remove the `num_args` after I wrote the test for it in #3017 . Now this should be possible:

```
--slot.paymasters 0x1,0x2 0x3,0x4
```

without quotes.

@glihm 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for specifying multiple paymaster accounts by removing the requirement for quotation marks, making it clearer to input multiple values separated by spaces.
- **Refactor**
  - Improved the command-line argument behavior to naturally accept a variable number of paymaster accounts, streamlining the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->