### PR TITLE
build(katana): explorer ui build script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,9 @@ ARG RUST_VERSION
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends protobuf-compiler libprotobuf-dev libclang-dev libzstd-dev make pkg-config libssl-dev
 
-RUN apt-get install -y gh libgmp3-dev software-properties-common curl git
+RUN apt-get install -y gh libgmp3-dev software-properties-common curl git unzip
+
+RUN curl -fsSL https://bun.sh/install | bash && . /root/.bashrc
 
 RUN curl -L https://foundry.paradigm.xyz/ | bash && . /root/.bashrc && foundryup
 ENV PATH="${PATH}:/root/.foundry/bin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+        # Workaround for https://github.com/actions/runner-images/issues/6775
+      - run: git config --global --add safe.directory "*"
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo build -r --bin katana

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,32 +11,6 @@ env:
   RUST_VERSION: 1.81.0
 
 jobs:
-  build-explorer:
-    runs-on: ubuntu-latest
-    needs: [fmt, cairofmt]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-      - name: Initialize submodules
-        run: |
-          git submodule add -f -b main https://github.com/cartridge-gg/explorer crates/katana/explorer/ui
-          ls -la
-          ls -la crates/katana/explorer/ui || echo "Explorer dir not found"
-      - uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-      - name: Build Explorer UI
-        run: |
-          cd crates/katana/explorer/ui
-          bun install
-          bun run build
-      - uses: actions/upload-artifact@v4
-        with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
-
   build:
     runs-on: ubuntu-latest-4-cores
     needs: [fmt, cairofmt, build-explorer]
@@ -47,10 +21,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      - uses: actions/download-artifact@v4
-        with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo build -r --bin katana

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest-4-cores
-    needs: [fmt, cairofmt, build-explorer]
+    needs: [fmt, cairofmt]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
     steps:
@@ -34,7 +34,7 @@ jobs:
           path: bins
 
   test:
-    needs: [ensure-docker, build-explorer]
+    needs: [ensure-docker]
     runs-on: ubuntu-latest-32-cores
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
@@ -68,7 +68,7 @@ jobs:
 
   ensure-wasm:
     runs-on: ubuntu-latest
-    needs: [fmt, cairofmt, build-explorer]
+    needs: [fmt, cairofmt]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
     steps:
@@ -86,7 +86,7 @@ jobs:
       - run: cargo build -r --target wasm32-unknown-unknown -p torii-client
 
   ensure-windows:
-    needs: [ensure-docker, build-explorer]
+    needs: [ensure-docker]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
@@ -186,7 +186,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest-4-cores
-    needs: [fmt, cairofmt, build-explorer]
+    needs: [fmt, cairofmt]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
     steps:
@@ -212,7 +212,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    needs: [fmt, cairofmt, build-explorer]
+    needs: [fmt, cairofmt]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         # Workaround for https://github.com/actions/runner-images/issues/6775
       - run: git config --global --add safe.directory "*"
       - uses: oven-sh/setup-bun@v1
-         with:
-           bun-version: latest
+        with:
+          bun-version: latest
       - uses: Swatinem/rust-cache@v2
       - run: |
           git submodule update --init --recursive --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           submodules: recursive
           fetch-depth: 0
         # Workaround for https://github.com/actions/runner-images/issues/6775
+      - uses: oven-sh/setup-bun@v2
       - run: git config --global --add safe.directory "*"
       - uses: Swatinem/rust-cache@v2
       - run: |
@@ -34,6 +35,10 @@ jobs:
         with:
           name: dojo-bins
           path: bins
+      - uses: actions/upload-artifact@v4
+        with:
+          name: explorer-dist
+          path: crates/katana/explorer/ui/dist
 
   test:
     needs: [ensure-docker]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           fetch-depth: 0
         # Workaround for https://github.com/actions/runner-images/issues/6775
       - run: git config --global --add safe.directory "*"
+      - uses: oven-sh/setup-bun@v1
+         with:
+           bun-version: latest
       - uses: Swatinem/rust-cache@v2
       - run: |
           git submodule update --init --recursive --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,6 @@ jobs:
         with:
           name: dojo-bins
           path: bins
-      - uses: actions/upload-artifact@v4
-        with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
 
   test:
     needs: [ensure-docker]
@@ -54,13 +50,11 @@ jobs:
         with:
           name: dojo-bins
           path: /tmp/bins
-      - uses: actions/download-artifact@v4
+      # Workaround for https://github.com/actions/runner-images/issues/6775
+      - run: git config --global --add safe.directory "*"
+      - uses: oven-sh/setup-bun@v1
         with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
