### PR TITLE
feat(katana): trace gas usage

### DIFF
--- a/crates/katana/executor/src/implementation/blockifier/mod.rs
+++ b/crates/katana/executor/src/implementation/blockifier/mod.rs
@@ -250,7 +250,7 @@ impl<'a> BlockExecutor<'a> for StarknetVMProcessor<'a> {
                                 state.declared_classes.insert(class_hash, class.as_ref().clone());
                             }
 
-                            crate::utils::log_resources(&trace.actual_resources);
+                            crate::utils::log_resources(&trace.actual_resources, receipt);
                         }
 
                         ExecutionResult::Failed { error } => {

--- a/crates/katana/executor/src/implementation/blockifier/utils.rs
+++ b/crates/katana/executor/src/implementation/blockifier/utils.rs
@@ -587,11 +587,11 @@ pub fn to_exec_info(exec_info: TransactionExecutionInfo, r#type: TxType) -> TxEx
             ),
             n_reverted_steps: exec_info.transaction_receipt.resources.n_reverted_steps,
             data_availability: L1Gas {
-                l1_gas: exec_info.transaction_receipt.da_gas.l1_data_gas,
+                l1_gas: exec_info.transaction_receipt.da_gas.l1_gas,
                 l1_data_gas: exec_info.transaction_receipt.da_gas.l1_data_gas,
             },
             total_gas_consumed: L1Gas {
-                l1_gas: exec_info.transaction_receipt.gas.l1_data_gas,
+                l1_gas: exec_info.transaction_receipt.gas.l1_gas,
                 l1_data_gas: exec_info.transaction_receipt.gas.l1_data_gas,
             },
         },

--- a/crates/katana/executor/src/utils.rs
+++ b/crates/katana/executor/src/utils.rs
@@ -29,7 +29,7 @@ pub fn log_resources(resources: &TxResources, receipt: &Receipt) {
     mapped_strings.push(format!("DA L1: {}", resources.data_availability.l1_gas));
     mapped_strings.push(format!("DA L1 Data: {}", resources.data_availability.l1_data_gas));
 
-    mapped_strings.push(format!("Gas consumed: {}", receipt.fee().gas_consumed));
+    mapped_strings.push(format!("Total consumed: {}", receipt.fee().gas_consumed));
     mapped_strings.push(format!(
         "Overall Fee: {:.8} {}",
         receipt.fee().overall_fee as f64 / 100.0 / 10_f64.powf(18.0),

--- a/crates/katana/executor/src/utils.rs
+++ b/crates/katana/executor/src/utils.rs
@@ -9,7 +9,7 @@ use tracing::trace;
 
 pub(crate) const LOG_TARGET: &str = "executor";
 
-pub fn log_resources(resources: &TxResources) {
+pub fn log_resources(resources: &TxResources, receipt: &Receipt) {
     let mut mapped_strings = Vec::new();
 
     for (builtin, count) in &resources.vm_resources.builtin_instance_counter {
@@ -22,6 +22,24 @@ pub fn log_resources(resources: &TxResources) {
     mapped_strings.insert(1, format!("memory holes: {}", resources.vm_resources.n_memory_holes));
 
     trace!(target: LOG_TARGET, usage = mapped_strings.join(" | "), "Transaction resource usage.");
+
+    let mut mapped_strings = Vec::new();
+    mapped_strings.push(format!("L1: {}", resources.total_gas_consumed.l1_gas));
+    mapped_strings.push(format!("L1 Data: {}", resources.total_gas_consumed.l1_data_gas));
+    mapped_strings.push(format!("DA L1: {}", resources.data_availability.l1_gas));
+    mapped_strings.push(format!("DA L1 Data: {}", resources.data_availability.l1_data_gas));
+
+    mapped_strings.push(format!("Gas consumed: {}", receipt.fee().gas_consumed));
+    mapped_strings.push(format!(
+        "Overall Fee: {:.8} {}",
+        receipt.fee().overall_fee as f64 / 100.0 / 10_f64.powf(18.0),
+        match receipt.fee().unit {
+            katana_primitives::fee::PriceUnit::Wei => "ETH",
+            katana_primitives::fee::PriceUnit::Fri => "STRK",
+        },
+    ));
+
+    trace!(target: LOG_TARGET, usage = mapped_strings.join(" | "), "Gas usage.");
 }
 
 pub(crate) fn build_receipt(tx: TxRef<'_>, fee: TxFeeInfo, info: &TxExecInfo) -> Receipt {


### PR DESCRIPTION
I think there is still some issues with gas computation, l1_data_gas is always 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction logging now captures detailed resource metrics, including gas consumption and fee breakdowns, offering clearer insights into transaction performance.
  - Updated data mapping for gas usage ensures more accurate reporting in transaction summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->