### PR TITLE
fix(utils/invoker): add split for big multicalls

### DIFF
--- a/bin/sozo/src/commands/auth.rs
+++ b/bin/sozo/src/commands/auth.rs
@@ -374,8 +374,10 @@ async fn clone_permissions(
         }
     }
 
-    let res = invoker.multicall().await?;
-    println!("{}", res);
+    let txs_results = invoker.multicall().await?;
+    for r in &txs_results {
+        println!("{}", r);
+    }
 
     Ok(())
 }
@@ -592,8 +594,10 @@ async fn update_owners(
         invoker.add_call(call);
     }
 
-    let res = invoker.multicall().await?;
-    println!("{}", res);
+    let txs_results = invoker.multicall().await?;
+    for r in &txs_results {
+        println!("{}", r);
+    }
 
     Ok(())
 }
@@ -634,8 +638,10 @@ async fn update_writers(
         invoker.add_call(call);
     }
 
-    let res = invoker.multicall().await?;
-    println!("{}", res);
+    let txs_results = invoker.multicall().await?;
+    for r in &txs_results {
+        println!("{}", r);
+    }
 
     Ok(())
 }

--- a/bin/sozo/src/commands/execute.rs
+++ b/bin/sozo/src/commands/execute.rs
@@ -167,9 +167,8 @@ impl ExecuteArgs {
         }
 
         let txs_results = invoker.multicall().await?;
-
-        for tx_result in &txs_results {
-            println!("{}", tx_result);
+        for r in &txs_results {
+            println!("{}", r);
         }
 
         #[cfg(feature = "walnut")]

--- a/bin/sozo/src/commands/execute.rs
+++ b/bin/sozo/src/commands/execute.rs
@@ -166,14 +166,19 @@ impl ExecuteArgs {
             });
         }
 
-        let tx_result = invoker.multicall().await?;
+        let txs_results = invoker.multicall().await?;
+
+        for tx_result in &txs_results {
+            println!("{}", tx_result);
+        }
 
         #[cfg(feature = "walnut")]
         if let Some(walnut_debugger) = walnut_debugger {
-            walnut_debugger.debug_transaction(ui, &tx_result)?;
+            for tx_result in &txs_results {
+                walnut_debugger.debug_transaction(ui, tx_result)?;
+            }
         }
 
-        println!("{}", tx_result);
         Ok(())
     }
 }

--- a/bin/sozo/src/commands/options/transaction.rs
+++ b/bin/sozo/src/commands/options/transaction.rs
@@ -35,6 +35,12 @@ pub struct TransactionOptions {
     #[arg(help = "Display the link to debug the transaction with Walnut.")]
     #[arg(global = true)]
     pub walnut: bool,
+
+    #[arg(long)]
+    #[arg(help = "Maximum number of calls to send in a single transaction. By default, there is \
+                  no limit and Sozo will attempt to send all the calls in one transaction.")]
+    #[arg(global = true)]
+    pub max_calls: Option<usize>,
 }
 
 impl TransactionOptions {
@@ -54,6 +60,7 @@ impl TransactionOptions {
                 receipt: self.receipt,
                 fee_config: FeeConfig { gas: self.gas, gas_price: self.gas_price },
                 walnut: self.walnut,
+                max_calls: self.max_calls,
             }),
         }
     }
@@ -68,6 +75,7 @@ impl TryFrom<TransactionOptions> for TxnConfig {
             receipt: value.receipt,
             walnut: value.walnut,
             fee_config: FeeConfig { gas: value.gas, gas_price: value.gas_price },
+            max_calls: value.max_calls,
         })
     }
 }
@@ -86,6 +94,7 @@ mod tests {
             gas: Some(1000),
             gas_price: Some(100),
             walnut: false,
+            max_calls: Some(10),
         };
 
         let config: TxnConfig = opts.try_into()?;
@@ -93,6 +102,7 @@ mod tests {
         assert!(config.wait);
         assert!(config.receipt);
         assert!(!config.walnut);
+        assert_eq!(config.max_calls, Some(10));
 
         assert_eq!(config.fee_config.gas, Some(1000));
         assert_eq!(config.fee_config.gas_price, Some(100));

--- a/crates/dojo/utils/src/tx/invoker.rs
+++ b/crates/dojo/utils/src/tx/invoker.rs
@@ -75,32 +75,77 @@ where
         Ok(TransactionResult::Hash(tx.transaction_hash))
     }
 
