### PR TITLE
fix(dojoup): `-h` not available on linux

### DIFF
--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -71,7 +71,7 @@ set_default_version() {
 		rm -rf "$DEFAULT_TOOLCHAIN_DIR"
 	fi
 
-	ln -sfh "$requested_toolchain_path" "$DEFAULT_TOOLCHAIN_DIR"
+	ln -sf "$requested_toolchain_path" "$DEFAULT_TOOLCHAIN_DIR"
 }
 
 # Function to get the active Dojo version


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of setting the default toolchain version by updating the method used to create symbolic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->