### PR TITLE
fix(signer): resolve keystore path before retrieving private key

### DIFF
--- a/bin/sozo/Cargo.toml
+++ b/bin/sozo/Cargo.toml
@@ -24,7 +24,7 @@ dojo-utils.workspace = true
 dojo-world.workspace = true
 katana-rpc-api.workspace = true
 notify = "7.0.0"
-tabled = { version = "0.16.0", features = [ "ansi" ] }
+resolve-path = "0.1.0"
 scarb.workspace = true
 scarb-metadata.workspace = true
 scarb-ui.workspace = true
@@ -33,10 +33,11 @@ serde.workspace = true
 serde_json.workspace = true
 smol_str.workspace = true
 sozo-ops.workspace = true
-sozo-walnut = { workspace = true, optional = true }
 sozo-scarbext.workspace = true
+sozo-walnut = { workspace = true, optional = true }
 starknet.workspace = true
 starknet-crypto.workspace = true
+tabled = { version = "0.16.0", features = ["ansi"] }
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
@@ -44,19 +45,19 @@ tracing-log.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 
-reqwest = { workspace = true, features = [ "json" ], optional = true }
+reqwest = { workspace = true, features = ["json"], optional = true }
 
 [dev-dependencies]
-dojo-test-utils = { workspace = true, features = [ "build-examples" ] }
+dojo-test-utils = { workspace = true, features = ["build-examples"] }
 katana-runner.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 
 [features]
-default = [ "controller", "walnut" ]
+default = ["controller", "walnut"]
 
-controller = [ "dep:reqwest", "dep:slot" ]
-walnut = [ "dep:sozo-walnut", "sozo-ops/walnut" ]
+controller = ["dep:reqwest", "dep:slot"]
+walnut = ["dep:sozo-walnut", "sozo-ops/walnut"]
 
 [[bench]]
 harness = false

--- a/bin/sozo/src/commands/options/signer.rs
+++ b/bin/sozo/src/commands/options/signer.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+use std::str::FromStr;
+
 use anyhow::{anyhow, Result};
 use clap::Args;
 use dojo_utils::env::{
@@ -5,9 +8,6 @@ use dojo_utils::env::{
 };
 use dojo_utils::keystore::prompt_password_if_needed;
 use dojo_world::config::Environment;
-use std::path::Path;
-use std::str::FromStr;
-
 use resolve_path::PathResolveExt;
 use starknet::core::types::Felt;
 use starknet::signers::{LocalWallet, SigningKey};

--- a/bin/sozo/src/commands/options/signer.rs
+++ b/bin/sozo/src/commands/options/signer.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use anyhow::{anyhow, Result};
 use clap::Args;
 use dojo_utils::env::{
@@ -7,6 +5,10 @@ use dojo_utils::env::{
 };
 use dojo_utils::keystore::prompt_password_if_needed;
 use dojo_world::config::Environment;
+use std::path::Path;
+use std::str::FromStr;
+
+use resolve_path::PathResolveExt;
 use starknet::core::types::Felt;
 use starknet::signers::{LocalWallet, SigningKey};
 use tracing::trace;
@@ -93,7 +95,7 @@ impl SignerOptions {
 
             let password = prompt_password_if_needed(maybe_password, no_wait)?;
 
-            let private_key = SigningKey::from_keystore(path, &password)?;
+            let private_key = SigningKey::from_keystore(Path::new(path).resolve(), &password)?;
             return Ok(Some(private_key));
         }
 
@@ -116,7 +118,7 @@ impl SignerOptions {
 
             let password = prompt_password_if_needed(maybe_password, no_wait)?;
 
-            let private_key = SigningKey::from_keystore(path, &password)?;
+            let private_key = SigningKey::from_keystore(Path::new(path).resolve(), &password)?;
             return Ok(Some(private_key));
         }
 


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

Added support for `~` in keystore paths 

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

Not sure how to test this as its local file system dependent  

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This update improves system stability and reliability without altering user-facing functionality.

- **Chores**
  - Streamlined dependency configurations and standardized formatting to ensure consistent performance and smoother maintenance across the application.

- **Bug Fixes**
  - Enhanced secure key access by ensuring storage locations are determined correctly, resulting in improved reliability when retrieving secure credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->