### PR TITLE
fix(lang): ensure unit type is supported for `Introspect`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,7 +2238,6 @@ dependencies = [
 [[package]]
 name = "create-output-dir"
 version = "1.0.0"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.0",
@@ -2639,29 +2638,6 @@ version = "1.5.0"
 
 [[package]]
 name = "dojo-lang"
-version = "1.5.0-alpha.2"
-source = "git+https://github.com/dojoengine/dojo?rev=86a22f0749b01bc2a4f0b1f4bd0566dc14df11ee#86a22f0749b01bc2a4f0b1f4bd0566dc14df11ee"
-dependencies = [
- "anyhow",
- "cairo-lang-defs",
- "cairo-lang-diagnostics",
- "cairo-lang-filesystem",
- "cairo-lang-plugins",
- "cairo-lang-semantic",
- "cairo-lang-syntax",
- "cairo-lang-utils",
- "dojo-types 1.5.0-alpha.2",
- "itertools 0.12.1",
- "regex",
- "serde",
- "smol_str",
- "starknet 0.12.0",
- "starknet-crypto 0.7.4",
- "tracing",
-]
-
-[[package]]
-name = "dojo-lang"
 version = "1.5.0"
 dependencies = [
  "anyhow",
@@ -2672,7 +2648,7 @@ dependencies = [
  "cairo-lang-semantic",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "dojo-types 1.5.0",
+ "dojo-types",
  "itertools 0.12.1",
  "regex",
  "serde",
@@ -2687,7 +2663,7 @@ name = "dojo-language-server"
 version = "1.5.0"
 dependencies = [
  "clap",
- "dojo-lang 1.5.0",
+ "dojo-lang",
 ]
 
 [[package]]
@@ -2716,28 +2692,6 @@ dependencies = [
  "scarb",
  "scarb-ui",
  "toml 0.8.19",
-]
-
-[[package]]
-name = "dojo-types"
-version = "1.5.0-alpha.2"
-source = "git+https://github.com/dojoengine/dojo?rev=86a22f0749b01bc2a4f0b1f4bd0566dc14df11ee#86a22f0749b01bc2a4f0b1f4bd0566dc14df11ee"
-dependencies = [
- "anyhow",
- "cainome 0.5.0",
- "crypto-bigint",
- "hex",
- "indexmap 2.7.1",
- "itertools 0.12.1",
- "num-traits 0.2.19",
- "regex",
- "serde",
- "serde_json",
- "starknet 0.12.0",
- "starknet-crypto 0.7.4",
- "strum",
- "strum_macros",
- "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2788,7 +2742,7 @@ dependencies = [
  "async-trait",
  "cainome 0.5.0",
  "cairo-lang-starknet-classes",
- "dojo-types 1.5.0",
+ "dojo-types",
  "futures",
  "hex",
  "hex-literal",
@@ -6061,7 +6015,6 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "once_map"
 version = "0.0.1"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
 dependencies = [
  "dashmap",
  "futures",
@@ -7339,7 +7292,6 @@ dependencies = [
 [[package]]
 name = "scarb"
 version = "2.10.1"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7374,7 +7326,7 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "directories",
- "dojo-lang 1.5.0-alpha.2",
+ "dojo-lang",
  "dunce",
  "flate2",
  "fs4",
@@ -7399,7 +7351,7 @@ dependencies = [
  "scarb-build-metadata",
  "scarb-metadata",
  "scarb-proc-macro-server-types",
- "scarb-stable-hash 1.0.0 (git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d)",
+ "scarb-stable-hash 1.0.0",
  "scarb-ui",
  "semver",
  "semver-pubgrub",
@@ -7432,7 +7384,6 @@ dependencies = [
 [[package]]
 name = "scarb-build-metadata"
 version = "2.10.1"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
 dependencies = [
  "cargo_metadata",
 ]
@@ -7440,7 +7391,6 @@ dependencies = [
 [[package]]
 name = "scarb-metadata"
 version = "1.13.0"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
 dependencies = [
  "camino",
  "derive_builder",
@@ -7453,11 +7403,18 @@ dependencies = [
 [[package]]
 name = "scarb-proc-macro-server-types"
 version = "0.1.0"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
 dependencies = [
  "cairo-lang-macro",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "scarb-stable-hash"
+version = "1.0.0"
+dependencies = [
+ "data-encoding",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -7471,18 +7428,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "scarb-stable-hash"
-version = "1.0.0"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
-dependencies = [
- "data-encoding",
- "xxhash-rust",
-]
-
-[[package]]
 name = "scarb-ui"
 version = "0.1.5"
-source = "git+https://github.com/dojoengine/scarb?rev=b2ce4fa03bed98ca44918c390df0e190b637894d#b2ce4fa03bed98ca44918c390df0e190b637894d"
 dependencies = [
  "anyhow",
  "camino",
@@ -7985,7 +7932,7 @@ dependencies = [
  "colored",
  "dojo-bindgen",
  "dojo-test-utils",
- "dojo-types 1.5.0",
+ "dojo-types",
  "dojo-utils",
  "dojo-world",
  "katana-runner 1.2.3",
@@ -8026,7 +7973,7 @@ dependencies = [
  "colored",
  "colored_json",
  "dojo-test-utils",
- "dojo-types 1.5.0",
+ "dojo-types",
  "dojo-utils",
  "dojo-world",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,7 @@ dependencies = [
 [[package]]
 name = "create-output-dir"
 version = "1.0.0"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
 dependencies = [
  "anyhow",
  "core-foundation 0.10.0",
@@ -2648,7 +2649,30 @@ dependencies = [
  "cairo-lang-semantic",
  "cairo-lang-syntax",
  "cairo-lang-utils",
- "dojo-types",
+ "dojo-types 1.5.0",
+ "itertools 0.12.1",
+ "regex",
+ "serde",
+ "smol_str",
+ "starknet 0.12.0",
+ "starknet-crypto 0.7.4",
+ "tracing",
+]
+
+[[package]]
+name = "dojo-lang"
+version = "1.5.0"
+source = "git+https://github.com/dojoengine/dojo?rev=b362ad537832c30f4e8c2559467e5e793097c188#b362ad537832c30f4e8c2559467e5e793097c188"
+dependencies = [
+ "anyhow",
+ "cairo-lang-defs",
+ "cairo-lang-diagnostics",
+ "cairo-lang-filesystem",
+ "cairo-lang-plugins",
+ "cairo-lang-semantic",
+ "cairo-lang-syntax",
+ "cairo-lang-utils",
+ "dojo-types 1.5.0 (git+https://github.com/dojoengine/dojo?rev=b362ad537832c30f4e8c2559467e5e793097c188)",
  "itertools 0.12.1",
  "regex",
  "serde",
@@ -2663,7 +2687,7 @@ name = "dojo-language-server"
 version = "1.5.0"
 dependencies = [
  "clap",
- "dojo-lang",
+ "dojo-lang 1.5.0",
 ]
 
 [[package]]
@@ -2716,6 +2740,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dojo-types"
+version = "1.5.0"
+source = "git+https://github.com/dojoengine/dojo?rev=b362ad537832c30f4e8c2559467e5e793097c188#b362ad537832c30f4e8c2559467e5e793097c188"
+dependencies = [
+ "anyhow",
+ "cainome 0.5.0",
+ "crypto-bigint",
+ "hex",
+ "indexmap 2.7.1",
+ "itertools 0.12.1",
+ "num-traits 0.2.19",
+ "regex",
+ "serde",
+ "serde_json",
+ "starknet 0.12.0",
+ "starknet-crypto 0.7.4",
+ "strum",
+ "strum_macros",
+ "thiserror 1.0.63",
+]
+
+[[package]]
 name = "dojo-utils"
 version = "1.5.0"
 dependencies = [
@@ -2742,7 +2788,7 @@ dependencies = [
  "async-trait",
  "cainome 0.5.0",
  "cairo-lang-starknet-classes",
- "dojo-types",
+ "dojo-types 1.5.0",
  "futures",
  "hex",
  "hex-literal",
@@ -6015,6 +6061,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 [[package]]
 name = "once_map"
 version = "0.0.1"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
 dependencies = [
  "dashmap",
  "futures",
@@ -7292,6 +7339,7 @@ dependencies = [
 [[package]]
 name = "scarb"
 version = "2.10.1"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7326,7 +7374,7 @@ dependencies = [
  "derive_builder",
  "dialoguer",
  "directories",
- "dojo-lang",
+ "dojo-lang 1.5.0 (git+https://github.com/dojoengine/dojo?rev=b362ad537832c30f4e8c2559467e5e793097c188)",
  "dunce",
  "flate2",
  "fs4",
@@ -7351,7 +7399,7 @@ dependencies = [
  "scarb-build-metadata",
  "scarb-metadata",
  "scarb-proc-macro-server-types",
- "scarb-stable-hash 1.0.0",
+ "scarb-stable-hash 1.0.0 (git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59)",
  "scarb-ui",
  "semver",
  "semver-pubgrub",
@@ -7384,6 +7432,7 @@ dependencies = [
 [[package]]
 name = "scarb-build-metadata"
 version = "2.10.1"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
 dependencies = [
  "cargo_metadata",
 ]
@@ -7391,6 +7440,7 @@ dependencies = [
 [[package]]
 name = "scarb-metadata"
 version = "1.13.0"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
 dependencies = [
  "camino",
  "derive_builder",
@@ -7403,18 +7453,11 @@ dependencies = [
 [[package]]
 name = "scarb-proc-macro-server-types"
 version = "0.1.0"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
 dependencies = [
  "cairo-lang-macro",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "scarb-stable-hash"
-version = "1.0.0"
-dependencies = [
- "data-encoding",
- "xxhash-rust",
 ]
 
 [[package]]
@@ -7428,8 +7471,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "scarb-stable-hash"
+version = "1.0.0"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
+dependencies = [
+ "data-encoding",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "scarb-ui"
 version = "0.1.5"
+source = "git+https://github.com/dojoengine/scarb?rev=937955721f0218a7971baed79d5d4e82fa022c59#937955721f0218a7971baed79d5d4e82fa022c59"
 dependencies = [
  "anyhow",
  "camino",
@@ -7932,7 +7985,7 @@ dependencies = [
  "colored",
  "dojo-bindgen",
  "dojo-test-utils",
- "dojo-types",
+ "dojo-types 1.5.0",
  "dojo-utils",
  "dojo-world",
  "katana-runner 1.2.3",
@@ -7973,7 +8026,7 @@ dependencies = [
  "colored",
  "colored_json",
  "dojo-test-utils",
- "dojo-types",
+ "dojo-types 1.5.0",
  "dojo-utils",
  "dojo-world",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,9 +158,9 @@ rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 salsa = "0.16.1"
 
-scarb = { git = "https://github.com/dojoengine/scarb", rev = "b2ce4fa03bed98ca44918c390df0e190b637894d" }
-scarb-metadata = { git = "https://github.com/dojoengine/scarb", rev = "b2ce4fa03bed98ca44918c390df0e190b637894d" }
-scarb-ui = { git = "https://github.com/dojoengine/scarb", rev = "b2ce4fa03bed98ca44918c390df0e190b637894d" }
+scarb = { path = "/Users/glihm/swm/scarb/scarb" }
+scarb-metadata = { path = "/Users/glihm/swm/scarb/scarb-metadata" }
+scarb-ui = { path = "/Users/glihm/swm/scarb/utils/scarb-ui" }
 
 semver = "1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,9 +158,9 @@ rstest = "0.18.2"
 rstest_reuse = "0.6.0"
 salsa = "0.16.1"
 
-scarb = { path = "/Users/glihm/swm/scarb/scarb" }
-scarb-metadata = { path = "/Users/glihm/swm/scarb/scarb-metadata" }
-scarb-ui = { path = "/Users/glihm/swm/scarb/utils/scarb-ui" }
+scarb = { git = "https://github.com/dojoengine/scarb", rev = "937955721f0218a7971baed79d5d4e82fa022c59" }
+scarb-metadata = { git = "https://github.com/dojoengine/scarb", rev = "937955721f0218a7971baed79d5d4e82fa022c59" }
+scarb-ui = { git = "https://github.com/dojoengine/scarb", rev = "937955721f0218a7971baed79d5d4e82fa022c59" }
 
 semver = "1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/dojo/lang/src/derive_macros/introspect/utils.rs
+++ b/crates/dojo/lang/src/derive_macros/introspect/utils.rs
@@ -161,6 +161,8 @@ fn test_extract_composite_inner_type_with_tuples() {
         ),
         ("(u8, u32) // comment", "u8,u32"),
         ("(u8, u32), // comment", "u8,u32"),
+        // Unity type is a special case (empty tuple).
+        ("()", ""),
     ];
 
     for (tuple, expected) in test_cases {
@@ -223,16 +225,4 @@ fn test_extract_composite_inner_type_with_spans() {
 #[should_panic(expected = "'u8, u16' must contain the 'Span<' prefix and the '>' suffix.")]
 fn test_extract_composite_inner_type_with_spans_bad_ty() {
     let _ = extract_composite_inner_type("u8, u16", SPAN_PREFIX, SPAN_SUFFIX);
-}
-
-#[test]
-fn test_extract_composite_inner_type_with_unit_type() {
-    let test_cases = [
-        ("()", ""),
-    ];
-
-    for (unit, expected) in test_cases {
-        let result = extract_composite_inner_type(unit, TUPLE_PREFIX, TUPLE_SUFFIX);
-        assert!(result == expected, "bad unit: {} result: {} expected: {}", unit, result, expected);
-    }
 }


### PR DESCRIPTION
Unit type is a special type `()`, and considered as an empty tuple when parsing types.

This PR ensure that the old syntax using explicit unit type is handled by introspect.

```rust
pub enum A {
    a: (),
}

// Is the same as
pub enum A {
    a,
}
```
And the new way dojo lang parses the types (to exclude comments), wasn't taking in account the unit type.