### PR TITLE
feat(katana): add support for sovereign mode for `init` command

### DIFF
--- a/bin/katana/src/cli/init/mod.rs
+++ b/bin/katana/src/cli/init/mod.rs
@@ -69,7 +69,6 @@ pub struct InitArgs {
     /// Initialize a sovereign chain with no settlement layer, by only publishing the state updates
     /// and proofs on a Data Availability Layer. By using this flag, no settlement option is
     /// required.
-    #[arg(long = "sovereign")]
     #[arg(help = "Initialize a sovereign chain with no settlement layer, by only publishing the \
                   state updates and proofs on a Data Availability Layer.")]
     #[arg(requires_all = ["id"])]

--- a/bin/katana/src/cli/init/prompt.rs
+++ b/bin/katana/src/cli/init/prompt.rs
@@ -63,8 +63,7 @@ pub async fn prompt() -> Result<AnyOutcome> {
         SettlementChainOpt::Sepolia => SettlementChainProvider::sn_sepolia(),
 
         SettlementChainOpt::Sovereign => {
-            let slot_paymasters = collect_slot_paymasters()?;
-
+            let slot_paymasters = prompt_slot_paymasters()?;
             return Ok(AnyOutcome::Sovereign(SovereignOutcome {
                 id: chain_id,
                 #[cfg(feature = "init-slot")]
@@ -170,7 +169,7 @@ pub async fn prompt() -> Result<AnyOutcome> {
         DeploymentOutcome { contract_address: address, block_number }
     };
 
-    let slot_paymasters = collect_slot_paymasters()?;
+    let slot_paymasters = prompt_slot_paymasters()?;
 
     Ok(AnyOutcome::Persistent(PersistentOutcome {
         id: chain_id,
@@ -183,7 +182,7 @@ pub async fn prompt() -> Result<AnyOutcome> {
     }))
 }
 
-fn collect_slot_paymasters() -> Result<Option<Vec<slot::PaymasterAccountArgs>>> {
+fn prompt_slot_paymasters() -> Result<Option<Vec<slot::PaymasterAccountArgs>>> {
     // It's wrapped like this because the prompt validator requires captured variables to have
     // 'static lifetime.
     let slot_paymasters: Rc<RefCell<Vec<PaymasterAccountArgs>>> = Default::default();

--- a/crates/katana/chain-spec/src/lib.rs
+++ b/crates/katana/chain-spec/src/lib.rs
@@ -101,4 +101,9 @@ pub enum SettlementLayer {
         // the block at which the core contract was deployed
         block: BlockNumber,
     },
+
+    Sovereign {
+        // Once Katana can sync from data availability layer, we can add the details of the data
+        // availability layer to the chain spec for Katana to sync from it.
+    },
 }

--- a/crates/katana/messaging/src/lib.rs
+++ b/crates/katana/messaging/src/lib.rs
@@ -136,6 +136,9 @@ impl MessagingConfig {
                 from_block: *block,
                 interval: 2,
             },
+            katana_chain_spec::SettlementLayer::Sovereign { .. } => {
+                panic!("Sovereign chains are not supported for messaging.")
+            }
         }
     }
 }

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -231,7 +231,13 @@ pub async fn build(mut config: Config) -> Result<Node> {
             }
             // TODO: not sure if fixed would be better here since it doesn't directly depends on the
             // settlement layer.
-            SettlementLayer::Sovereign { .. } => GasOracle::sampled_starknet(),
+            SettlementLayer::Sovereign { .. } => GasOracle::fixed(
+                GasPrices { eth: DEFAULT_ETH_L1_GAS_PRICE, strk: DEFAULT_STRK_L1_GAS_PRICE },
+                GasPrices {
+                    eth: DEFAULT_ETH_L1_DATA_GAS_PRICE,
+                    strk: DEFAULT_STRK_L1_DATA_GAS_PRICE,
+                },
+            ),
         }
     } else {
         // Use default fixed gas prices if no url and if no fixed prices are provided

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -229,8 +229,6 @@ pub async fn build(mut config: Config) -> Result<Node> {
             SettlementLayer::Ethereum { rpc_url, .. } => {
                 GasOracle::sampled_ethereum(rpc_url.clone())
             }
-            // TODO: not sure if fixed would be better here since it doesn't directly depends on the
-            // settlement layer.
             SettlementLayer::Sovereign { .. } => GasOracle::fixed(
                 GasPrices { eth: DEFAULT_ETH_L1_GAS_PRICE, strk: DEFAULT_STRK_L1_GAS_PRICE },
                 GasPrices {

--- a/crates/katana/node/src/lib.rs
+++ b/crates/katana/node/src/lib.rs
@@ -229,6 +229,9 @@ pub async fn build(mut config: Config) -> Result<Node> {
             SettlementLayer::Ethereum { rpc_url, .. } => {
                 GasOracle::sampled_ethereum(rpc_url.clone())
             }
+            // TODO: not sure if fixed would be better here since it doesn't directly depends on the
+            // settlement layer.
+            SettlementLayer::Sovereign { .. } => GasOracle::sampled_starknet(),
         }
     } else {
         // Use default fixed gas prices if no url and if no fixed prices are provided


### PR DESCRIPTION
Currently, Katana only supports the `init` command for persistent rollup, which can be cumbersome for users that only wants to send proofs on a DA layer using sovereign mode.

This PR aims at proposing a simplified `katana init` flow for sovereign rollup, to ensure that Katana can be started in provable mode without providing settlement information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a sovereign chain option that allows initializing a chain without a settlement layer.
  - Enhanced chain setup by requiring a valid chain identifier and offering additional configuration fields.
  - Updated the outcome display to clearly differentiate between traditional and sovereign chain configurations.
  - Improved safeguards by flagging unsupported configurations for certain messaging features.

- **Documentation**
  - Updated guidance to help users understand the enhanced chain initialization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->