### PR TITLE
opt(torii-indexer): batching requests for ercs

### DIFF
--- a/crates/torii/sqlite/src/erc.rs
+++ b/crates/torii/sqlite/src/erc.rs
@@ -197,12 +197,10 @@ impl Sql {
             ProviderResponseData::Call(name) if name.len() == 1 => {
                 parse_cairo_short_string(&name[0]).unwrap()
             }
-            ProviderResponseData::Call(name) => {
-                ByteArray::cairo_deserialize(name, 0)
-                    .expect("Return value not ByteArray")
-                    .to_string()
-                    .expect("Return value not String")
-            }
+            ProviderResponseData::Call(name) => ByteArray::cairo_deserialize(name, 0)
+                .expect("Return value not ByteArray")
+                .to_string()
+                .expect("Return value not String"),
             _ => return Err(anyhow::anyhow!("Invalid response for name")),
         };
 
@@ -211,12 +209,10 @@ impl Sql {
             ProviderResponseData::Call(symbol) if symbol.len() == 1 => {
                 parse_cairo_short_string(&symbol[0]).unwrap()
             }
-            ProviderResponseData::Call(symbol) => {
-                ByteArray::cairo_deserialize(symbol, 0)
-                    .expect("Return value not ByteArray")
-                    .to_string()
-                    .expect("Return value not String")
-            }
+            ProviderResponseData::Call(symbol) => ByteArray::cairo_deserialize(symbol, 0)
+                .expect("Return value not ByteArray")
+                .to_string()
+                .expect("Return value not String"),
             _ => return Err(anyhow::anyhow!("Invalid response for symbol")),
         };
 

--- a/crates/torii/sqlite/src/executor/erc.rs
+++ b/crates/torii/sqlite/src/executor/erc.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use cainome::cairo_serde::{ByteArray, CairoSerde};
-use data_url::DataUrl;
 use data_url::mime::Mime;
+use data_url::DataUrl;
 use reqwest::Client;
 use starknet::core::types::{BlockId, BlockTag, FunctionCall, U256};
 use starknet::core::utils::{get_selector_from_name, parse_cairo_short_string};
@@ -18,8 +18,8 @@ use crate::executor::LOG_TARGET;
 use crate::simple_broker::SimpleBroker;
 use crate::types::{ContractType, OptimisticToken, OptimisticTokenBalance, Token, TokenBalance};
 use crate::utils::{
-    I256, felt_and_u256_to_sql_string, felt_to_sql_string, fetch_content_from_ipfs,
-    sanitize_json_string, sql_string_to_u256, u256_to_sql_string,
+    felt_and_u256_to_sql_string, felt_to_sql_string, fetch_content_from_ipfs, sanitize_json_string,
+    sql_string_to_u256, u256_to_sql_string, I256,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/torii/sqlite/src/executor/erc.rs
+++ b/crates/torii/sqlite/src/executor/erc.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use cainome::cairo_serde::{ByteArray, CairoSerde};
-use data_url::mime::Mime;
 use data_url::DataUrl;
+use data_url::mime::Mime;
 use reqwest::Client;
 use starknet::core::types::{BlockId, BlockTag, FunctionCall, U256};
 use starknet::core::utils::{get_selector_from_name, parse_cairo_short_string};
 use starknet::providers::Provider;
 use starknet_crypto::Felt;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use super::{ApplyBalanceDiffQuery, BrokerMessage, Executor};
 use crate::constants::{SQL_FELT_DELIMITER, TOKEN_BALANCE_TABLE};
@@ -18,8 +18,8 @@ use crate::executor::LOG_TARGET;
 use crate::simple_broker::SimpleBroker;
 use crate::types::{ContractType, OptimisticToken, OptimisticTokenBalance, Token, TokenBalance};
 use crate::utils::{
-    felt_and_u256_to_sql_string, felt_to_sql_string, fetch_content_from_ipfs, sanitize_json_string,
-    sql_string_to_u256, u256_to_sql_string, I256,
+    I256, felt_and_u256_to_sql_string, felt_to_sql_string, fetch_content_from_ipfs,
+    sanitize_json_string, sql_string_to_u256, u256_to_sql_string,
 };
 
 #[derive(Debug, Clone)]
@@ -319,6 +319,7 @@ impl<'c, P: Provider + Sync + Send + 'static> Executor<'c, P> {
             .with_context(|| format!("Failed to execute721Token query: {:?}", result))?;
 
         if let Some(token) = token {
+            info!(target: LOG_TARGET, name = %result.name, symbol = %result.symbol, contract_address = %token.contract_address, token_id = %result.query.token_id, "NFT token registered.");
             SimpleBroker::publish(unsafe {
                 std::mem::transmute::<Token, OptimisticToken>(token.clone())
             });

--- a/crates/torii/sqlite/src/executor/mod.rs
+++ b/crates/torii/sqlite/src/executor/mod.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
 use tokio::sync::{Semaphore, oneshot};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::constants::TOKENS_TABLE;
 use crate::simple_broker::SimpleBroker;
@@ -757,6 +757,7 @@ impl<'c, P: Provider + Sync + Send + 'static> Executor<'c, P> {
                 .bind(register_erc20_token.decimals);
 
                 let token = query.fetch_one(&mut **tx).await?;
+                info!(target: LOG_TARGET, name = %register_erc20_token.name, symbol = %register_erc20_token.symbol, contract_address = %token.contract_address, "Registered ERC20 token.");
 
                 self.publish_queue.push(BrokerMessage::TokenRegistered(token));
             }

--- a/crates/torii/sqlite/src/executor/mod.rs
+++ b/crates/torii/sqlite/src/executor/mod.rs
@@ -14,8 +14,8 @@ use starknet::core::types::{BlockId, BlockTag, Felt, FunctionCall};
 use starknet::core::utils::{get_selector_from_name, parse_cairo_short_string};
 use starknet::providers::{Provider, ProviderRequestData, ProviderResponseData};
 use tokio::sync::broadcast::{Receiver, Sender};
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
-use tokio::sync::{Semaphore, oneshot};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::{oneshot, Semaphore};
 use tokio::task::JoinSet;
 use tokio::time::Instant;
 use tracing::{debug, error, info, warn};
@@ -27,7 +27,7 @@ use crate::types::{
     EventMessage as EventMessageUpdated, Model as ModelRegistered, OptimisticEntity,
     OptimisticEventMessage, ParsedCall, Token, TokenBalance, Transaction,
 };
-use crate::utils::{I256, felt_to_sql_string, felts_to_sql_string};
+use crate::utils::{felt_to_sql_string, felts_to_sql_string, I256};
 
 pub mod erc;
 pub use erc::{RegisterErc20TokenQuery, RegisterNftTokenQuery};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optimized token information retrieval by consolidating multiple data requests into a single, efficient operation.
  - Enhanced efficiency in fetching NFT metadata through batch requests, reducing the number of asynchronous calls.
  - Improved logging capabilities for NFT token registration, providing better context on registered tokens.
- **Bug Fixes**
  - Enhanced error handling for unexpected response types during token metadata retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->