### PR TITLE
refactor(torii): model reader without call to world

### DIFF
--- a/crates/dojo/world/src/contracts/model.rs
+++ b/crates/dojo/world/src/contracts/model.rs
@@ -88,11 +88,11 @@ where
         address: Felt,
         class_hash: Felt,
         world: &'a WorldContractReader<P>,
-    ) -> Result<ModelRPCReader<'a, P>, ModelError> {
+    ) -> ModelRPCReader<'a, P> {
         let selector = naming::compute_selector_from_names(namespace, name);
         let contract_reader = ModelContractReader::new(address, world.provider());
 
-        Ok(Self {
+        Self {
             namespace: namespace.into(),
             name: name.into(),
             selector,
@@ -100,7 +100,7 @@ where
             contract_address: address,
             world_reader: world,
             model_reader: contract_reader,
-        })
+        }
     }
 
     pub async fn new_from_world(
@@ -125,7 +125,7 @@ where
             return Err(ModelError::ModelNotFound);
         }
 
-        Ok(Self::new(namespace, name, contract_address.0, class_hash, world).await?)
+        Ok(Self::new(namespace, name, contract_address.0, class_hash, world).await)
     }
 
     pub async fn entity_storage(&self, keys: &[Felt]) -> Result<Vec<Felt>, ModelError> {

--- a/crates/dojo/world/src/contracts/world.rs
+++ b/crates/dojo/world/src/contracts/world.rs
@@ -24,7 +24,7 @@ where
     ) -> Result<ModelRPCReader<'_, P>, ModelError> {
         let (namespace, name) =
             naming::split_tag(tag).map_err(|e| ModelError::TagError(e.to_string()))?;
-        ModelRPCReader::new(&namespace, &name, self).await
+        ModelRPCReader::new_from_world(&namespace, &name, self).await
     }
 
     pub async fn model_reader(
@@ -32,15 +32,8 @@ where
         namespace: &str,
         name: &str,
     ) -> Result<ModelRPCReader<'_, P>, ModelError> {
-        ModelRPCReader::new(namespace, name, self).await
+        ModelRPCReader::new_from_world(namespace, name, self).await
     }
 
-    pub async fn model_reader_with_block(
-        &self,
-        namespace: &str,
-        name: &str,
-        block_id: BlockId,
-    ) -> Result<ModelRPCReader<'_, P>, ModelError> {
-        ModelRPCReader::new_with_block(namespace, name, self, block_id).await
-    }
+    pub async fn model_reader_with
 }

--- a/crates/dojo/world/src/contracts/world.rs
+++ b/crates/dojo/world/src/contracts/world.rs
@@ -1,6 +1,4 @@
 use std::result::Result;
-
-use starknet::core::types::BlockId;
 use starknet::providers::Provider;
 
 pub use super::abigen::world::{
@@ -34,6 +32,4 @@ where
     ) -> Result<ModelRPCReader<'_, P>, ModelError> {
         ModelRPCReader::new_from_world(namespace, name, self).await
     }
-
-    pub async fn model_reader_with
 }

--- a/crates/dojo/world/src/contracts/world.rs
+++ b/crates/dojo/world/src/contracts/world.rs
@@ -1,4 +1,5 @@
 use std::result::Result;
+
 use starknet::providers::Provider;
 
 pub use super::abigen::world::{

--- a/crates/torii/indexer/src/processors/register_event.rs
+++ b/crates/torii/indexer/src/processors/register_event.rs
@@ -3,7 +3,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use anyhow::{Error, Ok, Result};
 use async_trait::async_trait;
 use dojo_world::contracts::abigen::world::Event as WorldEvent;
-use dojo_world::contracts::model::ModelReader;
+use dojo_world::contracts::model::{ModelRPCReader, ModelReader};
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{BlockId, Event};
 use starknet::providers::Provider;
@@ -79,11 +79,10 @@ where
 
         // Called model here by language, but it's an event. Torii rework will make clear
         // distinction.
-        let model = if config.strict_model_reader {
-            world.model_reader_with_block(&namespace, &name, BlockId::Number(block_number)).await?
-        } else {
-            world.model_reader(&namespace, &name).await?
-        };
+        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        if config.strict_model_reader {
+            model.set_block(BlockId::Number(block_number)).await;
+        }
         let schema = model.schema().await?;
         let layout = model.layout().await?;
 

--- a/crates/torii/indexer/src/processors/register_event.rs
+++ b/crates/torii/indexer/src/processors/register_event.rs
@@ -81,7 +81,7 @@ where
         // distinction.
         let mut model =
             ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
-                .await?;
+                .await;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/register_event.rs
+++ b/crates/torii/indexer/src/processors/register_event.rs
@@ -79,7 +79,9 @@ where
 
         // Called model here by language, but it's an event. Torii rework will make clear
         // distinction.
-        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        let mut model =
+            ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
+                .await?;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/register_model.rs
+++ b/crates/torii/indexer/src/processors/register_model.rs
@@ -77,7 +77,7 @@ where
             return Ok(());
         }
 
