### PR TITLE
Fix broken getting started link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It is designed to significantly reduce the complexity of developing provable app
 
 ## Getting Started
 
-See the [getting started](https://book.dojoengine.org/getting-started) section in the Dojo book to start building provable applications with Dojo.
+See the [getting started](https://book.dojoengine.org/tutorials/dojo-starter) section in the Dojo book to start building provable applications with Dojo.
 
 You can find more detailed documentation in the Dojo Book [here](https://book.dojoengine.org/).
 


### PR DESCRIPTION

Fix broken getting started link in README
Description
Fixes #3232 - The getting started link in README was returning a 404 error.
Changes Made

Updated the broken link from https://book.dojoengine.org/getting-started
To the working link https://book.dojoengine.org/tutorials/dojo-starter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "getting started" link in the README to direct users to the latest tutorial page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->