### PR TITLE
fix(bindgen): fix ts bytearray type mapping

### DIFF
--- a/crates/dojo/bindgen/src/plugins/typescript/generator/function.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/function.rs
@@ -19,8 +19,8 @@ impl TsFunctionGenerator {
             buffer.insert(
                 1,
                 format!(
-                    "import {{ Account, AccountInterface, {}, CairoOption, CairoCustomEnum, \
-                     ByteArray }} from \"starknet\";",
+                    "import {{ Account, AccountInterface, {}, CairoOption, CairoCustomEnum }} \
+                     from \"starknet\";",
                     JS_BIGNUMBERISH
                 ),
             );

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/mod.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/mod.rs
@@ -162,7 +162,7 @@ impl From<&str> for JsPrimitiveInputType {
         match value {
             CAIRO_FELT252 => JsPrimitiveInputType(JS_BIGNUMBERISH.to_owned()),
             CAIRO_CONTRACT_ADDRESS => JsPrimitiveInputType(JS_STRING.to_owned()),
-            CAIRO_BYTE_ARRAY => JsPrimitiveInputType(CAIRO_BYTE_ARRAY.to_owned()),
+            CAIRO_BYTE_ARRAY => JsPrimitiveInputType(JS_STRING.to_owned()),
             CAIRO_U8 => JsPrimitiveInputType(JS_BIGNUMBERISH.to_owned()),
             CAIRO_U16 => JsPrimitiveInputType(JS_BIGNUMBERISH.to_owned()),
             CAIRO_U32 => JsPrimitiveInputType(JS_BIGNUMBERISH.to_owned()),
@@ -376,13 +376,19 @@ mod tests {
         Tuple,
     };
 
-    use crate::plugins::typescript::generator::constants::JS_BIGNUMBERISH;
+    use crate::plugins::typescript::generator::constants::{JS_BIGNUMBERISH, JS_STRING};
     use crate::plugins::typescript::generator::{
-        generate_type_init, JsPrimitiveDefaultValue, JsPrimitiveType,
+        generate_type_init, JsPrimitiveDefaultValue, JsPrimitiveInputType, JsPrimitiveType,
     };
 
     impl PartialEq<JsPrimitiveType> for &str {
         fn eq(&self, other: &JsPrimitiveType) -> bool {
+            self == &other.0.as_str()
+        }
+    }
+
+    impl PartialEq<JsPrimitiveInputType> for &str {
+        fn eq(&self, other: &JsPrimitiveInputType) -> bool {
             self == &other.0.as_str()
         }
     }
@@ -865,6 +871,18 @@ mod tests {
             is_event: false,
             alias: None,
         }
+    }
+
+    #[test]
+    fn test_byte_array_input_type() {
+        assert_eq!(
+            JS_STRING,
+            JsPrimitiveInputType::from(&Token::CoreBasic(CoreBasic {
+                type_path: "core::byte_array::ByteArray".to_owned()
+            }))
+        );
+        // Also test with the short form
+        assert_eq!(JS_STRING, JsPrimitiveInputType::from("ByteArray"));
     }
 
     fn create_option_custom_enum_token() -> Composite {

--- a/crates/macros/merge-options/src/lib.rs
+++ b/crates/macros/merge-options/src/lib.rs
@@ -52,7 +52,7 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields};
 ///     pub fn merge(&mut self, other: Option<&Self>) {
 ///         if let Some(other) = other {
 ///             let default_values = Self::default();
-///             
+///
 ///             if self.port == default_values.port {
 ///                 self.port = other.port;
 ///             }


### PR DESCRIPTION
# Description

## Related issue

#3216 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of byte array types in TypeScript code generation, ensuring correct input type mapping.
- **Tests**
  - Added tests to verify accurate mapping of byte array types to string inputs.
- **Style**
  - Removed unnecessary trailing whitespace in documentation comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->