### PR TITLE
[sozo] remove double library print

### DIFF
--- a/bin/sozo/src/commands/inspect.rs
+++ b/bin/sozo/src/commands/inspect.rs
@@ -357,7 +357,6 @@ fn inspect_world(world_diff: &WorldDiff) {
     print_table(&libraries_disp, Some(Color::FG_BRIGHT_BLACK), None);
     print_table(&models_disp, Some(Color::FG_BRIGHT_BLACK), None);
     print_table(&events_disp, Some(Color::FG_BRIGHT_BLACK), None);
-    print_table(&libraries_disp, Some(Color::FG_BRIGHT_BLACK), None);
     print_table(&external_contracts_disp, Some(Color::FG_BRIGHT_BLACK), None);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the world inspection display by removing the library resources section. Other key details, such as namespaces, contracts, models, events, and external components, continue to be presented as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->