### PR TITLE
feat(katana): extract RpcOptions from ServerOptions

### DIFF
--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -713,14 +713,14 @@ chain_id.Named = "Mainnet"
 
     #[test]
     fn http_modules() {
-        // If the `--http.api` isn't specified, only starknet module will be exposed.
+        // If the `--rpc.api` isn't specified, only starknet module will be exposed.
         let config = NodeArgs::parse_from(["katana"]).config().unwrap();
         let modules = config.rpc.apis;
         assert_eq!(modules.len(), 1);
         assert!(modules.contains(&RpcModuleKind::Starknet));
 
-        // If the `--http.api` is specified, only the ones in the list will be exposed.
-        let config = NodeArgs::parse_from(["katana", "--http.api", "saya,torii"]).config().unwrap();
+        // If the `--rpc.api` is specified, only the ones in the list will be exposed.
+        let config = NodeArgs::parse_from(["katana", "--rpc.api", "saya,torii"]).config().unwrap();
         let modules = config.rpc.apis;
         assert_eq!(modules.len(), 2);
         assert!(modules.contains(&RpcModuleKind::Saya));
@@ -728,7 +728,7 @@ chain_id.Named = "Mainnet"
 
         // Specifiying the dev module without enabling dev mode is forbidden.
         let err =
-            NodeArgs::parse_from(["katana", "--http.api", "starknet,dev"]).config().unwrap_err();
+            NodeArgs::parse_from(["katana", "--rpc.api", "starknet,dev"]).config().unwrap_err();
         assert!(
             err.to_string()
                 .contains("The `dev` module can only be enabled in dev mode (ie `--dev` flag)")

--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -103,7 +103,6 @@ pub struct NodeArgs {
     #[command(flatten)]
     pub server: ServerOptions,
 
-    #[cfg(feature = "server")]
     #[command(flatten)]
     pub rpc: RpcOptions,
 

--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -103,6 +103,10 @@ pub struct NodeArgs {
     #[command(flatten)]
     pub server: ServerOptions,
 
+    #[cfg(feature = "server")]
+    #[command(flatten)]
+    pub rpc: RpcOptions,
+
     #[command(flatten)]
     pub starknet: StarknetOptions,
 
@@ -223,7 +227,7 @@ impl NodeArgs {
     fn rpc_config(&self) -> Result<RpcConfig> {
         #[cfg(feature = "server")]
         {
-            let modules = if let Some(modules) = &self.server.http_modules {
+            let modules = if let Some(modules) = &self.rpc.http_modules {
                 // TODO: This check should be handled in the `katana-node` level. Right now if you
                 // instantiate katana programmatically, you can still add the dev module without
                 // enabling dev mode.
@@ -271,13 +275,13 @@ impl NodeArgs {
                 apis: modules,
                 port: self.server.http_port,
                 addr: self.server.http_addr,
-                max_connections: self.server.max_connections,
+                max_connections: self.rpc.max_connections,
                 cors_origins,
                 max_request_body_size: None,
                 max_response_body_size: None,
-                max_event_page_size: Some(self.server.max_event_page_size),
-                max_proof_keys: Some(self.server.max_proof_keys),
-                max_call_gas: Some(self.server.max_call_gas),
+                max_event_page_size: Some(self.rpc.max_event_page_size),
+                max_proof_keys: Some(self.rpc.max_proof_keys),
+                max_call_gas: Some(self.rpc.max_call_gas),
             })
         }
 
@@ -426,6 +430,7 @@ impl NodeArgs {
         #[cfg(feature = "server")]
         {
             self.server.merge(config.server.as_ref());
+            self.rpc.merge(config.rpc.as_ref());
 
             if self.metrics == MetricsOptions::default() {
                 if let Some(metrics) = config.metrics {

--- a/crates/katana/cli/src/file.rs
+++ b/crates/katana/cli/src/file.rs
@@ -24,6 +24,8 @@ pub struct NodeArgsConfig {
     #[cfg(feature = "server")]
     pub server: Option<ServerOptions>,
     #[cfg(feature = "server")]
+    pub rpc: Option<RpcOptions>,
+    #[cfg(feature = "server")]
     pub metrics: Option<MetricsOptions>,
 }
 
@@ -67,6 +69,7 @@ impl TryFrom<NodeArgs> for NodeArgsConfig {
         {
             node_config.server =
                 if args.server == ServerOptions::default() { None } else { Some(args.server) };
+            node_config.rpc = if args.rpc == RpcOptions::default() { None } else { Some(args.rpc) };
             node_config.metrics =
                 if args.metrics == MetricsOptions::default() { None } else { Some(args.metrics) };
         }

--- a/crates/katana/cli/src/file.rs
+++ b/crates/katana/cli/src/file.rs
@@ -21,10 +21,9 @@ pub struct NodeArgsConfig {
     pub forking: Option<ForkingOptions>,
     #[serde(rename = "dev")]
     pub development: Option<DevOptions>,
+    pub rpc: Option<RpcOptions>,
     #[cfg(feature = "server")]
     pub server: Option<ServerOptions>,
-    #[cfg(feature = "server")]
-    pub rpc: Option<RpcOptions>,
     #[cfg(feature = "server")]
     pub metrics: Option<MetricsOptions>,
 }
@@ -64,12 +63,12 @@ impl TryFrom<NodeArgs> for NodeArgsConfig {
             if args.forking == ForkingOptions::default() { None } else { Some(args.forking) };
         node_config.development =
             if args.development == DevOptions::default() { None } else { Some(args.development) };
+        node_config.rpc = if args.rpc == RpcOptions::default() { None } else { Some(args.rpc) };
 
         #[cfg(feature = "server")]
         {
             node_config.server =
                 if args.server == ServerOptions::default() { None } else { Some(args.server) };
-            node_config.rpc = if args.rpc == RpcOptions::default() { None } else { Some(args.rpc) };
             node_config.metrics =
                 if args.metrics == MetricsOptions::default() { None } else { Some(args.metrics) };
         }

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -134,7 +134,7 @@ impl ServerOptions {
 #[command(next_help_heading = "Rpc options")]
 pub struct RpcOptions {
     /// API's offered over the HTTP-RPC interface.
-    #[arg(long = "rpc.api", value_name = "MODULES")]
+    #[arg(long = "rpc.api", value_name = "MODULES", alias = "http.api")]
     #[arg(value_parser = RpcModulesList::parse)]
     #[serde(default)]
     pub http_modules: Option<RpcModulesList>,

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -99,9 +99,42 @@ pub struct ServerOptions {
         deserialize_with = "deserialize_cors_origins"
     )]
     pub http_cors_origins: Vec<HeaderValue>,
+}
 
+#[cfg(feature = "server")]
+impl Default for ServerOptions {
+    fn default() -> Self {
+        ServerOptions {
+            http_addr: DEFAULT_RPC_ADDR,
+            http_port: DEFAULT_RPC_PORT,
+            http_cors_origins: Vec::new(),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl ServerOptions {
+    pub fn merge(&mut self, other: Option<&Self>) {
+        if let Some(other) = other {
+            if self.http_addr == DEFAULT_RPC_ADDR {
+                self.http_addr = other.http_addr;
+            }
+            if self.http_port == DEFAULT_RPC_PORT {
+                self.http_port = other.http_port;
+            }
+            if self.http_cors_origins.is_empty() {
+                self.http_cors_origins = other.http_cors_origins.clone();
+            }
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+#[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
+#[command(next_help_heading = "Rpc options")]
+pub struct RpcOptions {
     /// API's offered over the HTTP-RPC interface.
-    #[arg(long = "http.api", value_name = "MODULES")]
+    #[arg(long = "rpc.api", value_name = "MODULES")]
     #[arg(value_parser = RpcModulesList::parse)]
     #[serde(default)]
     pub http_modules: Option<RpcModulesList>,
@@ -138,12 +171,9 @@ pub struct ServerOptions {
 }
 
 #[cfg(feature = "server")]
-impl Default for ServerOptions {
+impl Default for RpcOptions {
     fn default() -> Self {
-        ServerOptions {
-            http_addr: DEFAULT_RPC_ADDR,
-            http_port: DEFAULT_RPC_PORT,
-            http_cors_origins: Vec::new(),
+        RpcOptions {
             http_modules: None,
             max_event_page_size: DEFAULT_RPC_MAX_EVENT_PAGE_SIZE,
             max_proof_keys: DEFAULT_RPC_MAX_PROOF_KEYS,
@@ -156,18 +186,9 @@ impl Default for ServerOptions {
 }
 
 #[cfg(feature = "server")]
-impl ServerOptions {
+impl RpcOptions {
     pub fn merge(&mut self, other: Option<&Self>) {
         if let Some(other) = other {
-            if self.http_addr == DEFAULT_RPC_ADDR {
-                self.http_addr = other.http_addr;
-            }
-            if self.http_port == DEFAULT_RPC_PORT {
-                self.http_port = other.http_port;
-            }
-            if self.http_cors_origins.is_empty() {
-                self.http_cors_origins = other.http_cors_origins.clone();
-            }
             if self.http_modules.is_none() {
                 self.http_modules = other.http_modules.clone();
             }

--- a/crates/katana/cli/src/options.rs
+++ b/crates/katana/cli/src/options.rs
@@ -7,20 +7,18 @@
 //!
 //! Currently, the merge is made at the top level of the commands.
 
-#[cfg(feature = "server")]
-use std::net::IpAddr;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 
 use clap::Args;
 use katana_node::config::execution::{DEFAULT_INVOCATION_MAX_STEPS, DEFAULT_VALIDATION_MAX_STEPS};
 #[cfg(feature = "server")]
 use katana_node::config::metrics::{DEFAULT_METRICS_ADDR, DEFAULT_METRICS_PORT};
-#[cfg(feature = "server")]
-use katana_node::config::rpc::{RpcModulesList, DEFAULT_RPC_MAX_PROOF_KEYS};
-#[cfg(feature = "server")]
 use katana_node::config::rpc::{
-    DEFAULT_RPC_ADDR, DEFAULT_RPC_MAX_CALL_GAS, DEFAULT_RPC_MAX_EVENT_PAGE_SIZE, DEFAULT_RPC_PORT,
+    RpcModulesList, DEFAULT_RPC_MAX_CALL_GAS, DEFAULT_RPC_MAX_EVENT_PAGE_SIZE,
+    DEFAULT_RPC_MAX_PROOF_KEYS,
 };
+#[cfg(feature = "server")]
+use katana_node::config::rpc::{DEFAULT_RPC_ADDR, DEFAULT_RPC_PORT};
 use katana_primitives::block::BlockHashOrNumber;
 use katana_primitives::chain::ChainId;
 use katana_primitives::genesis::Genesis;
@@ -129,7 +127,6 @@ impl ServerOptions {
     }
 }
 
-#[cfg(feature = "server")]
 #[derive(Debug, Args, Clone, Serialize, Deserialize, PartialEq)]
 #[command(next_help_heading = "Rpc options")]
 pub struct RpcOptions {
@@ -170,7 +167,6 @@ pub struct RpcOptions {
     pub max_call_gas: u64,
 }
 
-#[cfg(feature = "server")]
 impl Default for RpcOptions {
     fn default() -> Self {
         RpcOptions {
@@ -185,7 +181,6 @@ impl Default for RpcOptions {
     }
 }
 
-#[cfg(feature = "server")]
 impl RpcOptions {
     pub fn merge(&mut self, other: Option<&Self>) {
         if let Some(other) = other {
@@ -499,12 +494,10 @@ fn default_http_port() -> u16 {
     DEFAULT_RPC_PORT
 }
 
-#[cfg(feature = "server")]
 fn default_page_size() -> u64 {
     DEFAULT_RPC_MAX_EVENT_PAGE_SIZE
 }
 
-#[cfg(feature = "server")]
 fn default_proof_keys() -> u64 {
     katana_node::config::rpc::DEFAULT_RPC_MAX_PROOF_KEYS
 }
@@ -519,7 +512,6 @@ fn default_metrics_port() -> u16 {
     DEFAULT_METRICS_PORT
 }
 
-#[cfg(feature = "server")]
 fn default_max_call_gas() -> u64 {
     DEFAULT_RPC_MAX_CALL_GAS
 }

--- a/crates/torii/libp2p/src/test.rs
+++ b/crates/torii/libp2p/src/test.rs
@@ -178,12 +178,12 @@ async fn test_client_messaging() -> Result<(), Box<dyn Error>> {
             .sign(&message_hash)
             .unwrap();
 
+    sleep(std::time::Duration::from_secs(2)).await;
+
     client
         .command_sender
         .publish(Message { message: typed_data, signature: vec![signature.r, signature.s] })
         .await?;
-
-    sleep(std::time::Duration::from_secs(2)).await;
 
     loop {
         select! {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated RPC configuration options that allow users to customize HTTP modules and connection parameters independently.
  - Enhanced the configuration merging process to provide improved default values and seamless integration when using a configuration file.
  - Added support for SQL-related command-line arguments and configuration options, enhancing the application's configurability.
  - Introduced new modules for resources, tools, and types within the MCP package, promoting organized code structure.
  - Enhanced the Relay functionality to manage peer connections effectively and improve message handling.
  - Added new constants and methods for improved handling of JSON-RPC messages and server-sent events (SSE).
  - Added a new optional field to support RPC options in the node configuration, now always present regardless of feature flags.
  - Updated command-line interface to recognize `http.api` as an alternative to `rpc.api` for specifying modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->