### PR TITLE
refactor(torii-grpc): remove historical form subscriptions

### DIFF
--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -143,10 +143,9 @@ impl Client {
     pub async fn on_entity_updated(
         &self,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<EntityUpdateStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
-        let stream = grpc_client.subscribe_entities(clauses, historical).await?;
+        let stream = grpc_client.subscribe_entities(clauses).await?;
         Ok(stream)
     }
 
@@ -155,10 +154,9 @@ impl Client {
         &self,
         subscription_id: u64,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<(), Error> {
         let mut grpc_client = self.inner.write().await;
-        grpc_client.update_entities_subscription(subscription_id, clauses, historical).await?;
+        grpc_client.update_entities_subscription(subscription_id, clauses).await?;
         Ok(())
     }
 
@@ -166,10 +164,9 @@ impl Client {
     pub async fn on_event_message_updated(
         &self,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<EntityUpdateStreaming, Error> {
         let mut grpc_client = self.inner.write().await;
-        let stream = grpc_client.subscribe_event_messages(clauses, historical).await?;
+        let stream = grpc_client.subscribe_event_messages(clauses).await?;
         Ok(stream)
     }
 
@@ -178,12 +175,9 @@ impl Client {
         &self,
         subscription_id: u64,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<(), Error> {
         let mut grpc_client = self.inner.write().await;
-        grpc_client
-            .update_event_messages_subscription(subscription_id, clauses, historical)
-            .await?;
+        grpc_client.update_event_messages_subscription(subscription_id, clauses).await?;
         Ok(())
     }
 

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -174,24 +174,20 @@ message SubscribeModelsResponse {
 
 message SubscribeEntitiesRequest {
     repeated types.EntityKeysClause clauses = 1;
-    bool historical = 2;
 }
 
 message SubscribeEventMessagesRequest {
     repeated types.EntityKeysClause clauses = 1;
-    bool historical = 2;
 }
 
 message UpdateEntitiesSubscriptionRequest {
     uint64 subscription_id = 1;
     repeated types.EntityKeysClause clauses = 2;
-    bool historical = 3;
 }
 
 message UpdateEventMessagesSubscriptionRequest {
     uint64 subscription_id = 1;
     repeated types.EntityKeysClause clauses = 2;
-    bool historical = 3;
 }
 
 message SubscribeEntityResponse {

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -261,12 +261,11 @@ impl WorldClient {
     pub async fn subscribe_entities(
         &mut self,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<EntityUpdateStreaming, Error> {
         let clauses = clauses.into_iter().map(|c| c.into()).collect();
         let stream = self
             .inner
-            .subscribe_entities(SubscribeEntitiesRequest { clauses, historical })
+            .subscribe_entities(SubscribeEntitiesRequest { clauses })
             .await
             .map_err(Error::Grpc)
             .map(|res| res.into_inner())?;
@@ -284,7 +283,6 @@ impl WorldClient {
         &mut self,
         subscription_id: u64,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<(), Error> {
         let clauses = clauses.into_iter().map(|c| c.into()).collect();
 
@@ -292,7 +290,6 @@ impl WorldClient {
             .update_entities_subscription(UpdateEntitiesSubscriptionRequest {
                 subscription_id,
                 clauses,
-                historical,
             })
             .await
             .map_err(Error::Grpc)
@@ -303,12 +300,11 @@ impl WorldClient {
     pub async fn subscribe_event_messages(
         &mut self,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<EntityUpdateStreaming, Error> {
         let clauses = clauses.into_iter().map(|c| c.into()).collect();
         let stream = self
             .inner
-            .subscribe_event_messages(SubscribeEventMessagesRequest { clauses, historical })
+            .subscribe_event_messages(SubscribeEventMessagesRequest { clauses })
             .await
             .map_err(Error::Grpc)
             .map(|res| res.into_inner())?;
@@ -326,14 +322,12 @@ impl WorldClient {
         &mut self,
         subscription_id: u64,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<(), Error> {
         let clauses = clauses.into_iter().map(|c| c.into()).collect();
         self.inner
             .update_event_messages_subscription(UpdateEventMessagesSubscriptionRequest {
                 subscription_id,
                 clauses,
-                historical,
             })
             .await
             .map_err(Error::Grpc)

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -1505,8 +1505,7 @@ impl proto::world::world_server::World for DojoWorld {
         &self,
         request: Request<UpdateEntitiesSubscriptionRequest>,
     ) -> ServiceResult<()> {
-        let UpdateEntitiesSubscriptionRequest { subscription_id, clauses } =
-            request.into_inner();
+        let UpdateEntitiesSubscriptionRequest { subscription_id, clauses } = request.into_inner();
         self.entity_manager
             .update_subscriber(
                 subscription_id,

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -1491,10 +1491,10 @@ impl proto::world::world_server::World for DojoWorld {
         &self,
         request: Request<SubscribeEntitiesRequest>,
     ) -> ServiceResult<Self::SubscribeEntitiesStream> {
-        let SubscribeEntitiesRequest { clauses, historical } = request.into_inner();
+        let SubscribeEntitiesRequest { clauses } = request.into_inner();
         let rx = self
             .entity_manager
-            .add_subscriber(clauses.into_iter().map(|keys| keys.into()).collect(), historical)
+            .add_subscriber(clauses.into_iter().map(|keys| keys.into()).collect())
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -1505,13 +1505,12 @@ impl proto::world::world_server::World for DojoWorld {
         &self,
         request: Request<UpdateEntitiesSubscriptionRequest>,
     ) -> ServiceResult<()> {
-        let UpdateEntitiesSubscriptionRequest { subscription_id, clauses, historical } =
+        let UpdateEntitiesSubscriptionRequest { subscription_id, clauses } =
             request.into_inner();
         self.entity_manager
             .update_subscriber(
                 subscription_id,
                 clauses.into_iter().map(|keys| keys.into()).collect(),
-                historical,
             )
             .await;
 
@@ -1629,10 +1628,10 @@ impl proto::world::world_server::World for DojoWorld {
         &self,
         request: Request<SubscribeEventMessagesRequest>,
     ) -> ServiceResult<Self::SubscribeEntitiesStream> {
-        let SubscribeEventMessagesRequest { clauses, historical } = request.into_inner();
+        let SubscribeEventMessagesRequest { clauses } = request.into_inner();
         let rx = self
             .event_message_manager
-            .add_subscriber(clauses.into_iter().map(|keys| keys.into()).collect(), historical)
+            .add_subscriber(clauses.into_iter().map(|keys| keys.into()).collect())
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -1643,13 +1642,12 @@ impl proto::world::world_server::World for DojoWorld {
         &self,
         request: Request<UpdateEventMessagesSubscriptionRequest>,
     ) -> ServiceResult<()> {
-        let UpdateEventMessagesSubscriptionRequest { subscription_id, clauses, historical } =
+        let UpdateEventMessagesSubscriptionRequest { subscription_id, clauses } =
             request.into_inner();
         self.event_message_manager
             .update_subscriber(
                 subscription_id,
                 clauses.into_iter().map(|keys| keys.into()).collect(),
-                historical,
             )
             .await;
 

--- a/crates/torii/grpc/src/server/subscriptions/entity.rs
+++ b/crates/torii/grpc/src/server/subscriptions/entity.rs
@@ -59,11 +59,7 @@ impl EntityManager {
         Ok(receiver)
     }
 
-    pub async fn update_subscriber(
-        &self,
-        id: u64,
-        clauses: Vec<EntityKeysClause>,
-    ) {
+    pub async fn update_subscriber(&self, id: u64, clauses: Vec<EntityKeysClause>) {
         let sender = {
             let subscribers = self.subscribers.read().await;
             if let Some(subscriber) = subscribers.get(&id) {
@@ -73,10 +69,7 @@ impl EntityManager {
             }
         };
 
-        self.subscribers
-            .write()
-            .await
-            .insert(id, EntitiesSubscriber { clauses, sender });
+        self.subscribers.write().await.insert(id, EntitiesSubscriber { clauses, sender });
     }
 
     pub(super) async fn remove_subscriber(&self, id: u64) {

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -30,8 +30,6 @@ pub(crate) const LOG_TARGET: &str = "torii::grpc::server::subscriptions::event_m
 pub struct EventMessageSubscriber {
     /// Entity ids that the subscriber is interested in
     pub(crate) clauses: Vec<EntityKeysClause>,
-    /// Whether the subscriber is interested in historical event messages
-    pub(crate) historical: bool,
     /// The channel to send the response back to the subscriber.
     pub(crate) sender: Sender<Result<proto::world::SubscribeEntityResponse, tonic::Status>>,
 }
@@ -45,7 +43,6 @@ impl EventMessageManager {
     pub async fn add_subscriber(
         &self,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) -> Result<Receiver<Result<proto::world::SubscribeEntityResponse, tonic::Status>>, Error> {
         let subscription_id = rand::thread_rng().gen::<u64>();
         let (sender, receiver) = channel(1);
@@ -58,7 +55,7 @@ impl EventMessageManager {
         self.subscribers
             .write()
             .await
-            .insert(subscription_id, EventMessageSubscriber { clauses, historical, sender });
+            .insert(subscription_id, EventMessageSubscriber { clauses, sender });
 
         Ok(receiver)
     }
@@ -67,7 +64,6 @@ impl EventMessageManager {
         &self,
         id: u64,
         clauses: Vec<EntityKeysClause>,
-        historical: bool,
     ) {
         let sender = {
             let subscribers = self.subscribers.read().await;
@@ -81,7 +77,7 @@ impl EventMessageManager {
         self.subscribers
             .write()
             .await
-            .insert(id, EventMessageSubscriber { clauses, historical, sender });
+            .insert(id, EventMessageSubscriber { clauses, sender });
     }
 
     pub(super) async fn remove_subscriber(&self, id: u64) {
@@ -135,11 +131,6 @@ impl Service {
             .map_err(ParseError::FromStr)?;
 
         for (idx, sub) in subs.subscribers.read().await.iter() {
-            // Check if the subscriber is interested in this historical or non-historical event
-            if sub.historical != entity.historical {
-                continue;
-            }
-
             // Check if the subscriber is interested in this entity
             // If we have a clause of hashed keys, then check that the id of the entity
             // is in the list of hashed keys.

--- a/crates/torii/grpc/src/server/subscriptions/event_message.rs
+++ b/crates/torii/grpc/src/server/subscriptions/event_message.rs
@@ -60,11 +60,7 @@ impl EventMessageManager {
         Ok(receiver)
     }
 
-    pub async fn update_subscriber(
-        &self,
-        id: u64,
-        clauses: Vec<EntityKeysClause>,
-    ) {
+    pub async fn update_subscriber(&self, id: u64, clauses: Vec<EntityKeysClause>) {
         let sender = {
             let subscribers = self.subscribers.read().await;
             if let Some(subscriber) = subscribers.get(&id) {
@@ -74,10 +70,7 @@ impl EventMessageManager {
             }
         };
 
-        self.subscribers
-            .write()
-            .await
-            .insert(id, EventMessageSubscriber { clauses, sender });
+        self.subscribers.write().await.insert(id, EventMessageSubscriber { clauses, sender });
     }
 
     pub(super) async fn remove_subscriber(&self, id: u64) {

--- a/crates/torii/sqlite/src/executor/mod.rs
+++ b/crates/torii/sqlite/src/executor/mod.rs
@@ -461,7 +461,6 @@ impl<'c, P: Provider + Sync + Send + 'static> Executor<'c, P> {
                 let mut entity_updated = EntityUpdated::from_row(&row)?;
                 entity_updated.updated_model = Some(entity.ty.clone());
                 entity_updated.deleted = false;
-                entity_updated.historical = entity.is_historical;
 
                 if entity_updated.keys.is_empty() {
                     warn!(target: LOG_TARGET, "Entity has been updated without being set before. Keys are not known and non-updated values will be NULL.");
@@ -640,7 +639,6 @@ impl<'c, P: Provider + Sync + Send + 'static> Executor<'c, P> {
 
                 let mut event_message = EventMessageUpdated::from_row(&event_messages_row)?;
                 event_message.updated_model = Some(em_query.ty);
-                event_message.historical = em_query.is_historical;
 
                 SimpleBroker::publish(unsafe {
                     std::mem::transmute::<EventMessageUpdated, OptimisticEventMessage>(

--- a/crates/torii/sqlite/src/types.rs
+++ b/crates/torii/sqlite/src/types.rs
@@ -45,8 +45,6 @@ pub struct Entity {
     pub updated_model: Option<Ty>,
     #[sqlx(skip)]
     pub deleted: bool,
-    #[sqlx(skip)]
-    pub historical: bool,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]
@@ -64,8 +62,6 @@ pub struct OptimisticEntity {
     pub updated_model: Option<Ty>,
     #[sqlx(skip)]
     pub deleted: bool,
-    #[sqlx(skip)]
-    pub historical: bool,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]
@@ -81,8 +77,6 @@ pub struct EventMessage {
     // this should never be None
     #[sqlx(skip)]
     pub updated_model: Option<Ty>,
-    #[sqlx(skip)]
-    pub historical: bool,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]
@@ -98,8 +92,6 @@ pub struct OptimisticEventMessage {
     // this should never be None
     #[sqlx(skip)]
     pub updated_model: Option<Ty>,
-    #[sqlx(skip)]
-    pub historical: bool,
 }
 
 #[derive(FromRow, Deserialize, Debug, Clone)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined subscription interfaces for live updates by removing legacy options for historical data.
  - Simplified communication and update processes across the system for entity and event message subscriptions.
  - Reduced complexity in subscriber management by eliminating differentiation between historical and non-historical data.

This update delivers a cleaner, more efficient experience by focusing on current real-time updates without the additional complexity of managing historical data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->