### PR TITLE
fix(katana): compute genesis state root in a separate provider

### DIFF
--- a/crates/katana/core/tests/backend.rs
+++ b/crates/katana/core/tests/backend.rs
@@ -77,6 +77,19 @@ fn can_initialize_genesis(#[case] chain: ChainSpec) {
     backend.init_genesis().expect("failed to initialize genesis");
 }
 
+#[rstest]
+#[case::dev(ChainSpec::Dev(dev_chain_spec()))]
+#[case::rollup(ChainSpec::Rollup(rollup_chain_spec()))]
+fn can_reinitialize_genesis(#[case] chain: ChainSpec) {
+    let db = DbProvider::new_ephemeral();
+
+    let backend = backend_with_db(&chain, db.clone());
+    backend.init_genesis().expect("failed to initialize genesis");
+
+    let backend = backend_with_db(&chain, db);
+    backend.init_genesis().unwrap();
+}
+
 #[test]
 fn reinitialize_with_different_rollup_chain_spec() {
     let db = DbProvider::new_ephemeral();

--- a/crates/katana/storage/provider/src/providers/db/trie.rs
+++ b/crates/katana/storage/provider/src/providers/db/trie.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeMap, HashMap};
-use std::fmt::Debug;
 
 use katana_db::abstraction::Database;
 use katana_db::tables;
@@ -8,20 +7,15 @@ use katana_primitives::block::BlockNumber;
 use katana_primitives::class::{ClassHash, CompiledClassHash};
 use katana_primitives::state::StateUpdates;
 use katana_primitives::{ContractAddress, Felt};
-use katana_trie::{compute_contract_state_hash, ClassesTrie, ContractsTrie, StoragesTrie};
+use katana_trie::{
+    compute_contract_state_hash, ClassesTrie, ContractLeaf, ContractsTrie, StoragesTrie,
+};
 
 use crate::error::ProviderError;
 use crate::providers::db::DbProvider;
 use crate::traits::state::{StateFactoryProvider, StateProvider};
 use crate::traits::trie::TrieWriter;
 use crate::ProviderResult;
-
-#[derive(Debug, Default)]
-struct ContractLeaf {
-    pub class_hash: Option<Felt>,
-    pub storage_root: Option<Felt>,
-    pub nonce: Option<Felt>,
-}
 
 impl<Db: Database> TrieWriter for DbProvider<Db> {
     fn trie_insert_declared_classes(

--- a/crates/katana/trie/src/contracts.rs
+++ b/crates/katana/trie/src/contracts.rs
@@ -45,3 +45,10 @@ where
         self.trie.commit(block.into())
     }
 }
+
+#[derive(Debug, Default)]
+pub struct ContractLeaf {
+    pub class_hash: Option<Felt>,
+    pub storage_root: Option<Felt>,
+    pub nonce: Option<Felt>,
+}

--- a/crates/katana/trie/src/lib.rs
+++ b/crates/katana/trie/src/lib.rs
@@ -13,7 +13,7 @@ mod id;
 mod storages;
 
 pub use classes::*;
-pub use contracts::ContractsTrie;
+pub use contracts::*;
 pub use id::CommitId;
 pub use storages::StoragesTrie;
 


### PR DESCRIPTION
When `katana --chain <ID>` is started with an already initialized database ie `--db-dir <PATH>`, the chain's genesis block hash corresponds will be compared to the existing block hash in the provided database. To perform this comparison, the genesis state root needs to computed first. Currently, the computation is done against the same database that we provide (remember the database has already been initialized, and may have other state apart from the genesis) and the trie computation logic (the call to `trie_insert_declared_classes` and `trie_insert_contract_updates` in the `compute_new_state_root` function) will automatically writes the updates into the db. Thus, OVERWRITING the already established tries and resulted in a completely different state root value. 

So the fix is to perform the check first - checking whether there's a genesis block or not in the database: If yes, then we compute the genesis state using a separate provider to avoid overwriting the db. Else, (meaning the db is empty and hasn't been initialized yet) we compute it using the db storage provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced block commitment operations, including specialized handling for initial blocks and improved block hash tracking.
  - Expanded contract state management with a new structure that provides more detailed data during trie updates.
  - Added a test function to verify backend reinitialization of the genesis state.

- **Refactor**
  - Consolidated contract state definitions by adopting a shared implementation.
  - Streamlined state update routines and broadened module exports to offer more comprehensive functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->