### PR TITLE
fix: sozo build --typescript now properly orders contracts.gen.ts

### DIFF
--- a/crates/dojo/bindgen/src/plugins/typescript/writer.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/writer.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use cainome::parser::tokens::Composite;
+use dojo_world::contracts::naming;
 
 use crate::error::BindgenResult;
 use crate::plugins::{BindgenContractGenerator, BindgenModelGenerator, BindgenWriter, Buffer};
@@ -148,7 +149,15 @@ impl BindgenWriter for TsFileContractWriter {
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
-        functions.sort_by(|(_, af), (_, bf)| af.name.cmp(&bf.name));
+
+        functions.sort_by(|(ca, af), (cb, bf)| {
+            let contract_a = naming::get_name_from_tag(&ca.tag);
+            let contract_b = naming::get_name_from_tag(&cb.tag);
+            let function_a = format!("{}_{}", contract_a, af.name);
+            let function_b = format!("{}_{}", contract_b, bf.name);
+
+            function_a.cmp(&function_b)
+        });
 
         let code = self
             .generators


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

## Related issue
#2943



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the ordering of functions in generated contracts, ensuring a more intuitive grouping based on both the contract context and function names. This enhancement leads to clearer and more consistent output for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->