### PR TITLE
feat: remove fieldOrder in ts bindgen

### DIFF
--- a/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
@@ -30,6 +30,3 @@ pub(crate) const CAIRO_OPTION_TYPE_PATH: &str = "core::option::Option";
 pub(crate) const SN_IMPORT_SEARCH: &str = "} from 'starknet';";
 pub(crate) const CAIRO_OPTION_TOKEN: &str = "CairoOption, CairoOptionVariant,";
 pub(crate) const CAIRO_ENUM_TOKEN: &str = "CairoCustomEnum,";
-
-pub(crate) const WITH_FIELD_ORDER_TYPE_DEF: &str =
-    "type WithFieldOrder<T> = T & { fieldOrder: string[] };\n";

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
@@ -1,8 +1,6 @@
 use cainome::parser::tokens::{Composite, CompositeType, Token};
 
-use super::constants::{
-    BIGNUMNERISH_IMPORT, CAIRO_OPTION_IMPORT, SN_IMPORT_SEARCH, WITH_FIELD_ORDER_TYPE_DEF,
-};
+use super::constants::{BIGNUMNERISH_IMPORT, CAIRO_OPTION_IMPORT, SN_IMPORT_SEARCH};
 use super::{token_is_option, JsPrimitiveType};
 use crate::error::BindgenResult;
 use crate::plugins::typescript::generator::constants::CAIRO_OPTION_TOKEN;
@@ -27,12 +25,6 @@ impl TsInterfaceGenerator {
             }
         }
     }
