### PR TITLE
fix(constants): correct typo in BIGNUMBERISH_IMPORT constant name

### DIFF
--- a/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/constants.rs
@@ -23,7 +23,7 @@ pub const JS_BOOLEAN: &str = "boolean";
 pub const JS_STRING: &str = "string";
 pub const JS_BIGNUMBERISH: &str = "BigNumberish";
 
-pub(crate) const BIGNUMNERISH_IMPORT: &str = "import { BigNumberish } from 'starknet';\n";
+pub(crate) const BIGNUMBERISH_IMPORT: &str = "import { BigNumberish } from 'starknet';\n";
 pub(crate) const CAIRO_OPTION_IMPORT: &str = "import { CairoOption } from 'starknet';\n";
 pub(crate) const CAIRO_ENUM_IMPORT: &str = "import { CairoCustomEnum } from 'starknet';\n";
 pub(crate) const CAIRO_OPTION_TYPE_PATH: &str = "core::option::Option";

--- a/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
+++ b/crates/dojo/bindgen/src/plugins/typescript/generator/interface.rs
@@ -1,6 +1,6 @@
 use cainome::parser::tokens::{Composite, CompositeType, Token};
 
-use super::constants::{BIGNUMNERISH_IMPORT, CAIRO_OPTION_IMPORT, SN_IMPORT_SEARCH};
+use super::constants::{BIGNUMBERISH_IMPORT, CAIRO_OPTION_IMPORT, SN_IMPORT_SEARCH};
 use super::{token_is_option, JsPrimitiveType};
 use crate::error::BindgenResult;
 use crate::plugins::typescript::generator::constants::CAIRO_OPTION_TOKEN;
@@ -11,7 +11,7 @@ impl TsInterfaceGenerator {
     fn check_import(&self, token: &Composite, buffer: &mut Buffer) {
         // only search for end part of the import, as we append the other imports afterward
         if !buffer.has("BigNumberish } from 'starknet';") {
-            buffer.push(BIGNUMNERISH_IMPORT.to_owned());
+            buffer.push(BIGNUMBERISH_IMPORT.to_owned());
         }
 
         // type is Option, need to import CairoOption


### PR DESCRIPTION


Renamed BIGNUMNERISH_IMPORT to BIGNUMBERISH_IMPORT for consistency and to prevent confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typographical error in an internal constant name related to TypeScript code generation. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->