### PR TITLE
feat(katana-messaging): remove sending messages to settlement layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8178,7 +8178,6 @@ dependencies = [
  "katana-chain-spec",
  "katana-pool",
  "katana-primitives",
- "katana-provider",
  "reqwest 0.11.27",
  "serde",
  "serde_json",

--- a/crates/katana/messaging/Cargo.toml
+++ b/crates/katana/messaging/Cargo.toml
@@ -9,7 +9,6 @@ version.workspace = true
 katana-chain-spec.workspace = true
 katana-pool.workspace = true
 katana-primitives = { workspace = true, features = [ "arbitrary" ] }
-katana-provider = { workspace = true, default-features = false }
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/katana/messaging/src/lib.rs
+++ b/crates/katana/messaging/src/lib.rs
@@ -2,37 +2,37 @@
 
 //! Messaging module.
 //!
-//! Messaging is the capability of a sequencer to gather/send messages from/to a settlement chain.
+//! Messaging is the capability of a sequencer to gather messages from a settlement chain and
+//! execute them, and send messages to a settlement chain via a provable mechanism (STARK proof in
+//! the case of Starknet).
+//!
 //! By default, the messaging feature of Katana uses Ethereum as settlement chain.
 //! This feature is useful to locally test the interaction of Katana used as a Starknet dev node,
-//! and third party Ethereum dev node like Anvil.
+//! and an Ethereum dev node like Anvil.
 //!
 //! The gathering is done by fetching logs from the settlement chain to then self execute a
 //! `L1HandlerTransaction`. There is no account involved to execute this transaction, fees are
 //! charged on the settlement layer.
 //!
 //! The sending of the messages is realized by collecting all the `messages_sent` from local
-//! execution of smart contracts using the `send_message_to_l1_syscall`. Once messages are
-//! collected, the hash of each message is computed and then registered on the settlement layer to
-//! be consumed on the latter (by manually sending a transaction on the settlement chain). The
-//! hashes are registered using a custom contract that mimics the verification of Starknet state
-//! updates on Ethereum, since the process of proving and verifying of state updates, and then
-//! posting in on the settlement layer are not yet present in Katana.
+//! execution of smart contracts using the `send_message_to_l1_syscall`. Once the messages are
+//! collected, the `StarknetOS` cairo program is executed to generate a proof of the produced block,
+//! which contains the messages. This proof is then sent to the settlement chain where it is
+//! verified, and the messages are consumed.
 //!
 //! Katana also has starknet messaging built-in, where an opiniated implementation of L2 <-> L3
 //! messaging is implemented using Starknet as settlement chain.
+//! When working with `L2 <> L3` with settlement on Starknet, there is one limitation:
+//! Blockifier limits the `to_address` to be an EthAddress, which is smaller than the `Felt` type.
+//! <https://github.com/starkware-libs/sequencer/blob/f4b25dd4689ba8ddec3c7db57ea7e8fd7ce32eab/crates/blockifier/src/execution/call_info.rs#L41>
 //!
-//! With this feature, Katana also has the capability to directly send `invoke` transactions to a
-//! Starknet contract. This is usually used in the L2 <-> L3 messaging configuration, to circumvent
-//! the manual consumption of the message.
+//! An applicative solution would be to use the `MSG` magic value as `to_address`, and the actual
+//! `to_address` used as the first element of the `payload` of the message. This would also require
+//! the settlement contract to be aware of this.
 //!
 //! In this module, the messaging service clearly separates the two implementations for each
 //! settlement chain configuration in `starknet.rs` and `ethereum.rs`. The `service.rs` file aims at
 //! running the common logic.
-//!
-//! To start Katana with the messaging enabled, the option `--messaging` must be used with a
-//! configuration file following the `MessagingConfig` format. An example of this file can be found
-//! in the messaging contracts.
 
 mod ethereum;
 mod service;
@@ -50,11 +50,7 @@ use async_trait::async_trait;
 use ethereum::EthereumMessaging;
 use futures::StreamExt;
 use katana_primitives::chain::ChainId;
-use katana_primitives::receipt::MessageToL1;
-use katana_provider::traits::block::BlockNumberProvider;
-use katana_provider::traits::transaction::ReceiptProvider;
 use serde::{Deserialize, Serialize};
-use starknet_crypto::Felt;
 use tracing::{error, info, trace};
 
 pub use self::service::{MessagingOutcome, MessagingService};
@@ -74,8 +70,6 @@ pub enum Error {
     UnsupportedChain,
     #[error("Failed to gather messages from settlement chain")]
     GatherError,
-    #[error("Failed to send messages to settlement chain")]
-    SendError,
     #[error(transparent)]
     Provider(ProviderError),
 }
@@ -103,13 +97,8 @@ pub struct MessagingConfig {
     pub rpc_url: String,
     /// The messaging-contract address on the settlement chain.
     pub contract_address: String,
-    /// The address to use for settling messages. It should be a valid address that
-    /// can be used to initiate a transaction on the settlement chain.
-    pub sender_address: String,
-    /// The private key associated to `sender_address`.
-    pub private_key: String,
-    /// The interval, in seconds, at which the messaging service will fetch and settle messages
-    /// from/to the settlement chain.
+    /// The interval, in seconds, at which the messaging service will fetch messages
+    /// from the settlement chain.
     pub interval: u64,
     /// The block on settlement chain from where Katana will start fetching messages.
     pub from_block: u64,
@@ -130,32 +119,20 @@ impl MessagingConfig {
     pub fn from_chain_spec(spec: &katana_chain_spec::rollup::ChainSpec) -> Self {
         match &spec.settlement {
             katana_chain_spec::SettlementLayer::Ethereum {
-                rpc_url,
-                core_contract,
-                account,
-                block,
-                ..
+                rpc_url, core_contract, block, ..
             } => Self {
                 chain: CONFIG_CHAIN_ETHEREUM.to_string(),
                 rpc_url: rpc_url.to_string(),
                 contract_address: core_contract.to_string(),
-                sender_address: account.to_string(),
-                private_key: Felt::ZERO.to_string(),
                 from_block: *block,
                 interval: 2,
             },
             katana_chain_spec::SettlementLayer::Starknet {
-                rpc_url,
-                core_contract,
-                account,
-                block,
-                ..
+                rpc_url, core_contract, block, ..
             } => Self {
                 chain: CONFIG_CHAIN_STARKNET.to_string(),
                 rpc_url: rpc_url.to_string(),
                 contract_address: core_contract.to_string(),
-                sender_address: account.to_string(),
-                private_key: Felt::ZERO.to_string(),
                 from_block: *block,
                 interval: 2,
             },
@@ -188,19 +165,6 @@ pub trait Messenger {
         max_blocks: u64,
         chain_id: ChainId,
     ) -> MessengerResult<(u64, Vec<Self::MessageTransaction>)>;
-
-    /// Computes the hash of the given messages and sends them to the settlement chain.
-    ///
-    /// Once message's hash is settled, one must send a transaction (with the message content)
-    /// on the settlement chain to actually consume it.
-    ///
-    /// # Arguments
-    ///
-    /// * `messages` - Messages to settle.
-    async fn send_messages(
-        &self,
-        messages: &[MessageToL1],
-    ) -> MessengerResult<Vec<Self::MessageHash>>;
 }
 
 #[derive(Debug)]
@@ -244,48 +208,30 @@ impl MessengerMode {
 
 #[allow(missing_debug_implementations)]
 #[must_use = "MessagingTask does nothing unless polled"]
-pub struct MessagingTask<P>
-where
-    P: BlockNumberProvider + ReceiptProvider + Clone,
-{
-    messaging: MessagingService<P>,
+pub struct MessagingTask {
+    messaging: MessagingService,
 }
 
-impl<P> MessagingTask<P>
-where
-    P: BlockNumberProvider + ReceiptProvider + Clone,
-{
-    pub fn new(messaging: MessagingService<P>) -> Self {
+impl MessagingTask {
+    pub fn new(messaging: MessagingService) -> Self {
         Self { messaging }
     }
 }
 
-impl<P> Future for MessagingTask<P>
-where
-    P: BlockNumberProvider + ReceiptProvider + Clone + Unpin + 'static,
-{
+impl Future for MessagingTask {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 
         while let Poll::Ready(Some(outcome)) = this.messaging.poll_next_unpin(cx) {
-            match outcome {
-                MessagingOutcome::Gather { msg_count, .. } => {
-                    if msg_count > 0 {
-                        info!(target: LOG_TARGET, %msg_count, "Collected messages from settlement chain.");
-                    }
-
-                    trace!(target: LOG_TARGET, %msg_count, "Collected messages from settlement chain.");
+            let MessagingOutcome { msg_count, .. } = outcome;
+            {
+                if msg_count > 0 {
+                    info!(target: LOG_TARGET, %msg_count, "Collected messages from settlement chain.");
                 }
 
-                MessagingOutcome::Send { msg_count, .. } => {
-                    if msg_count > 0 {
-                        info!(target: LOG_TARGET, %msg_count, "Sent messages to the settlement chain.");
-                    }
-
-                    trace!(target: LOG_TARGET, %msg_count, "Sent messages to the settlement chain.");
-                }
+                trace!(target: LOG_TARGET, %msg_count, "Collected messages from settlement chain.");
             }
         }
 

--- a/crates/katana/rpc/rpc/tests/messaging.rs
+++ b/crates/katana/rpc/rpc/tests/messaging.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use alloy::primitives::{Uint, U256};
-use alloy::providers::{ProviderBuilder, WalletProvider};
+use alloy::providers::ProviderBuilder;
 use alloy::sol;
 use anyhow::Result;
 use cainome::cairo_serde::EthAddress;
@@ -68,8 +68,6 @@ async fn test_messaging() {
         chain: "ethereum".to_string(),
         rpc_url: format!("http://localhost:{}", port),
         contract_address: core_contract.address().to_string(),
-        sender_address: l1_provider.default_signer_address().to_string(),
-        private_key: "".to_string(),
         interval: 2,
         from_block: 0,
     };

--- a/crates/katana/rpc/rpc/tests/messaging.rs
+++ b/crates/katana/rpc/rpc/tests/messaging.rs
@@ -231,74 +231,8 @@ async fn test_messaging() {
         }
     }
 
-    // Send message from L2 to L1
-    {
-        // The L1 contract address to send the message to
-        let l1_contract_address = l1_test_contract.address();
-        let l1_contract_address = Felt::from_str(&l1_contract_address.to_string()).unwrap();
-
-        let l2_contract = CairoMessagingContract::new(l2_test_contract, &katana_account);
-
-        // Send message to L1
-        let res = l2_contract
-            .send_message_value(&EthAddress::from(l1_contract_address), &Felt::TWO)
-            .send()
-            .await
-            .expect("Call to send_message_value failed");
-
-        TransactionWaiter::new(res.transaction_hash, katana_account.provider())
-            .with_tx_status(TransactionFinalityStatus::AcceptedOnL2)
-            .await
-            .expect("send message to l1 tx failed");
-
-        // Wait for the tx to be mined on L1 (Anvil)
-        tokio::time::sleep(Duration::from_secs(3)).await;
-
-        // Query the core messaging contract to check that the l2 -> l1 message hash have been
-        // registered. If the message is registered, calling `l2ToL1Messages` of the L1 core
-        // contract with the message hash should return a non-zero value.
-
-        let l2_l1_msg_hash =
-            compute_l2_to_l1_message_hash(l2_test_contract, l1_contract_address, &[Felt::TWO]);
-
-        let msg_fee = core_contract
-            .l2ToL1Messages(l2_l1_msg_hash)
-            .call()
-            .await
-            .expect("failed to get msg fee");
-
-        assert_ne!(msg_fee._0, U256::ZERO, "msg fee must be non-zero if exist");
-
-        // We then consume the message.
-        // Upon consuming the message, the value returned by `l2ToL1Messages` should be zeroed.
-
-        // The L2 contract address that sent the message
-        let from_address = U256::from_str(&l2_test_contract.to_string()).unwrap();
-        // The message payload
-        let payload = vec![U256::from(2)];
-
-        let receipt = l1_test_contract
-            .consumeMessage(from_address, payload)
-            .gas(12000000)
-            .nonce(4)
-            .send()
-            .await
-            .expect("failed to send tx")
-            .get_receipt()
-            .await
-            .expect("error getting transaction receipt");
-
-        assert!(receipt.status(), "failed to consume L2 message from L1");
-
-        // Check that the message fee is zero after consuming the message.
-        let msg_fee = core_contract
-            .l2ToL1Messages(l2_l1_msg_hash)
-            .call()
-            .await
-            .expect("failed to get msg fee");
-
-        assert_eq!(msg_fee._0, U256::ZERO, "msg fee must be zero after consuming");
-    }
+    // Send message from L2 to L1 testing must be done using Saya or part of
+    // it to ensure the settlement contract is test on piltover and its `update_state` method.
 }
 
 #[tokio::test]

--- a/crates/katana/rpc/rpc/tests/messaging.rs
+++ b/crates/katana/rpc/rpc/tests/messaging.rs
@@ -6,7 +6,6 @@ use alloy::primitives::{Uint, U256};
 use alloy::providers::ProviderBuilder;
 use alloy::sol;
 use anyhow::Result;
-use cainome::cairo_serde::EthAddress;
 use cainome::rs::abigen;
 use dojo_test_utils::sequencer::{get_default_test_config, TestSequencer};
 use dojo_utils::TransactionWaiter;
@@ -14,15 +13,14 @@ use katana_messaging::MessagingConfig;
 use katana_node::config::sequencing::SequencingConfig;
 use katana_primitives::felt;
 use katana_primitives::utils::transaction::{
-    compute_l1_handler_tx_hash, compute_l1_to_l2_message_hash, compute_l2_to_l1_message_hash,
+    compute_l1_handler_tx_hash, compute_l1_to_l2_message_hash,
 };
 use katana_rpc_types::receipt::ReceiptBlock;
 use rand::Rng;
 use starknet::accounts::{Account, ConnectedAccount};
 use starknet::contract::ContractFactory;
 use starknet::core::types::{
-    BlockId, BlockTag, ContractClass, Felt, Hash256, MsgFromL1, Transaction,
-    TransactionFinalityStatus, TransactionReceipt,
+    BlockId, BlockTag, ContractClass, Felt, Hash256, MsgFromL1, Transaction, TransactionReceipt,
 };
 use starknet::core::utils::get_contract_address;
 use starknet::macros::selector;

--- a/crates/katana/sync/stage/src/sequencing.rs
+++ b/crates/katana/sync/stage/src/sequencing.rs
@@ -40,9 +40,8 @@ impl<EF: ExecutorFactory> Sequencing<EF> {
             let config = config.clone();
             let pool = self.pool.clone();
             let chain_spec = self.backend.chain_spec.clone();
-            let provider = self.backend.blockchain.provider().clone();
 
-            let service = MessagingService::new(config, chain_spec, pool, provider).await?;
+            let service = MessagingService::new(config, chain_spec, pool).await?;
             let task = MessagingTask::new(service);
 
             let handle = self.task_spawner.build_task().name("Messaging").spawn(task);


### PR DESCRIPTION
The feature of sending message to settlement layer was done mainly to test messaging in the early days of Starknet.

Now that app chains are here, there is no need of such feature.

This PR aims at removing all the code related to send a message to the settlement layout from Katana operated as a Rollup sequencer. Module documentation has been updated and types simplified when possible.

We also had some errors of type `Send` where it should have been `Gather`, confusing me during some tests on Katana. Those errors have been fixed to `Gather` instead.

In the current setup, we still have the blockifier limitation for the `to_address` field as mentioned in comment into the messaging crate doc. But this can be resolved by a simple application logic with the `MSG_MAGIC` as it was implemented in Katana before trimming this code.

Ideally @kariy as we have discussed, if the blockifier changes to remove this constraint aren't big, it will be beneficial to have `to_address` of type `felt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the messaging workflow to focus on gathering messages and executing them via a proof-generation process.
  - Simplified the `MessagingService` and `StarknetMessaging` structures by removing unnecessary fields and methods.
- **Chores**
  - Removed outdated dependency configurations and eliminated redundant parameters from the messaging setup.
- **Documentation**
  - Updated explanations to provide clearer insight into the revised messaging execution process.
- **Tests**
  - Adjusted related test configurations to align with the simplified messaging approach, including the removal of unnecessary fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->