### PR TITLE
fix(dojoup): remove new line in the source cmd

### DIFF
--- a/dojoup/install
+++ b/dojoup/install
@@ -73,9 +73,7 @@ SOURCE_COMMAND=". \"$ENV_FILE\""
 
 case $(basename "$SHELL") in
 zsh)
-	commands=(
-		$SOURCE_COMMAND
-	)
+	commands=("$SOURCE_COMMAND")
 
     zsh_config=$HOME/.zshrc
 
@@ -96,9 +94,7 @@ zsh)
     fi
     ;;
 bash)
-    commands=(
-    	$SOURCE_COMMAND
-    )
+    commands=("$SOURCE_COMMAND")
 
     bash_configs=(
         "$HOME/.bashrc"


### PR DESCRIPTION
# Description

<!--
A description of what this PR is solving.
-->

Fixed the issue where in the bashrc a new line is added between the '.' and the source path

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal handling of shell command assignment for improved code clarity. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->