### PR TITLE
fix(torii-libp2p): ensure build not in wasm and avoid crash on invalid message

### DIFF
--- a/crates/torii/libp2p/Cargo.toml
+++ b/crates/torii/libp2p/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-client = [ "dep:libp2p-webrtc", "dep:rand" ]
+client = [ ]
 server = [ "dep:sqlx", "dep:torii-sqlite", "dep:dojo-types", "dep:dojo-world", "dep:starknet-crypto", "dep:chrono", "dep:libp2p-webrtc", "dep:rand" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -43,9 +43,10 @@ wasm-bindgen-futures = "0.4.40"
 wasm-bindgen-test = "0.3.40"
 wasm-timer = "0.2.5"
 
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", features = [ "dns", "ed25519", "gossipsub", "identify", "macros", "noise", "ping", "quic", "relay", "tcp", "tokio", "websocket", "yamux" ], rev = "cdc9638" }
+libp2p-webrtc = { git = "https://github.com/libp2p/rust-libp2p", features = [ "pem", "tokio" ], rev = "cdc9638" }
+rand.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 libp2p = { git = "https://github.com/libp2p/rust-libp2p", features = [ "ed25519", "gossipsub", "identify", "macros", "noise", "ping", "tcp", "wasm-bindgen", "yamux" ], rev = "cdc9638" }

--- a/crates/torii/libp2p/Cargo.toml
+++ b/crates/torii/libp2p/Cargo.toml
@@ -6,7 +6,7 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-client = [  ]
+client = [ "dep:libp2p-webrtc", "dep:rand" ]
 server = [ "dep:sqlx", "dep:torii-sqlite", "dep:dojo-types", "dep:dojo-world", "dep:starknet-crypto", "dep:chrono", "dep:libp2p-webrtc", "dep:rand" ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/torii/libp2p/src/server/mod.rs
+++ b/crates/torii/libp2p/src/server/mod.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use std::{fs, io};
 
 use chrono::Utc;
+use dojo_types::naming::is_valid_tag;
 use dojo_types::schema::Ty;
 use dojo_world::contracts::naming::compute_selector_from_tag;
 use futures::StreamExt;
@@ -511,6 +512,13 @@ fn ty_keys(ty: &Ty) -> Result<Vec<Felt>, Error> {
 fn ty_model_id(ty: &Ty) -> Result<Felt, Error> {
     let namespaced_name = ty.name();
 
+    if !is_valid_tag(&namespaced_name) {
+        return Err(Error::InvalidMessageError(format!(
+            "Invalid message model (invalid tag): {}",
+            namespaced_name
+        )));
+    }
+
     let selector = compute_selector_from_tag(&namespaced_name);
     Ok(selector)
 }
@@ -518,6 +526,13 @@ fn ty_model_id(ty: &Ty) -> Result<Felt, Error> {
 // Validates the message model
 // and returns the identity and signature
 async fn validate_message(db: &Sql, message: &TypedData) -> Result<Ty, Error> {
+    if !is_valid_tag(&message.primary_type) {
+        return Err(Error::InvalidMessageError(format!(
+            "Invalid message model (invalid tag): {}",
+            message.primary_type
+        )));
+    }
+
     let selector = compute_selector_from_tag(&message.primary_type);
 
     let mut ty = db


### PR DESCRIPTION
This PR ensures:
1. `torii-relay` can be built without targeting `wasm`.
2. When an invalid message is sent (mostly providing a model name that is not following the dojo `tag` convention `namespace-name`) Torii doesn't crash on an unwrap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This release refines core operations to improve system stability and enhance overall performance. End-users will benefit from smoother, more reliable interactions as the system now detects and handles errors more effectively.

- **Chores**
  - Updated the `client` feature to remove unnecessary dependencies, optimizing performance.

- **Bug Fixes**
  - Strengthened validation checks for message tags, ensuring smoother processing and reducing potential disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->