### PR TITLE
chore(katana): more descriptive error

### DIFF
--- a/crates/katana/explorer/build.rs
+++ b/crates/katana/explorer/build.rs
@@ -24,6 +24,12 @@ fn main() {
             panic!("Failed to update git submodule");
         }
 
+        let bun_check = Command::new("bun").arg("--version").output();
+
+        if bun_check.is_err() || !bun_check.unwrap().status.success() {
+            panic!("Bun is not installed. Please install Bun at https://bun.sh .");
+        }
+
         // Install dependencies if node_modules doesn't exist
         // $CARGO_MANIFEST_DIR/ui/node_modules
         if !Path::new(&ui_dir).join("node_modules").exists() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a pre-build validation to ensure the bun package manager is installed. Users will now receive guidance to install bun if it isn't detected, helping guarantee that all required tools are present for a successful build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->