### PR TITLE
feat(sozo): unreal bindings handle int64 and ControllerConnect

### DIFF
--- a/crates/dojo/bindgen/src/plugins/unrealengine/mod.rs
+++ b/crates/dojo/bindgen/src/plugins/unrealengine/mod.rs
@@ -23,15 +23,15 @@ impl UnrealEnginePlugin {
             "i8" => "int".to_string(),
             "i16" => "int".to_string(),
             "i32" => "int".to_string(),
-            "i64" => "long".to_string(),
+            "i64" => "int64".to_string(),
             "i128" => "FString".to_string(),
             "u8" => "int".to_string(),
             "u16" => "int".to_string(),
             "u32" => "int".to_string(),
-            "u64" => "long".to_string(),
+            "u64" => "int64".to_string(),
             "u128" => "FString".to_string(),
             "u256" => "FString".to_string(),
-            "usize" => "long".to_string(),
+            "usize" => "int64".to_string(),
             "bool" => "bool".to_string(),
             "felt252" => "FString".to_string(),
             "bytes31" => "FString".to_string(),
@@ -941,7 +941,7 @@ public:
         }}
     }}
 
-    static long ConvertToLong(const Member* member) {{
+    static int64 ConvertToLong(const Member* member) {{
         switch(member->ty->primitive.tag) {{
             case Primitive_Tag::I64: return member->ty->primitive.i64;
             case Primitive_Tag::U64: return member->ty->primitive.u64;
@@ -1014,6 +1014,16 @@ static TArray<FString> ConvertToFeltHexa(const T& value, const char* valueType) 
             return TArray<FString>{{TEXT("0x") + hexValue}};
         }}
     }}
+    else if constexpr (std::is_same_v<T, int64>) {{
+        if (strcmp(valueType, "u64") == 0 ||
+            strcmp(valueType, "i64") == 0) {{
+            FString hexValue = FString::Printf(TEXT("%X"), static_cast<int64>(value));
+            while (hexValue.Len() < 64) {{
+                hexValue = TEXT("0") + hexValue;
+            }}
+            return TArray<FString>{TEXT("0x") + hexValue};
+        }}
+    }}
     else if constexpr (std::is_same_v<T, bool>) {{
         if (strcmp(valueType, "bool") == 0) {{
             FString hexValue = FString::Printf(TEXT("%X"), value ? 1 : 0);
@@ -1078,7 +1088,7 @@ static void ConvertTyToUnrealEngineType(const Member* member, const char* expect
             output = TypeConverter::ConvertToInt(member);
         }}
     }}
-    else if constexpr (std::is_same_v<T, long>) {{
+    else if constexpr (std::is_same_v<T, int64>) {{
         if (strcmp(expectedType, "i64") == 0 ||
         strcmp(expectedType, "u64") == 0 ||
         strcmp(expectedType, "usize") == 0) {{

--- a/crates/dojo/bindgen/src/plugins/unrealengine/mod.rs
+++ b/crates/dojo/bindgen/src/plugins/unrealengine/mod.rs
@@ -840,8 +840,7 @@ void ADojoHelpers::CallController{namespace}{system}{selector}(const FController
                             .iter()
                             .map(|field| {
                                 format!(
-                                    r#"strings.Append(ConvertToFeltHexa<{cpp_type}>(value.{name}, \
-                                     "{type_name}"));"#,
+                                    r#"strings.Append(ConvertToFeltHexa<{cpp_type}>(value.{name}, "{type_name}"));"#,
                                     cpp_type = Self::map_type(&field.token),
                                     name = Self::to_pascal_case(&field.name),
                                     type_name = &field.token.type_name(),
@@ -1021,7 +1020,7 @@ static TArray<FString> ConvertToFeltHexa(const T& value, const char* valueType) 
             while (hexValue.Len() < 64) {{
                 hexValue = TEXT("0") + hexValue;
             }}
-            return TArray<FString>{TEXT("0x") + hexValue};
+            return TArray<FString>{{TEXT("0x") + hexValue}};
         }}
     }}
     else if constexpr (std::is_same_v<T, bool>) {{
@@ -1060,8 +1059,7 @@ static TArray<FString> ConvertToFeltHexa(const T& value, const char* valueType) 
 }}
 
 template<typename T>
-static void ConvertTyToUnrealEngineType(const Member* member, const char* expectedName, const \
-             char* expectedType, T& output) {{
+static void ConvertTyToUnrealEngineType(const Member* member, const char* expectedName, const char* expectedType, T& output) {{
     if (strcmp(member->name, expectedName) != 0) {{
         return;
     }}
@@ -1154,8 +1152,7 @@ void ADojoHelpers::SetContractsAddresses(const TMap<FString,FString>& addresses)
     ContractsAddresses = addresses;
 }}
 
-FAccount ADojoHelpers::CreateAccountDeprecated(const FString& rpc_url, const FString& \
-             address, const FString& private_key)
+FAccount ADojoHelpers::CreateAccountDeprecated(const FString& rpc_url, const FString& address, const FString& private_key)
 {{
     FAccount account;
 

--- a/crates/dojo/bindgen/src/plugins/unrealengine/mod.rs
+++ b/crates/dojo/bindgen/src/plugins/unrealengine/mod.rs
@@ -455,6 +455,9 @@ public:
     UFUNCTION(BlueprintCallable)
     void ControllerGetAccountOrConnect(const FString& rpc_url, const FString& chain_id);
 
+    UFUNCTION(BlueprintCallable)
+    void ControllerConnect(const FString& rpc_url);
+
     DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnDojoControllerAccount,
                                                 struct FControllerAccount,
                                                 Account);
@@ -1198,6 +1201,16 @@ void ADojoHelpers::ControllerGetAccountOrConnect(const FString& rpc_url, const F
 
     FDojoModule::ControllerGetAccountOrConnect(rpc_url_string.c_str(), chain_id_string.c_str(), \
              policies, nbPolicies, ControllerCallbackProxy);
+}}
+
+
+void ADojoHelpers::ControllerConnect(const FString& rpc_url)
+{{
+    std::string rpc_url_string = std::string(TCHAR_TO_UTF8(*rpc_url));
+
+    {policies}
+
+    FDojoModule::ControllerConnect(rpc_url_string.c_str(), policies, nbPolicies, ControllerCallbackProxy);
 }}
 
 void ADojoHelpers::ControllerCallbackProxy(ControllerAccount *account)


### PR DESCRIPTION
# Description

A few improvements in the unrealengine bindings:
- using int64 instead of long to be able to use long in UE5 Blueprint
- adding ControllerConnect that forces the browser to opens without checking of an account is already connected

## Checklist

- [X] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [X] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [X] I've commented my code
- [X] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new method to allow controller connection using an RPC URL from within Unreal Engine.

- **Improvements**
  - Unified handling of 64-bit integer types, ensuring they are consistently represented as `int64` in Unreal Engine integrations.

- **Bug Fixes**
  - Minor formatting corrections and removal of redundant line breaks for improved code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->