### PR TITLE
opt(torii-runner): verify contracts deployment in parallel

### DIFF
--- a/crates/dojo/lang/Scarb.lock
+++ b/crates/dojo/lang/Scarb.lock
@@ -3,4 +3,4 @@ version = 1
 
 [[package]]
 name = "dojo_plugin"
-version = "2.9.2"
+version = "2.9.4"

--- a/crates/torii/cli/src/args.rs
+++ b/crates/torii/cli/src/args.rs
@@ -208,13 +208,11 @@ mod test {
 
         assert_eq!(torii_args.db_dir, None);
 
-        assert!(!torii_args.runner.explorer);
-        assert!(!torii_args.runner.check_contracts);
-
         assert_eq!(torii_args.indexing, IndexingOptions::default());
         assert_eq!(torii_args.events, EventsOptions::default());
         assert_eq!(torii_args.erc, ErcOptions::default());
         assert_eq!(torii_args.sql, SqlOptions::default());
+        assert_eq!(torii_args.runner, RunnerOptions::default());
         assert_eq!(torii_args.server, ServerOptions::default());
         assert_eq!(torii_args.relay, RelayOptions::default());
         assert_eq!(torii_args.metrics, MetricsOptions::default());

--- a/crates/torii/cli/src/args.rs
+++ b/crates/torii/cli/src/args.rs
@@ -36,13 +36,12 @@ pub struct ToriiArgs {
     )]
     pub db_dir: Option<PathBuf>,
 
-    /// Open World Explorer on the browser.
-    #[arg(long, help = "Open World Explorer on the browser.")]
-    pub explorer: bool,
-
     /// Configuration file
     #[arg(long, help = "Configuration file to setup Torii.")]
     pub config: Option<PathBuf>,
+
+    #[command(flatten)]
+    pub runner: RunnerOptions,
 
     #[command(flatten)]
     pub indexing: IndexingOptions,
@@ -75,12 +74,12 @@ impl Default for ToriiArgs {
             world_address: None,
             rpc: Url::parse(DEFAULT_RPC_URL).unwrap(),
             db_dir: None,
-            explorer: false,
             config: None,
             indexing: IndexingOptions::default(),
             events: EventsOptions::default(),
             erc: ErcOptions::default(),
             sql: SqlOptions::default(),
+            runner: RunnerOptions::default(),
             #[cfg(feature = "server")]
             metrics: MetricsOptions::default(),
             #[cfg(feature = "server")]
@@ -209,7 +208,8 @@ mod test {
 
         assert_eq!(torii_args.db_dir, None);
 
-        assert!(!torii_args.explorer);
+        assert!(!torii_args.runner.explorer);
+        assert!(!torii_args.runner.check_contracts);
 
         assert_eq!(torii_args.indexing, IndexingOptions::default());
         assert_eq!(torii_args.events, EventsOptions::default());

--- a/crates/torii/cli/src/options.rs
+++ b/crates/torii/cli/src/options.rs
@@ -372,7 +372,7 @@ impl Default for SqlOptions {
     }
 }
 
-#[derive(Debug, clap::Args, Clone, Serialize, Deserialize, PartialEq, MergeOptions)]
+#[derive(Default, Debug, clap::Args, Clone, Serialize, Deserialize, PartialEq, MergeOptions)]
 #[serde(default)]
 #[command(next_help_heading = "Runner options")]
 pub struct RunnerOptions {
@@ -391,12 +391,6 @@ pub struct RunnerOptions {
         help = "Check if contracts are deployed before starting torii."
     )]
     pub check_contracts: bool,
-}
-
-impl Default for RunnerOptions {
-    fn default() -> Self {
-        Self { explorer: false, check_contracts: false }
-    }
 }
 
 // Parses clap cli argument which is expected to be in the format:

--- a/crates/torii/cli/src/options.rs
+++ b/crates/torii/cli/src/options.rs
@@ -372,6 +372,33 @@ impl Default for SqlOptions {
     }
 }
 
+#[derive(Debug, clap::Args, Clone, Serialize, Deserialize, PartialEq, MergeOptions)]
+#[serde(default)]
+#[command(next_help_heading = "Runner options")]
+pub struct RunnerOptions {
+    /// Open World Explorer on the browser.
+    #[arg(
+        long = "runner.explorer",
+        default_value_t = false,
+        help = "Open World Explorer on the browser."
+    )]
+    pub explorer: bool,
+
+    /// Check if contracts are deployed before starting torii.
+    #[arg(
+        long = "runner.check_contracts",
+        default_value_t = false,
+        help = "Check if contracts are deployed before starting torii."
+    )]
+    pub check_contracts: bool,
+}
+
+impl Default for RunnerOptions {
+    fn default() -> Self {
+        Self { explorer: false, check_contracts: false }
+    }
+}
+
 // Parses clap cli argument which is expected to be in the format:
 // - model-tag:field1,field2;othermodel-tag:field3,field4
 fn parse_model_indices(part: &str) -> anyhow::Result<ModelIndices> {

--- a/crates/torii/runner/src/lib.rs
+++ b/crates/torii/runner/src/lib.rs
@@ -21,10 +21,10 @@ use constants::UDC_ADDRESS;
 use dojo_metrics::exporters::prometheus::PrometheusRecorder;
 use dojo_world::contracts::world::WorldContractReader;
 use futures::future::join_all;
-use sqlx::SqlitePool;
 use sqlx::sqlite::{
     SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous,
 };
+use sqlx::SqlitePool;
 use starknet::core::types::{BlockId, BlockTag};
 use starknet::providers::jsonrpc::HttpTransport;
 use starknet::providers::{JsonRpcClient, Provider};
@@ -42,7 +42,7 @@ use torii_sqlite::simple_broker::SimpleBroker;
 use torii_sqlite::types::{Contract, ContractType, Model};
 use torii_sqlite::{Sql, SqlConfig};
 use tracing::{error, info, warn};
-use tracing_subscriber::{EnvFilter, fmt};
+use tracing_subscriber::{fmt, EnvFilter};
 use url::form_urlencoded;
 
 mod constants;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a consolidated set of command-line options, enabling users to control the browser launch for the explorer functionality and to specify whether contract deployments should be verified before running the application.

- **Refactor**
  - Enhanced the contract verification process to run concurrently, improving efficiency during application startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->