### PR TITLE
feat(katana) : add feature flag for controller

### DIFF
--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -138,7 +138,7 @@ impl NodeArgs {
             utils::print_intro(self, &node.backend.chain_spec);
         }
 
-        // Get chain ID before launching the node                               
+        // Get chain ID before launching the node
         let chain_id = node.backend.chain_spec.id();
 
         // Launch the node

--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -138,6 +138,9 @@ impl NodeArgs {
             utils::print_intro(self, &node.backend.chain_spec);
         }
 
+        // Get chain ID before launching the node                               
+        let chain_id = node.backend.chain_spec.id();
+
         // Launch the node
         let handle = node.launch().await.context("failed to launch node")?;
 
@@ -146,7 +149,7 @@ impl NodeArgs {
             let rpc_url = format!("http://{}", handle.rpc.addr());
             let rpc_url = Url::parse(&rpc_url).context("failed to parse node url")?;
             let addr = SocketAddr::new(self.explorer.explorer_addr, self.explorer.explorer_port);
-            let _ = Explorer::new(rpc_url)?.start(addr)?;
+            let _ = Explorer::new(rpc_url, chain_id.to_string())?.start(addr)?;
         }
 
         // Wait until an OS signal (ie SIGINT, SIGTERM) is received or the node is shutdown.

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -161,8 +161,8 @@ fn setup_env(html: &str, rpc_url: &Url, chain_id: &str) -> String {
     let escaped_chain_id = chain_id.replace("\"", "\\\"").replace("<", "&lt;").replace(">", "&gt;");
 
     // We inject the RPC URL and chain ID into the HTML for the controller to use.
-    // The chain rpc and chain id are required params to initialize the controller.
-    // (ref - https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L32)
+    // The chain rpc and chain id are required params to initialize the controller <https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L32>.
+    // The parameters are consumed by the explorer here <https://github.com/cartridge-gg/explorer/blob/68ac4ea9500a90abc0d7c558440a99587cb77585/src/constants/rpc.ts#L14-L15>. 
 
     // NOTE: ENABLE_CONTROLLER feature flag is a temporary solution to handle the controller.
     // The controller expects to have a `defaultChainId` but we don't have a way

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 #[derive(Debug)]
 pub struct Explorer {
-    // The JSON-RPC url of the chain that the explorer will connect to.
+    /// The JSON-RPC url of the chain that the explorer will connect to.
     rpc_url: Url,
     // The chain ID of the network
     chain_id: String,

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -11,7 +11,7 @@ use url::Url;
 pub struct Explorer {
     /// The JSON-RPC url of the chain that the explorer will connect to.
     rpc_url: Url,
-    // The chain ID of the network
+    /// The chain ID of the network
     chain_id: String,
 }
 

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -37,7 +37,6 @@ impl Explorer {
         let rpc_url = self.rpc_url.clone();
         let chain_id = self.chain_id.clone();
 
-
         // TODO: handle cancellation
         let _handle = thread::spawn(move || {
             for request in server.incoming_requests() {
@@ -162,16 +161,17 @@ fn setup_env(html: &str, rpc_url: &Url, chain_id: &str) -> String {
     let escaped_chain_id = chain_id.replace("\"", "\\\"").replace("<", "&lt;").replace(">", "&gt;");
 
     // We inject the RPC URL and chain ID into the HTML for the controller to use.
-    // The chain rpc and chain id are required params to initialize the controller. 
+    // The chain rpc and chain id are required params to initialize the controller.
     // (ref - https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L32)
 
-    // NOTE: ENABLE_CONTROLLER feature flag is a temporary solution to handle the controller. 
-    // The controller expects to have a `defaultChainId` but we don't have a way 
+    // NOTE: ENABLE_CONTROLLER feature flag is a temporary solution to handle the controller.
+    // The controller expects to have a `defaultChainId` but we don't have a way
     // to set it in the explorer yet in development mode (locally running katana instance).
-    // The temporary solution is to disable the controller by setting the ENABLE_CONTROLLER flag to false for these explorers.
-    // Once we have an updated controller JS SDK which can handle the chain ID of local katana instances then we can remove this 
-    // flag value. (ref - https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L57)
-    // TODO: remove the ENABLE_CONTROLLER flag once we have a proper way to handle the chain ID for local katana instances.
+    // The temporary solution is to disable the controller by setting the ENABLE_CONTROLLER flag to
+    // false for these explorers. Once we have an updated controller JS SDK which can handle the
+    // chain ID of local katana instances then we can remove this flag value. (ref - https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L57)
+    // TODO: remove the ENABLE_CONTROLLER flag once we have a proper way to handle the chain ID for
+    // local katana instances.
     let script = format!(
         r#"<script>
             window.RPC_URL = "{}";

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -189,7 +189,7 @@ fn setup_env(html: &str, rpc_url: &Url, chain_id: &str) -> String {
     }
 }
 
-// Gets the content type for a file based on its extension.
+/// Gets the content type for a file based on its extension.
 fn get_content_type(path: &str) -> &'static str {
     match path.rsplit('.').next() {
         Some("html") => "text/html",

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -162,7 +162,7 @@ fn setup_env(html: &str, rpc_url: &Url, chain_id: &str) -> String {
 
     // We inject the RPC URL and chain ID into the HTML for the controller to use.
     // The chain rpc and chain id are required params to initialize the controller <https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L32>.
-    // The parameters are consumed by the explorer here <https://github.com/cartridge-gg/explorer/blob/68ac4ea9500a90abc0d7c558440a99587cb77585/src/constants/rpc.ts#L14-L15>. 
+    // The parameters are consumed by the explorer here <https://github.com/cartridge-gg/explorer/blob/68ac4ea9500a90abc0d7c558440a99587cb77585/src/constants/rpc.ts#L14-L15>.
 
     // NOTE: ENABLE_CONTROLLER feature flag is a temporary solution to handle the controller.
     // The controller expects to have a `defaultChainId` but we don't have a way

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -152,8 +152,8 @@ impl ExplorerHandle {
 #[folder = "ui/dist"]
 struct ExplorerAssets;
 
-// This function adds a script tag to the HTML that sets up environment variables
-// for the explorer to use.
+/// This function adds a script tag to the HTML that sets up environment variables
+/// for the explorer to use.
 fn setup_env(html: &str, rpc_url: &Url, chain_id: &str) -> String {
     // Escape special characters to prevent XSS
     let rpc_url = rpc_url.to_string();

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -134,7 +134,7 @@ impl Explorer {
     }
 }
 
-// Handle to the explorer server.
+/// Handle to the explorer server.
 #[derive(Debug)]
 pub struct ExplorerHandle {
     addr: SocketAddr,

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -147,7 +147,7 @@ impl ExplorerHandle {
     }
 }
 
-// Embedded explorer UI files.
+/// Embedded explorer UI files.
 #[derive(RustEmbed)]
 #[folder = "ui/dist"]
 struct ExplorerAssets;

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -28,7 +28,7 @@ impl Explorer {
         Ok(Self { rpc_url, chain_id })
     }
 
-    // Start the explorer server at the given address.
+    /// Start the explorer server at the given address.
     pub fn start(&self, addr: SocketAddr) -> Result<ExplorerHandle> {
         let server =
             Server::http(addr).map_err(|e| anyhow!("Failed to start explorer server: {}", e))?;

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -141,7 +141,7 @@ pub struct ExplorerHandle {
 }
 
 impl ExplorerHandle {
-    // Returns the socket address of the explorer.
+    /// Returns the socket address of the explorer.
     pub fn addr(&self) -> &SocketAddr {
         &self.addr
     }

--- a/crates/katana/explorer/src/lib.rs
+++ b/crates/katana/explorer/src/lib.rs
@@ -9,9 +9,9 @@ use url::Url;
 
 #[derive(Debug)]
 pub struct Explorer {
-    /// The JSON-RPC url of the chain that the explorer will connect to.
+    // The JSON-RPC url of the chain that the explorer will connect to.
     rpc_url: Url,
-    /// The chain ID of the network
+    // The chain ID of the network
     chain_id: String,
 }
 
@@ -28,7 +28,7 @@ impl Explorer {
         Ok(Self { rpc_url, chain_id })
     }
 
-    /// Start the explorer server at the given address.
+    // Start the explorer server at the given address.
     pub fn start(&self, addr: SocketAddr) -> Result<ExplorerHandle> {
         let server =
             Server::http(addr).map_err(|e| anyhow!("Failed to start explorer server: {}", e))?;
@@ -135,33 +135,43 @@ impl Explorer {
     }
 }
 
-/// Handle to the explorer server.
+// Handle to the explorer server.
 #[derive(Debug)]
 pub struct ExplorerHandle {
     addr: SocketAddr,
 }
 
 impl ExplorerHandle {
-    /// Returns the socket address of the explorer.
+    // Returns the socket address of the explorer.
     pub fn addr(&self) -> &SocketAddr {
         &self.addr
     }
 }
 
-/// Embedded explorer UI files.
+// Embedded explorer UI files.
 #[derive(RustEmbed)]
 #[folder = "ui/dist"]
 struct ExplorerAssets;
 
-/// This function adds a script tag to the HTML that sets up environment variables
-/// for the explorer to use.
+// This function adds a script tag to the HTML that sets up environment variables
+// for the explorer to use.
 fn setup_env(html: &str, rpc_url: &Url, chain_id: &str) -> String {
     // Escape special characters to prevent XSS
     let rpc_url = rpc_url.to_string();
     let escaped_url = rpc_url.replace("\"", "\\\"").replace("<", "&lt;").replace(">", "&gt;");
     let escaped_chain_id = chain_id.replace("\"", "\\\"").replace("<", "&lt;").replace(">", "&gt;");
 
+    // We inject the RPC URL and chain ID into the HTML for the controller to use.
+    // The chain rpc and chain id are required params to initialize the controller. 
+    // (ref - https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L32)
 
+    // NOTE: ENABLE_CONTROLLER feature flag is a temporary solution to handle the controller. 
+    // The controller expects to have a `defaultChainId` but we don't have a way 
+    // to set it in the explorer yet in development mode (locally running katana instance).
+    // The temporary solution is to disable the controller by setting the ENABLE_CONTROLLER flag to false for these explorers.
+    // Once we have an updated controller JS SDK which can handle the chain ID of local katana instances then we can remove this 
+    // flag value. (ref - https://github.com/cartridge-gg/controller/blob/main/packages/controller/src/controller.ts#L57)
+    // TODO: remove the ENABLE_CONTROLLER flag once we have a proper way to handle the chain ID for local katana instances.
     let script = format!(
         r#"<script>
             window.RPC_URL = "{}";
@@ -179,7 +189,7 @@ fn setup_env(html: &str, rpc_url: &Url, chain_id: &str) -> String {
     }
 }
 
-/// Gets the content type for a file based on its extension.
+// Gets the content type for a file based on its extension.
 fn get_content_type(path: &str) -> &'static str {
     match path.rsplit('.').next() {
         Some("html") => "text/html",


### PR DESCRIPTION
# Description

I add the configuration of adding a chain id to the cartridge controller in the explorer. These values are injected in the client for the controller to consume. I also add a feature flag which is needed since controller doesn't support local development with katana. Once this is live, we can enable the flag here

<!--
A description of what this PR is solving.
-->

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [x] I've formatted my code (`scripts/prettier.sh`, `scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [x] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [x] I've commented my code
- [x] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The explorer now initializes with a network chain identifier to ensure it uses the correct network context.
  - The client-facing environment has been enhanced to include both the endpoint details and chain identification, providing improved configuration for the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->