-    /// Invokes all the calls in one single transaction.
-    pub async fn multicall(&self) -> Result<TransactionResult, TransactionError<A::SignError>> {
+    /// Invokes all the calls in a multicall fashion. If the calls are too many,
+    /// it will split them into multiple transactions using the `max_calls` config.
+    /// By default there is no limit, but this may cause the transaction to fail if the calls are
+    /// too many, and the resources to execute the transaction are too high.
+    pub async fn multicall(
+        &self,
+    ) -> Result<Vec<TransactionResult>, TransactionError<A::SignError>> {
         if self.calls.is_empty() {
-            return Ok(TransactionResult::Noop);
+            return Ok(vec![TransactionResult::Noop]);
         }
 
         trace!(?self.calls, "Invoke contract multicall.");
 
-        let tx =
-            self.account.execute_v3(self.calls.clone()).send_with_cfg(&self.txn_config).await?;
+        if let Some(max_calls) = self.txn_config.max_calls {
+            // Split the calls into multiple transactions, using the max_calls as the number of
+            // calls per transaction.
+            let mut results = vec![];
+            let calls_chunks = self.calls.chunks(max_calls);
 
-        trace!(
-            transaction_hash = format!("{:#066x}", tx.transaction_hash),
-            "Invoke contract multicall."
-        );
+            for chunk in calls_chunks {
+                let tx =
+                    self.account.execute_v3(chunk.to_vec()).send_with_cfg(&self.txn_config).await?;
 
-        if self.txn_config.wait {
-            let receipt =
-                TransactionWaiter::new(tx.transaction_hash, &self.account.provider()).await?;
+                trace!(
+                    transaction_hash = format!("{:#066x}", tx.transaction_hash),
+                    "Invoke contract multicall chunk."
+                );
 
-            if self.txn_config.receipt {
-                return Ok(TransactionResult::HashReceipt(tx.transaction_hash, Box::new(receipt)));
+                if self.txn_config.wait {
+                    let receipt =
+                        TransactionWaiter::new(tx.transaction_hash, &self.account.provider())
+                            .await?;
+
+                    if self.txn_config.receipt {
+                        results.push(TransactionResult::HashReceipt(
+                            tx.transaction_hash,
+                            Box::new(receipt),
+                        ));
+                    } else {
+                        results.push(TransactionResult::Hash(tx.transaction_hash));
+                    }
+                } else {
+                    results.push(TransactionResult::Hash(tx.transaction_hash));
+                }
             }
-        }
 
-        Ok(TransactionResult::Hash(tx.transaction_hash))
+            Ok(results)
+        } else {
+            // No max_calls limit, execute all calls in a single transaction
+            let tx =
+                self.account.execute_v3(self.calls.clone()).send_with_cfg(&self.txn_config).await?;
+
+            trace!(
+                transaction_hash = format!("{:#066x}", tx.transaction_hash),
+                "Invoke contract multicall."
+            );
+
+            if self.txn_config.wait {
+                let receipt =
+                    TransactionWaiter::new(tx.transaction_hash, &self.account.provider()).await?;
+
+                if self.txn_config.receipt {
+                    return Ok(vec![TransactionResult::HashReceipt(
+                        tx.transaction_hash,
+                        Box::new(receipt),
+                    )]);
+                }
+            }
+
+            Ok(vec![TransactionResult::Hash(tx.transaction_hash)])
+        }
     }
 
     /// Invokes all the calls individually, usually used for debugging if a multicall failed.

--- a/crates/dojo/utils/src/tx/invoker.rs
+++ b/crates/dojo/utils/src/tx/invoker.rs
@@ -94,11 +94,18 @@ where
             let mut results = vec![];
             let calls_chunks = self.calls.chunks(max_calls);
 
-            for chunk in calls_chunks {
+            trace!(
+                n_chunks = calls_chunks.len(),
+                ?calls_chunks,
+                "Invoke contract multicall chunks."
+            );
+
+            for (i, chunk) in calls_chunks.enumerate() {
                 let tx =
                     self.account.execute_v3(chunk.to_vec()).send_with_cfg(&self.txn_config).await?;
 
                 trace!(
+                    chunk = i,
                     transaction_hash = format!("{:#066x}", tx.transaction_hash),
                     "Invoke contract multicall chunk."
                 );

--- a/crates/dojo/utils/src/tx/mod.rs
+++ b/crates/dojo/utils/src/tx/mod.rs
@@ -40,11 +40,21 @@ pub struct TxnConfig {
     pub walnut: bool,
     /// The fee configuration to use for the transaction.
     pub fee_config: FeeConfig,
+    /// The maximum number of calls to send in a single transaction.
+    /// This number could vary depending on the calls content, and is mostly
+    /// here to ensure the migration is not stuck if too much resources have to be registered.
+    pub max_calls: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
 pub enum TxnAction {
-    Send { wait: bool, receipt: bool, fee_config: FeeConfig, walnut: bool },
+    Send {
+        wait: bool,
+        receipt: bool,
+        fee_config: FeeConfig,
+        walnut: bool,
+        max_calls: Option<usize>,
+    },
     Estimate,
     Simulate,
 }

--- a/crates/sozo/ops/src/migrate/mod.rs
+++ b/crates/sozo/ops/src/migrate/mod.rs
@@ -569,12 +569,17 @@ where
 
             invoker.extend_calls(deploy_calls.values().cloned().collect());
 
-            let tx = invoker.multicall().await?;
+            let txs_results = invoker.multicall().await?;
 
-            // if some external contracts have been deployed, we need to
+            // If some external contracts have been deployed, we need to
             // get the block number of the multicall tx.
+            // Since the multicall may be split into multiple transactions, we take the block number
+            // of the first transaction.
             if !deploy_calls.is_empty() {
-                if let TransactionResult::Hash(tx_hash) = tx {
+                // TODO: @remybar, wondering if here we should
+                // also handle the case when it contains the receipt
+                // already, due to the tx configuration.
+                if let TransactionResult::Hash(tx_hash) = txs_results[0] {
                     let receipt =
                         TransactionWaiter::new(tx_hash, &self.world.account.provider()).await?;
                     let block_number =

--- a/examples/simple/dojo_sepolia.toml
+++ b/examples/simple/dojo_sepolia.toml
@@ -1,13 +1,13 @@
 [world]
 description = "Simple world."
 name = "simple"
-seed = "simple2"
+seed = "simple-a"
 
 [env]
 rpc_url = "https://api.cartridge.gg/x/starknet/sepolia"
 # Default account for katana with seed = 0
 account_address = "0x4ba5ae775eb7da75f092b3b30b03bce15c3476337ef5f9e3cdf18db7a7534bd"
-keystore_path = "/path/keystore"
+keystore_path = "~/.snaccounts/dev-sepolia.key"
 #world_address = "0x077c0dc7c1aba7f8842aff393ce6aa71fa675b4ced1bc927f7fc971b6acd92fc"
 
 [namespace]

--- a/examples/simple/manifest_sepolia.json
+++ b/examples/simple/manifest_sepolia.json
@@ -1,8 +1,8 @@
 {
   "world": {
     "class_hash": "0x1d0991eab5221c28225755937ec958aa073617c9b1d4f5e3c82b9f27cf85ea4",
-    "address": "0x171cc059f78dec4a90b737a225e38b10d31b4fdd950ed372a25f18ddc4167a9",
-    "seed": "simple_glihm1",
+    "address": "0x21a0e84f871395c7e960a71da17522b84c258adbaedda630f33f518c45d256d",
+    "seed": "simple-a",
     "name": "simple",
     "entrypoints": [
       "uuid",
@@ -1489,7 +1489,7 @@
   },
   "contracts": [
     {
-      "address": "0x201518db7836777f4a4e5a751552d489f9b33c656ba2e43cdf8e050bf25f407",
+      "address": "0x6a2afae6e22605b009e2bfd5e2379edb511626a15a9867c799a972057e9d32d",
       "class_hash": "0x4362b8f7dc8151be93879ce44e942c615b0ffdee0bd7f3475f4262c8ab0f006",
       "abi": [
         {
@@ -1747,7 +1747,7 @@
       ]
     },
     {
-      "address": "0x25e14050c3ac27b210f31c5e0d38011a112db932d331030eb58c03e3a142846",
+      "address": "0x4a6683ba670ab00dfcc0d608924b2c80abdd4d55edb7e6303e5046203403060",
       "class_hash": "0x1e4810ddf40157ffd4262ce2f37d7f3d031d4f66672c3fce3434561b924302d",
       "abi": [
         {
@@ -1923,7 +1923,7 @@
       ]
     },
     {
-      "address": "0x13393ba83e8af45aa6093682889ed511d5ac7a6cec2d0f4f60d1b438a7a00f9",
+      "address": "0x2fd1dd54aa3da52d80e0530e576fc8353cc378aed37a2d88ce570d352a30b80",
       "class_hash": "0x4362b8f7dc8151be93879ce44e942c615b0ffdee0bd7f3475f4262c8ab0f006",
       "abi": [
         {


### PR DESCRIPTION
This PR adds a split to multicalls to ensure the user can control the maximum number of calls in a multi call.

Due to reduction of the network resources for a single transaction, when too much models are registered in the same transaction, this latter can fail.

By adding a `max_calls` parameter, the user can adjust the number of calls in a multi call to avoid such issue.

By default, there is no limit if the `max_calls` is not supplied, and Sozo will attempt to send only one transaction per migration step.