### PR TITLE
feat(torii-graphql): add erc1155 to union

### DIFF
--- a/crates/torii/graphql/src/constants.rs
+++ b/crates/torii/graphql/src/constants.rs
@@ -41,6 +41,7 @@ pub const TOKEN_UNION_TYPE_NAME: &str = "ERC__Token";
 
 pub const ERC20_TYPE_NAME: &str = "ERC20__Token";
 pub const ERC721_TYPE_NAME: &str = "ERC721__Token";
+pub const ERC1155_TYPE_NAME: &str = "ERC1155__Token";
 
 // objects' single and plural names
 pub const ENTITY_NAMES: (&str, &str) = ("entity", "entities");
@@ -55,6 +56,7 @@ pub const PAGE_INFO_NAMES: (&str, &str) = ("pageInfo", "");
 
 pub const ERC20_TOKEN_NAME: (&str, &str) = ("erc20Token", "");
 pub const ERC721_TOKEN_NAME: (&str, &str) = ("erc721Token", "");
+pub const ERC1155_TOKEN_NAME: (&str, &str) = ("erc1155Token", "");
 
 pub const TOKEN_BALANCE_NAME: (&str, &str) = ("", "tokenBalances");
 pub const TOKEN_TRANSFER_NAME: (&str, &str) = ("", "tokenTransfers");

--- a/crates/torii/graphql/src/mapping.rs
+++ b/crates/torii/graphql/src/mapping.rs
@@ -177,6 +177,19 @@ lazy_static! {
         (Name::new("imagePath"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
     ]);
 
+    pub static ref ERC1155_TOKEN_TYPE_MAPPING: TypeMapping = IndexMap::from([
+        (Name::new("name"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("symbol"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("tokenId"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("contractAddress"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("amount"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("metadata"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+        (Name::new("metadataName"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("metadataDescription"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("metadataAttributes"), TypeData::Simple(TypeRef::named(TypeRef::STRING))),
+        (Name::new("imagePath"), TypeData::Simple(TypeRef::named_nn(TypeRef::STRING))),
+    ]);
+
     pub static ref EMPTY_MAPPING: TypeMapping = IndexMap::from([
         (Name::new("id"), TypeData::Simple(TypeRef::named(TypeRef::ID))),
     ]);

--- a/crates/torii/graphql/src/schema.rs
+++ b/crates/torii/graphql/src/schema.rs
@@ -11,12 +11,14 @@ use super::object::model_data::ModelDataObject;
 use super::types::ScalarType;
 use super::utils;
 use crate::constants::{
-    EMPTY_TYPE_NAME, ERC20_TYPE_NAME, ERC721_TYPE_NAME, QUERY_TYPE_NAME, SUBSCRIPTION_TYPE_NAME,
-    TOKEN_UNION_TYPE_NAME,
+    EMPTY_TYPE_NAME, ERC1155_TYPE_NAME, ERC20_TYPE_NAME, ERC721_TYPE_NAME, QUERY_TYPE_NAME,
+    SUBSCRIPTION_TYPE_NAME, TOKEN_UNION_TYPE_NAME,
 };
 use crate::object::controller::ControllerObject;
 use crate::object::empty::EmptyObject;
-use crate::object::erc::erc_token::{Erc20TokenObject, Erc721TokenObject, TokenObject};
+use crate::object::erc::erc_token::{
+    Erc1155TokenObject, Erc20TokenObject, Erc721TokenObject, TokenObject,
+};
 use crate::object::erc::token_balance::ErcBalanceObject;
 use crate::object::erc::token_transfer::ErcTransferObject;
 use crate::object::event_message::EventMessageObject;
@@ -131,6 +133,7 @@ async fn build_objects(pool: &SqlitePool) -> Result<(Vec<ObjectVariant>, Vec<Uni
         ObjectVariant::Basic(Box::new(PageInfoObject)),
         ObjectVariant::Basic(Box::new(Erc721TokenObject)),
         ObjectVariant::Basic(Box::new(Erc20TokenObject)),
+        ObjectVariant::Basic(Box::new(Erc1155TokenObject)),
         ObjectVariant::Basic(Box::new(EmptyObject)),
     ];
 
@@ -141,7 +144,8 @@ async fn build_objects(pool: &SqlitePool) -> Result<(Vec<ObjectVariant>, Vec<Uni
     // erc_token union object
     let erc_token_union = Union::new(TOKEN_UNION_TYPE_NAME)
         .possible_type(ERC20_TYPE_NAME)
-        .possible_type(ERC721_TYPE_NAME);
+        .possible_type(ERC721_TYPE_NAME)
+        .possible_type(ERC1155_TYPE_NAME);
 
     unions.push(erc_token_union);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for ERC1155 tokens, enabling enhanced token representation which includes comprehensive metadata handling.
  - Expanded token attribute and balance processing to integrate ERC1155 details alongside existing token standards.
  - Introduced new constants and mappings for ERC1155 token types and names in the GraphQL schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->