### PR TITLE
fix(katana): merging server args from file

### DIFF
--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -228,6 +228,7 @@ impl NodeArgs {
 
                 modules
             };
+
             Ok(RpcConfig {
                 apis: modules,
                 port: self.server.http_port,
@@ -386,11 +387,7 @@ impl NodeArgs {
 
         #[cfg(feature = "server")]
         {
-            if self.server == ServerOptions::default() {
-                if let Some(server) = config.server {
-                    self.server = server;
-                }
-            }
+            self.server.merge(config.server.as_ref());
 
             if self.metrics == MetricsOptions::default() {
                 if let Some(metrics) = config.metrics {

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -143,7 +143,7 @@ impl Default for ServerOptions {
             http_addr: DEFAULT_RPC_ADDR,
             http_port: DEFAULT_RPC_PORT,
             http_cors_origins: Vec::new(),
-            http_modules: Some(RpcModulesList::default()),
+            http_modules: None,
             max_event_page_size: DEFAULT_RPC_MAX_EVENT_PAGE_SIZE,
             max_proof_keys: DEFAULT_RPC_MAX_PROOF_KEYS,
             max_connections: None,

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -154,6 +154,44 @@ impl Default for ServerOptions {
     }
 }
 
+#[cfg(feature = "server")]
+impl ServerOptions {
+    pub fn merge(&mut self, other: Option<&Self>) {
+        if let Some(other) = other {
+            if self.http_addr == DEFAULT_RPC_ADDR {
+                self.http_addr = other.http_addr;
+            }
+            if self.http_port == DEFAULT_RPC_PORT {
+                self.http_port = other.http_port;
+            }
+            if self.http_cors_origins.is_empty() {
+                self.http_cors_origins = other.http_cors_origins.clone();
+            }
+            if self.http_modules.is_none() {
+                self.http_modules = other.http_modules.clone();
+            }
+            if self.max_connections.is_none() {
+                self.max_connections = other.max_connections;
+            }
+            if self.max_request_body_size.is_none() {
+                self.max_request_body_size = other.max_request_body_size;
+            }
+            if self.max_response_body_size.is_none() {
+                self.max_response_body_size = other.max_response_body_size;
+            }
+            if self.max_event_page_size == DEFAULT_RPC_MAX_EVENT_PAGE_SIZE {
+                self.max_event_page_size = other.max_event_page_size;
+            }
+            if self.max_proof_keys == DEFAULT_RPC_MAX_PROOF_KEYS {
+                self.max_proof_keys = other.max_proof_keys;
+            }
+            if self.max_call_gas == DEFAULT_RPC_MAX_CALL_GAS {
+                self.max_call_gas = other.max_call_gas;
+            }
+        }
+    }
+}
+
 #[derive(Debug, Args, Clone, Serialize, Deserialize, Default, PartialEq)]
 #[command(next_help_heading = "Starknet options")]
 pub struct StarknetOptions {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated default server behavior so that RPC modules are now disabled by default. Users must explicitly enable desired modules during configuration, offering enhanced control and a streamlined setup.
  - Improved the handling of server configuration options by allowing for more flexible merging from configuration files.
  - Enhanced the RPC server configuration with additional parameters for improved customizability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->