### PR TITLE
fix(Dockerfile): move dependencies in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ FROM ubuntu:24.04 AS base
 RUN apt-get update && \
     apt-get install -y curl ca-certificates tini && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    cp /usr/bin/tini /tini
 
-ENTRYPOINT ["/usr/bin/tini", "--"]
+ENTRYPOINT ["/tini", "--"]
 
 ARG TARGETPLATFORM
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:24.04 as builder
+FROM ubuntu:24.04 AS builder
 
-RUN apt-get update && apt install -y git libtool automake autoconf make tini ca-certificates curl
+RUN apt-get update && apt install -y git libtool automake autoconf make
 
 RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && cd curtailer \
@@ -14,13 +14,14 @@ RUN git clone https://github.com/Comcast/Infinite-File-Curtailer.git curtailer \
     && make install \
     && curtail --version
 
-FROM ubuntu:24.04 as base
+FROM ubuntu:24.04 AS base
 
-COPY --from=builder /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder /usr/bin/curl /usr/bin/curl
+RUN apt-get update && \
+    apt-get install -y curl ca-certificates tini && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/bin/tini /tini
-ENTRYPOINT ["/tini", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
Moved installation of curl, ca-certificates, and tini to the base image stage. Cleaned up apt cache to reduce image size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated package installation steps in the Dockerfile for improved clarity and efficiency.
  - Added cleanup steps to reduce image size after package installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->