### PR TITLE
feat(katana): configurable max gas for rpc call

### DIFF
--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -238,6 +238,7 @@ impl NodeArgs {
                 cors_origins: self.server.http_cors_origins.clone(),
                 max_event_page_size: Some(self.server.max_event_page_size),
                 max_proof_keys: Some(self.server.max_proof_keys),
+                max_call_gas: Some(self.server.max_call_gas),
             })
         }
 

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -14,6 +14,7 @@ use clap::Args;
 use katana_node::config::execution::{DEFAULT_INVOCATION_MAX_STEPS, DEFAULT_VALIDATION_MAX_STEPS};
 #[cfg(feature = "server")]
 use katana_node::config::metrics::{DEFAULT_METRICS_ADDR, DEFAULT_METRICS_PORT};
+use katana_node::config::rpc::DEFAULT_RPC_MAX_CALL_GAS;
 #[cfg(feature = "server")]
 use katana_node::config::rpc::{RpcModulesList, DEFAULT_RPC_MAX_PROOF_KEYS};
 #[cfg(feature = "server")]
@@ -128,6 +129,12 @@ pub struct ServerOptions {
     #[arg(default_value_t = DEFAULT_RPC_MAX_PROOF_KEYS)]
     #[serde(default = "default_proof_keys")]
     pub max_proof_keys: u64,
+
+    /// Maximum gas for the `starknet_call` RPC method.
+    #[arg(long = "rpc.max-call-gas", value_name = "GAS")]
+    #[arg(default_value_t = DEFAULT_RPC_MAX_CALL_GAS)]
+    #[serde(default = "default_max_call_gas")]
+    pub max_call_gas: u64,
 }
 
 #[cfg(feature = "server")]
@@ -143,6 +150,7 @@ impl Default for ServerOptions {
             max_connections: None,
             max_request_body_size: None,
             max_response_body_size: None,
+            max_call_gas: DEFAULT_RPC_MAX_CALL_GAS,
         }
     }
 }

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -418,3 +418,8 @@ fn default_metrics_addr() -> IpAddr {
 fn default_metrics_port() -> u16 {
     DEFAULT_METRICS_PORT
 }
+
+#[cfg(feature = "server")]
+fn default_max_call_gas() -> u64 {
+    DEFAULT_RPC_MAX_CALL_GAS
+}

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -14,12 +14,11 @@ use clap::Args;
 use katana_node::config::execution::{DEFAULT_INVOCATION_MAX_STEPS, DEFAULT_VALIDATION_MAX_STEPS};
 #[cfg(feature = "server")]
 use katana_node::config::metrics::{DEFAULT_METRICS_ADDR, DEFAULT_METRICS_PORT};
-use katana_node::config::rpc::DEFAULT_RPC_MAX_CALL_GAS;
 #[cfg(feature = "server")]
 use katana_node::config::rpc::{RpcModulesList, DEFAULT_RPC_MAX_PROOF_KEYS};
 #[cfg(feature = "server")]
 use katana_node::config::rpc::{
-    DEFAULT_RPC_ADDR, DEFAULT_RPC_MAX_EVENT_PAGE_SIZE, DEFAULT_RPC_PORT,
+    DEFAULT_RPC_ADDR, DEFAULT_RPC_MAX_CALL_GAS, DEFAULT_RPC_MAX_EVENT_PAGE_SIZE, DEFAULT_RPC_PORT,
 };
 use katana_primitives::block::BlockHashOrNumber;
 use katana_primitives::chain::ChainId;

--- a/crates/katana/executor/src/implementation/blockifier/mod.rs
+++ b/crates/katana/executor/src/implementation/blockifier/mod.rs
@@ -93,6 +93,7 @@ pub struct StarknetVMProcessor<'a> {
     simulation_flags: ExecutionFlags,
     stats: ExecutionStats,
     bouncer: Bouncer,
+    max_call_gas: u64,
 }
 
 impl<'a> StarknetVMProcessor<'a> {
@@ -118,6 +119,7 @@ impl<'a> StarknetVMProcessor<'a> {
             simulation_flags,
             stats: Default::default(),
             bouncer,
+            max_call_gas: cfg_env.max_call_gas,
         }
     }
 
@@ -329,7 +331,7 @@ impl ExecutorExt for StarknetVMProcessor<'_> {
         let block_context = &self.block_context;
         let mut state = self.state.inner.lock();
         let state = MutRefState::new(&mut state.cached_state);
-        let retdata = call::execute_call(call, state, block_context, 1_000_000_000)?;
+        let retdata = call::execute_call(call, state, block_context, self.max_call_gas)?;
         Ok(retdata)
     }
 }