-        let model = if config.strict_model_reader {
+        let model = if config.strict_model_reader {s
             world.model_reader_with_block(&namespace, &name, BlockId::Number(block_number)).await?
         } else {
             world.model_reader(&namespace, &name).await?

--- a/crates/torii/indexer/src/processors/register_model.rs
+++ b/crates/torii/indexer/src/processors/register_model.rs
@@ -77,7 +77,9 @@ where
             return Ok(());
         }
 
-        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        let mut model =
+            ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
+                .await?;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/register_model.rs
+++ b/crates/torii/indexer/src/processors/register_model.rs
@@ -79,7 +79,7 @@ where
 
         let mut model =
             ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
-                .await?;
+                .await;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/register_model.rs
+++ b/crates/torii/indexer/src/processors/register_model.rs
@@ -3,7 +3,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use anyhow::{Error, Ok, Result};
 use async_trait::async_trait;
 use dojo_world::contracts::abigen::world::Event as WorldEvent;
-use dojo_world::contracts::model::ModelReader;
+use dojo_world::contracts::model::{ModelRPCReader, ModelReader};
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{BlockId, Event};
 use starknet::providers::Provider;
@@ -77,11 +77,10 @@ where
             return Ok(());
         }
 
-        let model = if config.strict_model_reader {s
-            world.model_reader_with_block(&namespace, &name, BlockId::Number(block_number)).await?
-        } else {
-            world.model_reader(&namespace, &name).await?
-        };
+        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        if config.strict_model_reader {
+            model.set_block(BlockId::Number(block_number)).await;
+        }
         let schema = model.schema().await?;
         let layout = model.layout().await?;
 

--- a/crates/torii/indexer/src/processors/upgrade_event.rs
+++ b/crates/torii/indexer/src/processors/upgrade_event.rs
@@ -90,7 +90,7 @@ where
 
         let mut model =
             ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
-                .await?;
+                .await;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/upgrade_event.rs
+++ b/crates/torii/indexer/src/processors/upgrade_event.rs
@@ -3,7 +3,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use anyhow::{Error, Result};
 use async_trait::async_trait;
 use dojo_world::contracts::abigen::world::Event as WorldEvent;
-use dojo_world::contracts::model::ModelReader;
+use dojo_world::contracts::model::{ModelRPCReader, ModelReader};
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{BlockId, Event};
 use starknet::providers::Provider;
@@ -88,11 +88,10 @@ where
         let namespace = model.namespace;
         let prev_schema = model.schema;
 
-        let model = if config.strict_model_reader {
-            world.model_reader_with_block(&namespace, &name, BlockId::Number(block_number)).await?
-        } else {
-            world.model_reader(&namespace, &name).await?
-        };
+        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        if config.strict_model_reader {
+            model.set_block(BlockId::Number(block_number)).await;
+        }
         let new_schema = model.schema().await?;
         let schema_diff = prev_schema.diff(&new_schema);
         // No changes to the schema. This can happen if torii is re-run with a fresh database.

--- a/crates/torii/indexer/src/processors/upgrade_event.rs
+++ b/crates/torii/indexer/src/processors/upgrade_event.rs
@@ -88,7 +88,9 @@ where
         let namespace = model.namespace;
         let prev_schema = model.schema;
 
-        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        let mut model =
+            ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
+                .await?;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/upgrade_model.rs
+++ b/crates/torii/indexer/src/processors/upgrade_model.rs
@@ -86,7 +86,9 @@ where
         let namespace = model.namespace;
         let prev_schema = model.schema;
 
-        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        let mut model =
+            ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
+                .await?;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/upgrade_model.rs
+++ b/crates/torii/indexer/src/processors/upgrade_model.rs
@@ -88,7 +88,7 @@ where
 
         let mut model =
             ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world)
-                .await?;
+                .await;
         if config.strict_model_reader {
             model.set_block(BlockId::Number(block_number)).await;
         }

--- a/crates/torii/indexer/src/processors/upgrade_model.rs
+++ b/crates/torii/indexer/src/processors/upgrade_model.rs
@@ -3,7 +3,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use anyhow::{Error, Result};
 use async_trait::async_trait;
 use dojo_world::contracts::abigen::world::Event as WorldEvent;
-use dojo_world::contracts::model::ModelReader;
+use dojo_world::contracts::model::{ModelRPCReader, ModelReader};
 use dojo_world::contracts::world::WorldContractReader;
 use starknet::core::types::{BlockId, Event};
 use starknet::providers::Provider;
@@ -86,11 +86,10 @@ where
         let namespace = model.namespace;
         let prev_schema = model.schema;
 
-        let model = if config.strict_model_reader {
-            world.model_reader_with_block(&namespace, &name, BlockId::Number(block_number)).await?
-        } else {
-            world.model_reader(&namespace, &name).await?
-        };
+        let mut model = ModelRPCReader::new(&namespace, &name, event.address.0, event.class_hash.0, world).await?;
+        if config.strict_model_reader {
+            model.set_block(BlockId::Number(block_number)).await;
+        }
         let new_schema = model.schema().await?;
         let schema_diff = prev_schema.diff(&new_schema);
         // No changes to the schema. This can happen if torii is re-run with a fresh database.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined option for accessing model data with simplified parameter handling.
	- Added a method for setting the block in the model reader.
- **Refactor**
	- Consolidated legacy initialization methods to create a more consistent and maintainable model retrieval process.
	- Transitioned to using `ModelRPCReader` for model data access across various processors, enhancing the overall workflow.
- **Bug Fixes**
	- Corrected a minor typographical error in model configuration to ensure reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->