### PR TITLE
fix(torii): u256 json serialization as string

### DIFF
--- a/crates/dojo/types/src/schema.rs
+++ b/crates/dojo/types/src/schema.rs
@@ -303,11 +303,7 @@ impl Ty {
                     let diff_elements: Vec<Ty> =
                         t1.iter().zip(t2.iter()).filter_map(|(ty1, ty2)| ty1.diff(ty2)).collect();
 
-                    if diff_elements.is_empty() {
-                        None
-                    } else {
-                        Some(Ty::Tuple(diff_elements))
-                    }
+                    if diff_elements.is_empty() { None } else { Some(Ty::Tuple(diff_elements)) }
                 }
             }
             (Ty::Array(a1), Ty::Array(a2)) => {

--- a/crates/dojo/types/src/schema.rs
+++ b/crates/dojo/types/src/schema.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 use std::str::FromStr;
 
 use cainome::cairo_serde::{ByteArray, CairoSerde};
-use crypto_bigint::{Encoding, U256};
+use crypto_bigint::U256;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
@@ -303,7 +303,11 @@ impl Ty {
                     let diff_elements: Vec<Ty> =
                         t1.iter().zip(t2.iter()).filter_map(|(ty1, ty2)| ty1.diff(ty2)).collect();
 
-                    if diff_elements.is_empty() { None } else { Some(Ty::Tuple(diff_elements)) }
+                    if diff_elements.is_empty() {
+                        None
+                    } else {
+                        Some(Ty::Tuple(diff_elements))
+                    }
                 }
             }
             (Ty::Array(a1), Ty::Array(a2)) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the encoding and decoding of large integer values. Instead of a detailed object structure with multiple fields, these values are now represented as a concise hexadecimal string (prefixed with "0x"), streamlining the data interchange format and potentially improving performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->