### PR TITLE
feat(torii-grpc): retrieving and subscribe historical entities

### DIFF
--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -112,10 +112,10 @@ impl Client {
     /// entities, this is less efficient as it requires an additional query for each entity's
     /// model data. Specifying a clause can optimize the query by limiting the retrieval to specific
     /// type of entites matching keys and/or models.
-    pub async fn entities(&self, query: Query) -> Result<Vec<Entity>, Error> {
+    pub async fn entities(&self, query: Query, historical: bool) -> Result<Vec<Entity>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveEntitiesResponse { entities, total_count: _ } =
-            grpc_client.retrieve_entities(query).await?;
+            grpc_client.retrieve_entities(query, historical).await?;
         Ok(entities.into_iter().map(TryInto::try_into).collect::<Result<Vec<Entity>, _>>()?)
     }
 
@@ -143,9 +143,10 @@ impl Client {
     pub async fn on_entity_updated(
         &self,
         clauses: Vec<EntityKeysClause>,
+        historical: bool,
     ) -> Result<EntityUpdateStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
-        let stream = grpc_client.subscribe_entities(clauses).await?;
+        let stream = grpc_client.subscribe_entities(clauses, historical).await?;
         Ok(stream)
     }
 
@@ -154,9 +155,10 @@ impl Client {
         &self,
         subscription_id: u64,
         clauses: Vec<EntityKeysClause>,
+        historical: bool,
     ) -> Result<(), Error> {
         let mut grpc_client = self.inner.write().await;
-        grpc_client.update_entities_subscription(subscription_id, clauses).await?;
+        grpc_client.update_entities_subscription(subscription_id, clauses, historical).await?;
         Ok(())
     }
 

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -174,6 +174,7 @@ message SubscribeModelsResponse {
 
 message SubscribeEntitiesRequest {
     repeated types.EntityKeysClause clauses = 1;
+    bool historical = 2;
 }
 
 message SubscribeEventMessagesRequest {
@@ -184,6 +185,7 @@ message SubscribeEventMessagesRequest {
 message UpdateEntitiesSubscriptionRequest {
     uint64 subscription_id = 1;
     repeated types.EntityKeysClause clauses = 2;
+    bool historical = 3;
 }
 
 message UpdateEventMessagesSubscriptionRequest {
@@ -200,6 +202,8 @@ message SubscribeEntityResponse {
 message RetrieveEntitiesRequest {
     // The entities to retrieve
     types.Query query = 1;
+    // Should we retrieve historical entities?
+    bool historical = 2;
 }
 
 message RetrieveEventMessagesRequest {

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -214,8 +214,9 @@ impl WorldClient {
     pub async fn retrieve_entities(
         &mut self,
         query: Query,
+        historical: bool,
     ) -> Result<RetrieveEntitiesResponse, Error> {
-        let request = RetrieveEntitiesRequest { query: Some(query.into()) };
+        let request = RetrieveEntitiesRequest { query: Some(query.into()), historical };
         self.inner.retrieve_entities(request).await.map_err(Error::Grpc).map(|res| res.into_inner())
     }
 
@@ -260,11 +261,12 @@ impl WorldClient {
     pub async fn subscribe_entities(
         &mut self,
         clauses: Vec<EntityKeysClause>,
+        historical: bool,
     ) -> Result<EntityUpdateStreaming, Error> {
         let clauses = clauses.into_iter().map(|c| c.into()).collect();
         let stream = self
             .inner
-            .subscribe_entities(SubscribeEntitiesRequest { clauses })
+            .subscribe_entities(SubscribeEntitiesRequest { clauses, historical })
             .await
             .map_err(Error::Grpc)
             .map(|res| res.into_inner())?;
@@ -282,6 +284,7 @@ impl WorldClient {
         &mut self,
         subscription_id: u64,
         clauses: Vec<EntityKeysClause>,
+        historical: bool,
     ) -> Result<(), Error> {
         let clauses = clauses.into_iter().map(|c| c.into()).collect();
 
@@ -289,6 +292,7 @@ impl WorldClient {
             .update_entities_subscription(UpdateEntitiesSubscriptionRequest {
                 subscription_id,
                 clauses,
+                historical,
             })
             .await
             .map_err(Error::Grpc)

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -405,15 +405,20 @@ impl DojoWorld {
                 r#"
                 SELECT COUNT(*) FROM {table}
                 JOIN {model_relation_table} ON {table}.id = {model_relation_table}.entity_id
-                WHERE {where_clause}
+                {}
                 GROUP BY {table}.event_id
-            "#
+            "#,
+                if where_clause.is_empty() {
+                    String::new()
+                } else {
+                    format!("WHERE {}", where_clause)
+                }
             );
             let mut total_count = sqlx::query_scalar(&count_query);
             for value in &bind_values {
                 total_count = total_count.bind(value);
             }
-            let total_count = total_count.fetch_one(&self.pool).await?;
+            let total_count = total_count.fetch_optional(&self.pool).await?.unwrap_or(0);
             if total_count == 0 {
                 return Ok((Vec::new(), 0));
             }
@@ -424,11 +429,16 @@ impl DojoWorld {
                 SELECT {table}.id, {table}.data, {table}.model_id, group_concat({model_relation_table}.model_id) as model_ids
                 FROM {table}
                 JOIN {model_relation_table} ON {table}.id = {model_relation_table}.entity_id
-                WHERE {where_clause}
+                {}
                 GROUP BY {table}.event_id
                 ORDER BY {table}.event_id DESC
-             "#
-                ),
+             "#,
+                if where_clause.is_empty() {
+                    String::new()
+                } else {
+                    format!("WHERE {}", where_clause)
+                }
+            ),
                 bind_values,
                 limit,
                 offset
@@ -533,15 +543,20 @@ impl DojoWorld {
                 r#"
                 SELECT COUNT(*) FROM {table}
                 JOIN {model_relation_table} ON {table}.id = {model_relation_table}.entity_id
-                WHERE {where_clause}
+                {}
                 GROUP BY {table}.event_id
-            "#
+            "#,
+                if where_clause.is_empty() {
+                    String::new()
+                } else {
+                    format!("WHERE {}", where_clause)
+                }
             );
             let mut total_count = sqlx::query_scalar(&count_query);
             for value in &bind_values {
                 total_count = total_count.bind(value);
             }
-            let total_count = total_count.fetch_one(&self.pool).await?;
+            let total_count = total_count.fetch_optional(&self.pool).await?.unwrap_or(0);
             if total_count == 0 {
                 return Ok((Vec::new(), 0));
             }
@@ -552,10 +567,15 @@ impl DojoWorld {
                     SELECT {table}.id, {table}.data, {table}.model_id, group_concat({model_relation_table}.model_id) as model_ids
                     FROM {table}
                     JOIN {model_relation_table} ON {table}.id = {model_relation_table}.entity_id
-                    WHERE {where_clause}
+                    {}
                     GROUP BY {table}.event_id
                     ORDER BY {table}.event_id DESC
-                 "#
+                 "#,
+                    if where_clause.is_empty() {
+                        String::new()
+                    } else {
+                        format!("WHERE {}", where_clause)
+                    }
                 ),
                 bind_values,
                 limit,

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -62,7 +62,12 @@ impl EntityManager {
         Ok(receiver)
     }
 
-    pub async fn update_subscriber(&self, id: u64, clauses: Vec<EntityKeysClause>, historical: bool) {
+    pub async fn update_subscriber(
+        &self,
+        id: u64,
+        clauses: Vec<EntityKeysClause>,
+        historical: bool,
+    ) {
         let sender = {
             let subscribers = self.subscribers.read().await;
             if let Some(subscriber) = subscribers.get(&id) {
@@ -72,7 +77,10 @@ impl EntityManager {
             }
         };
 
-        self.subscribers.write().await.insert(id, EntitiesSubscriber { clauses, historical, sender });
+        self.subscribers
+            .write()
+            .await
+            .insert(id, EntitiesSubscriber { clauses, historical, sender });
     }
 
     pub(super) async fn remove_subscriber(&self, id: u64) {
@@ -132,7 +140,7 @@ impl Service {
             if sub.historical != entity.historical {
                 continue;
             }
-            
+
             // Check if the subscriber is interested in this entity
             // If we have a clause of hashed keys, then check that the id of the entity
             // is in the list of hashed keys.

--- a/crates/torii/sqlite/src/executor/mod.rs
+++ b/crates/torii/sqlite/src/executor/mod.rs
@@ -461,6 +461,7 @@ impl<'c, P: Provider + Sync + Send + 'static> Executor<'c, P> {
                 let mut entity_updated = EntityUpdated::from_row(&row)?;
                 entity_updated.updated_model = Some(entity.ty.clone());
                 entity_updated.deleted = false;
+                entity_updated.historical = entity.is_historical;
 
                 if entity_updated.keys.is_empty() {
                     warn!(target: LOG_TARGET, "Entity has been updated without being set before. Keys are not known and non-updated values will be NULL.");

--- a/crates/torii/sqlite/src/types.rs
+++ b/crates/torii/sqlite/src/types.rs
@@ -45,6 +45,8 @@ pub struct Entity {
     pub updated_model: Option<Ty>,
     #[sqlx(skip)]
     pub deleted: bool,
+    #[sqlx(skip)]
+    pub historical: bool,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]
@@ -62,6 +64,8 @@ pub struct OptimisticEntity {
     pub updated_model: Option<Ty>,
     #[sqlx(skip)]
     pub deleted: bool,
+    #[sqlx(skip)]
+    pub historical: bool,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled clients to indicate interest in historical data when querying entities and events.
  - Enhanced subscription services so users can opt-in for historical data updates.
  - Improved data processing to factor in historical status, allowing for more refined entity handling.
  - Introduced a new database table for managing historical entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->