### PR TITLE
fix(dojoup): wrong link to versions registry

### DIFF
--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -22,7 +22,7 @@ KATANA_REPO="dojoengine/katana"
 TORII_REPO="dojoengine/torii"
 
 # Toolchain versions compatibility registry
-VERSIONS_JSON_URL="https://raw.githubusercontent.com/dojoengine/dojo/new-dojoup/versions.json"
+VERSIONS_JSON_URL="https://raw.githubusercontent.com/dojoengine/dojo/refs/heads/main/versions.json"
 
 # All components
 COMPONENT_BINARY=("sozo" "torii" "katana" "dojo-language-server")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source URL for fetching toolchain version compatibility data to use a more stable main branch reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->