--- a/crates/katana/node-bindings/src/lib.rs
+++ b/crates/katana/node-bindings/src/lib.rs
@@ -188,6 +188,7 @@ pub struct Katana {
     http_addr: Option<SocketAddr>,
     http_port: Option<u16>,
     rpc_max_connections: Option<u64>,
+    rpc_max_call_gas: Option<u64>,
     http_cors_domain: Option<String>,
 
     // Dev options
@@ -323,6 +324,12 @@ impl Katana {
     /// Sets the maximum number of concurrent connections allowed.
     pub const fn rpc_max_connections(mut self, max_connections: u64) -> Self {
         self.rpc_max_connections = Some(max_connections);
+        self
+    }
+
+    /// Sets the maximum gas for the `starknet_call` RPC method.
+    pub const fn rpc_max_call_gas(mut self, max_call_gas: u64) -> Self {
+        self.rpc_max_call_gas = Some(max_call_gas);
         self
     }
 
@@ -523,6 +530,10 @@ impl Katana {
 
         if let Some(max_connections) = self.rpc_max_connections {
             cmd.arg("--rpc.max-connections").arg(max_connections.to_string());
+        }
+
+        if let Some(max_call_gas) = self.rpc_max_call_gas {
+            cmd.arg("--rpc.max-call-gas").arg(max_call_gas.to_string());
         }
 
         if let Some(allowed_origins) = self.http_cors_domain {

--- a/crates/katana/node/src/config/rpc.rs
+++ b/crates/katana/node/src/config/rpc.rs
@@ -11,7 +11,8 @@ pub const DEFAULT_RPC_PORT: u16 = 5050;
 pub const DEFAULT_RPC_MAX_EVENT_PAGE_SIZE: u64 = 1024;
 /// Default maximmum number of keys for the `starknet_getStorageProof` RPC method.
 pub const DEFAULT_RPC_MAX_PROOF_KEYS: u64 = 100;
-
+/// Default maximum gas for the `starknet_call` RPC method.
+pub const DEFAULT_RPC_MAX_CALL_GAS: u64 = 1_000_000_000;
 /// List of RPC modules supported by Katana.
 #[derive(
     Debug,
@@ -45,6 +46,7 @@ pub struct RpcConfig {
     pub max_response_body_size: Option<u32>,
     pub max_proof_keys: Option<u64>,
     pub max_event_page_size: Option<u64>,
+    pub max_call_gas: Option<u64>,
 }
 
 impl RpcConfig {
@@ -66,6 +68,7 @@ impl Default for RpcConfig {
             apis: RpcModulesList::default(),
             max_event_page_size: Some(DEFAULT_RPC_MAX_EVENT_PAGE_SIZE),
             max_proof_keys: Some(DEFAULT_RPC_MAX_PROOF_KEYS),
+            max_call_gas: Some(DEFAULT_RPC_MAX_CALL_GAS),
         }
     }
 }

--- a/crates/katana/node/src/config/rpc.rs
+++ b/crates/katana/node/src/config/rpc.rs
@@ -13,6 +13,7 @@ pub const DEFAULT_RPC_MAX_EVENT_PAGE_SIZE: u64 = 1024;
 pub const DEFAULT_RPC_MAX_PROOF_KEYS: u64 = 100;
 /// Default maximum gas for the `starknet_call` RPC method.
 pub const DEFAULT_RPC_MAX_CALL_GAS: u64 = 1_000_000_000;
+
 /// List of RPC modules supported by Katana.
 #[derive(
     Debug,

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -182,11 +182,16 @@ pub async fn build(mut config: Config) -> Result<Node> {
         .with_account_validation(config.dev.account_validation)
         .with_fee(config.dev.fee);
 
-    let executor_factory = Arc::new(BlockifierFactory::new(
-        cfg_env,
-        execution_flags,
-        config.sequencing.block_limits(),
-    ));
+    let executor_factory = {
+        let mut factory =
+            BlockifierFactory::new(cfg_env, execution_flags, config.sequencing.block_limits());
+
+        if let Some(max_call_gas) = config.rpc.max_call_gas {
+            factory.set_max_call_gas(max_call_gas);
+        }
+
+        Arc::new(factory)
+    };
 
     // --- build backend
 

--- a/crates/katana/primitives/src/env.rs
+++ b/crates/katana/primitives/src/env.rs
@@ -30,6 +30,8 @@ pub struct CfgEnv {
     pub validate_max_n_steps: u32,
     /// The maximum recursion depth allowed.
     pub max_recursion_depth: usize,
+    /// The maximum gas allowed for the `starknet_call` RPC method.
+    pub max_call_gas: u64,
 }
 
 /// The contract addresses of the tokens used for the fees.

--- a/crates/katana/primitives/src/env.rs
+++ b/crates/katana/primitives/src/env.rs
@@ -30,8 +30,6 @@ pub struct CfgEnv {
     pub validate_max_n_steps: u32,
     /// The maximum recursion depth allowed.
     pub max_recursion_depth: usize,
-    /// The maximum gas allowed for the `starknet_call` RPC method.
-    pub max_call_gas: u64,
 }
 
 /// The contract addresses of the tokens used for the fees.


### PR DESCRIPTION
#2969


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Now allows you to set a custom maximum gas limit for contract calls made via the RPC interface.
  - Introduced a new command-line option to specify this gas cap, offering more control over RPC execution.
  - Updated default settings ensure optimal initial gas limits.

- **Refactor**
  - Enhanced the internal configuration process to seamlessly incorporate the new gas limit option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->