### PR TITLE
Fix(dojo-lang): extract inner type from composite types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,7 @@ dependencies = [
 [[package]]
 name = "create-output-dir"
 version = "1.0.0"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.0",
@@ -2639,28 +2639,6 @@ version = "1.5.0-alpha.2"
 
 [[package]]
 name = "dojo-lang"
-version = "1.4.1"
-source = "git+https://github.com/dojoengine/dojo?rev=ee5cbda7fedf69a372559d158b9c4d8aa892d7b9#ee5cbda7fedf69a372559d158b9c4d8aa892d7b9"
-dependencies = [
- "anyhow",
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-plugins",
- "cairo-lang-semantic",
- "cairo-lang-syntax",
- "cairo-lang-utils",
- "dojo-types 1.4.1",
- "itertools 0.12.1",
- "serde",
- "smol_str",
- "starknet 0.12.0",
- "starknet-crypto 0.7.4",
- "tracing",
-]
-
-[[package]]
-name = "dojo-lang"
 version = "1.5.0-alpha.2"
 dependencies = [
  "anyhow",
@@ -2673,6 +2651,30 @@ dependencies = [
  "cairo-lang-utils",
  "dojo-types 1.5.0-alpha.2",
  "itertools 0.12.1",
+ "regex",
+ "serde",
+ "smol_str",
+ "starknet 0.12.0",
+ "starknet-crypto 0.7.4",
+ "tracing",
+]
+
+[[package]]
+name = "dojo-lang"
+version = "1.5.0-alpha.2"
+source = "git+https://github.com/remybar/dojo?rev=2ca73e9869562f74acf4a221ba941d910d3060ae#2ca73e9869562f74acf4a221ba941d910d3060ae"
+dependencies = [
+ "anyhow",
+ "cairo-lang-defs",
+ "cairo-lang-diagnostics",
+ "cairo-lang-filesystem",
+ "cairo-lang-plugins",
+ "cairo-lang-semantic",
+ "cairo-lang-syntax",
+ "cairo-lang-utils",
+ "dojo-types 1.5.0-alpha.2 (git+https://github.com/remybar/dojo?rev=2ca73e9869562f74acf4a221ba941d910d3060ae)",
+ "itertools 0.12.1",
+ "regex",
  "serde",
  "smol_str",
  "starknet 0.12.0",
@@ -2718,8 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "dojo-types"
-version = "1.4.1"
-source = "git+https://github.com/dojoengine/dojo?rev=ee5cbda7fedf69a372559d158b9c4d8aa892d7b9#ee5cbda7fedf69a372559d158b9c4d8aa892d7b9"
+version = "1.5.0-alpha.2"
 dependencies = [
  "anyhow",
  "cainome 0.5.0",
@@ -2741,6 +2742,7 @@ dependencies = [
 [[package]]
 name = "dojo-types"
 version = "1.5.0-alpha.2"
+source = "git+https://github.com/remybar/dojo?rev=2ca73e9869562f74acf4a221ba941d910d3060ae#2ca73e9869562f74acf4a221ba941d910d3060ae"
 dependencies = [
  "anyhow",
  "cainome 0.5.0",
@@ -6059,7 +6061,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "once_map"
 version = "0.0.1"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "dashmap",
  "futures",
@@ -7337,7 +7339,7 @@ dependencies = [
 [[package]]
 name = "scarb"
 version = "2.10.1"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7372,7 +7374,7 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "directories",
- "dojo-lang 1.4.1",
+ "dojo-lang 1.5.0-alpha.2 (git+https://github.com/remybar/dojo?rev=2ca73e9869562f74acf4a221ba941d910d3060ae)",
  "dunce",
  "flate2",
  "fs4",
@@ -7397,7 +7399,7 @@ dependencies = [
  "scarb-build-metadata",
  "scarb-metadata",
  "scarb-proc-macro-server-types",
- "scarb-stable-hash 1.0.0 (git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6)",
+ "scarb-stable-hash 1.0.0 (git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0)",
  "scarb-ui",
  "semver",
  "semver-pubgrub",
@@ -7430,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "scarb-build-metadata"
 version = "2.10.1"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "cargo_metadata",
 ]
@@ -7438,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "scarb-metadata"
 version = "1.13.0"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "camino",
  "derive_builder",
@@ -7451,7 +7453,7 @@ dependencies = [
 [[package]]
 name = "scarb-proc-macro-server-types"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "cairo-lang-macro",
  "serde",
@@ -7471,7 +7473,7 @@ dependencies = [
 [[package]]
 name = "scarb-stable-hash"
 version = "1.0.0"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "data-encoding",
  "xxhash-rust",
@@ -7480,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "scarb-ui"
 version = "0.1.5"
-source = "git+https://github.com/dojoengine/scarb?rev=d749b9545f5c50b078870a322a12efe7a17914b6#d749b9545f5c50b078870a322a12efe7a17914b6"
+source = "git+https://github.com/remybar/scarb?rev=6dd858df6e35a4539d6d4d76a424f4f45dc394a0#6dd858df6e35a4539d6d4d76a424f4f45dc394a0"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,9 +157,9 @@ rpassword = "7.2.0"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 salsa = "0.16.1"
-scarb = { git = "https://github.com/remybar/scarb", rev = "6dd858df6e35a4539d6d4d76a424f4f45dc394a0" }
-scarb-metadata = { git = "https://github.com/remybar/scarb", rev = "6dd858df6e35a4539d6d4d76a424f4f45dc394a0" }
-scarb-ui = { git = "https://github.com/remybar/scarb", rev = "6dd858df6e35a4539d6d4d76a424f4f45dc394a0" }
+scarb = { git = "https://github.com/remybar/scarb", rev = "a0fe9c520f4565c0309ead9efb6328ad5be97a11" }
+scarb-metadata = { git = "https://github.com/remybar/scarb", rev = "a0fe9c520f4565c0309ead9efb6328ad5be97a11" }
+scarb-ui = { git = "https://github.com/remybar/scarb", rev = "a0fe9c520f4565c0309ead9efb6328ad5be97a11" }
 semver = "1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,9 +157,9 @@ rpassword = "7.2.0"
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 salsa = "0.16.1"
-scarb = { git = "https://github.com/dojoengine/scarb", rev = "d749b9545f5c50b078870a322a12efe7a17914b6" }
-scarb-metadata = { git = "https://github.com/dojoengine/scarb", rev = "d749b9545f5c50b078870a322a12efe7a17914b6" }
-scarb-ui = { git = "https://github.com/dojoengine/scarb", rev = "d749b9545f5c50b078870a322a12efe7a17914b6" }
+scarb = { git = "https://github.com/remybar/scarb", rev = "6dd858df6e35a4539d6d4d76a424f4f45dc394a0" }
+scarb-metadata = { git = "https://github.com/remybar/scarb", rev = "6dd858df6e35a4539d6d4d76a424f4f45dc394a0" }
+scarb-ui = { git = "https://github.com/remybar/scarb", rev = "6dd858df6e35a4539d6d4d76a424f4f45dc394a0" }
 semver = "1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }

--- a/crates/dojo/core-cairo-test/src/tests/model/model.cairo
+++ b/crates/dojo/core-cairo-test/src/tests/model/model.cairo
@@ -61,6 +61,16 @@ struct FooSchema {
     v3: AStruct,
 }
 
+// to test the issue https://github.com/dojoengine/dojo/issues/3199
+// see `extract_composite_inner_type` function in dojo-lang.
+#[derive(Copy, Drop, Serde, Debug)]
+#[dojo::model]
+struct ModelWithCommentOnLastFied {
+    #[key]
+    k1: u8,
+    v1: Span<u32> // a comment without a comma 
+}
+
 fn namespace_def() -> NamespaceDef {
     NamespaceDef {
         namespace: "dojo_cairo_test",

--- a/crates/dojo/lang/Cargo.toml
+++ b/crates/dojo/lang/Cargo.toml
@@ -20,6 +20,7 @@ cairo-lang-syntax.workspace = true
 cairo-lang-utils.workspace = true
 dojo-types.workspace = true
 itertools.workspace = true
+regex.workspace = true
 serde.workspace = true
 smol_str.workspace = true
 starknet.workspace = true

--- a/crates/dojo/lang/src/derive_macros/introspect/utils.rs
+++ b/crates/dojo/lang/src/derive_macros/introspect/utils.rs
@@ -1,7 +1,15 @@
+use regex;
 use std::collections::HashMap;
 
 #[derive(Clone, Default, Debug)]
 pub struct TypeIntrospection(pub usize, pub Vec<usize>);
+
+const TUPLE_PREFIX: &str = "(";
+const TUPLE_SUFFIX: &str = ")";
+const SPAN_PREFIX: &str = "Span<";
+const SPAN_SUFFIX: &str = ">";
+const ARRAY_PREFIX: &str = "Array<";
+const ARRAY_SUFFIX: &str = ">";
 
 // Provides type introspection information for primitive types
 pub fn primitive_type_introspection() -> HashMap<String, TypeIntrospection> {
@@ -32,32 +40,52 @@ pub fn is_byte_array(ty: &str) -> bool {
 }
 
 pub fn is_array(ty: &str) -> bool {
-    ty.starts_with("Array<") || ty.starts_with("Span<")
+    ty.starts_with(ARRAY_PREFIX) || ty.starts_with(SPAN_PREFIX)
 }
 
 pub fn is_tuple(ty: &str) -> bool {
-    ty.starts_with('(')
+    ty.starts_with(TUPLE_PREFIX)
 }
 
 pub fn get_array_item_type(ty: &str) -> String {
-    if ty.starts_with("Array<") {
-        ty.trim().strip_prefix("Array<").unwrap().strip_suffix('>').unwrap().to_string()
+    if ty.starts_with(ARRAY_PREFIX) {
+        extract_composite_inner_type(ty, ARRAY_PREFIX, ARRAY_SUFFIX)
     } else {
-        ty.trim().strip_prefix("Span<").unwrap().strip_suffix('>').unwrap().to_string()
+        extract_composite_inner_type(ty, SPAN_PREFIX, SPAN_SUFFIX)
     }
+}
+
+/// Extracts the inner type of a composite type such as tuple, array or span.
+///
+/// # Arguments
+///   * `ty` - the composite type
+///   * `prefix` - the prefix used to delimit the beginning of the composite type
+///   * `suffix` - the suffix used to delimit the end of the composite type
+///
+/// # Examples
+///    extract_composite_inner_type("Array<(u8, u16)", "Array<", ">") returns "u8, u16"
+pub fn extract_composite_inner_type(ty: &str, prefix: &str, suffix: &str) -> String {
+    // Note: Until at least 2.11, in cairo_lang_* crates, if there is a comment after a struct field type,
+    // without a comma, like `v1: Span<u32> // comment`, the comment is included in the type definition
+    // while reading it from the AST.
+    let re = regex::Regex::new(&format!(
+        "{}\\s*(\\S*.*\\S+)\\s*{}",
+        regex::escape(prefix),
+        regex::escape(suffix)
+    ))
+    .unwrap();
+
+    let caps = re
+        .captures(ty)
+        .expect(&format!("'{ty}' must contain the '{prefix}' prefix and the '{suffix}' suffix."));
+
+    caps[1].to_string().replace(" ", "")
 }
 
 /// split a tuple in array of items (nested tuples are not splitted).
 /// example (u8, (u16, u32), u128) -> ["u8", "(u16, u32)", "u128"]
 pub fn get_tuple_item_types(ty: &str) -> Vec<String> {
-    let tuple_str = ty
-        .trim()
-        .strip_prefix('(')
-        .unwrap()
-        .strip_suffix(')')
-        .unwrap()
-        .to_string()
-        .replace(' ', "");
+    let tuple_str = extract_composite_inner_type(ty, TUPLE_PREFIX, TUPLE_SUFFIX);
     let mut items = vec![];
     let mut current_item = "".to_string();
     let mut level = 0;
@@ -75,10 +103,10 @@ pub fn get_tuple_item_types(ty: &str) -> Vec<String> {
         } else {
             current_item.push(c);
 
-            if c == '(' {
+            if c.to_string() == TUPLE_PREFIX {
                 level += 1;
             }
-            if c == ')' {
+            if c.to_string() == TUPLE_SUFFIX {
                 level -= 1;
             }
         }
@@ -133,4 +161,83 @@ pub fn test_get_tuple_item_types() {
             expected.iter().map(|x| x.to_string()).collect::<Vec<_>>(),
         )
     }
+}
+
+#[test]
+fn test_extract_composite_inner_type_with_tuples() {
+    let test_cases = [
+        ("(u8,)", "u8,"),
+        ("(u8,),", "u8,"),
+        ("(u8, u16)", "u8,u16"),
+        ("(u8, u16,)", "u8,u16,"),
+        ("(u8, u16, (u32,))", "u8,u16,(u32,)"),
+        ("(u8, u16, (u32,),)", "u8,u16,(u32,),"),
+        (
+            "(u8, (Span<u32>, u32, Option<Array<u8>,) u16, (u32,),)",
+            "u8,(Span<u32>,u32,Option<Array<u8>,)u16,(u32,),",
+        ),
+        ("(u8, u32) // comment", "u8,u32"),
+        ("(u8, u32), // comment", "u8,u32"),
+    ];
+
+    for (tuple, expected) in test_cases {
+        let result = extract_composite_inner_type(tuple, TUPLE_PREFIX, TUPLE_SUFFIX);
+        assert!(
+            result == expected,
+            "bad tuple: {} result: {} expected: {}",
+            tuple,
+            result,
+            expected
+        );
+    }
+}
+
+#[test]
+#[should_panic(expected = "'u8, u16' must contain the '(' prefix and the ')' suffix.")]
+fn test_extract_composite_inner_type_with_tuples_bad_ty() {
+    let _ = extract_composite_inner_type("u8, u16", TUPLE_PREFIX, TUPLE_SUFFIX);
+}
+
+#[test]
+fn test_extract_composite_inner_type_with_arrays() {
+    let test_cases = [
+        ("Array<u8>", "u8"),
+        ("Array<(u8, u16)>", "(u8,u16)"),
+        ("Array<Array<(u8, u16)>>", "Array<(u8,u16)>"),
+        ("Array<(u8, u16)> // comment", "(u8,u16)"),
+        ("Array<(u8, u16)>, // comment", "(u8,u16)"),
+    ];
+
+    for (arr, expected) in test_cases {
+        let result = extract_composite_inner_type(arr, ARRAY_PREFIX, ARRAY_SUFFIX);
+        assert!(result == expected, "bad array: {} result: {} expected: {}", arr, result, expected);
+    }
+}
+
+#[test]
+#[should_panic(expected = "'u8, u16' must contain the 'Array<' prefix and the '>' suffix.")]
+fn test_extract_composite_inner_type_with_arrays_bad_ty() {
+    let _ = extract_composite_inner_type("u8, u16", ARRAY_PREFIX, ARRAY_SUFFIX);
+}
+
+#[test]
+fn test_extract_composite_inner_type_with_spans() {
+    let test_cases = [
+        ("Span<u8>", "u8"),
+        ("Span<(u8, u16)>", "(u8,u16)"),
+        ("Span<Array<(u8, u16)>>", "Array<(u8,u16)>"),
+        ("Span<(u8, u16)> // comment", "(u8,u16)"),
+        ("Span<(u8, u16)>, // comment", "(u8,u16)"),
+    ];
+
+    for (sp, expected) in test_cases {
+        let result = extract_composite_inner_type(sp, SPAN_PREFIX, SPAN_SUFFIX);
+        assert!(result == expected, "bad span: {} result: {} expected: {}", sp, result, expected);
+    }
+}
+
+#[test]
+#[should_panic(expected = "'u8, u16' must contain the 'Span<' prefix and the '>' suffix.")]
+fn test_extract_composite_inner_type_with_spans_bad_ty() {
+    let _ = extract_composite_inner_type("u8, u16", SPAN_PREFIX, SPAN_SUFFIX);
 }

--- a/crates/dojo/lang/src/derive_macros/introspect/utils.rs
+++ b/crates/dojo/lang/src/derive_macros/introspect/utils.rs
@@ -1,5 +1,6 @@
-use regex;
 use std::collections::HashMap;
+
+use regex;
 
 #[derive(Clone, Default, Debug)]
 pub struct TypeIntrospection(pub usize, pub Vec<usize>);
@@ -65,9 +66,9 @@ pub fn get_array_item_type(ty: &str) -> String {
 /// # Examples
 ///    extract_composite_inner_type("Array<(u8, u16)", "Array<", ">") returns "u8, u16"
 pub fn extract_composite_inner_type(ty: &str, prefix: &str, suffix: &str) -> String {
-    // Note: Until at least 2.11, in cairo_lang_* crates, if there is a comment after a struct field type,
-    // without a comma, like `v1: Span<u32> // comment`, the comment is included in the type definition
-    // while reading it from the AST.
+    // Note: Until at least 2.11, in cairo_lang_* crates, if there is a comment after a struct field
+    // type, without a comma, like `v1: Span<u32> // comment`, the comment is included in the
+    // type definition while reading it from the AST.
     let re = regex::Regex::new(&format!(
         "{}\\s*(\\S*.*\\S+)\\s*{}",
         regex::escape(prefix),
@@ -77,8 +78,8 @@ pub fn extract_composite_inner_type(ty: &str, prefix: &str, suffix: &str) -> Str
 
     let caps = re
         .captures(ty)
-        .expect(&format!("'{ty}' must contain the '{prefix}' prefix and the '{suffix}' suffix."));
-
+        .unwrap_or_else(|| panic!("'{ty}' must contain the '{prefix}' prefix and the '{suffix}' suffix."));
+ 
     caps[1].to_string().replace(" ", "")
 }
 

--- a/crates/dojo/lang/src/derive_macros/introspect/utils.rs
+++ b/crates/dojo/lang/src/derive_macros/introspect/utils.rs
@@ -76,10 +76,10 @@ pub fn extract_composite_inner_type(ty: &str, prefix: &str, suffix: &str) -> Str
     ))
     .unwrap();
 
-    let caps = re
-        .captures(ty)
-        .unwrap_or_else(|| panic!("'{ty}' must contain the '{prefix}' prefix and the '{suffix}' suffix."));
- 
+    let caps = re.captures(ty).unwrap_or_else(|| {
+        panic!("'{ty}' must contain the '{prefix}' prefix and the '{suffix}' suffix.")
+    });
+
     caps[1].to_string().replace(" ", "")
 }
 


### PR DESCRIPTION
# Description

Probably due to an issue in `cairo_lang_*` crates, in a struct, when there is a comment after the last field type, without a comma and on the same line, the comment is included in the field type expression while parsing the code and building the AST. An issue will be raised for that on the Starkware repo.

To be more robust on our side, the inner type of a composite type like tuple, array or span is now extracted with a regex.

## Related issue

https://github.com/dojoengine/dojo/issues/3199

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [X] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [X] No documentation needed

## Checklist

- [X] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [X] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [X] I've commented my code
- [X] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new struct for testing purposes in the model tests.
- **Chores**
  - Updated dependencies to use a different repository source.
  - Added a new dependency to the workspace.
- **Tests**
  - Introduced additional unit tests to improve coverage for composite type parsing.
- **Refactor**
  - Improved and centralized logic for parsing composite types, enhancing robustness and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->