-
-    fn add_input_type(&self, buffer: &mut Buffer) {
-        if !buffer.has(WITH_FIELD_ORDER_TYPE_DEF) {
-            buffer.push(WITH_FIELD_ORDER_TYPE_DEF.to_owned());
-        }
-    }
 }
 
 impl BindgenModelGenerator for TsInterfaceGenerator {
@@ -47,7 +39,6 @@ impl BindgenModelGenerator for TsInterfaceGenerator {
         }
 
         self.check_import(token, buffer);
-        self.add_input_type(buffer);
 
         Ok(format!(
             "// Type definition for `{path}` struct

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/mod.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/mod.rs
@@ -33,8 +33,7 @@ pub(crate) fn get_namespace_and_path(token: &Composite) -> (String, String, Stri
 /// Generates default values for each fields of the struct.
 pub(crate) fn generate_type_init(token: &Composite) -> String {
     format!(
-        "{{\n\t\t\tfieldOrder: [{}],\n{}\n\t\t}}",
-        token.inners.iter().map(|i| format!("'{}'", i.name)).collect::<Vec<String>>().join(", "),
+        "{{\n{}\n\t\t}}",
         token
             .inners
             .iter()
@@ -809,7 +808,6 @@ mod tests {
         // the content of generate_type_init is wrapped in a function that adds brackets before and
         // after
         let expected = "{
-\t\t\tfieldOrder: ['field1', 'field2', 'field3'],
 \t\t\tfield1: 0,
 \t\t\tfield2: 0,
 \t\t\tfield3: 0,

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/schema.rs
@@ -26,9 +26,8 @@ impl TsSchemaGenerator {
         let schema_type = "export interface SchemaType extends ISchemaType";
         if !buffer.has(schema_type) {
             buffer.push(format!(
-                "export interface SchemaType extends ISchemaType {{\n\t{ns}: {{\n\t\t{}: \
-                 WithFieldOrder<{}>,\n\t}},\n}}",
-                type_name, type_name
+                "export interface SchemaType extends ISchemaType {{\n\t{ns}: {{\n\t\t{type_name}: \
+                 {type_name},\n\t}},\n}}",
             ));
             return;
         }
@@ -36,13 +35,13 @@ impl TsSchemaGenerator {
         // check if namespace is defined in interface. if not, add it.
         // next, find where namespace was defined in interface and add property to it.
         if !self.namespace_is_defined(buffer, &ns) {
-            let gen = format!("\n\t{ns}: {{\n\t\t{type_name}: WithFieldOrder<{type_name}>,\n\t}},");
+            let gen = format!("\n\t{ns}: {{\n\t\t{type_name}: {type_name},\n\t}},");
             buffer.insert_after(gen, schema_type, ",", 1);
             return;
         }
 
         // type has already been initialized
-        let gen = format!("\n\t\t{type_name}: WithFieldOrder<{type_name}>,");
+        let gen = format!("\n\t\t{type_name}: {type_name},");
         if buffer.has(&gen) {
             return;
         }
@@ -171,7 +170,7 @@ mod tests {
         let _result = generator.generate(&token, &mut buffer);
         assert_eq!(
             "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
-             {\n\t\tTestStruct: WithFieldOrder<TestStruct>,\n\t},\n}",
+             {\n\t\tTestStruct: TestStruct,\n\t},\n}",
             buffer[1]
         );
     }
@@ -187,7 +186,7 @@ mod tests {
         assert_ne!(0, buffer.len());
         assert_eq!(
             "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
-             {\n\t\tTestStruct: WithFieldOrder<TestStruct>,\n\t},\n}",
+             {\n\t\tTestStruct: TestStruct,\n\t},\n}",
             buffer[0]
         );
 
@@ -195,26 +194,23 @@ mod tests {
         generator.handle_schema_type(&token_2, &mut buffer);
         assert_eq!(
             "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
-             {\n\t\tTestStruct: WithFieldOrder<TestStruct>,\n\t\tAvailableTheme: \
-             WithFieldOrder<AvailableTheme>,\n\t},\n}",
+             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n}",
             buffer[0]
         );
         let token_3 = create_test_struct_token("Player", "combat");
         generator.handle_schema_type(&token_3, &mut buffer);
         assert_eq!(
             "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
-             {\n\t\tTestStruct: WithFieldOrder<TestStruct>,\n\t\tAvailableTheme: \
-             WithFieldOrder<AvailableTheme>,\n\t},\n\tcombat: {\n\t\tPlayer: \
-             WithFieldOrder<Player>,\n\t},\n}",
+             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: \
+             {\n\t\tPlayer: Player,\n\t},\n}",
             buffer[0]
         );
         let token_4 = create_test_struct_token("Position", "combat");
         generator.handle_schema_type(&token_4, &mut buffer);
         assert_eq!(
             "export interface SchemaType extends ISchemaType {\n\tonchain_dash: \
-             {\n\t\tTestStruct: WithFieldOrder<TestStruct>,\n\t\tAvailableTheme: \
-             WithFieldOrder<AvailableTheme>,\n\t},\n\tcombat: {\n\t\tPlayer: \
-             WithFieldOrder<Player>,\n\t\tPosition: WithFieldOrder<Position>,\n\t},\n}",
+             {\n\t\tTestStruct: TestStruct,\n\t\tAvailableTheme: AvailableTheme,\n\t},\n\tcombat: \
+             {\n\t\tPlayer: Player,\n\t\tPosition: Position,\n\t},\n}",
             buffer[0]
         );
     }
@@ -230,8 +226,7 @@ mod tests {
         assert_eq!(
             buffer[0],
             "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
+             {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
         );
 
         let token_2 = create_test_struct_token("AvailableTheme", "onchain_dash");
@@ -240,10 +235,8 @@ mod tests {
         assert_eq!(
             buffer[0],
             "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
+             {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
+             {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
         );
 
         let token_3 = create_test_struct_token("Player", "combat");
@@ -252,12 +245,10 @@ mod tests {
         assert_eq!(
             buffer[0],
             "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n};"
+             {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
+             {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: \
+             {\n\t\tPlayer: {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: \
+             0,\n\t\t},\n\t},\n};"
         );
 
         let token_4 = create_test_struct_token("Position", "combat");
@@ -266,13 +257,10 @@ mod tests {
         assert_eq!(
             buffer[0],
             "export const schema: SchemaType = {\n\tonchain_dash: {\n\t\tTestStruct: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: {\n\t\tPlayer: \
-             {\n\t\t\tfieldOrder: ['field1', 'field2', 'field3'],\n\t\t\tfield1: \
-             0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tPosition: {\n\t\t\tfieldOrder: \
-             ['field1', 'field2', 'field3'],\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: \
+             {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t\tAvailableTheme: \
+             {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: 0,\n\t\t},\n\t},\n\tcombat: \
+             {\n\t\tPlayer: {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: \
+             0,\n\t\t},\n\t\tPosition: {\n\t\t\tfield1: 0,\n\t\t\tfield2: 0,\n\t\t\tfield3: \
              0,\n\t\t},\n\t},\n};"
         );
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the generation of TypeScript type declarations by eliminating redundant type wrappers and properties, resulting in clearer and more consistent schema outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->