### PR TITLE
refactor(torii-libp2p): ignore publish for empty peers & own messages

### DIFF
--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -225,6 +225,11 @@ impl<P: Provider + Sync> Relay<P> {
                             message_id,
                             message,
                         }) => {
+                            // Ignore our own messages
+                            if peer_id == self.swarm.local_peer_id() {
+                                continue;
+                            }
+
                             // Deserialize typed data.
                             // We shouldn't panic here
                             let data = match serde_json::from_slice::<Message>(&message.data) {

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -235,7 +235,7 @@ impl<P: Provider + Sync> Relay<P> {
                             let data = match serde_json::from_slice::<Message>(&message.data) {
                                 Ok(message) => message,
                                 Err(e) => {
-                                    info!(
+                                    warn!(
                                         target: LOG_TARGET,
                                         error = %e,
                                         "Deserializing message."
@@ -247,7 +247,7 @@ impl<P: Provider + Sync> Relay<P> {
                             let ty = match validate_message(&self.db, &data.message).await {
                                 Ok(parsed_message) => parsed_message,
                                 Err(e) => {
-                                    info!(
+                                    warn!(
                                         target: LOG_TARGET,
                                         error = %e,
                                         "Validating message."
@@ -361,7 +361,7 @@ impl<P: Provider + Sync> Relay<P> {
                                     continue;
                                 }
                             } {
-                                info!(
+                                warn!(
                                     target: LOG_TARGET,
                                     message_id = %message_id,
                                     peer_id = %peer_id,
@@ -381,7 +381,7 @@ impl<P: Provider + Sync> Relay<P> {
                             )
                             .await
                             {
-                                info!(
+                                warn!(
                                     target: LOG_TARGET,
                                     error = %e,
                                     "Setting message."
@@ -418,7 +418,7 @@ impl<P: Provider + Sync> Relay<P> {
                                     "Forwarded message to peers."
                                 ),
                                 Err(Error::PublishError(PublishError::InsufficientPeers)) => {},
-                                Err(e) => info!(
+                                Err(e) => warn!(
                                     target: LOG_TARGET,
                                     error = %e,
                                     "Publishing message to peers."

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -417,7 +417,7 @@ impl<P: Provider + Sync> Relay<P> {
                                     target: LOG_TARGET,
                                     "Forwarded message to peers."
                                 ),
-                                Err(Error::PublishError(PublishError::InsufficientPeers)) => {},
+                                Err(Error::PublishError(PublishError::InsufficientPeers)) => {}
                                 Err(e) => warn!(
                                     target: LOG_TARGET,
                                     error = %e,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message handling by skipping self-originated messages, reducing unnecessary operations and preventing potential recursion issues.
  - Minor formatting adjustment in error handling to conform with style guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->