### PR TITLE
fix(torii-graphql): option enums in arrays

### DIFF
--- a/crates/torii/graphql/src/object/model_data.rs
+++ b/crates/torii/graphql/src/object/model_data.rs
@@ -216,7 +216,7 @@ pub fn object(type_name: &str, type_mapping: &TypeMapping, path_array: Vec<Strin
                     // Simple types resolution
                     return match value {
                         Value::Object(value_mapping) => {
-                            Ok(Some(value_mapping.get(&field_name).unwrap_or(&Value::Null).clone()))
+                            Ok(Some(value_mapping.get(&field_name).unwrap().clone()))
                         }
                         _ => Err("Incorrect value, requires Value::Object".into()),
                     };

--- a/crates/torii/graphql/src/object/model_data.rs
+++ b/crates/torii/graphql/src/object/model_data.rs
@@ -216,7 +216,7 @@ pub fn object(type_name: &str, type_mapping: &TypeMapping, path_array: Vec<Strin
                     // Simple types resolution
                     return match value {
                         Value::Object(value_mapping) => {
-                            Ok(Some(value_mapping.get(&field_name).unwrap().clone()))
+                            Ok(Some(value_mapping.get(&field_name).unwrap_or(&Value::Null).clone()))
                         }
                         _ => Err("Incorrect value, requires Value::Object".into()),
                     };

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -189,18 +189,16 @@ pub fn value_mapping_from_row(
                         ) {
                             match value {
                                 Value::Object(obj) => {
-                                    for (field_name, field_value) in obj.iter_mut() {
-                                        if type_data.type_mapping().unwrap().contains_key("option")
-                                            && field_value == &Value::List(vec![])
-                                        {
-                                            continue;
+                                    for (field_name, field_type) in type_data.type_mapping().unwrap().iter() {
+                                        if let Some(field_value) = obj.get_mut(field_name) {
+                                            populate_value(
+                                                field_value,
+                                                field_type,
+                                                entity_id,
+                                            );
+                                        } else {
+                                            obj.insert(field_name.clone(), Value::Null);
                                         }
-
-                                        populate_value(
-                                            field_value,
-                                            &type_data.type_mapping().unwrap()[field_name],
-                                            entity_id,
-                                        );
                                     }
 
                                     if type_data.type_mapping().map_or(false, |mapping| {

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -190,6 +190,12 @@ pub fn value_mapping_from_row(
                             match value {
                                 Value::Object(obj) => {
                                     for (field_name, field_value) in obj.iter_mut() {
+                                        if type_data.type_mapping().unwrap().contains_key("option")
+                                            && field_value == &Value::List(vec![])
+                                        {
+                                            continue;
+                                        }
+
                                         populate_value(
                                             field_value,
                                             &type_data.type_mapping().unwrap()[field_name],

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -189,13 +189,11 @@ pub fn value_mapping_from_row(
                         ) {
                             match value {
                                 Value::Object(obj) => {
-                                    for (field_name, field_type) in type_data.type_mapping().unwrap().iter() {
+                                    for (field_name, field_type) in
+                                        type_data.type_mapping().unwrap().iter()
+                                    {
                                         if let Some(field_value) = obj.get_mut(field_name) {
-                                            populate_value(
-                                                field_value,
-                                                field_type,
-                                                entity_id,
-                                            );
+                                            populate_value(field_value, field_type, entity_id);
                                         } else {
                                             obj.insert(field_name.clone(), Value::Null);
                                         }

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -195,19 +195,14 @@ pub fn value_mapping_from_row(
                                         if let Some(field_value) = obj.get_mut(field_name) {
                                             populate_value(field_value, field_type, entity_id);
                                         } else {
-                                            obj.insert(field_name.clone(), Value::Null);
+                                            obj.insert(field_name.clone(), if field_name == "option" {
+                                                Value::String(obj.keys().next().unwrap().to_string())
+                                            } else {
+                                                Value::Null
+                                            });
                                         }
                                     }
-
-                                    if type_data.type_mapping().map_or(false, |mapping| {
-                                        mapping.contains_key(&Name::new("option"))
-                                    }) {
-                                        obj.insert(
-                                            Name::new("option"),
-                                            Value::String(obj.keys().next().unwrap().to_string()),
-                                        );
-                                    }
-
+                                    
                                     // insert $entity_id$ relation
                                     if let Some(entity_id) = entity_id {
                                         obj.insert(

--- a/crates/torii/graphql/src/query/mod.rs
+++ b/crates/torii/graphql/src/query/mod.rs
@@ -195,14 +195,19 @@ pub fn value_mapping_from_row(
                                         if let Some(field_value) = obj.get_mut(field_name) {
                                             populate_value(field_value, field_type, entity_id);
                                         } else {
-                                            obj.insert(field_name.clone(), if field_name == "option" {
-                                                Value::String(obj.keys().next().unwrap().to_string())
-                                            } else {
-                                                Value::Null
-                                            });
+                                            obj.insert(
+                                                field_name.clone(),
+                                                if field_name == "option" {
+                                                    Value::String(
+                                                        obj.keys().next().unwrap().to_string(),
+                                                    )
+                                                } else {
+                                                    Value::Null
+                                                },
+                                            );
                                         }
                                     }
-                                    
+
                                     // insert $entity_id$ relation
                                     if let Some(entity_id) = entity_id {
                                         obj.insert(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data mapping to ensure every expected field appears in query responses. Now, if a field is missing, a default value (null or a specific fallback for certain fields) is provided, yielding more consistent and predictable data outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->