### PR TITLE
ci(release): change preview tag format in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       preview:
-        description: 'Create a preview release'
-        type: boolean
-        default: true
+        description: 'Preview tag if not empty. Needs to be in format vX.Y.Z-preview.X'
+        type: string
   pull_request:
     types: [closed]
     branches:
@@ -28,8 +27,13 @@ jobs:
       - name: Get version
         id: release_info
         run: |
-          if [[ "${{ github.event.inputs.preview || 'false' }}" == "true" ]]; then
-            echo "tag_name=preview--$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          if [[ "${{ github.event.inputs.preview || 'false' }}" != "false" ]]; then
+            # check if valid
+            if [[ ! "${{ github.event.inputs.preview }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]; then
+              echo "Invalid preview tag format. Needs to be in format vX.Y.Z-preview.X"
+              exit 1
+            fi
+            echo "tag_name=${{ github.event.inputs.preview }}" >> $GITHUB_OUTPUT
           else
             cargo install cargo-get
             echo "tag_name=v$(cargo get workspace.package.version)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Ensure the preview tag follows the format vX.Y.Z-preview.X and add string input validation in the release workflow. Update logic to handle invalid formats gracefully.
