### PR TITLE
feat(torii-grpc): pagination for tokens & order by & next cursor 

### DIFF
--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -138,7 +138,7 @@ impl Client {
     pub async fn entities(&self, query: Query, historical: bool) -> Result<Vec<Entity>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveEntitiesResponse { entities, total_count: _ } =
-            grpc_client.retrieve_entities(query, historical).await?;
+            grpc_client.retrieve_entities(query, historical).await?;s
         Ok(entities.into_iter().map(TryInto::try_into).collect::<Result<Vec<Entity>, _>>()?)
     }
 

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -138,7 +138,7 @@ impl Client {
     pub async fn entities(&self, query: Query, historical: bool) -> Result<Vec<Entity>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveEntitiesResponse { entities, total_count: _ } =
-            grpc_client.retrieve_entities(query, historical).await?;s
+            grpc_client.retrieve_entities(query, historical).await?;
         Ok(entities.into_iter().map(TryInto::try_into).collect::<Result<Vec<Entity>, _>>()?)
     }
 

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -105,7 +105,13 @@ impl Client {
     ) -> Result<Vec<TokenBalance>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveTokenBalancesResponse { balances } = grpc_client
-            .retrieve_token_balances(account_addresses, contract_addresses, token_ids, limit, offset)
+            .retrieve_token_balances(
+                account_addresses,
+                contract_addresses,
+                token_ids,
+                limit,
+                offset,
+            )
             .await?;
         Ok(balances.into_iter().map(TryInto::try_into).collect::<Result<Vec<TokenBalance>, _>>()?)
     }

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -87,10 +87,11 @@ impl Client {
         token_ids: Vec<U256>,
         limit: Option<u32>,
         offset: Option<u32>,
+        cursor: Option<String>,
     ) -> Result<Vec<Token>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveTokensResponse { tokens } =
-            grpc_client.retrieve_tokens(contract_addresses, token_ids, limit, offset).await?;
+            grpc_client.retrieve_tokens(contract_addresses, token_ids, limit, offset, cursor).await?;
         Ok(tokens.into_iter().map(TryInto::try_into).collect::<Result<Vec<Token>, _>>()?)
     }
 
@@ -102,6 +103,7 @@ impl Client {
         token_ids: Vec<U256>,
         limit: Option<u32>,
         offset: Option<u32>,
+        cursor: Option<String>,
     ) -> Result<Vec<TokenBalance>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveTokenBalancesResponse { balances } = grpc_client
@@ -111,6 +113,7 @@ impl Client {
                 token_ids,
                 limit,
                 offset,
+                cursor,
             )
             .await?;
         Ok(balances.into_iter().map(TryInto::try_into).collect::<Result<Vec<TokenBalance>, _>>()?)

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -90,8 +90,9 @@ impl Client {
         cursor: Option<String>,
     ) -> Result<Vec<Token>, Error> {
         let mut grpc_client = self.inner.write().await;
-        let RetrieveTokensResponse { tokens } =
-            grpc_client.retrieve_tokens(contract_addresses, token_ids, limit, offset, cursor).await?;
+        let RetrieveTokensResponse { tokens } = grpc_client
+            .retrieve_tokens(contract_addresses, token_ids, limit, offset, cursor)
+            .await?;
         Ok(tokens.into_iter().map(TryInto::try_into).collect::<Result<Vec<Token>, _>>()?)
     }
 

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -17,7 +17,7 @@ use torii_grpc::proto::world::{
 };
 use torii_grpc::types::schema::Entity;
 use torii_grpc::types::{
-    Controller, EntityKeysClause, Event, EventQuery, Query, Token, TokenBalance,
+    Controller, EntityKeysClause, Event, EventQuery, Page, Query, Token, TokenBalance,
 };
 use torii_relay::client::EventLoop;
 use torii_relay::types::Message;
@@ -88,15 +88,15 @@ impl Client {
         limit: Option<u32>,
         offset: Option<u32>,
         cursor: Option<String>,
-    ) -> Result<(Vec<Token>, String), Error> {
+    ) -> Result<Page<Token>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveTokensResponse { tokens, next_cursor } = grpc_client
             .retrieve_tokens(contract_addresses, token_ids, limit, offset, cursor)
             .await?;
