### PR TITLE
feat(torii-cli): dump config when path is specified but no file

### DIFF
--- a/crates/torii/cli/src/args.rs
+++ b/crates/torii/cli/src/args.rs
@@ -74,12 +74,12 @@ impl ToriiArgs {
                 if let Some(parent) = path.parent() {
                     std::fs::create_dir_all(parent)?;
                 }
-                
+
                 // Convert current args to config and save it
                 let config = ToriiArgsConfig::try_from(self.clone())?;
                 let config_str = toml::to_string_pretty(&config)?;
                 std::fs::write(path, config_str)?;
-                
+
                 // Return the config we just created
                 config
             }

--- a/crates/torii/cli/src/args.rs
+++ b/crates/torii/cli/src/args.rs
@@ -163,9 +163,6 @@ impl TryFrom<ToriiArgs> for ToriiArgsConfig {
     type Error = anyhow::Error;
 
     fn try_from(args: ToriiArgs) -> Result<Self> {
-        // Ensure the config file is merged with the CLI arguments.
-        let args = args.with_config_file()?;
-
         let mut config =
             ToriiArgsConfig { world_address: args.world_address, ..Default::default() };
 


### PR DESCRIPTION
#3063 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced configuration management to automatically generate a new configuration file with default settings when one is not found, ensuring a smoother initialization experience.
  - Improved error handling for configuration files, allowing the application to initialize with sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->