### PR TITLE
fix(torii-artifacts): ignore hash file from entries

### DIFF
--- a/crates/torii/server/src/artifacts.rs
+++ b/crates/torii/server/src/artifacts.rs
@@ -115,7 +115,9 @@ fn file_name_from_dir_and_query(
             entry
                 .file_name()
                 .to_str()
-                .map(|name| name.starts_with("image") && !name.contains('@') && !name.ends_with(".hash"))
+                .map(|name| {
+                    name.starts_with("image") && !name.contains('@') && !name.ends_with(".hash")
+                })
                 .unwrap_or(false)
         })
         .with_context(|| "Failed to find base image")?;

--- a/crates/torii/server/src/artifacts.rs
+++ b/crates/torii/server/src/artifacts.rs
@@ -115,7 +115,7 @@ fn file_name_from_dir_and_query(
             entry
                 .file_name()
                 .to_str()
-                .map(|name| name.starts_with("image") && !name.contains('@'))
+                .map(|name| name.starts_with("image") && !name.contains('@') && !name.ends_with(".hash"))
                 .unwrap_or(false)
         })
         .with_context(|| "Failed to find base image")?;

--- a/examples/spawn-and-move/dope.toml
+++ b/examples/spawn-and-move/dope.toml
@@ -1,0 +1,14 @@
+rpc = "https://api.cartridge.gg/x/starknet/mainnet"
+#world_address = "0x04f3dccb47477c087ad9c76b8067b8aadded57f8df7f2d7543e6066bcb25332c"
+world_address = "0x0"
+
+[indexing]
+allowed_origins = ["*"]
+world_block = 889004
+pending = true
+transactions = true
+contracts = [
+    "ERC721:0x051d0844f96f86c7363cc7eb3ab939e0ef5b70939dcbc17895b2fa178d9af420",
+    "ERC721:0x0537fa10cefbb8ff7e61e86e950746809f95faa7398f250f0063069b29bb7933",
+]
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Refined image file filtering to ensure only appropriate images are processed, preventing unwanted file types from affecting the display or handling of images.
  
- **New Features**
	- Introduced a new configuration file `dope.toml` for blockchain interaction settings, including RPC endpoint and indexing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->