-        Ok((
-            tokens.into_iter().map(TryInto::try_into).collect::<Result<Vec<Token>, _>>()?,
+        Ok(Page {
+            items: tokens.into_iter().map(TryInto::try_into).collect::<Result<Vec<Token>, _>>()?,
             next_cursor,
-        ))
+        })
     }
 
     /// Retrieves token balances for account addresses and contract addresses.
@@ -108,7 +108,7 @@ impl Client {
         limit: Option<u32>,
         offset: Option<u32>,
         cursor: Option<String>,
-    ) -> Result<(Vec<TokenBalance>, String), Error> {
+    ) -> Result<Page<TokenBalance>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveTokenBalancesResponse { balances, next_cursor } = grpc_client
             .retrieve_token_balances(
@@ -120,13 +120,13 @@ impl Client {
                 cursor,
             )
             .await?;
-        Ok((
-            balances
+        Ok(Page {
+            items: balances
                 .into_iter()
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<TokenBalance>, _>>()?,
             next_cursor,
-        ))
+        })
     }
 
     /// Retrieves entities matching query parameter.

--- a/crates/torii/client/src/client/mod.rs
+++ b/crates/torii/client/src/client/mod.rs
@@ -85,10 +85,12 @@ impl Client {
         &self,
         contract_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
+        limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<Vec<Token>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveTokensResponse { tokens } =
-            grpc_client.retrieve_tokens(contract_addresses, token_ids).await?;
+            grpc_client.retrieve_tokens(contract_addresses, token_ids, limit, offset).await?;
         Ok(tokens.into_iter().map(TryInto::try_into).collect::<Result<Vec<Token>, _>>()?)
     }
 
