### PR TITLE
fix(dojo-core): add test to showcase serialization issue on options

### DIFF
--- a/crates/dojo/core-cairo-test/src/lib.cairo
+++ b/crates/dojo/core-cairo-test/src/lib.cairo
@@ -43,13 +43,7 @@ mod tests {
 
     mod helpers {
         mod helpers;
-        pub use helpers::{
-            DOJO_NSH, SimpleEvent, e_SimpleEvent, Foo, m_Foo, foo_invalid_name, foo_setter,
-            test_contract, test_contract_with_dojo_init_args, Sword, Case, Character, Abilities,
-            Stats, Weapon, Ibar, IbarDispatcher, IbarDispatcherTrait, bar, deploy_world,
-            deploy_world_and_bar, deploy_world_and_foo, drop_all_events, IFooSetter,
-            IFooSetterDispatcher, IFooSetterDispatcherTrait, NotCopiable,
-        };
+        pub use helpers::*;
 
         mod event;
         pub use event::{

--- a/crates/dojo/core-cairo-test/src/tests/helpers/helpers.cairo
+++ b/crates/dojo/core-cairo-test/src/tests/helpers/helpers.cairo
@@ -35,6 +35,22 @@ pub struct NotCopiable {
     pub b: ByteArray,
 }
 
+#[derive(Drop, Serde, Debug, PartialEq, Introspect)]
+pub enum EnumOne {
+    One,
+    Two: u32,
+    Three: (felt252, u32),
+}
+
+#[derive(Drop, Serde, Debug)]
+#[dojo::model]
+pub struct WithOptionAndEnums {
+    #[key]
+    pub id: u32,
+    pub a: EnumOne,
+    pub b: Option<u32>,
+}
+
 #[starknet::contract]
 pub mod foo_invalid_name {
     use dojo::model::IModel;

--- a/crates/dojo/core-cairo-test/src/tests/world/storage.cairo
+++ b/crates/dojo/core-cairo-test/src/tests/world/storage.cairo
@@ -1,6 +1,6 @@
 use dojo::model::ModelStorage;
 
-use crate::tests::helpers::{deploy_world_and_foo, Foo, NotCopiable};
+use crate::tests::helpers::{deploy_world_and_foo, Foo, NotCopiable, EnumOne, WithOptionAndEnums};
 
 #[test]
 fn write_simple() {
@@ -121,4 +121,17 @@ fn write_multiple_not_copiable() {
         assert_eq!(m.a, array![]);
         assert_eq!(m.b, "");
     };
+}
+
+#[test]
+fn write_read_option_enums() {
+    let (mut world, _) = deploy_world_and_foo();
+
+    let key: u32 = 1;
+
+    let wo: WithOptionAndEnums = world.read_model(key);
+    assert_eq!(wo.a, EnumOne::One);
+    // Should have been `Option::None`. Need to find a way to mitigate this issue
+    // using a `DojoOption` converter or customizing the serialization.
+    assert_eq!(wo.b, Option::Some(0));
 }


### PR DESCRIPTION
@remybar this is the issue mentioned by message.

Let's see what could be the best solution for that, of it's something we need to be aware of, and accept the behavior.

But this is very error prone for users. We will document it if we don't have an evident fix without breaking storage backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined module export management for improved maintainability.
- **New Features**
	- Extended data modeling with additional types to support more complex scenarios.
- **Tests**
	- Introduced a new test ensuring proper handling of models with optional and enumerated fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->