### PR TITLE
Update starter link after `dojoup install`

### DIFF
--- a/dojoup/dojoup
+++ b/dojoup/dojoup
@@ -600,7 +600,7 @@ welcome_msg() {
 
 Congratulations on successfully installing ${dojo}Dojo${clear} ${DOJOUP_VERSION}! 🥷
 
-For more info on how to get started, check out the Dojo Getting Started Guide: https://book.dojoengine.org/getting-started/quick-start
+For more info on getting started, check out the Dojo Starter guide: https://book.dojoengine.org/tutorials/dojo-starter
 
 ═════════════════════════════════════════════════════════════════════════
 

--- a/scripts/rebuild_test_artifacts.sh
+++ b/scripts/rebuild_test_artifacts.sh
@@ -38,4 +38,3 @@ KATANA_RUNNER_BIN=/tmp/katana cargo generate-test-db
 
 # Extracts the database for testing.
 bash ./scripts/extract_test_db.sh
-


### PR DESCRIPTION
After consolidating the `installation` and `quick-start` pages, the link given by the `dojoup install` command is broken. This PR updates the link to point new users to the `dojo-starter` tutorial.