### PR TITLE
refactor(dojo-types): derive ord and partial ord for primitive

### DIFF
--- a/crates/dojo/types/src/primitive.rs
+++ b/crates/dojo/types/src/primitive.rs
@@ -22,6 +22,8 @@ use super::primitive_conversion::try_from_felt;
     PartialEq,
     Hash,
     Eq,
+    PartialOrd,
+    Ord,
 )]
 #[serde(tag = "scalar_type", content = "value")]
 #[strum(serialize_all = "lowercase")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled comparison and sorting of items using the Primitive enum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->