### PR TITLE
fix(cairo-bench): use write and threshold + refactor fixed size array

### DIFF
--- a/bin/cairo-bench/src/main.rs
+++ b/bin/cairo-bench/src/main.rs
@@ -77,7 +77,7 @@ struct Args {
     pub threshold: Option<u128>,
 
     #[arg(long, help = "Override the reference file corresponding to the provided manifest file.")]
-    pub update_ref: bool,
+    pub write: bool,
 
     #[arg(long, help = "Just show what has changed.")]
     pub change_only: bool,
@@ -516,7 +516,7 @@ fn main() {
         let ref_test_results = read_ref_tests(&ref_file);
         let results = compare_tests(&ref_test_results, &new_test_results);
 
-        if args.update_ref {
+        if args.write {
             write_ref_file(&ref_file, &new_test_results);
         }
 

--- a/bin/sozo/src/commands/options/transaction.rs
+++ b/bin/sozo/src/commands/options/transaction.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Args;
 use dojo_utils::{FeeConfig, TxnAction, TxnConfig};
 
@@ -7,13 +7,11 @@ use dojo_utils::{FeeConfig, TxnAction, TxnConfig};
 pub struct TransactionOptions {
     #[arg(help_heading = "Transaction options - STRK")]
     #[arg(long, help = "Maximum L1 gas amount.")]
-    #[arg(conflicts_with_all = ["max_fee_raw", "fee_estimate_multiplier"])]
     #[arg(global = true)]
     pub gas: Option<u64>,
 
     #[arg(help_heading = "Transaction options - STRK")]
     #[arg(long, help = "Maximum L1 gas price in STRK.")]
-    #[arg(conflicts_with_all = ["max_fee_raw", "fee_estimate_multiplier"])]
     #[arg(global = true)]
     pub gas_price: Option<u128>,
 

--- a/bin/sozo/src/commands/options/transaction.rs
+++ b/bin/sozo/src/commands/options/transaction.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::Args;
 use dojo_utils::{FeeConfig, TxnAction, TxnConfig};
 

--- a/crates/dojo/types/src/schema.rs
+++ b/crates/dojo/types/src/schema.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 use starknet::core::types::Felt;
 use strum_macros::AsRefStr;
 

--- a/crates/dojo/utils/src/tx/mod.rs
+++ b/crates/dojo/utils/src/tx/mod.rs
@@ -6,7 +6,7 @@ pub mod waiter;
 
 use std::fmt;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use colored_json::ToColoredJson;
 use reqwest::Url;
 use starknet::accounts::{
@@ -92,10 +92,8 @@ pub trait TransactionExt<T> {
     type R;
     type U;
 
-    /// Sets `fee_estimate_multiplier` and `max_fee_raw` from `TxnConfig` if its present before
+    /// Sets `l1_gas` and `l1_gas_price` from `TxnConfig` if its present before
     /// calling `send` method on the respective type.
-    /// NOTE: If both are specified `max_fee_raw` will take precedence and `fee_estimate_multiplier`
-    /// will be ignored by `starknet-rs`
     async fn send_with_cfg(self, txn_config: &TxnConfig) -> Result<Self::R, Self::U>;
 }
 

--- a/crates/dojo/utils/src/tx/mod.rs
+++ b/crates/dojo/utils/src/tx/mod.rs
@@ -6,7 +6,7 @@ pub mod waiter;
 
 use std::fmt;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use colored_json::ToColoredJson;
 use reqwest::Url;
 use starknet::accounts::{

--- a/crates/dojo/world/src/contracts/model.rs
+++ b/crates/dojo/world/src/contracts/model.rs
@@ -7,8 +7,8 @@ use dojo_types::primitive::{Primitive, PrimitiveError};
 use dojo_types::schema::{Enum, EnumOption, Member, Struct, Ty};
 use starknet::core::types::{BlockId, Felt};
 use starknet::core::utils::{
-    cairo_short_string_to_felt, parse_cairo_short_string, CairoShortStringToFeltError,
-    NonAsciiNameError, ParseCairoShortStringError,
+    CairoShortStringToFeltError, NonAsciiNameError, ParseCairoShortStringError,
+    cairo_short_string_to_felt, parse_cairo_short_string,
 };
 use starknet::providers::{Provider, ProviderError};
 
@@ -271,12 +271,9 @@ fn parse_schema(ty: &abigen::model::Ty) -> Result<Ty, ParseError> {
             Ok(Ty::Tuple(values))
         }
         abigen::model::Ty::FixedArray(values) => {
-            let values = values
-                .iter()
-                .map(|(ty, _)| parse_schema(ty))
-                .collect::<Result<Vec<_>, ParseError>>()?;
-
-            Ok(Ty::FixedSizeArray(values))
+            let (item_ty, length) = &values[0];
+            let item_ty = parse_schema(item_ty)?;
+            Ok(Ty::FixedSizeArray(vec![(item_ty, *length)]))
         }
         abigen::model::Ty::Array(values) => {
             let values = values.iter().map(parse_schema).collect::<Result<Vec<_>, ParseError>>()?;

--- a/crates/dojo/world/src/contracts/model.rs
+++ b/crates/dojo/world/src/contracts/model.rs
@@ -7,8 +7,8 @@ use dojo_types::primitive::{Primitive, PrimitiveError};
 use dojo_types::schema::{Enum, EnumOption, Member, Struct, Ty};
 use starknet::core::types::{BlockId, Felt};
 use starknet::core::utils::{
-    CairoShortStringToFeltError, NonAsciiNameError, ParseCairoShortStringError,
-    cairo_short_string_to_felt, parse_cairo_short_string,
+    cairo_short_string_to_felt, parse_cairo_short_string, CairoShortStringToFeltError,
+    NonAsciiNameError, ParseCairoShortStringError,
 };
 use starknet::providers::{Provider, ProviderError};
 


### PR DESCRIPTION
Some small commits for dev-1.6.0:
- remove the `update-ref-test-list` argument in `cairo-bench`,
- add `threshold` argument to `cairo-bench`,
- remove `max_fee_raw` and `fee_estimate_multiplier` conflicts rules as they don't exist anymore,
- update sozo model commands with fixed size arrays.