### PR TITLE
fix(bindgen): filter out Value models

### DIFF
--- a/crates/dojo/bindgen/src/plugins/typescript/writer.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/writer.rs
@@ -43,6 +43,7 @@ impl BindgenWriter for TsFileWriter {
                 composites
             })
             .filter(|c| !(c.type_path.starts_with("dojo::") || c.type_path.starts_with("core::")))
+            .filter(|c| !c.type_name().ends_with("Value"))
             .collect::<Vec<_>>();
 
         let mut m_composites = models
@@ -65,6 +66,7 @@ impl BindgenWriter for TsFileWriter {
                 composites
             })
             .filter(|c| !(c.type_path.starts_with("dojo::") || c.type_path.starts_with("core::")))
+            .filter(|c| !c.type_name().ends_with("Value"))
             .collect::<Vec<_>>();
 
         // Sort models based on their tag to ensure deterministic output.

--- a/crates/macros/merge-options/src/lib.rs
+++ b/crates/macros/merge-options/src/lib.rs
@@ -52,7 +52,7 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields};
 ///     pub fn merge(&mut self, other: Option<&Self>) {
 ///         if let Some(other) = other {
 ///             let default_values = Self::default();
-///             
+///
 ///             if self.port == default_values.port {
 ///                 self.port = other.port;
 ///             }


### PR DESCRIPTION
# Description


## Related issue
#3217 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filtering of certain types in TypeScript code generation to exclude items ending with "Value".
- **Style**
  - Minor improvements to import order and documentation formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->