### PR TITLE
feat(torii-libp2p): inter torii messaging for offchain messages

### DIFF
--- a/crates/torii/cli/src/options.rs
+++ b/crates/torii/cli/src/options.rs
@@ -75,6 +75,16 @@ pub struct RelayOptions {
     )]
     #[serde(default)]
     pub cert_path: Option<String>,
+
+    /// A list of other torii relays to connect to and sync with.
+    /// Right now, only offchain messages broadcasted by the relay will be synced.
+    #[arg(
+        long = "relay.peers",
+        value_delimiter = ',',
+        help = "A list of other torii relays to connect to and sync with."
+    )]
+    #[serde(default)]
+    pub peers: Vec<String>,
 }
 
 impl Default for RelayOptions {
@@ -85,6 +95,7 @@ impl Default for RelayOptions {
             websocket_port: DEFAULT_RELAY_WEBSOCKET_PORT,
             local_key_path: None,
             cert_path: None,
+            peers: vec![],
         }
     }
 }

--- a/crates/torii/libp2p/src/client/mod.rs
+++ b/crates/torii/libp2p/src/client/mod.rs
@@ -48,11 +48,10 @@ impl RelayClient {
     pub fn new(relay_addr: String) -> Result<Self, Error> {
         use libp2p::core::muxing::StreamMuxerBox;
         use libp2p::core::upgrade::Version;
-        use libp2p::{dns, websocket, Transport};
-        use libp2p_webrtc::tokio::Certificate;
+        use libp2p::{dns, tcp, websocket, Transport};
         use libp2p_webrtc as webrtc;
+        use libp2p_webrtc::tokio::Certificate;
         use rand::thread_rng;
-        use libp2p::tcp;
 
         let local_key = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(local_key.public());
@@ -123,8 +122,9 @@ impl RelayClient {
 
     #[cfg(target_arch = "wasm32")]
     pub fn new(relay_addr: String) -> Result<Self, Error> {
-        use libp2p::core::{upgrade::Version, Transport};
-        
+        use libp2p::core::upgrade::Version;
+        use libp2p::core::Transport;
+
         let local_key = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(local_key.public());
 

--- a/crates/torii/libp2p/src/client/mod.rs
+++ b/crates/torii/libp2p/src/client/mod.rs
@@ -5,14 +5,9 @@ use futures::channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures::channel::oneshot;
 use futures::lock::Mutex;
 use futures::{select, StreamExt};
-#[cfg(target_arch = "wasm32")]
-use libp2p::core::{upgrade::Version, Transport};
 use libp2p::gossipsub::{self, IdentTopic, MessageId};
 use libp2p::swarm::{NetworkBehaviour, Swarm, SwarmEvent};
-#[cfg(not(target_arch = "wasm32"))]
-use libp2p::tcp;
 use libp2p::{identify, identity, noise, ping, yamux, Multiaddr, PeerId};
-use libp2p_webrtc as webrtc;
 use tracing::info;
 
 pub mod events;
@@ -55,7 +50,9 @@ impl RelayClient {
         use libp2p::core::upgrade::Version;
         use libp2p::{dns, websocket, Transport};
         use libp2p_webrtc::tokio::Certificate;
+        use libp2p_webrtc as webrtc;
         use rand::thread_rng;
+        use libp2p::tcp;
 
         let local_key = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(local_key.public());
@@ -126,6 +123,8 @@ impl RelayClient {
 
     #[cfg(target_arch = "wasm32")]
     pub fn new(relay_addr: String) -> Result<Self, Error> {
+        use libp2p::core::{upgrade::Version, Transport};
+        
         let local_key = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(local_key.public());
 

--- a/crates/torii/libp2p/src/client/mod.rs
+++ b/crates/torii/libp2p/src/client/mod.rs
@@ -51,10 +51,11 @@ enum Command {
 impl RelayClient {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn new(relay_addr: String) -> Result<Self, Error> {
-        use libp2p::{core::{muxing::StreamMuxerBox, upgrade::Version}, dns, websocket};
+        use libp2p::core::muxing::StreamMuxerBox;
+        use libp2p::core::upgrade::Version;
+        use libp2p::{dns, websocket, Transport};
         use libp2p_webrtc::tokio::Certificate;
         use rand::thread_rng;
-        use libp2p::Transport;
 
         let local_key = identity::Keypair::generate_ed25519();
         let peer_id = PeerId::from(local_key.public());

--- a/crates/torii/libp2p/src/constants.rs
+++ b/crates/torii/libp2p/src/constants.rs
@@ -1,3 +1,4 @@
 pub(crate) const GOSSIPSUB_HEARTBEAT_INTERVAL_SECS: u64 = 10;
 pub(crate) const MESSAGING_TOPIC: &str = "message";
+pub(crate) const PEERS_MESSAGING_TOPIC: &str = "peers";
 pub(crate) const IDLE_CONNECTION_TIMEOUT_SECS: u64 = 60;

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -70,7 +70,16 @@ impl<P: Provider + Sync> Relay<P> {
         local_key_path: Option<String>,
         cert_path: Option<String>,
     ) -> Result<Self, Error> {
-        Self::new_with_peers(pool, provider, port, port_webrtc, port_websocket, local_key_path, cert_path, vec![])
+        Self::new_with_peers(
+            pool,
+            provider,
+            port,
+            port_webrtc,
+            port_websocket,
+            local_key_path,
+            cert_path,
+            vec![],
+        )
     }
 
     pub fn new_with_peers(

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -69,6 +69,18 @@ impl<P: Provider + Sync> Relay<P> {
         port_websocket: u16,
         local_key_path: Option<String>,
         cert_path: Option<String>,
+    ) -> Result<Self, Error> {
+        Self::new_with_peers(pool, provider, port, port_webrtc, port_websocket, local_key_path, cert_path, vec![])
+    }
+
+    pub fn new_with_peers(
+        pool: Sql,
+        provider: P,
+        port: u16,
+        port_webrtc: u16,
+        port_websocket: u16,
+        local_key_path: Option<String>,
+        cert_path: Option<String>,
         peers: Vec<String>,
     ) -> Result<Self, Error> {
         let local_key = if let Some(path) = local_key_path {

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -285,7 +285,7 @@ impl<P: Provider + Sync> Relay<P> {
                                         continue;
                                     }
                                 },
-                                None => match get_identity_from_ty(&ty) {
+                                _ => match get_identity_from_ty(&ty) {
                                     Ok(identity) => identity,
                                     Err(e) => {
                                         warn!(

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -82,6 +82,7 @@ impl<P: Provider + Sync> Relay<P> {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_peers(
         pool: Sql,
         provider: P,

--- a/crates/torii/runner/src/lib.rs
+++ b/crates/torii/runner/src/lib.rs
@@ -222,7 +222,7 @@ impl Runner {
         )
         .await?;
 
-        let mut libp2p_relay_server = torii_relay::server::Relay::new(
+        let mut libp2p_relay_server = torii_relay::server::Relay::new_with_peers(
             db,
             provider.clone(),
             self.args.relay.port,
@@ -230,6 +230,7 @@ impl Runner {
             self.args.relay.websocket_port,
             self.args.relay.local_key_path,
             self.args.relay.cert_path,
+            self.args.relay.peers,
         )
         .expect("Failed to start libp2p relay server");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced connectivity by adding support for additional transport protocols, including WebRTC and WebSocket connections.
  - Introduced a new command-line option for specifying other Torii relays to synchronize with.
  - Added a new messaging topic for peer communication.

- **Refactor**
  - Updated the Relay struct to initialize a list of peers for connection establishment.
  - Modified the Relay server instantiation to accept a list of peers for improved network behavior.
  - Refined handling of identity determination to allow more flexible processing of varied network scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->