### PR TITLE
fix(bindgen): use world namespace for imported models in TypeScript S…

### DIFF
--- a/crates/macros/merge-options/src/lib.rs
+++ b/crates/macros/merge-options/src/lib.rs
@@ -52,7 +52,7 @@ use syn::{parse_macro_input, Data, DeriveInput, Fields};
 ///     pub fn merge(&mut self, other: Option<&Self>) {
 ///         if let Some(other) = other {
 ///             let default_values = Self::default();
-///             
+///
 ///             if self.port == default_values.port {
 ///                 self.port = other.port;
 ///             }


### PR DESCRIPTION
…chemaType

## Related issue 

#3218 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for overriding the namespace in generated TypeScript schema types and constants using a special marker comment.
- **Tests**
  - Introduced tests to verify that the namespace override works when the marker is present in the buffer.
- **Documentation**
  - Cleaned up formatting in example code comments for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->