### PR TITLE
refactor(sozo): check RPC spec compatibility

### DIFF
--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -31,14 +31,14 @@ use crate::commands::options::world::WorldOptions;
 /// providers.
 pub const MAX_BLOCK_RANGE: u64 = 200_000;
 
-pub const _RPC_SPEC_VERSION: &str = "0.7.1";
+pub const RPC_SPEC_VERSION: &str = "0.8.1";
 
 pub const CALLDATA_DOC: &str = "
 Space separated values e.g., 0x12345 128 u256:9999999999 str:'hello world'.
 Sozo supports some prefixes that you can use to automatically parse some types. The supported \
                                 prefixes are:
     - u256: A 256-bit unsigned integer.
-    - sstr: A cairo short string. 
+    - sstr: A cairo short string.
             If the string contains spaces it must be between quotes (ex: sstr:'hello world')
     - str: A cairo string (ByteArray).
             If the string contains spaces it must be between quotes (ex: sstr:'hello world')
@@ -155,16 +155,12 @@ pub async fn get_world_diff_and_provider(
     let spec_version = provider.spec_version().await?;
     trace!(spec_version);
 
-    // TODO: @remybar @glihm currently Katana is using new types, but doesn't
-    // return the correct spec version. We comment this test for now to ensure
-    // one can deploy on sepolia/mainnet but also Katana.
-    //     if !is_compatible_version(&spec_version, RPC_SPEC_VERSION)? {
-    // return Err(anyhow!(
-    // "Unsupported Starknet RPC version: {}, expected {}.",
-    // spec_version,
-    // RPC_SPEC_VERSION
-    // ));
-    // }
+    if !is_compatible_version(&spec_version, RPC_SPEC_VERSION)? {
+        return Err(anyhow!(
+            "Unsupported Starknet RPC version: {spec_version}, expected {RPC_SPEC_VERSION}.",
+        ));
+    }
+
     let chain_id = provider.chain_id().await?;
     let chain_id = snutils::parse_cairo_short_string(&chain_id)
         .with_context(|| "Cannot parse chain_id as string")?;
@@ -233,7 +229,6 @@ pub async fn get_world_diff_and_account(
 ///
 /// * `Result<bool>` - Returns `true` if the provided version is compatible with the expected
 ///   version, `false` otherwise.
-#[allow(dead_code)]
 fn is_compatible_version(provided_version: &str, expected_version: &str) -> Result<bool> {
     use semver::{Version, VersionReq};
 


### PR DESCRIPTION
# Description

Katana now correctly returns the Starknet RPC spec version that it is using. We can include back the compatibility check that was commented out because Katana wasn't returning the correct RPC spec and was causing an issue with the RPC compatibility mismatch.

## Related issue

<!--
Please link related issues: Fixes #<issue_number>
More info: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for provider version, now displaying an error if the provider's version does not match the expected version.
* **Documentation**
  * Minor correction to documentation formatting for calldata description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->