### PR TITLE
fix(types): add more context on `Ty` diff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ indoc = "1.0.7"
 itertools = "0.12.1"
 jsonrpsee = { version = "0.16.2", default-features = false }
 lazy_static = "1.4.0"
-log = "0.4"
+log = "0.4.27"
 metrics = "0.23.0"
 num-bigint = "0.4.3"
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ indoc = "1.0.7"
 itertools = "0.12.1"
 jsonrpsee = { version = "0.16.2", default-features = false }
 lazy_static = "1.4.0"
-log = "0.4.21"
+log = "0.4"
 metrics = "0.23.0"
 num-bigint = "0.4.3"
 num-traits = { version = "0.2", default-features = false }


### PR DESCRIPTION
This PR aims at adding more context about a diff between two `Ty`.

By adding the list of members/variants that have been newly added to the new version of the `Ty`, it is easier for downstream usages like `torii` to take a different action on members/variants that have been added than the one that have been modified.