-      - name: Verify explorer UI assets
-        run: |
-          ls -la crates/katana/explorer/ui/dist || echo "Explorer UI dist directory not found"
+          bun-version: latest
       - run: |
           export PATH=/tmp/bins:$PATH
           chmod +x /tmp/bins/katana
@@ -83,13 +77,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
-        with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
-      - name: Verify explorer UI assets
-        run: |
-          ls -la crates/katana/explorer/ui/dist || echo "Explorer UI dist directory not found"
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown
       - run: cargo build -r --target wasm32-unknown-unknown -p torii-client
@@ -104,13 +91,11 @@ jobs:
           toolchain: ${{ env.rust_version }}
           target: x86_64-pc-windows-msvc
       - uses: swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
+      # Workaround for https://github.com/actions/runner-images/issues/6775
+      - run: git config --global --add safe.directory "*"
+      - uses: oven-sh/setup-bun@v1
         with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
-      - name: Verify explorer UI assets
-        run: |
-          dir crates\katana\explorer\ui\dist || echo "Explorer UI dist directory not found"
+          bun-version: latest
       - uses: arduino/setup-protoc@v2
         with:
           repo-token: ${{ secrets.github_token }}
@@ -201,18 +186,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
-        with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
       # Workaround for https://github.com/actions/runner-images/issues/6775
       - run: git config --global --add safe.directory "*"
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - name: Verify explorer UI assets
-        run: |
-          ls -la crates/katana/explorer/ui/dist || echo "Explorer UI dist directory not found"
       - run: scripts/clippy.sh
 
   fmt:
@@ -232,18 +210,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/download-artifact@v4
-        with:
-          name: explorer-dist
-          path: crates/katana/explorer/ui/dist
       # Workaround for https://github.com/actions/runner-images/issues/6775
       - run: git config --global --add safe.directory "*"
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-      - name: Verify explorer UI assets
-        run: |
-          ls -la crates/katana/explorer/ui/dist || echo "Explorer UI dist directory not found"
       - run: scripts/docs.sh
 
   test-hurl:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           git submodule update --init --recursive --force
+          ls crates/katana/explorer/ui
+          cd crates/katana/explorer/ui && bun install && bun run build
           cargo build -r --bin katana
           cargo build -r --bin sozo
           mkdir -p bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,8 @@ jobs:
         # Workaround for https://github.com/actions/runner-images/issues/6775
       - run: git config --global --add safe.directory "*"
       - uses: Swatinem/rust-cache@v2
-        with:
-          # Let's try with a brand new cache...
-          prefix-key: "explr"
       - run: |
+          git submodule update --init --recursive --force
           cargo build -r --bin katana
           cargo build -r --bin sozo
           mkdir -p bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
           bun-version: latest
       - uses: Swatinem/rust-cache@v2
       - run: |
-          git submodule update --init --recursive --force
-          ls crates/katana/explorer/ui
-          cd crates/katana/explorer/ui && bun install && bun run build
           cargo build -r --bin katana
           cargo build -r --bin sozo
           mkdir -p bins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,13 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     needs: [fmt, cairofmt]
     container:
-      image: ghcr.io/dojoengine/dojo-dev:v1.2.2
+      image: ghcr.io/dojoengine/dojo-dev:bin
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
           fetch-depth: 0
         # Workaround for https://github.com/actions/runner-images/issues/6775
-      - uses: oven-sh/setup-bun@v2
       - run: git config --global --add safe.directory "*"
       - uses: Swatinem/rust-cache@v2
       - run: |
@@ -44,7 +43,7 @@ jobs:
     needs: [ensure-docker]
     runs-on: ubuntu-latest-32-cores
     container:
-      image: ghcr.io/dojoengine/dojo-dev:v1.2.2
+      image: ghcr.io/dojoengine/dojo-dev:bun
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -77,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fmt, cairofmt, build]
     container:
-      image: ghcr.io/dojoengine/dojo-dev:v1.2.2
+      image: ghcr.io/dojoengine/dojo-dev:bun
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -195,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     needs: [fmt, cairofmt, build]
     container:
-      image: ghcr.io/dojoengine/dojo-dev:v1.2.2
+      image: ghcr.io/dojoengine/dojo-dev:bun
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -211,7 +210,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/dojoengine/dojo-dev:v1.2.2
+      image: ghcr.io/dojoengine/dojo-dev:bun
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
@@ -221,7 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fmt, cairofmt, build]
     container:
-      image: ghcr.io/dojoengine/dojo-dev:v1.2.2
+      image: ghcr.io/dojoengine/dojo-dev:bun
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
         # Workaround for https://github.com/actions/runner-images/issues/6775
       - run: git config --global --add safe.directory "*"
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Let's try with a brand new cache...
+          prefix-key: "explr"
       - run: |
           cargo build -r --bin katana
           cargo build -r --bin sozo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     needs: [fmt, cairofmt]
     container:
-      image: ghcr.io/dojoengine/dojo-dev:bin
+      image: ghcr.io/dojoengine/dojo-dev:bun
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-        # Workaround for https://github.com/actions/runner-images/issues/6775
+      # Workaround for https://github.com/actions/runner-images/issues/6775
       - run: git config --global --add safe.directory "*"
       - uses: oven-sh/setup-bun@v1
         with:
@@ -205,6 +205,11 @@ jobs:
         with:
           name: explorer-dist
           path: crates/katana/explorer/ui/dist
+      # Workaround for https://github.com/actions/runner-images/issues/6775
+      - run: git config --global --add safe.directory "*"
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
       - name: Verify explorer UI assets
         run: |
           ls -la crates/katana/explorer/ui/dist || echo "Explorer UI dist directory not found"
@@ -231,6 +236,11 @@ jobs:
         with:
           name: explorer-dist
           path: crates/katana/explorer/ui/dist
+      # Workaround for https://github.com/actions/runner-images/issues/6775
+      - run: git config --global --add safe.directory "*"
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
       - name: Verify explorer UI assets
         run: |
           ls -la crates/katana/explorer/ui/dist || echo "Explorer UI dist directory not found"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
   ensure-wasm:
     runs-on: ubuntu-latest
-    needs: [fmt, cairofmt]
+    needs: [fmt, cairofmt, build]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
     steps:
@@ -193,7 +193,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest-4-cores
-    needs: [fmt, cairofmt]
+    needs: [fmt, cairofmt, build]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
     steps:
@@ -219,7 +219,7 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
-    needs: [fmt, cairofmt]
+    needs: [fmt, cairofmt, build]
     container:
       image: ghcr.io/dojoengine/dojo-dev:v1.2.2
     steps:

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -8,6 +8,7 @@ fn main() {
     if std::env::var("CARGO_MANIFEST_DIR").is_ok() {
         // $CARGO_MANIFEST_DIR/ui/
         let ui_dir = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("ui");
+        println!("Explorer UI directory: {}", ui_dir.display());
 
         // Update git submodule
         println!("UI directory is empty, updating git submodule...");

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -16,6 +16,7 @@ fn main() {
             .arg("submodule")
             .arg("update")
             .arg("--init")
+            .arg("--force")
             .arg("--recursive")
             .status()
             .expect("Failed to update git submodule");

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -24,6 +24,16 @@ fn main() {
             panic!("Failed to update git submodule");
         }
 
+        // ls the content of ui directory and who the content:
+        let o =
+            Command::new("ls").current_dir(&ui_dir).output().expect("Failed to list UI directory");
+
+        if !o.status.success() {
+            panic!("Failed to list UI directory");
+        }
+
+        println!("UI directory content: {}", String::from_utf8_lossy(&o.stdout));
+
         // Install dependencies if node_modules doesn't exist
         // $CARGO_MANIFEST_DIR/ui/node_modules
         if !Path::new(&ui_dir).join("node_modules").exists() {

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=ui/");
+
+    // Check if we're in a build script
+    if std::env::var("CARGO_MANIFEST_DIR").is_ok() {
+        // $CARGO_MANIFEST_DIR/ui/
+        let ui_dir = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("ui");
+
+        // Update git submodule
+        println!("UI directory is empty, updating git submodule...");
+        let status = Command::new("git")
+            .arg("submodule")
+            .arg("update")
+            .arg("--init")
+            .arg("--recursive")
+            .status()
+            .expect("Failed to update git submodule");
+
+        if !status.success() {
+            panic!("Failed to update git submodule");
+        }
+
+        // Install dependencies if node_modules doesn't exist
+        // $CARGO_MANIFEST_DIR/ui/node_modules
+        if !Path::new(&ui_dir).join("node_modules").exists() {
+            println!("Installing UI dependencies...");
+            let status = Command::new("bun")
+                .current_dir(&ui_dir)
+                .arg("install")
+                .status()
+                .expect("Failed to install UI dependencies");
+
+            if !status.success() {
+                panic!("Failed to install UI dependencies");
+            }
+        }
+
+        println!("Building UI...");
+        let status = Command::new("bun")
+            .current_dir(&ui_dir)
+            .arg("run")
+            .arg("build")
+            .status()
+            .expect("Failed to build UI");
+
+        if !status.success() {
+            panic!("Failed to build UI");
+        }
+    }
+}

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -1,3 +1,4 @@
+use std::fs::canonicalize;
 use std::path::Path;
 use std::process::Command;
 
@@ -39,13 +40,15 @@ fn main() {
         if !Path::new(&ui_dir).join("node_modules").exists() {
             println!("Installing UI dependencies...");
 
-            let output =
-                Command::new("bun").current_dir(&ui_dir).arg("install").output().unwrap_or_else(
-                    |e| {
-                        println!("Failed to execute bun install: {}", e);
-                        std::process::exit(1);
-                    },
-                );
+            let output = Command::new("bun")
+                // Attempt with canonicalize to avoid relative path issues mentioned in the doc.
+                .current_dir(&canonicalize(&ui_dir).unwrap())
+                .arg("install")
+                .output()
+                .unwrap_or_else(|e| {
+                    println!("Failed to execute bun install: {}", e);
+                    std::process::exit(1);
+                });
 
             if !output.status.success() {
                 println!("bun install failed with status: {}", output.status);

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -1,4 +1,3 @@
-use std::fs::canonicalize;
 use std::path::Path;
 use std::process::Command;
 
@@ -25,42 +24,17 @@ fn main() {
             panic!("Failed to update git submodule");
         }
 
-        // ls the content of ui directory and who the content:
-        let o =
-            Command::new("ls").current_dir(&ui_dir).output().expect("Failed to list UI directory");
-
-        if !o.status.success() {
-            panic!("Failed to list UI directory");
-        }
-
-        println!("UI directory content: {}", String::from_utf8_lossy(&o.stdout));
-
         // Install dependencies if node_modules doesn't exist
         // $CARGO_MANIFEST_DIR/ui/node_modules
         if !Path::new(&ui_dir).join("node_modules").exists() {
             println!("Installing UI dependencies...");
 
-            let output = Command::new("bun")
-                // Attempt with canonicalize to avoid relative path issues mentioned in the doc.
-                .current_dir(&canonicalize(&ui_dir).unwrap())
+            let status = Command::new("bun")
+                .current_dir(&ui_dir)
                 .arg("install")
-                .output()
-                .unwrap_or_else(|e| {
-                    println!("Failed to execute bun install: {}", e);
-                    std::process::exit(1);
-                });
+                .status()
+                .expect("Failed to install UI dependencies");
 
-            if !output.status.success() {
-                println!("bun install failed with status: {}", output.status);
-                println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
-                println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
-                std::process::exit(1);
-            }
-            // let status = Command::new("bun")
-            // .current_dir(&ui_dir)
-            // .arg("install")
-            // .status()
-            // .expect("Failed to install UI dependencies");
             if !status.success() {
                 panic!("Failed to install UI dependencies");
             }

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -43,13 +43,11 @@ fn main() {
                 println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
                 std::process::exit(1);
             }
-/*
-            let status = Command::new("bun")
-                .current_dir(&ui_dir)
-                .arg("install")
-                .status()
-                .expect("Failed to install UI dependencies");
- */
+            // let status = Command::new("bun")
+            // .current_dir(&ui_dir)
+            // .arg("install")
+            // .status()
+            // .expect("Failed to install UI dependencies");
             if !status.success() {
                 panic!("Failed to install UI dependencies");
             }

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -28,12 +28,28 @@ fn main() {
         // $CARGO_MANIFEST_DIR/ui/node_modules
         if !Path::new(&ui_dir).join("node_modules").exists() {
             println!("Installing UI dependencies...");
+
+            let output =
+                Command::new("bun").current_dir(&ui_dir).arg("install").output().unwrap_or_else(
+                    |e| {
+                        println!("Failed to execute bun install: {}", e);
+                        std::process::exit(1);
+                    },
+                );
+
+            if !output.status.success() {
+                println!("bun install failed with status: {}", output.status);
+                println!("stdout: {}", String::from_utf8_lossy(&output.stdout));
+                println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+                std::process::exit(1);
+            }
+/*
             let status = Command::new("bun")
                 .current_dir(&ui_dir)
                 .arg("install")
                 .status()
                 .expect("Failed to install UI dependencies");
-
+ */
             if !status.success() {
                 panic!("Failed to install UI dependencies");
             }

--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -16,7 +16,6 @@ fn main() {
             .arg("submodule")
             .arg("update")
             .arg("--init")
-            .arg("--force")
             .arg("--recursive")
             .status()
             .expect("Failed to update git submodule");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined the build and deployment workflow by removing the `build-explorer` job and its associated steps.
  - Enhanced the process that ensures the user interface is updated and its dependencies are managed automatically.
  - Updated the Dockerfile to include additional packages and a new command for installing Bun.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->