@@ -98,10 +100,12 @@ impl Client {
         account_addresses: Vec<Felt>,
         contract_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
+        limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<Vec<TokenBalance>, Error> {
         let mut grpc_client = self.inner.write().await;
         let RetrieveTokenBalancesResponse { balances } = grpc_client
-            .retrieve_token_balances(account_addresses, contract_addresses, token_ids)
+            .retrieve_token_balances(account_addresses, contract_addresses, token_ids, limit, offset)
             .await?;
         Ok(balances.into_iter().map(TryInto::try_into).collect::<Result<Vec<TokenBalance>, _>>()?)
     }

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -103,6 +103,8 @@ message RetrieveTokensRequest {
     uint32 limit = 3;
     // The offset to retrieve tokens from
     uint32 offset = 4;
+    // The cursor to start the query from
+    string cursor = 5;
 }
 
 // A request to subscribe to token updates
@@ -115,7 +117,8 @@ message SubscribeTokensRequest {
 
 // A response containing tokens
 message RetrieveTokensResponse {
-    repeated types.Token tokens = 1;
+    string next_cursor = 1;
+    repeated types.Token tokens = 2;
 }
 
 // A response containing token updates
@@ -148,6 +151,8 @@ message RetrieveTokenBalancesRequest {
     uint32 limit = 4;
     // The offset to retrieve token balances from
     uint32 offset = 5;
+    // The cursor to start the query from
+    string cursor = 6;
 }
 
 // A request to subscribe to token balance updates
@@ -162,7 +167,8 @@ message SubscribeTokenBalancesRequest {
 
 // A response containing token balances
 message RetrieveTokenBalancesResponse {
-    repeated types.TokenBalance balances = 1;
+    string next_cursor = 1;
+    repeated types.TokenBalance balances = 2;
 }
 
 // A request to subscribe to indexer updates.

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -99,6 +99,10 @@ message RetrieveTokensRequest {
     repeated bytes contract_addresses = 1;
     // The list of token IDs to retrieve tokens for
     repeated bytes token_ids = 2;
+    // The number of tokens to retrieve
+    uint32 limit = 3;
+    // The offset to retrieve tokens from
+    uint32 offset = 4;
 }
 
 // A response containing tokens
@@ -132,6 +136,10 @@ message RetrieveTokenBalancesRequest {
     repeated bytes contract_addresses = 2;
     // The list of token IDs to retrieve balances for
     repeated bytes token_ids = 3;
+    // The number of token balances to retrieve
+    uint32 limit = 4;
+    // The offset to retrieve token balances from
+    uint32 offset = 5;
 }
 
 // A response containing token balances

--- a/crates/torii/grpc/proto/world.proto
+++ b/crates/torii/grpc/proto/world.proto
@@ -35,13 +35,13 @@ service World {
     rpc UpdateEventMessagesSubscription (UpdateEventMessagesSubscriptionRequest) returns (google.protobuf.Empty);
 
     // Subscribe to token balance updates.
-    rpc SubscribeTokenBalances (RetrieveTokenBalancesRequest) returns (stream SubscribeTokenBalancesResponse);
+    rpc SubscribeTokenBalances (SubscribeTokenBalancesRequest) returns (stream SubscribeTokenBalancesResponse);
 
     // Update token balance subscription
     rpc UpdateTokenBalancesSubscription (UpdateTokenBalancesSubscriptionRequest) returns (google.protobuf.Empty);
 
     // Subscribe to token updates.
-    rpc SubscribeTokens (RetrieveTokensRequest) returns (stream SubscribeTokensResponse);
+    rpc SubscribeTokens (SubscribeTokensRequest) returns (stream SubscribeTokensResponse);
 
     // Update token subscription
     rpc UpdateTokensSubscription (UpdateTokenSubscriptionRequest) returns (google.protobuf.Empty);
@@ -105,6 +105,14 @@ message RetrieveTokensRequest {
     uint32 offset = 4;
 }
 
+// A request to subscribe to token updates
+message SubscribeTokensRequest {
+    // The list of contract addresses to subscribe to
+    repeated bytes contract_addresses = 1;
+    // The list of token IDs to subscribe to
+    repeated bytes token_ids = 2;
+}
+
 // A response containing tokens
 message RetrieveTokensResponse {
     repeated types.Token tokens = 1;
@@ -140,6 +148,16 @@ message RetrieveTokenBalancesRequest {
     uint32 limit = 4;
     // The offset to retrieve token balances from
     uint32 offset = 5;
+}
+
+// A request to subscribe to token balance updates
+message SubscribeTokenBalancesRequest {
+    // The account addresses to subscribe to
+    repeated bytes account_addresses = 1;
+    // The list of token contract addresses to subscribe to
+    repeated bytes contract_addresses = 2;
+    // The list of token IDs to subscribe to
+    repeated bytes token_ids = 3;
 }
 
 // A response containing token balances

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -131,7 +131,7 @@ impl WorldClient {
                 token_ids: token_ids.into_iter().map(|id| id.to_be_bytes().to_vec()).collect(),
                 limit: limit.unwrap_or_default(),
                 offset: offset.unwrap_or_default(),
-                cursor: cursor.unwrap_or_default()
+                cursor: cursor.unwrap_or_default(),
             })
             .await
             .map_err(Error::Grpc)
@@ -216,7 +216,7 @@ impl WorldClient {
                 token_ids: token_ids.into_iter().map(|id| id.to_be_bytes().to_vec()).collect(),
                 limit: limit.unwrap_or_default(),
                 offset: offset.unwrap_or_default(),
-                cursor: cursor.unwrap_or_default()
+                cursor: cursor.unwrap_or_default(),
             })
             .await
             .map_err(Error::Grpc)

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -18,10 +18,10 @@ use crate::proto::world::{
     RetrieveTokensRequest, RetrieveTokensResponse, SubscribeEntitiesRequest,
     SubscribeEntityResponse, SubscribeEventMessagesRequest, SubscribeEventsRequest,
     SubscribeEventsResponse, SubscribeIndexerRequest, SubscribeIndexerResponse,
-    SubscribeModelsRequest, SubscribeModelsResponse, SubscribeTokenBalancesResponse,
-    SubscribeTokensResponse, UpdateEntitiesSubscriptionRequest,
-    UpdateEventMessagesSubscriptionRequest, UpdateTokenBalancesSubscriptionRequest,
-    UpdateTokenSubscriptionRequest, WorldMetadataRequest,
+    SubscribeModelsRequest, SubscribeModelsResponse, SubscribeTokenBalancesRequest,
+    SubscribeTokenBalancesResponse, SubscribeTokensRequest, SubscribeTokensResponse,
+    UpdateEntitiesSubscriptionRequest, UpdateEventMessagesSubscriptionRequest,
+    UpdateTokenBalancesSubscriptionRequest, UpdateTokenSubscriptionRequest, WorldMetadataRequest,
 };
 use crate::types::schema::{Entity, SchemaError};
 use crate::types::{
@@ -118,6 +118,8 @@ impl WorldClient {
         &mut self,
         contract_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
+        limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<RetrieveTokensResponse, Error> {
         self.inner
             .retrieve_tokens(RetrieveTokensRequest {
@@ -126,6 +128,8 @@ impl WorldClient {
                     .map(|c| c.to_bytes_be().to_vec())
                     .collect(),
                 token_ids: token_ids.into_iter().map(|id| id.to_be_bytes().to_vec()).collect(),
+                limit: limit.unwrap_or(0),
+                offset: offset.unwrap_or(0),
             })
             .await
             .map_err(Error::Grpc)
@@ -137,7 +141,7 @@ impl WorldClient {
         contract_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
     ) -> Result<TokenUpdateStreaming, Error> {
-        let request = RetrieveTokensRequest {
+        let request = SubscribeTokensRequest {
             contract_addresses: contract_addresses
                 .into_iter()
                 .map(|c| c.to_bytes_be().to_vec())
@@ -193,6 +197,8 @@ impl WorldClient {
         account_addresses: Vec<Felt>,
         contract_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
+        limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<RetrieveTokenBalancesResponse, Error> {
         self.inner
             .retrieve_token_balances(RetrieveTokenBalancesRequest {
@@ -205,6 +211,8 @@ impl WorldClient {
                     .map(|c| c.to_bytes_be().to_vec())
                     .collect(),
                 token_ids: token_ids.into_iter().map(|id| id.to_be_bytes().to_vec()).collect(),
+                limit: limit.unwrap_or(0),
+                offset: offset.unwrap_or(0),
             })
             .await
             .map_err(Error::Grpc)
@@ -383,7 +391,7 @@ impl WorldClient {
         account_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
     ) -> Result<TokenBalanceStreaming, Error> {
-        let request = RetrieveTokenBalancesRequest {
+        let request = SubscribeTokenBalancesRequest {
             contract_addresses: contract_addresses
                 .into_iter()
                 .map(|c| c.to_bytes_be().to_vec())

--- a/crates/torii/grpc/src/client.rs
+++ b/crates/torii/grpc/src/client.rs
@@ -120,6 +120,7 @@ impl WorldClient {
         token_ids: Vec<U256>,
         limit: Option<u32>,
         offset: Option<u32>,
+        cursor: Option<String>,
     ) -> Result<RetrieveTokensResponse, Error> {
         self.inner
             .retrieve_tokens(RetrieveTokensRequest {
@@ -128,8 +129,9 @@ impl WorldClient {
                     .map(|c| c.to_bytes_be().to_vec())
                     .collect(),
                 token_ids: token_ids.into_iter().map(|id| id.to_be_bytes().to_vec()).collect(),
-                limit: limit.unwrap_or(0),
-                offset: offset.unwrap_or(0),
+                limit: limit.unwrap_or_default(),
+                offset: offset.unwrap_or_default(),
+                cursor: cursor.unwrap_or_default()
             })
             .await
             .map_err(Error::Grpc)
@@ -199,6 +201,7 @@ impl WorldClient {
         token_ids: Vec<U256>,
         limit: Option<u32>,
         offset: Option<u32>,
+        cursor: Option<String>,
     ) -> Result<RetrieveTokenBalancesResponse, Error> {
         self.inner
             .retrieve_token_balances(RetrieveTokenBalancesRequest {
@@ -211,8 +214,9 @@ impl WorldClient {
                     .map(|c| c.to_bytes_be().to_vec())
                     .collect(),
                 token_ids: token_ids.into_iter().map(|id| id.to_be_bytes().to_vec()).collect(),
-                limit: limit.unwrap_or(0),
-                offset: offset.unwrap_or(0),
+                limit: limit.unwrap_or_default(),
+                offset: offset.unwrap_or_default(),
+                cursor: cursor.unwrap_or_default()
             })
             .await
             .map_err(Error::Grpc)

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -845,6 +845,8 @@ impl DojoWorld {
         &self,
         contract_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
+        limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<RetrieveTokensResponse, Status> {
         let mut query = "SELECT * FROM tokens".to_string();
         let mut bind_values = Vec::new();
@@ -861,8 +863,16 @@ impl DojoWorld {
             bind_values.extend(token_ids.iter().map(|id| u256_to_sql_string(&(*id).into())));
         }
 
+        if let Some(limit) = limit {
+            query += &format!(" LIMIT {}", limit);
+        }
+
+        if let Some(offset) = offset {
+            query += &format!(" OFFSET {}", offset);
+        }
+
         if !conditions.is_empty() {
-            query += &format!(" WHERE {}", conditions.join(" AND "));
+            query += &format!(" WHERE {} ORDER BY id", conditions.join(" AND "));
         }
 
         let mut query = sqlx::query_as(&query);
@@ -882,6 +892,8 @@ impl DojoWorld {
         account_addresses: Vec<Felt>,
         contract_addresses: Vec<Felt>,
         token_ids: Vec<U256>,
+        limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<RetrieveTokenBalancesResponse, Status> {
         let mut query = "SELECT * FROM token_balances".to_string();
         let mut bind_values = Vec::new();
@@ -906,8 +918,16 @@ impl DojoWorld {
             bind_values.extend(token_ids.iter().map(|id| u256_to_sql_string(&(*id).into())));
         }
 
+        if let Some(limit) = limit {
+            query += &format!(" LIMIT {}", limit);
+        }
+
+        if let Some(offset) = offset {
+            query += &format!(" OFFSET {}", offset);
+        }
+
         if !conditions.is_empty() {
-            query += &format!(" WHERE {}", conditions.join(" AND "));
+            query += &format!(" WHERE {} ORDER BY token_id", conditions.join(" AND "));
         }
 
         let mut query = sqlx::query_as(&query);

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -825,7 +825,7 @@ impl DojoWorld {
 
         if let Some(cursor) = cursor {
             bind_values.push(cursor);
-            conditions.push(format!("id > ?"));
+            conditions.push("id > ?".to_string());
         }
 
         if !conditions.is_empty() {
@@ -891,7 +891,7 @@ impl DojoWorld {
 
         if let Some(cursor) = cursor {
             bind_values.push(cursor);
-            conditions.push(format!("id > ?"));
+            conditions.push("id > ?".to_string());
         }
 
         if !conditions.is_empty() {
@@ -901,11 +901,13 @@ impl DojoWorld {
         query += " ORDER BY id";
 
         if let Some(limit) = limit {
-            query += &format!(" LIMIT {}", limit);
+            query += " LIMIT ?";
+            bind_values.push(limit.to_string());
         }
 
         if let Some(offset) = offset {
-            query += &format!(" OFFSET {}", offset);
+            query += " OFFSET ?";
+            bind_values.push(offset.to_string());
         }
 
         let mut query = sqlx::query_as(&query);

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -822,16 +822,18 @@ impl DojoWorld {
             bind_values.extend(token_ids.iter().map(|id| u256_to_sql_string(&(*id).into())));
         }
 
+        if !conditions.is_empty() {
+            query += &format!(" WHERE {}", conditions.join(" AND "));
+        }
+
+        query += " ORDER BY id";
+
         if let Some(limit) = limit {
             query += &format!(" LIMIT {}", limit);
         }
 
         if let Some(offset) = offset {
             query += &format!(" OFFSET {}", offset);
-        }
-
-        if !conditions.is_empty() {
-            query += &format!(" WHERE {} ORDER BY id", conditions.join(" AND "));
         }
 
         let mut query = sqlx::query_as(&query);
@@ -877,16 +879,18 @@ impl DojoWorld {
             bind_values.extend(token_ids.iter().map(|id| u256_to_sql_string(&(*id).into())));
         }
 
+        if !conditions.is_empty() {
+            query += &format!(" WHERE {}", conditions.join(" AND "));
+        }
+
+        query += " ORDER BY token_id";
+
         if let Some(limit) = limit {
             query += &format!(" LIMIT {}", limit);
         }
 
         if let Some(offset) = offset {
             query += &format!(" OFFSET {}", offset);
-        }
-
-        if !conditions.is_empty() {
-            query += &format!(" WHERE {} ORDER BY token_id", conditions.join(" AND "));
         }
 
         let mut query = sqlx::query_as(&query);

--- a/crates/torii/grpc/src/server/mod.rs
+++ b/crates/torii/grpc/src/server/mod.rs
@@ -63,10 +63,10 @@ use crate::proto::world::{
     RetrieveEventMessagesRequest, RetrieveTokenBalancesRequest, RetrieveTokenBalancesResponse,
     RetrieveTokensRequest, RetrieveTokensResponse, SubscribeEntitiesRequest,
     SubscribeEntityResponse, SubscribeEventMessagesRequest, SubscribeEventsResponse,
-    SubscribeIndexerRequest, SubscribeIndexerResponse, SubscribeTokenBalancesResponse,
-    SubscribeTokensResponse, UpdateEventMessagesSubscriptionRequest,
-    UpdateTokenBalancesSubscriptionRequest, UpdateTokenSubscriptionRequest, WorldMetadataRequest,
-    WorldMetadataResponse,
+    SubscribeIndexerRequest, SubscribeIndexerResponse, SubscribeTokenBalancesRequest,
+    SubscribeTokenBalancesResponse, SubscribeTokensRequest, SubscribeTokensResponse,
+    UpdateEventMessagesSubscriptionRequest, UpdateTokenBalancesSubscriptionRequest,
+    UpdateTokenSubscriptionRequest, WorldMetadataRequest, WorldMetadataResponse,
 };
 use crate::proto::{self};
 use crate::types::schema::SchemaError;
@@ -266,8 +266,8 @@ impl DojoWorld {
         table: &str,
         model_relation_table: &str,
         entity_relation_column: &str,
-        limit: u32,
-        offset: u32,
+        limit: Option<u32>,
+        offset: Option<u32>,
         dont_include_hashed_keys: bool,
         order_by: Option<&str>,
         entity_models: Vec<String>,
@@ -278,28 +278,14 @@ impl DojoWorld {
             model_relation_table,
             entity_relation_column,
             None,
-            Some(limit),
-            Some(offset),
+            limit,
+            offset,
             dont_include_hashed_keys,
             order_by,
             entity_models,
             entity_updated_after,
         )
         .await
-    }
-
-    async fn events_all(&self, limit: u32, offset: u32) -> Result<Vec<proto::types::Event>, Error> {
-        let query = r#"
-            SELECT keys, data, transaction_hash
-            FROM events
-            ORDER BY id DESC
-            LIMIT ? OFFSET ?
-         "#
-        .to_string();
-
-        let row_events: Vec<(String, String, String)> =
-            sqlx::query_as(&query).bind(limit).bind(offset).fetch_all(&self.pool).await?;
-        row_events.iter().map(map_row_to_event).collect()
     }
 
     async fn fetch_historical_event_messages(
@@ -607,33 +593,6 @@ impl DojoWorld {
             .collect::<Result<Vec<_>, Error>>()?;
 
         Ok((entities, total_count))
-    }
-
-    pub(crate) async fn events_by_keys(
-        &self,
-        keys_clause: &proto::types::KeysClause,
-        limit: Option<u32>,
-        offset: Option<u32>,
-    ) -> Result<Vec<proto::types::Event>, Error> {
-        let keys_pattern = build_keys_pattern(keys_clause)?;
-
-        let events_query = r#"
-            SELECT keys, data, transaction_hash
-            FROM events
-            WHERE keys REGEXP ?
-            ORDER BY id DESC
-            LIMIT ? OFFSET ?
-        "#
-        .to_string();
-
-        let row_events: Vec<(String, String, String)> = sqlx::query_as(&events_query)
-            .bind(&keys_pattern)
-            .bind(limit)
-            .bind(offset)
-            .fetch_all(&self.pool)
-            .await?;
-
-        row_events.iter().map(map_row_to_event).collect()
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1014,14 +973,17 @@ impl DojoWorld {
             ),
         };
 
+        let limit = if query.limit > 0 { Some(query.limit) } else { None };
+        let offset = if query.offset > 0 { Some(query.offset) } else { None };
+
         let (entities, total_count) = match query.clause {
             None => {
                 self.entities_all(
                     table,
                     model_relation_table,
                     entity_relation_column,
-                    query.limit,
-                    query.offset,
+                    limit,
+                    offset,
                     query.dont_include_hashed_keys,
                     order_by,
                     query.entity_models,
@@ -1044,8 +1006,8 @@ impl DojoWorld {
                             } else {
                                 Some(hashed_keys)
                             },
-                            Some(query.limit),
-                            Some(query.offset),
+                            limit,
+                            offset,
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
@@ -1059,8 +1021,8 @@ impl DojoWorld {
                             model_relation_table,
                             entity_relation_column,
                             &keys,
-                            Some(query.limit),
-                            Some(query.offset),
+                            limit,
+                            offset,
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
@@ -1074,8 +1036,8 @@ impl DojoWorld {
                             model_relation_table,
                             entity_relation_column,
                             member,
-                            Some(query.limit),
-                            Some(query.offset),
+                            limit,
+                            offset,
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
@@ -1089,8 +1051,8 @@ impl DojoWorld {
                             model_relation_table,
                             entity_relation_column,
                             composite,
-                            Some(query.limit),
-                            Some(query.offset),
+                            limit,
+                            offset,
                             query.dont_include_hashed_keys,
                             order_by,
                             query.entity_models,
@@ -1109,10 +1071,46 @@ impl DojoWorld {
         &self,
         query: &proto::types::EventQuery,
     ) -> Result<proto::world::RetrieveEventsResponse, Error> {
-        let events = match &query.keys {
-            None => self.events_all(query.limit, query.offset).await?,
-            Some(keys) => self.events_by_keys(keys, Some(query.limit), Some(query.offset)).await?,
+        let limit = if query.limit > 0 { Some(query.limit) } else { None };
+        let offset = if query.offset > 0 { Some(query.offset) } else { None };
+
+        let mut bind_values = Vec::new();
+        let keys_pattern = if let Some(keys_clause) = &query.keys {
+            build_keys_pattern(keys_clause)?
+        } else {
+            String::new()
         };
+
+        let mut events_query = r#"
+            SELECT keys, data, transaction_hash
+            FROM events
+        "#
+        .to_string();
+
+        if !keys_pattern.is_empty() {
+            events_query = format!("{} WHERE keys REGEXP ?", events_query);
+            bind_values.push(keys_pattern);
+        }
+
+        events_query = format!("{} ORDER BY id DESC", events_query);
+
+        if let Some(limit) = limit {
+            events_query = format!("{} LIMIT ?", events_query);
+            bind_values.push(limit.to_string());
+        }
+        if let Some(offset) = offset {
+            events_query = format!("{} OFFSET ?", events_query);
+            bind_values.push(offset.to_string());
+        }
+
+        let mut row_events = sqlx::query_as(&events_query);
+        for value in &bind_values {
+            row_events = row_events.bind(value);
+        }
+        let row_events = row_events.fetch_all(&self.pool).await?;
+
+        let events = row_events.iter().map(map_row_to_event).collect::<Result<Vec<_>, Error>>()?;
+
         Ok(RetrieveEventsResponse { events })
     }
 
@@ -1153,6 +1151,7 @@ fn process_event_field(data: &str) -> Result<Vec<Vec<u8>>, Error> {
     Ok(data
         .trim_end_matches('/')
         .split('/')
+        .filter(|&d| !d.is_empty())
         .map(|d| Felt::from_str(d).map_err(ParseError::FromStr).map(|f| f.to_bytes_be().to_vec()))
         .collect::<Result<Vec<_>, _>>()?)
 }
@@ -1411,7 +1410,8 @@ impl proto::world::world_server::World for DojoWorld {
         &self,
         request: Request<RetrieveTokensRequest>,
     ) -> Result<Response<RetrieveTokensResponse>, Status> {
-        let RetrieveTokensRequest { contract_addresses, token_ids } = request.into_inner();
+        let RetrieveTokensRequest { contract_addresses, token_ids, limit, offset } =
+            request.into_inner();
         let contract_addresses = contract_addresses
             .iter()
             .map(|address| Felt::from_bytes_be_slice(address))
@@ -1420,7 +1420,12 @@ impl proto::world::world_server::World for DojoWorld {
             token_ids.iter().map(|id| crypto_bigint::U256::from_be_slice(id)).collect::<Vec<_>>();
 
         let tokens = self
-            .retrieve_tokens(contract_addresses, token_ids)
+            .retrieve_tokens(
+                contract_addresses,
+                token_ids,
+                if limit > 0 { Some(limit) } else { None },
+                if offset > 0 { Some(offset) } else { None },
+            )
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(tokens))
@@ -1428,9 +1433,9 @@ impl proto::world::world_server::World for DojoWorld {
 
     async fn subscribe_tokens(
         &self,
-        request: Request<RetrieveTokensRequest>,
+        request: Request<SubscribeTokensRequest>,
     ) -> ServiceResult<Self::SubscribeTokensStream> {
-        let RetrieveTokensRequest { contract_addresses, token_ids } = request.into_inner();
+        let SubscribeTokensRequest { contract_addresses, token_ids } = request.into_inner();
         let contract_addresses = contract_addresses
             .iter()
             .map(|address| Felt::from_bytes_be_slice(address))
@@ -1465,8 +1470,13 @@ impl proto::world::world_server::World for DojoWorld {
         &self,
         request: Request<RetrieveTokenBalancesRequest>,
     ) -> Result<Response<RetrieveTokenBalancesResponse>, Status> {
-        let RetrieveTokenBalancesRequest { account_addresses, contract_addresses, token_ids } =
-            request.into_inner();
+        let RetrieveTokenBalancesRequest {
+            account_addresses,
+            contract_addresses,
+            token_ids,
+            limit,
+            offset,
+        } = request.into_inner();
         let account_addresses = account_addresses
             .iter()
             .map(|address| Felt::from_bytes_be_slice(address))
@@ -1478,7 +1488,13 @@ impl proto::world::world_server::World for DojoWorld {
         let token_ids = token_ids.iter().map(|id| U256::from_be_slice(id)).collect::<Vec<_>>();
 
         let balances = self
-            .retrieve_token_balances(account_addresses, contract_addresses, token_ids)
+            .retrieve_token_balances(
+                account_addresses,
+                contract_addresses,
+                token_ids,
+                if limit > 0 { Some(limit) } else { None },
+                if offset > 0 { Some(offset) } else { None },
+            )
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(balances))
@@ -1540,9 +1556,9 @@ impl proto::world::world_server::World for DojoWorld {
 
     async fn subscribe_token_balances(
         &self,
-        request: Request<RetrieveTokenBalancesRequest>,
+        request: Request<SubscribeTokenBalancesRequest>,
     ) -> ServiceResult<Self::SubscribeTokenBalancesStream> {
-        let RetrieveTokenBalancesRequest { contract_addresses, account_addresses, token_ids } =
+        let SubscribeTokenBalancesRequest { contract_addresses, account_addresses, token_ids } =
             request.into_inner();
         let contract_addresses = contract_addresses
             .iter()

--- a/crates/torii/grpc/src/types/mod.rs
+++ b/crates/torii/grpc/src/types/mod.rs
@@ -19,6 +19,12 @@ use crate::proto::{self};
 pub mod schema;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
+pub struct Page<T> {
+    pub items: Vec<T>,
+    pub next_cursor: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Hash, Eq, Clone)]
 pub struct Controller {
     pub address: Felt,
     pub username: String,


### PR DESCRIPTION
#3142 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced subscription requests for token updates and token balance updates.
  - Enabled pagination for token and token balance retrieval by adding limit, offset, and cursor options.
  - Added a new struct for paginated data representation, including a list of items and a next cursor.
  - Updated methods to support controlled paging and consistent ordering of results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->