### PR TITLE
fix(katana): using outdated state when creating the paymaster txs

### DIFF
--- a/crates/katana/cli/src/args.rs
+++ b/crates/katana/cli/src/args.rs
@@ -177,7 +177,7 @@ impl NodeArgs {
 
     fn init_logging(&self) -> Result<()> {
         const DEFAULT_LOG_FILTER: &str =
-            "pipeline=debug,stage=debug,info,tasks=debug,executor=trace,forking::backend=trace,\
+            "info,executor=trace,pipeline=debug,stage=debug,tasks=debug,forking::backend=trace,\
              blockifier=off,jsonrpsee_server=off,hyper=off,messaging=debug,node=error";
 
         let filter = if self.development.dev {

--- a/crates/katana/rpc/rpc/src/cartridge.rs
+++ b/crates/katana/rpc/rpc/src/cartridge.rs
@@ -138,9 +138,7 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
             // ====================== CONTROLLER DEPLOYMENT ======================
             // Check if the controller is already deployed. If not, deploy it.
 
-            let mut controller_deployed = false;
-
-            let controller_is_deployed = {
+            let is_controller_deployed = {
 	            match this.pending_executor().as_ref() {
 	                Some(executor) => executor.read().state().class_hash_of_contract(address)?.is_some(),
 	                None => {
@@ -149,7 +147,7 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
 	            }
             };
 
-            if !controller_is_deployed {
+            if !is_controller_deployed {
 	           	debug!(target: "rpc::cartridge", controller = %address, "Controller not yet deployed");
                 if let Some(tx) =
                     futures::executor::block_on(craft_deploy_cartridge_controller_tx(
@@ -163,7 +161,6 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
                 {
                 	debug!(target: "rpc::cartridge", controller = %address, tx = format!("{:#x}", tx.hash),  "Inserting Controller deployment transaction");
                     this.pool.add_transaction(tx)?;
-                    controller_deployed = true;
                 }
             }
 
@@ -171,7 +168,7 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
 
             // If we submitted a deploy Controller transaction, then the execute from outside
             // transaction nonce should be incremented.
-            if controller_deployed {
+            if !is_controller_deployed {
                 nonce += Nonce::ONE;
             }
 

--- a/crates/katana/rpc/rpc/src/cartridge.rs
+++ b/crates/katana/rpc/rpc/src/cartridge.rs
@@ -149,7 +149,7 @@ impl<EF: ExecutorFactory> CartridgeApi<EF> {
 	            }
             };
 
-            if dbg!(!controller_is_deployed) {
+            if !controller_is_deployed {
 	           	debug!(target: "rpc::cartridge", controller = %address, "Controller not yet deployed");
                 if let Some(tx) =
                     futures::executor::block_on(craft_deploy_cartridge_controller_tx(

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -268,7 +268,12 @@ impl<EF: ExecutorFactory> StarknetApiServer for StarknetApi<EF> {
             let paymaster_nonce = match self.nonce_at(block_id, *paymaster_address).await {
                 Ok(nonce) => nonce,
                 Err(err) => match err {
-                    StarknetApiError::ContractNotFound => Nonce::default(),
+                    // this should be unreachable bcs we already checked for the paymaster account
+                    // existence earlier
+                    StarknetApiError::ContractNotFound => {
+                        let error = anyhow!("Cartridge paymaster account doesn't exist");
+                        return Err(Error::from(error))?;
+                    }
                     _ => return Err(Error::from(err)),
                 },
             };

--- a/crates/katana/rpc/rpc/src/starknet/read.rs
+++ b/crates/katana/rpc/rpc/src/starknet/read.rs
@@ -5,7 +5,6 @@ use jsonrpsee::core::{async_trait, Error, RpcResult};
 use katana_executor::{EntryPointCall, ExecutorFactory};
 use katana_primitives::block::BlockIdOrTag;
 use katana_primitives::class::ClassHash;
-use katana_primitives::contract::Nonce;
 use katana_primitives::genesis::allocation::GenesisAccountAlloc;
 use katana_primitives::transaction::{ExecutableTx, ExecutableTxWithHash, TxHash};
 use katana_primitives::{ContractAddress, Felt};


### PR DESCRIPTION
Currently, the creation of paymaster transaction(s) does not take into account the 'pending' state. Evident in the usage of:

```rust
// crates/katana/rpc/rpc/src/cartridge.rs

let provider = this.backend.blockchain.provider();
let state = provider.latest()?;

// ...

if state.class_hash_of_contract(address)?.is_none() {
// ...
}
```

as well as:

```rust
// crates/katana/rpc/rpc/src/starknet/read.rs
let paymaster_nonce = state.nonce(paymaster_address)?;
```

where `state` is actually the 'latest' state (doesn't include pending state):

https://github.com/dojoengine/dojo/blob/5e0de118533a00267895e5e58cf86ae10d844fb8/crates/katana/rpc/rpc/src/starknet/read.rs#L250-L257

This becomes an issue when `katana` is running in interval block production where some expected state may still be 'pending'. Where the transactions that we send using the paymaster flow may still be in the pending block, and querying the nonce from the latest state results in an invalid/outdated nonce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced deployment transactions with consolidated nonce management and state checks for improved reliability.

- **Refactor**
  - Updated logging settings to adjust message prioritization.
  - Streamlined error handling during fee estimation to provide clearer notifications when account issues arise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->