### PR TITLE
fix(ci): decouple release from docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,83 @@
+# Dojo docker image build and push workflow.
+#
+# This workflow is triggered by a workflow_dispatch event or when a new release with a tag starting with `v` is published.
+#
+# The docker image is built by using `dojoup` to bundle the Dojo binaries with the docker image, there is no heavy compilation
+# of the Dojo binaries during this workflow.
+#
+# The docker image is pushed to the GitHub Container Registry: https://github.com/dojoengine/dojo/pkgs/container/dojo
+#
+name: docker build and push
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "The docker image tag name"
+        required: true
+        type: string
+      dojo_version:
+        description: "The dojo version to install in the docker image"
+        required: true
+        type: string
+  push:
+    tags:
+      - 'v*'  
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_VERSION: 1.85.0
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.version_info.outputs.tag_name }}
+      dojo_version: ${{ steps.version_info.outputs.dojo_version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract version info
+        id: version_info
+        run: |
+         if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            # Extract tag name from ref
+            echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "dojo_version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          else
+            # We're supposed to be in a workflow_dispatch here.
+            # A `if` is not used at the job level since the id of a step must be unique across the job.
+            if [ -z "${{ inputs.tag_name }}" ]; then
+              echo "tag_name is empty"
+              exit 1
+            fi
+            echo "tag_name=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+            echo "dojo_version=${{ inputs.dojo_version }}" >> $GITHUB_OUTPUT
+          fi
+
+  docker-build-and-push:
+    runs-on: ubuntu-latest-32-cores
+    needs: prepare
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.tag_name }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            DOJO_VERSION=${{ needs.prepare.outputs.dojo_version }}

--- a/.github/workflows/release-dispatch.yml
+++ b/.github/workflows/release-dispatch.yml
@@ -1,4 +1,14 @@
+# Dojo release dispatch workflow.
+#
+# This workflow is used to manually trigger a release.
+#
+# The workflow will propose a release with the same version as the one passed as input to the workflow, taking care of updating Cargo.toml versions.
+#
+# The workflow will create a PR, which must be manually merged to trigger the release.
+# If the release triggered by the merged of this PR fails, the `release.yml` workflow can be used to be triggered again on main.
+#
 name: release-dispatch
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,14 @@
+# Dojo release workflow.
+#
+# The main goal of this workflow is to build in release mode the Dojo binaries for all supported platforms.
+# Those binaries are then uploaded to be available in `assets` section of the release.
+#
+# At the end of this workflow, a draft release is created on GitHub, which must be manually published by a maintainer.
+# This ensure the release can be reviewed before it is published.
+#
+# The Dojo docker image is not built during this workflow, to decouple the release of the binaries from the docker image,
+# which happens in the `docker.yml` workflow.
+#
 name: release
 
 on:
@@ -127,22 +138,6 @@ jobs:
           fi
         shell: bash
 
-      # We move binaries so they match $TARGETPLATFORM in the Docker build
-      - name: Move Binaries
-        if: ${{ env.PLATFORM_NAME == 'linux' }}
-        run: |
-          mkdir -p $PLATFORM_NAME/$ARCH
-          mv target/$TARGET/release/sozo $PLATFORM_NAME/$ARCH
-        shell: bash
-
-      # Upload these for use with the Docker build later
-      - name: Upload docker binaries
-        uses: actions/upload-artifact@v4
-        with:
-          name: binaries-${{ matrix.job.target }}
-          path: ${{ env.PLATFORM_NAME }}
-          retention-days: 1
-
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -151,12 +146,11 @@ jobs:
           retention-days: 1
 
   create-draft-release:
-    runs-on: ubuntu-latest-32-cores
+    runs-on: ubuntu-latest
     needs: [prepare, release]
     env:
       GITHUB_USER: ${{ github.repository_owner }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: ${{ !contains(needs.prepare.outputs.tag_name, 'preview') }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v4
@@ -171,48 +165,3 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
       - run: gh release create ${{ steps.version_info.outputs.version }} ./artifacts/*.{gz,zip} --generate-notes --draft
-
-  docker-build-and-push:
-    runs-on: ubuntu-latest-32-cores
-    needs: [prepare, release]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Download binaries
-        uses: actions/download-artifact@v4
-        with:
-          pattern: binaries-*
-          path: artifacts/linux
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push docker image
-        if: ${{ contains(needs.prepare.outputs.tag_name, 'preview') }}
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.tag_name }}
-          platforms: linux/amd64,linux/arm64
-          build-contexts: |
-            artifacts=artifacts
-
-      - name: Build and push docker image
-        if: ${{ !contains(needs.prepare.outputs.tag_name, 'preview') }}
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io/${{ github.repository }}:${{ needs.prepare.outputs.tag_name }}
-          platforms: linux/amd64,linux/arm64
-          build-contexts: |
-            artifacts=artifacts

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ LABEL description="Dojo is a provable game engine and toolchain for building onc
     documentation="https://book.dojoengine.org/"
 
 COPY dojoup/dojoup /usr/local/bin/dojoup
-RUN echo "DOJO_VERSION: $DOJO_VERSION"
-# Once new dojoup is ok, use the DOJO_VERSION input from the workflow to install the correct version.
-# RUN dojoup -v $DOJO_VERSION
+RUN chmod +x /usr/local/bin/dojoup
+RUN dojoup install $DOJO_VERSION
 
 COPY --from=builder /usr/local/bin/curtail /usr/local/bin/curtail

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,18 +24,16 @@ RUN apt-get update && \
 
 ENTRYPOINT ["/tini", "--"]
 
-ARG TARGETPLATFORM
+ARG DOJO_VERSION
 
 LABEL description="Dojo is a provable game engine and toolchain for building onchain games and autonomous worlds with Cairo" \
     authors="tarrence <tarrence@cartridge.gg>" \
     source="https://github.com/dojoengine/dojo" \
     documentation="https://book.dojoengine.org/"
 
-COPY --from=artifacts --chmod=755 $TARGETPLATFORM/sozo /usr/local/bin/
-
-# We may not want to install sozo via dojoup though, only Katana and Torii?
-# Or we can let the use decide.
 COPY dojoup/dojoup /usr/local/bin/dojoup
+RUN echo "DOJO_VERSION: $DOJO_VERSION"
+# Once new dojoup is ok, use the DOJO_VERSION input from the workflow to install the correct version.
 # RUN dojoup -v $DOJO_VERSION
 
 COPY --from=builder /usr/local/bin/curtail /usr/local/bin/curtail


### PR DESCRIPTION
This pull request introduces several workflow updates and improvements to streamline the build and release processes for Dojo, while also simplifying the Docker image setup.

The changes include adding a dedicated workflow for building and pushing Docker images, decoupling Docker image creation from the release workflow, and introducing enhancements to the release process.

### Workflow Enhancements:

* **New Docker Workflow**: Added a new `.github/workflows/docker.yml` file to handle building and pushing Docker images. This workflow is triggered manually or by new release tags, ensuring the Docker image is built with the appropriate Dojo version.

* **Simplified Release Workflow**: Updated `.github/workflows/release.yml` to focus solely on building and uploading Dojo binaries in the release assets. The Docker image build steps were removed to decouple these processes.

### Dockerfile Update:

* **Removed Target Platform Artifacts**: Simplified the `Dockerfile` by removing platform-specific binary copying using the new dojoup instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new workflow to automate Docker image builds and pushes for the project, supporting both manual and tag-based triggers.
  - Updated documentation comments in the release workflow files for improved clarity.
  - Simplified the release workflow by removing Docker build steps and decoupling Docker image creation into a separate workflow.
  - Updated the Dockerfile to streamline the build process and use a version-specific argument for installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->