### PR TITLE
fix(Dockerfile): add curl installation and copy step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04 as builder
 
-RUN apt-get update && apt install -y git libtool automake autoconf make tini ca-certificates
+RUN apt-get update && apt install -y git libtool automake autoconf make tini ca-certificates curl
 
 RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && cd curtailer \
@@ -17,6 +17,7 @@ RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
 FROM ubuntu:24.04 as base
 
 COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder /usr/bin/curl /usr/bin/curl
 
 COPY --from=builder /usr/bin/tini /tini
 ENTRYPOINT ["/tini", "--"]


### PR DESCRIPTION
Ensure curl is available in the final image by installing and copying it during the build process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The container image now includes the curl utility to enhance runtime support and ensure smoother operations with additional dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->