### PR TITLE
feat(starknet): bump JSON-RPC spec to v0.9.0-rc.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       # This puts Katana in the path for integration tests.
       - name: Download Katana for integration tests
         run: |
-          curl -L https://github.com/dojoengine/katana/releases/download/v1.6.2/katana_v1.6.2_linux_amd64.tar.gz -o katana.tar.gz;
+          curl -L https://github.com/dojoengine/katana/releases/download/v1.7.0-alpha.0/katana_v1.7.0-alpha.0_linux_amd64.tar.gz -o katana.tar.gz;
           tar -C /usr/local/bin -xzf katana.tar.gz
 
       - run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,8 +12,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "auto_impl",
- "cainome",
- "cainome-cairo-serde",
+ "cainome 0.8.0",
+ "cainome-cairo-serde 0.2.1",
  "chrono",
  "ecdsa",
  "futures",
@@ -33,7 +33,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "serde_with",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-types-core",
  "thiserror 1.0.69",
@@ -1046,18 +1046,44 @@ source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome-cairo-serde",
- "cainome-cairo-serde-derive",
- "cainome-parser",
- "cainome-rs",
- "cainome-rs-macro",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/kariy/cainome?branch=snip12-rpc0.9)",
+ "cainome-parser 0.3.0",
+ "cainome-rs 0.3.1",
+ "cainome-rs-macro 0.3.0",
  "camino",
  "clap",
  "clap_complete",
  "convert_case 0.8.0",
  "serde",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-types-core",
+ "thiserror 2.0.12",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "cainome"
+version = "0.9.0"
+source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cainome-cairo-serde 0.3.0",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
+ "cainome-parser 0.5.0",
+ "cainome-rs 0.4.0",
+ "cainome-rs-macro 0.4.0",
+ "camino",
+ "clap",
+ "clap_complete",
+ "convert_case 0.8.0",
+ "serde",
+ "serde_json",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-types-core",
  "thiserror 2.0.12",
  "tracing",
@@ -1073,8 +1099,31 @@ dependencies = [
  "num-bigint",
  "serde",
  "serde_with",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-cairo-serde"
+version = "0.3.0"
+source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
+dependencies = [
+ "num-bigint",
+ "serde",
+ "serde_with",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-cairo-serde-derive"
+version = "0.1.0"
+source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unzip-n",
 ]
 
 [[package]]
@@ -1096,7 +1145,20 @@ dependencies = [
  "convert_case 0.8.0",
  "quote",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-parser"
+version = "0.5.0"
+source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
+dependencies = [
+ "convert_case 0.8.0",
+ "quote",
+ "serde_json",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 2.0.101",
  "thiserror 2.0.12",
 ]
@@ -1107,14 +1169,32 @@ version = "0.3.1"
 source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde",
- "cainome-parser",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-parser 0.3.0",
  "camino",
  "prettyplease",
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-rs"
+version = "0.4.0"
+source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.3.0",
+ "cainome-parser 0.5.0",
+ "camino",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 2.0.101",
  "thiserror 2.0.12",
 ]
@@ -1125,14 +1205,32 @@ version = "0.3.0"
 source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde",
- "cainome-parser",
- "cainome-rs",
+ "cainome-cairo-serde 0.2.1",
+ "cainome-parser 0.3.0",
+ "cainome-rs 0.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-rs-macro"
+version = "0.4.0"
+source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.3.0",
+ "cainome-parser 0.5.0",
+ "cainome-rs 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 2.0.101",
  "thiserror 2.0.12",
 ]
@@ -2464,7 +2562,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "cainome",
+ "cainome 0.9.0",
  "camino",
  "chrono",
  "convert_case 0.6.0",
@@ -2476,7 +2574,7 @@ dependencies = [
  "scarb-metadata-ext",
  "serde",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -2526,7 +2624,7 @@ name = "dojo-types"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome",
+ "cainome 0.9.0",
  "crypto-bigint",
  "hex",
  "indexmap 2.9.0",
@@ -2535,8 +2633,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "starknet",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum",
  "strum_macros",
  "thiserror 1.0.69",
@@ -2555,7 +2653,7 @@ dependencies = [
  "reqwest 0.12.15",
  "rpassword",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -2567,7 +2665,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome",
+ "cainome 0.9.0",
  "cairo-lang-starknet-classes",
  "dojo-types",
  "futures",
@@ -2579,8 +2677,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.22",
@@ -2593,7 +2691,7 @@ name = "dojo-world-abigen"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome",
+ "cainome 0.9.0",
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "camino",
@@ -2608,8 +2706,8 @@ name = "dojo_macros"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome",
- "cainome-cairo-serde",
+ "cainome 0.9.0",
+ "cainome-cairo-serde 0.3.0",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-macro",
@@ -2621,8 +2719,8 @@ dependencies = [
  "itertools 0.12.1",
  "regex",
  "smol_str",
- "starknet",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4348,7 +4446,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 1.0.69",
  "tracing",
  "url",
@@ -4364,7 +4462,7 @@ dependencies = [
  "jsonrpsee",
  "katana-node-bindings",
  "katana-runner-macro",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "tokio",
 ]
 
@@ -6952,7 +7050,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
- "cainome-cairo-serde",
+ "cainome-cairo-serde 0.2.1",
  "colored 2.2.0",
  "dialoguer",
  "dirs 5.0.1",
@@ -6963,7 +7061,7 @@ dependencies = [
  "reqwest 0.12.15",
  "serde",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -7036,7 +7134,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome",
+ "cainome 0.9.0",
  "cairo-lang-test-runner",
  "camino",
  "clap",
@@ -7062,8 +7160,8 @@ dependencies = [
  "sozo-mcp",
  "sozo-ops",
  "sozo-walnut",
- "starknet",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabled",
  "thiserror 1.0.69",
  "tokio",
@@ -7080,7 +7178,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome",
+ "cainome 0.9.0",
  "cairo-lang-sierra",
  "cairo-lang-test-plugin",
  "cairo-lang-test-runner",
@@ -7108,8 +7206,8 @@ dependencies = [
  "smol_str",
  "sozo-ops",
  "sozo-walnut",
- "starknet",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabled",
  "tempfile",
  "thiserror 1.0.69",
@@ -7129,7 +7227,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "async-trait",
- "cainome",
+ "cainome 0.9.0",
  "colored 2.2.0",
  "colored_json",
  "dojo-test-utils",
@@ -7147,8 +7245,8 @@ dependencies = [
  "serde_with",
  "sozo-walnut",
  "spinoff",
- "starknet",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.22",
@@ -7160,7 +7258,7 @@ name = "sozo-signers"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "starknet",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -7177,7 +7275,7 @@ dependencies = [
  "scarb-ui",
  "serde",
  "serde_json",
- "starknet",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
  "toml 0.8.22",
  "url",
@@ -7443,16 +7541,47 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "starknet"
 version = "0.17.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c9e90938ff10648a2ef87d1fee28fccdcc428f6ded1f9b64657ccfbbfeff64"
+dependencies = [
+ "starknet-accounts 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-contract 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-macros 0.2.5-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-providers 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-signers 0.14.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "starknet"
+version = "0.17.0-rc.2"
 source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
- "starknet-accounts",
- "starknet-contract",
- "starknet-core",
- "starknet-core-derive",
+ "starknet-accounts 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-contract 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core-derive 0.1.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-macros",
- "starknet-providers",
- "starknet-signers",
+ "starknet-macros 0.2.5-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-providers 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-signers 0.14.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+]
+
+[[package]]
+name = "starknet-accounts"
+version = "0.16.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b0a53f50fff55946699637e930eb764bb18ddabd392cbe4fd7271b2b223b40"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-providers 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-signers 0.14.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7462,10 +7591,25 @@ source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf
 dependencies = [
  "async-trait",
  "auto_impl",
- "starknet-core",
+ "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-providers",
- "starknet-signers",
+ "starknet-providers 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-signers 0.14.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starknet-contract"
+version = "0.16.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25948c499faf8de208ff6a64be5a87be8bb58cb30138dc578311ea7071190af8"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "starknet-accounts 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-providers 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.69",
 ]
 
@@ -7477,10 +7621,33 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts",
- "starknet-core",
- "starknet-providers",
+ "starknet-accounts 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-providers 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "starknet-core"
+version = "0.16.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6266bffbcf0ccfde812f9497dc847e2ea269bd4316e5373ec562165ceba014f"
+dependencies = [
+ "base64 0.21.7",
+ "crypto-bigint",
+ "flate2",
+ "foldhash",
+ "hex",
+ "indexmap 2.9.0",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "serde_json_pythonic",
+ "serde_with",
+ "sha3",
+ "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-types-core",
 ]
 
 [[package]]
@@ -7500,9 +7667,20 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-core-derive",
+ "starknet-core-derive 0.1.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-types-core",
+]
+
+[[package]]
+name = "starknet-core-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08520b7d80eda7bf1a223e8db4f9bb5779a12846f15ebf8f8d76667eca7f5ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7572,10 +7750,41 @@ dependencies = [
 [[package]]
 name = "starknet-macros"
 version = "0.2.5-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7b5b575473d4734c3b736735a2099cc14f66be26c6f9895c1a345f436012ed"
+dependencies = [
+ "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "starknet-macros"
+version = "0.2.5-rc.2"
 source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
- "starknet-core",
+ "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "starknet-providers"
+version = "0.16.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfab31dd85ecaef7d9d15e1c3bbefc06c7f0fe6fbe56a8bc2b26c9c1ba7d42f9"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "ethereum-types",
+ "flate2",
+ "getrandom 0.2.16",
+ "log",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -7593,9 +7802,26 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core",
+ "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "starknet-signers"
+version = "0.14.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd907b1e3da29d9215f8a41e980f5965c4bb28eb43ca55902d37ee2ccc032575"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "crypto-bigint",
+ "eth-keystore",
+ "getrandom 0.2.16",
+ "rand 0.8.5",
+ "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7609,7 +7835,7 @@ dependencies = [
  "eth-keystore",
  "getrandom 0.2.16",
  "rand 0.8.5",
- "starknet-core",
+ "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 1.0.69",
 ]
@@ -8548,7 +8774,7 @@ dependencies = [
  "clap",
  "num-traits",
  "sqlx",
- "starknet",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -9335,7 +9561,7 @@ dependencies = [
  "scarb-metadata",
  "scarb-metadata-ext",
  "sozo-ops",
- "starknet",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,8 +12,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "auto_impl",
- "cainome",
- "cainome-cairo-serde",
+ "cainome 0.9.0",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
  "chrono",
  "ecdsa",
  "futures",
@@ -33,8 +33,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "serde_with",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-crypto",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -894,7 +894,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -1046,18 +1046,44 @@ source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da2548
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome-cairo-serde",
- "cainome-cairo-serde-derive",
- "cainome-parser",
- "cainome-rs",
- "cainome-rs-macro",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
+ "cainome-parser 0.5.0",
+ "cainome-rs 0.4.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
+ "cainome-rs-macro 0.4.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
  "camino",
  "clap",
  "clap_complete",
  "convert_case 0.8.0",
  "serde",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-types-core",
+ "thiserror 2.0.12",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "cainome"
+version = "0.9.1"
+source = "git+https://github.com/cartridge-gg/cainome?rev=7d60de1#7d60de1780374b3644677f55cee053596e99f461"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
+ "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
+ "cainome-parser 0.5.1",
+ "cainome-rs 0.4.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
+ "cainome-rs-macro 0.4.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
+ "camino",
+ "clap",
+ "clap_complete",
+ "convert_case 0.8.0",
+ "serde",
+ "serde_json",
+ "starknet",
  "starknet-types-core",
  "thiserror 2.0.12",
  "tracing",
@@ -1073,7 +1099,19 @@ dependencies = [
  "num-bigint",
  "serde",
  "serde_with",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-cairo-serde"
+version = "0.3.0"
+source = "git+https://github.com/cartridge-gg/cainome?rev=7d60de1#7d60de1780374b3644677f55cee053596e99f461"
+dependencies = [
+ "num-bigint",
+ "serde",
+ "serde_with",
+ "starknet",
  "thiserror 2.0.12",
 ]
 
@@ -1089,6 +1127,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cainome-cairo-serde-derive"
+version = "0.1.0"
+source = "git+https://github.com/cartridge-gg/cainome?rev=7d60de1#7d60de1780374b3644677f55cee053596e99f461"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "unzip-n",
+]
+
+[[package]]
 name = "cainome-parser"
 version = "0.5.0"
 source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
@@ -1096,7 +1145,20 @@ dependencies = [
  "convert_case 0.8.0",
  "quote",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-parser"
+version = "0.5.1"
+source = "git+https://github.com/cartridge-gg/cainome?rev=7d60de1#7d60de1780374b3644677f55cee053596e99f461"
+dependencies = [
+ "convert_case 0.8.0",
+ "quote",
+ "serde_json",
+ "starknet",
  "syn 2.0.101",
  "thiserror 2.0.12",
 ]
@@ -1107,14 +1169,32 @@ version = "0.4.0"
 source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde",
- "cainome-parser",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
+ "cainome-parser 0.5.0",
  "camino",
  "prettyplease",
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-rs"
+version = "0.4.0"
+source = "git+https://github.com/cartridge-gg/cainome?rev=7d60de1#7d60de1780374b3644677f55cee053596e99f461"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
+ "cainome-parser 0.5.1",
+ "camino",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet",
  "syn 2.0.101",
  "thiserror 2.0.12",
 ]
@@ -1125,14 +1205,32 @@ version = "0.4.0"
 source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde",
- "cainome-parser",
- "cainome-rs",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
+ "cainome-parser 0.5.0",
+ "cainome-rs 0.4.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "syn 2.0.101",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cainome-rs-macro"
+version = "0.4.0"
+source = "git+https://github.com/cartridge-gg/cainome?rev=7d60de1#7d60de1780374b3644677f55cee053596e99f461"
+dependencies = [
+ "anyhow",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
+ "cainome-parser 0.5.1",
+ "cainome-rs 0.4.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "starknet",
  "syn 2.0.101",
  "thiserror 2.0.12",
 ]
@@ -1757,7 +1855,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto",
  "starknet-types-core",
  "thiserror-no-std",
  "zip",
@@ -1927,7 +2025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1936,7 +2034,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2288,7 +2386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.101",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2464,7 +2562,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "cainome",
+ "cainome 0.9.1",
  "camino",
  "chrono",
  "convert_case 0.6.0",
@@ -2476,7 +2574,7 @@ dependencies = [
  "scarb-metadata-ext",
  "serde",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -2526,7 +2624,7 @@ name = "dojo-types"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome",
+ "cainome 0.9.1",
  "crypto-bigint",
  "hex",
  "indexmap 2.9.0",
@@ -2535,8 +2633,8 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-crypto",
  "strum",
  "strum_macros",
  "thiserror 1.0.69",
@@ -2555,7 +2653,7 @@ dependencies = [
  "reqwest 0.12.15",
  "rpassword",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -2567,7 +2665,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome",
+ "cainome 0.9.1",
  "cairo-lang-starknet-classes",
  "dojo-types",
  "futures",
@@ -2579,8 +2677,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-crypto",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.22",
@@ -2593,7 +2691,7 @@ name = "dojo-world-abigen"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome",
+ "cainome 0.9.1",
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "camino",
@@ -2608,8 +2706,8 @@ name = "dojo_macros"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome",
- "cainome-cairo-serde",
+ "cainome 0.9.1",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/cartridge-gg/cainome?rev=7d60de1)",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-macro",
@@ -2621,8 +2719,8 @@ dependencies = [
  "itertools 0.12.1",
  "regex",
  "smol_str",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-crypto",
 ]
 
 [[package]]
@@ -3599,7 +3697,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4343,12 +4441,12 @@ dependencies = [
 [[package]]
 name = "katana-node-bindings"
 version = "1.6.3"
-source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d0f470bb0e31eb07cf887059839fba0b23c7a392"
+source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d81afa39a522cdfdc3999c1be5cdb8bd8460893c"
 dependencies = [
  "regex",
  "serde",
  "serde_json",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet",
  "thiserror 1.0.69",
  "tracing",
  "url",
@@ -4357,21 +4455,21 @@ dependencies = [
 [[package]]
 name = "katana-runner"
 version = "1.6.3"
-source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d0f470bb0e31eb07cf887059839fba0b23c7a392"
+source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d81afa39a522cdfdc3999c1be5cdb8bd8460893c"
 dependencies = [
  "anyhow",
  "assert_fs",
  "jsonrpsee",
  "katana-node-bindings",
  "katana-runner-macro",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet",
  "tokio",
 ]
 
 [[package]]
 name = "katana-runner-macro"
 version = "1.6.3"
-source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d0f470bb0e31eb07cf887059839fba0b23c7a392"
+source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d81afa39a522cdfdc3999c1be5cdb8bd8460893c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4508,7 +4606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -6952,7 +7050,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
- "cainome-cairo-serde",
+ "cainome-cairo-serde 0.3.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
  "colored 2.2.0",
  "dialoguer",
  "dirs 5.0.1",
@@ -6963,7 +7061,7 @@ dependencies = [
  "reqwest 0.12.15",
  "serde",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -7036,7 +7134,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome",
+ "cainome 0.9.1",
  "cairo-lang-test-runner",
  "camino",
  "clap",
@@ -7062,8 +7160,8 @@ dependencies = [
  "sozo-mcp",
  "sozo-ops",
  "sozo-walnut",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-crypto",
  "tabled",
  "thiserror 1.0.69",
  "tokio",
@@ -7080,7 +7178,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome",
+ "cainome 0.9.1",
  "cairo-lang-sierra",
  "cairo-lang-test-plugin",
  "cairo-lang-test-runner",
@@ -7108,8 +7206,8 @@ dependencies = [
  "smol_str",
  "sozo-ops",
  "sozo-walnut",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-crypto",
  "tabled",
  "tempfile",
  "thiserror 1.0.69",
@@ -7129,7 +7227,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "async-trait",
- "cainome",
+ "cainome 0.9.1",
  "colored 2.2.0",
  "colored_json",
  "dojo-test-utils",
@@ -7147,8 +7245,8 @@ dependencies = [
  "serde_with",
  "sozo-walnut",
  "spinoff",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
+ "starknet-crypto",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.22",
@@ -7160,7 +7258,7 @@ name = "sozo-signers"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
 ]
 
 [[package]]
@@ -7177,7 +7275,7 @@ dependencies = [
  "scarb-ui",
  "serde",
  "serde_json",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "thiserror 1.0.69",
  "toml 0.8.22",
  "url",
@@ -7446,29 +7544,14 @@ version = "0.17.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c9e90938ff10648a2ef87d1fee28fccdcc428f6ded1f9b64657ccfbbfeff64"
 dependencies = [
- "starknet-accounts 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-contract 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-macros 0.2.5-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-providers 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-signers 0.14.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "starknet"
-version = "0.17.0-rc.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "starknet-accounts 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-contract 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-core-derive 0.1.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-macros 0.2.5-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-providers 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-signers 0.14.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-accounts",
+ "starknet-contract",
+ "starknet-core",
+ "starknet-core-derive",
+ "starknet-crypto",
+ "starknet-macros",
+ "starknet-providers",
+ "starknet-signers",
 ]
 
 [[package]]
@@ -7479,24 +7562,10 @@ checksum = "27b0a53f50fff55946699637e930eb764bb18ddabd392cbe4fd7271b2b223b40"
 dependencies = [
  "async-trait",
  "auto_impl",
- "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-providers 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-signers 0.14.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-accounts"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "async-trait",
- "auto_impl",
- "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-providers 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-signers 0.14.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core",
+ "starknet-crypto",
+ "starknet-providers",
+ "starknet-signers",
  "thiserror 1.0.69",
 ]
 
@@ -7509,23 +7578,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-accounts 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-providers 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-contract"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "serde",
- "serde_json",
- "serde_with",
- "starknet-accounts 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-providers 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-accounts",
+ "starknet-core",
+ "starknet-providers",
  "thiserror 1.0.69",
 ]
 
@@ -7547,30 +7602,8 @@ dependencies = [
  "serde_json_pythonic",
  "serde_with",
  "sha3",
- "starknet-core-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
-]
-
-[[package]]
-name = "starknet-core"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "base64 0.21.7",
- "crypto-bigint",
- "flate2",
- "foldhash",
- "hex",
- "indexmap 2.9.0",
- "num-traits",
- "serde",
- "serde_json",
- "serde_json_pythonic",
- "serde_with",
- "sha3",
- "starknet-core-derive 0.1.0 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core-derive",
+ "starknet-crypto",
  "starknet-types-core",
 ]
 
@@ -7579,16 +7612,6 @@ name = "starknet-core-derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b08520b7d80eda7bf1a223e8db4f9bb5779a12846f15ebf8f8d76667eca7f5ad"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "starknet-core-derive"
-version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7609,25 +7632,7 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-curve 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-types-core",
- "zeroize",
-]
-
-[[package]]
-name = "starknet-crypto"
-version = "0.7.4"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "crypto-bigint",
- "hex",
- "hmac",
- "num-bigint",
- "num-integer",
- "num-traits",
- "rfc6979",
- "sha2",
- "starknet-curve 0.5.1 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-curve",
  "starknet-types-core",
  "zeroize",
 ]
@@ -7642,29 +7647,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "starknet-curve"
-version = "0.5.1"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "starknet-types-core",
-]
-
-[[package]]
 name = "starknet-macros"
 version = "0.2.5-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7b5b575473d4734c3b736735a2099cc14f66be26c6f9895c1a345f436012ed"
 dependencies = [
- "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "starknet-macros"
-version = "0.2.5-rc.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core",
  "syn 2.0.101",
 ]
 
@@ -7684,27 +7672,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "starknet-providers"
-version = "0.16.0-rc.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethereum-types",
- "flate2",
- "getrandom 0.2.16",
- "log",
- "reqwest 0.12.15",
- "serde",
- "serde_json",
- "serde_with",
- "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core",
  "thiserror 1.0.69",
  "url",
 ]
@@ -7721,24 +7689,8 @@ dependencies = [
  "eth-keystore",
  "getrandom 0.2.16",
  "rand 0.8.5",
- "starknet-core 0.16.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "starknet-signers"
-version = "0.14.0-rc.2"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
-dependencies = [
- "async-trait",
- "auto_impl",
- "crypto-bigint",
- "eth-keystore",
- "getrandom 0.2.16",
- "rand 0.8.5",
- "starknet-core 0.16.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet-core",
+ "starknet-crypto",
  "thiserror 1.0.69",
 ]
 
@@ -8676,7 +8628,7 @@ dependencies = [
  "clap",
  "num-traits",
  "sqlx",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -9005,7 +8957,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9463,7 +9415,7 @@ dependencies = [
  "scarb-metadata",
  "scarb-metadata-ext",
  "sozo-ops",
- "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,15 +5,15 @@ version = 4
 [[package]]
 name = "account_sdk"
 version = "0.1.0"
-source = "git+https://github.com/kariy/controller-rs?branch=feat%2Frpc0.9#9316aa1071b46df06adbef07c5083f2f354977a0"
+source = "git+https://github.com/kariy/controller-rs?branch=feat%2Frpc0.9#31e1904d3ea125a985004ccabde688b24af70a08"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "anyhow",
  "async-trait",
  "auto_impl",
- "cainome 0.8.0",
- "cainome-cairo-serde 0.2.1",
+ "cainome",
+ "cainome-cairo-serde",
  "chrono",
  "ecdsa",
  "futures",
@@ -33,8 +33,8 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "serde_with",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -1041,42 +1041,16 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cainome"
-version = "0.8.0"
-source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
-dependencies = [
- "anyhow",
- "async-trait",
- "cainome-cairo-serde 0.2.1",
- "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/kariy/cainome?branch=snip12-rpc0.9)",
- "cainome-parser 0.3.0",
- "cainome-rs 0.3.1",
- "cainome-rs-macro 0.3.0",
- "camino",
- "clap",
- "clap_complete",
- "convert_case 0.8.0",
- "serde",
- "serde_json",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "starknet-types-core",
- "thiserror 2.0.12",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "cainome"
 version = "0.9.0"
 source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome-cairo-serde 0.3.0",
- "cainome-cairo-serde-derive 0.1.0 (git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9)",
- "cainome-parser 0.5.0",
- "cainome-rs 0.4.0",
- "cainome-rs-macro 0.4.0",
+ "cainome-cairo-serde",
+ "cainome-cairo-serde-derive",
+ "cainome-parser",
+ "cainome-rs",
+ "cainome-rs-macro",
  "camino",
  "clap",
  "clap_complete",
@@ -1093,18 +1067,6 @@ dependencies = [
 
 [[package]]
 name = "cainome-cairo-serde"
-version = "0.2.1"
-source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
-dependencies = [
- "num-bigint",
- "serde",
- "serde_with",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cainome-cairo-serde"
 version = "0.3.0"
 source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
 dependencies = [
@@ -1124,30 +1086,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
  "unzip-n",
-]
-
-[[package]]
-name = "cainome-cairo-serde-derive"
-version = "0.1.0"
-source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
- "unzip-n",
-]
-
-[[package]]
-name = "cainome-parser"
-version = "0.3.0"
-source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
-dependencies = [
- "convert_case 0.8.0",
- "quote",
- "serde_json",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "syn 2.0.101",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1165,30 +1103,12 @@ dependencies = [
 
 [[package]]
 name = "cainome-rs"
-version = "0.3.1"
-source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
-dependencies = [
- "anyhow",
- "cainome-cairo-serde 0.2.1",
- "cainome-parser 0.3.0",
- "camino",
- "prettyplease",
- "proc-macro2",
- "quote",
- "serde_json",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "syn 2.0.101",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cainome-rs"
 version = "0.4.0"
 source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.3.0",
- "cainome-parser 0.5.0",
+ "cainome-cairo-serde",
+ "cainome-parser",
  "camino",
  "prettyplease",
  "proc-macro2",
@@ -1201,31 +1121,13 @@ dependencies = [
 
 [[package]]
 name = "cainome-rs-macro"
-version = "0.3.0"
-source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
-dependencies = [
- "anyhow",
- "cainome-cairo-serde 0.2.1",
- "cainome-parser 0.3.0",
- "cainome-rs 0.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "serde_json",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
- "syn 2.0.101",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cainome-rs-macro"
 version = "0.4.0"
 source = "git+https://github.com/kariy/cainome?branch=feat%2Frpc0.9#ed2a72da254852ba421a920da22724da434019d3"
 dependencies = [
  "anyhow",
- "cainome-cairo-serde 0.3.0",
- "cainome-parser 0.5.0",
- "cainome-rs 0.4.0",
+ "cainome-cairo-serde",
+ "cainome-parser",
+ "cainome-rs",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -2562,7 +2464,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
- "cainome 0.9.0",
+ "cainome",
  "camino",
  "chrono",
  "convert_case 0.6.0",
@@ -2624,7 +2526,7 @@ name = "dojo-types"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome 0.9.0",
+ "cainome",
  "crypto-bigint",
  "hex",
  "indexmap 2.9.0",
@@ -2665,7 +2567,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome 0.9.0",
+ "cainome",
  "cairo-lang-starknet-classes",
  "dojo-types",
  "futures",
@@ -2691,7 +2593,7 @@ name = "dojo-world-abigen"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome 0.9.0",
+ "cainome",
  "cairo-lang-starknet",
  "cairo-lang-starknet-classes",
  "camino",
@@ -2706,8 +2608,8 @@ name = "dojo_macros"
 version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
- "cainome 0.9.0",
- "cainome-cairo-serde 0.3.0",
+ "cainome",
+ "cainome-cairo-serde",
  "cairo-lang-defs",
  "cairo-lang-diagnostics",
  "cairo-lang-macro",
@@ -3697,7 +3599,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -7044,13 +6946,13 @@ dependencies = [
 [[package]]
 name = "slot"
 version = "0.48.0"
-source = "git+https://github.com/cartridge-gg/slot?branch=feat%2Frpc0.9#670690561515e30d831e682de74eb27fb939873e"
+source = "git+https://github.com/cartridge-gg/slot?branch=feat%2Frpc0.9#44d4c224edaf15d21a9d131c54f76894828e3ed6"
 dependencies = [
  "account_sdk",
  "anyhow",
  "axum",
  "base64 0.22.1",
- "cainome-cairo-serde 0.2.1",
+ "cainome-cairo-serde",
  "colored 2.2.0",
  "dialoguer",
  "dirs 5.0.1",
@@ -7061,7 +6963,7 @@ dependencies = [
  "reqwest 0.12.15",
  "serde",
  "serde_json",
- "starknet 0.17.0-rc.2 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
+ "starknet 0.17.0-rc.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -7134,7 +7036,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome 0.9.0",
+ "cainome",
  "cairo-lang-test-runner",
  "camino",
  "clap",
@@ -7178,7 +7080,7 @@ version = "1.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-trait",
- "cainome 0.9.0",
+ "cainome",
  "cairo-lang-sierra",
  "cairo-lang-test-plugin",
  "cairo-lang-test-runner",
@@ -7227,7 +7129,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "async-trait",
- "cainome 0.9.0",
+ "cainome",
  "colored 2.2.0",
  "colored_json",
  "dojo-test-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 4
 [[package]]
 name = "account_sdk"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/controller-rs?rev=660ead4#660ead4db4cd9ce6ebcdaed3ab9edb0466911676"
+source = "git+https://github.com/kariy/controller-rs?branch=feat%2Frpc0.9#9316aa1071b46df06adbef07c5083f2f354977a0"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -23,6 +23,7 @@ dependencies = [
  "js-sys",
  "k256",
  "lazy_static",
+ "nom",
  "num-traits",
  "once_cell",
  "primitive-types",
@@ -33,7 +34,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-types-core",
  "thiserror 1.0.69",
  "tokio",
@@ -1041,7 +1042,7 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 [[package]]
 name = "cainome"
 version = "0.8.0"
-source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1067,7 +1068,7 @@ dependencies = [
 [[package]]
 name = "cainome-cairo-serde"
 version = "0.2.1"
-source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "num-bigint",
  "serde",
@@ -1079,7 +1080,7 @@ dependencies = [
 [[package]]
 name = "cainome-cairo-serde-derive"
 version = "0.1.0"
-source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1090,7 +1091,7 @@ dependencies = [
 [[package]]
 name = "cainome-parser"
 version = "0.3.0"
-source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "convert_case 0.8.0",
  "quote",
@@ -1103,7 +1104,7 @@ dependencies = [
 [[package]]
 name = "cainome-rs"
 version = "0.3.1"
-source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "anyhow",
  "cainome-cairo-serde",
@@ -1121,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "cainome-rs-macro"
 version = "0.3.0"
-source = "git+https://github.com/cartridge-gg/cainome?branch=snip12#ef4344c14e2a67d480774fa827a1cc411240de80"
+source = "git+https://github.com/kariy/cainome?branch=snip12-rpc0.9#26ff63fdfd57c094ef1074d22936871440481283"
 dependencies = [
  "anyhow",
  "cainome-cairo-serde",
@@ -2062,6 +2063,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387461abbc748185c3a6e1673d826918b450b87ff22639429c694619a83b6cf6"
+dependencies = [
+ "cookie",
+ "idna 0.3.0",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,7 +2536,7 @@ dependencies = [
  "serde",
  "serde_json",
  "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "strum",
  "strum_macros",
  "thiserror 1.0.69",
@@ -2551,7 +2580,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.22",
@@ -2593,7 +2622,7 @@ dependencies = [
  "regex",
  "smol_str",
  "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
 ]
 
 [[package]]
@@ -3804,6 +3833,16 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
@@ -4303,8 +4342,8 @@ dependencies = [
 
 [[package]]
 name = "katana-node-bindings"
-version = "1.6.0-alpha.1"
-source = "git+https://github.com/dojoengine/katana?rev=4e9be9dbf92aa9f8e9ce5b49ffb39ea98d7c6571#4e9be9dbf92aa9f8e9ce5b49ffb39ea98d7c6571"
+version = "1.6.3"
+source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d0f470bb0e31eb07cf887059839fba0b23c7a392"
 dependencies = [
  "regex",
  "serde",
@@ -4317,8 +4356,8 @@ dependencies = [
 
 [[package]]
 name = "katana-runner"
-version = "1.6.0-alpha.1"
-source = "git+https://github.com/dojoengine/katana?rev=4e9be9dbf92aa9f8e9ce5b49ffb39ea98d7c6571#4e9be9dbf92aa9f8e9ce5b49ffb39ea98d7c6571"
+version = "1.6.3"
+source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d0f470bb0e31eb07cf887059839fba0b23c7a392"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -4331,8 +4370,8 @@ dependencies = [
 
 [[package]]
 name = "katana-runner-macro"
-version = "1.6.0-alpha.1"
-source = "git+https://github.com/dojoengine/katana?rev=4e9be9dbf92aa9f8e9ce5b49ffb39ea98d7c6571#4e9be9dbf92aa9f8e9ce5b49ffb39ea98d7c6571"
+version = "1.6.3"
+source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d0f470bb0e31eb07cf887059839fba0b23c7a392"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5580,6 +5619,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna 1.0.3",
+ "psl-types",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5873,6 +5928,8 @@ checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -6888,8 +6945,8 @@ dependencies = [
 
 [[package]]
 name = "slot"
-version = "0.47.0"
-source = "git+https://github.com/cartridge-gg/slot?rev=a2f8508ebe13a39127252ab7f6aafa0b26c1b375#a2f8508ebe13a39127252ab7f6aafa0b26c1b375"
+version = "0.48.0"
+source = "git+https://github.com/cartridge-gg/slot?branch=feat%2Frpc0.9#670690561515e30d831e682de74eb27fb939873e"
 dependencies = [
  "account_sdk",
  "anyhow",
@@ -7006,7 +7063,7 @@ dependencies = [
  "sozo-ops",
  "sozo-walnut",
  "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "tabled",
  "thiserror 1.0.69",
  "tokio",
@@ -7052,7 +7109,7 @@ dependencies = [
  "sozo-ops",
  "sozo-walnut",
  "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "tabled",
  "tempfile",
  "thiserror 1.0.69",
@@ -7091,7 +7148,7 @@ dependencies = [
  "sozo-walnut",
  "spinoff",
  "starknet",
- "starknet-crypto 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.22",
@@ -7385,14 +7442,14 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet"
-version = "0.15.1"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+version = "0.17.0-rc.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "starknet-accounts",
  "starknet-contract",
  "starknet-core",
  "starknet-core-derive",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-macros",
  "starknet-providers",
  "starknet-signers",
@@ -7400,13 +7457,13 @@ dependencies = [
 
 [[package]]
 name = "starknet-accounts"
-version = "0.14.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+version = "0.16.0-rc.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "async-trait",
  "auto_impl",
  "starknet-core",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-providers",
  "starknet-signers",
  "thiserror 1.0.69",
@@ -7414,8 +7471,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-contract"
-version = "0.14.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+version = "0.16.0-rc.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "serde",
  "serde_json",
@@ -7428,8 +7485,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-core"
-version = "0.14.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+version = "0.16.0-rc.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "base64 0.21.7",
  "crypto-bigint",
@@ -7444,14 +7501,14 @@ dependencies = [
  "serde_with",
  "sha3",
  "starknet-core-derive",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-core-derive"
 version = "0.1.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7480,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "starknet-crypto"
 version = "0.7.4"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "crypto-bigint",
  "hex",
@@ -7490,7 +7547,7 @@ dependencies = [
  "num-traits",
  "rfc6979",
  "sha2",
- "starknet-curve 0.5.1 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-curve 0.5.1 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "starknet-types-core",
  "zeroize",
 ]
@@ -7507,15 +7564,15 @@ dependencies = [
 [[package]]
 name = "starknet-curve"
 version = "0.5.1"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "starknet-types-core",
 ]
 
 [[package]]
 name = "starknet-macros"
-version = "0.2.3"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+version = "0.2.5-rc.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "starknet-core",
  "syn 2.0.101",
@@ -7523,8 +7580,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-providers"
-version = "0.14.1"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+version = "0.16.0-rc.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7543,8 +7600,8 @@ dependencies = [
 
 [[package]]
 name = "starknet-signers"
-version = "0.12.0"
-source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e#ff4222e7d1a6e3127d864539938680030df77c75"
+version = "0.14.0-rc.2"
+source = "git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634#993a708551f87bcfbf7fdf33f796b01f7521a634"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -7553,7 +7610,7 @@ dependencies = [
  "getrandom 0.2.16",
  "rand 0.8.5",
  "starknet-core",
- "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=ff4222e)",
+ "starknet-crypto 0.7.4 (git+https://github.com/xJonathanLEI/starknet-rs?rev=993a708551f87bcfbf7fdf33f796b01f7521a634)",
  "thiserror 1.0.69",
 ]
 
@@ -8427,7 +8484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 1.0.3",
  "percent-encoding",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ debug = true
 inherits = "release"
 
 [workspace.dependencies]
-cainome = { git = "https://github.com/kariy/cainome", branch = "snip12-rpc0.9", features = [ "abigen-rs" ] }
-cainome-cairo-serde = { git = "https://github.com/kariy/cainome", branch = "snip12-rpc0.9" }
+cainome = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9" }
 
 dojo-utils = { path = "crates/dojo/utils" }
 
@@ -241,8 +241,8 @@ alloy-transport = { version = "0.4", default-features = false }
 # starknet = "0.15.1"
 #starknet-crypto = { version = "0.7.3" }
 
-starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "993a708551f87bcfbf7fdf33f796b01f7521a634" }
-starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "993a708551f87bcfbf7fdf33f796b01f7521a634" }
+starknet = "0.17.0-rc.2"
+starknet-crypto = "0.7.4"
 starknet-types-core = { version = "0.1.7", features = [ "arbitrary", "hash" ] }
 
 bitvec = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ debug = true
 inherits = "release"
 
 [workspace.dependencies]
-cainome = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9", features = [ "abigen-rs" ] }
-cainome-cairo-serde = { git = "https://github.com/kariy/cainome", branch = "feat/rpc0.9" }
+cainome = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", rev = "7d60de1" }
 
 dojo-utils = { path = "crates/dojo/utils" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,13 +253,6 @@ quote = "1.0"
 syn = { version = "2.0", default-features = false }
 
 [patch.crates-io]
-# starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-# starknet-providers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-# starknet-accounts = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-# starknet-contract = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-# starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-# starknet-signers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-# starknet-macros = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
 cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo", rev = "64b88f06c6261ac67c6b478434c844d4af81e5a3" }
 cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", rev = "64b88f06c6261ac67c6b478434c844d4af81e5a3" }
 cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo", rev = "64b88f06c6261ac67c6b478434c844d4af81e5a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 resolver = "2"
 
 members = [
-	"bin/sozo",
 	"bin/cairo-bench",
+	"bin/sozo",
 	"crates/dojo/bindgen",
 	"crates/dojo/core",
 	"crates/dojo/macros",
@@ -15,11 +15,11 @@ members = [
 	"crates/macros/merge-options",
 	"crates/macros/merge-options/macro_test",
 	"crates/metrics",
+	"crates/sozo/mcp",
 	"crates/sozo/scarb_interop",
 	"crates/sozo/scarb_metadata_ext",
 	"crates/sozo/signers",
 	"crates/sozo/walnut",
-	"crates/sozo/mcp",
 	"examples/spawn-and-move",
 	"scripts/verify_db_balances",
 	"xtask/generate-test-db",
@@ -43,10 +43,8 @@ debug = true
 inherits = "release"
 
 [workspace.dependencies]
-cainome = { git = "https://github.com/cartridge-gg/cainome", branch = "snip12", features = [
-    "abigen-rs",
-] }
-cainome-cairo-serde = { git = "https://github.com/cartridge-gg/cainome", branch = "snip12" }
+cainome = { git = "https://github.com/kariy/cainome", branch = "snip12-rpc0.9", features = [ "abigen-rs" ] }
+cainome-cairo-serde = { git = "https://github.com/kariy/cainome", branch = "snip12-rpc0.9" }
 
 dojo-utils = { path = "crates/dojo/utils" }
 
@@ -77,18 +75,18 @@ torii-sqlite-types = { path = "crates/torii/sqlite/types" }
 torii-typed-data = { path = "crates/torii/typed-data" }
 
 # sozo
-sozo-ops = { path = "crates/sozo/ops" }
 scarb-interop = { path = "crates/sozo/scarb_interop" }
 scarb-metadata-ext = { path = "crates/sozo/scarb_metadata_ext" }
+sozo-mcp = { path = "crates/sozo/mcp" }
+sozo-ops = { path = "crates/sozo/ops" }
 sozo-signers = { path = "crates/sozo/signers" }
 sozo-walnut = { path = "crates/sozo/walnut" }
-sozo-mcp = { path = "crates/sozo/mcp" }
 
 # macros
 merge-options = { path = "crates/macros/merge-options" }
 
-# On the branch to support starknet 0.15.1
-katana-runner = { git = "https://github.com/dojoengine/katana", rev = "4e9be9dbf92aa9f8e9ce5b49ffb39ea98d7c6571" }
+# On the branch to support rpc 0.9 (incl starknet bump)
+katana-runner = { git = "https://github.com/dojoengine/katana", branch = "rpc/v0.9" }
 
 anyhow = "1.0.89"
 arbitrary = { version = "1.3.2", features = [ "derive" ] }
@@ -103,7 +101,6 @@ bytes = "1.6"
 # refer to Scarb git while `cairo-lang-macro` 0.2.0 (new api) is deployed on crates.io
 cairo-lang-macro = { version = "0.2.0", git = "https://github.com/software-mansion/scarb.git" }
 
-cairo-lang-primitive-token = "1"
 cairo-lang-compiler = "*"
 cairo-lang-debug = "*"
 cairo-lang-defs = "*"
@@ -113,6 +110,7 @@ cairo-lang-formatter = "*"
 cairo-lang-lowering = "*"
 cairo-lang-parser = "*"
 cairo-lang-plugins = { version = "*", features = [ "testing" ] }
+cairo-lang-primitive-token = "1"
 cairo-lang-project = "*"
 cairo-lang-semantic = "*"
 cairo-lang-sierra = "*"
@@ -171,8 +169,8 @@ rstest_reuse = "0.6.0"
 salsa = "0.16.1"
 
 # version 2.11.4+nightly-2025-05-08
-scarb-metadata = { git = "https://github.com/software-mansion/scarb", rev="4fdeb7810" }
-scarb-ui = { git = "https://github.com/software-mansion/scarb", rev="4fdeb7810" }
+scarb-metadata = { git = "https://github.com/software-mansion/scarb", rev = "4fdeb7810" }
+scarb-ui = { git = "https://github.com/software-mansion/scarb", rev = "4fdeb7810" }
 
 semver = "1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }
@@ -225,7 +223,7 @@ pprof = { version = "0.13.0", features = [ "criterion", "flamegraph" ] }
 
 # Slot integration. Dojo don't need to manually include `account_sdk` as dependency as `slot` already re-exports it.
 # This rev uses deps from `starknet-rs` 0.15.1 bump.
-slot = { git = "https://github.com/cartridge-gg/slot", rev = "a2f8508ebe13a39127252ab7f6aafa0b26c1b375" }
+slot = { git = "https://github.com/cartridge-gg/slot", branch = "feat/rpc0.9" }
 
 # alloy core
 alloy-primitives = { version = "0.8", default-features = false }
@@ -240,10 +238,11 @@ alloy-rpc-types-eth = { version = "0.4", default-features = false }
 alloy-signer = { version = "0.4", default-features = false }
 alloy-transport = { version = "0.4", default-features = false }
 
-starknet = "0.15.1"
-starknet-crypto = "0.7.3"
-#starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = #"ff4222e" }
+# starknet = "0.15.1"
 #starknet-crypto = { version = "0.7.3" }
+
+starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "993a708551f87bcfbf7fdf33f796b01f7521a634" }
+starknet-crypto = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "993a708551f87bcfbf7fdf33f796b01f7521a634" }
 starknet-types-core = { version = "0.1.7", features = [ "arbitrary", "hash" ] }
 
 bitvec = "1.0.1"
@@ -254,13 +253,13 @@ quote = "1.0"
 syn = { version = "2.0", default-features = false }
 
 [patch.crates-io]
-starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-starknet-providers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-starknet-accounts = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-starknet-contract = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-starknet-signers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
-starknet-macros = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
+# starknet = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
+# starknet-providers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
+# starknet-accounts = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
+# starknet-contract = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
+# starknet-core = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
+# starknet-signers = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
+# starknet-macros = { git = "https://github.com/xJonathanLEI/starknet-rs", rev = "ff4222e" }
 cairo-lang-casm = { git = "https://github.com/starkware-libs/cairo", rev = "64b88f06c6261ac67c6b478434c844d4af81e5a3" }
 cairo-lang-compiler = { git = "https://github.com/starkware-libs/cairo", rev = "64b88f06c6261ac67c6b478434c844d4af81e5a3" }
 cairo-lang-debug = { git = "https://github.com/starkware-libs/cairo", rev = "64b88f06c6261ac67c6b478434c844d4af81e5a3" }

--- a/bin/sozo/src/commands/call.rs
+++ b/bin/sozo/src/commands/call.rs
@@ -108,7 +108,7 @@ impl CallArgs {
         let block_id = if let Some(block_id) = self.block_id {
             dojo_utils::parse_block_id(block_id)?
         } else {
-            BlockId::Tag(BlockTag::Pending)
+            BlockId::Tag(BlockTag::PreConfirmed)
         };
 
         let (provider, _) = self.starknet.provider(profile_config.env.as_ref())?;

--- a/bin/sozo/src/commands/events.rs
+++ b/bin/sozo/src/commands/events.rs
@@ -176,7 +176,7 @@ async fn match_event<P: Provider + Send + Sync>(
     let block_id = if let Some(block_number) = block_number {
         BlockId::Number(block_number)
     } else {
-        BlockId::Tag(BlockTag::Pending)
+        BlockId::Tag(BlockTag::PreConfirmed)
     };
 
     let (name, content) = match event {

--- a/bin/sozo/src/commands/model.rs
+++ b/bin/sozo/src/commands/model.rs
@@ -164,7 +164,7 @@ impl ModelArgs {
             ModelCommand::Layout { tag_or_name, starknet, world, block } => {
                 let tag = tag_or_name.ensure_namespace(&default_ns);
                 let block_id =
-                    block.map(BlockId::Number).unwrap_or(BlockId::Tag(BlockTag::Pending));
+                    block.map(BlockId::Number).unwrap_or(BlockId::Tag(BlockTag::PreConfirmed));
 
                 let (world_diff, provider, _) =
                     utils::get_world_diff_and_provider(starknet, world, scarb_metadata).await?;
@@ -181,7 +181,7 @@ impl ModelArgs {
             ModelCommand::Schema { tag_or_name, to_json, starknet, world, block } => {
                 let tag = tag_or_name.ensure_namespace(&default_ns);
                 let block_id =
-                    block.map(BlockId::Number).unwrap_or(BlockId::Tag(BlockTag::Pending));
+                    block.map(BlockId::Number).unwrap_or(BlockId::Tag(BlockTag::PreConfirmed));
 
                 let (world_diff, provider, _) =
                     utils::get_world_diff_and_provider(starknet, world, scarb_metadata).await?;
@@ -199,7 +199,7 @@ impl ModelArgs {
             ModelCommand::Get { tag_or_name, keys, block, starknet, world } => {
                 let tag = tag_or_name.ensure_namespace(&default_ns);
                 let block_id =
-                    block.map(BlockId::Number).unwrap_or(BlockId::Tag(BlockTag::Pending));
+                    block.map(BlockId::Number).unwrap_or(BlockId::Tag(BlockTag::PreConfirmed));
 
                 let (world_diff, provider, _) =
                     utils::get_world_diff_and_provider(starknet, world, scarb_metadata).await?;

--- a/bin/sozo/src/commands/options/account/mod.rs
+++ b/bin/sozo/src/commands/options/account/mod.rs
@@ -132,7 +132,7 @@ impl AccountOptions {
 
         // The default is `Latest` in starknet-rs, which does not reflect
         // the nonce changes in the pending block.
-        account.set_block_id(BlockId::Tag(BlockTag::Pending));
+        account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
         Ok(account)
     }
 

--- a/bin/sozo/src/commands/options/account/provider.rs
+++ b/bin/sozo/src/commands/options/account/provider.rs
@@ -6,8 +6,9 @@ use starknet::core::types::{
     BroadcastedDeployAccountTransaction, BroadcastedInvokeTransaction, BroadcastedTransaction,
     ConfirmedBlockId, ContractClass, ContractStorageKeys, DeclareTransactionResult,
     DeployAccountTransactionResult, EventFilter, EventsPage, FeeEstimate, Felt, FunctionCall,
-    Hash256, InvokeTransactionResult, MaybePendingBlockWithReceipts, MaybePendingBlockWithTxHashes,
-    MaybePendingBlockWithTxs, MaybePendingStateUpdate, MessageWithStatus, MsgFromL1,
+    Hash256, InvokeTransactionResult, MaybePreConfirmedBlockWithReceipts,
+    MaybePreConfirmedBlockWithTxHashes, MaybePreConfirmedBlockWithTxs,
+    MaybePreConfirmedStateUpdate, MessageFeeEstimate, MessageStatus, MsgFromL1,
     SimulatedTransaction, SimulationFlag, SimulationFlagForEstimateFee, StorageProof,
     SyncStatusType, Transaction, TransactionReceiptWithBlockInfo, TransactionStatus,
     TransactionTrace, TransactionTraceWithHash,
@@ -37,7 +38,7 @@ where
     async fn get_block_with_tx_hashes<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxHashes, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxHashes, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -50,7 +51,7 @@ where
     async fn get_block_with_txs<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithTxs, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithTxs, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -63,7 +64,7 @@ where
     async fn get_block_with_receipts<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingBlockWithReceipts, ProviderError>
+    ) -> Result<MaybePreConfirmedBlockWithReceipts, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -76,7 +77,7 @@ where
     async fn get_state_update<B>(
         &self,
         block_id: B,
-    ) -> Result<MaybePendingStateUpdate, ProviderError>
+    ) -> Result<MaybePreConfirmedStateUpdate, ProviderError>
     where
         B: AsRef<BlockId> + Send + Sync,
     {
@@ -106,7 +107,7 @@ where
     async fn get_messages_status(
         &self,
         transaction_hash: Hash256,
-    ) -> Result<Vec<MessageWithStatus>, ProviderError> {
+    ) -> Result<Vec<MessageStatus>, ProviderError> {
         match self {
             Self::Left(p) => p.get_messages_status(transaction_hash).await,
             Self::Right(q) => q.get_messages_status(transaction_hash).await,
@@ -253,7 +254,7 @@ where
         &self,
         message: M,
         block_id: B,
-    ) -> Result<FeeEstimate, ProviderError>
+    ) -> Result<MessageFeeEstimate, ProviderError>
     where
         M: AsRef<MsgFromL1> + Send + Sync,
         B: AsRef<BlockId> + Send + Sync,
@@ -428,7 +429,7 @@ where
         block_id: B,
     ) -> Result<Vec<TransactionTraceWithHash>, ProviderError>
     where
-        B: AsRef<BlockId> + Send + Sync,
+        B: AsRef<ConfirmedBlockId> + Send + Sync,
     {
         match self {
             Self::Left(p) => p.trace_block_transactions(block_id).await,

--- a/crates/dojo/utils/src/tx/declarer.rs
+++ b/crates/dojo/utils/src/tx/declarer.rs
@@ -135,7 +135,7 @@ pub async fn is_declared<P>(
 where
     P: Provider,
 {
-    match provider.get_class(BlockId::Tag(BlockTag::Pending), class_hash).await {
+    match provider.get_class(BlockId::Tag(BlockTag::PreConfirmed), class_hash).await {
         Err(ProviderError::StarknetError(StarknetError::ClassHashNotFound)) => Ok(false),
         Ok(_) => {
             trace!(

--- a/crates/dojo/utils/src/tx/deployer.rs
+++ b/crates/dojo/utils/src/tx/deployer.rs
@@ -105,7 +105,7 @@ pub async fn is_deployed<P>(contract_address: Felt, provider: &P) -> Result<bool
 where
     P: Provider,
 {
-    match provider.get_class_hash_at(BlockId::Tag(BlockTag::Pending), contract_address).await {
+    match provider.get_class_hash_at(BlockId::Tag(BlockTag::PreConfirmed), contract_address).await {
         Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => Ok(false),
         Ok(_) => {
             trace!(

--- a/crates/dojo/utils/src/tx/mod.rs
+++ b/crates/dojo/utils/src/tx/mod.rs
@@ -191,8 +191,8 @@ pub fn parse_block_id(block_str: String) -> Result<BlockId> {
         let hash = Felt::from_hex(&block_str)
             .map_err(|_| anyhow!("Unable to parse block hash: {}", block_str))?;
         Ok(BlockId::Hash(hash))
-    } else if block_str.eq("pending") {
-        Ok(BlockId::Tag(BlockTag::Pending))
+    } else if block_str.eq("preconfirmed") {
+        Ok(BlockId::Tag(BlockTag::PreConfirmed))
     } else if block_str.eq("latest") {
         Ok(BlockId::Tag(BlockTag::Latest))
     } else {
@@ -257,7 +257,7 @@ pub async fn get_predeployed_accounts<A: ConnectedAccount>(
                 ExecutionEncoding::New,
             );
 
-            account.set_block_id(BlockId::Tag(BlockTag::Pending));
+            account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
 
             declarers.push(account);
         }

--- a/crates/dojo/world/src/contracts/abigen/model.rs
+++ b/crates/dojo/world/src/contracts/abigen/model.rs
@@ -16,7 +16,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> ModelContract<A> {
         Self {
             address,
             account,
-            block_id: starknet::core::types::BlockId::Tag(starknet::core::types::BlockTag::Pending),
+            block_id: starknet::core::types::BlockId::Tag(
+                starknet::core::types::BlockTag::PreConfirmed,
+            ),
         }
     }
     pub fn set_contract_address(&mut self, address: starknet::core::types::Felt) {
@@ -43,7 +45,9 @@ impl<P: starknet::providers::Provider + Sync> ModelContractReader<P> {
         Self {
             address,
             provider,
-            block_id: starknet::core::types::BlockId::Tag(starknet::core::types::BlockTag::Pending),
+            block_id: starknet::core::types::BlockId::Tag(
+                starknet::core::types::BlockTag::PreConfirmed,
+            ),
         }
     }
     pub fn set_contract_address(&mut self, address: starknet::core::types::Felt) {

--- a/crates/dojo/world/src/contracts/abigen/world.rs
+++ b/crates/dojo/world/src/contracts/abigen/world.rs
@@ -16,7 +16,9 @@ impl<A: starknet::accounts::ConnectedAccount + Sync> WorldContract<A> {
         Self {
             address,
             account,
-            block_id: starknet::core::types::BlockId::Tag(starknet::core::types::BlockTag::Pending),
+            block_id: starknet::core::types::BlockId::Tag(
+                starknet::core::types::BlockTag::PreConfirmed,
+            ),
         }
     }
     pub fn set_contract_address(&mut self, address: starknet::core::types::Felt) {
@@ -43,7 +45,9 @@ impl<P: starknet::providers::Provider + Sync> WorldContractReader<P> {
         Self {
             address,
             provider,
-            block_id: starknet::core::types::BlockId::Tag(starknet::core::types::BlockTag::Pending),
+            block_id: starknet::core::types::BlockId::Tag(
+                starknet::core::types::BlockTag::PreConfirmed,
+            ),
         }
     }
     pub fn set_contract_address(&mut self, address: starknet::core::types::Felt) {

--- a/crates/dojo/world/src/diff/mod.rs
+++ b/crates/dojo/world/src/diff/mod.rs
@@ -170,7 +170,7 @@ impl WorldDiff {
         P: Provider,
     {
         let is_deployed = match provider
-            .get_class_hash_at(BlockId::Tag(BlockTag::Pending), world_address)
+            .get_class_hash_at(BlockId::Tag(BlockTag::PreConfirmed), world_address)
             .await
         {
             Err(ProviderError::StarknetError(StarknetError::ContractNotFound)) => {

--- a/crates/dojo/world/src/remote/events_to_remote.rs
+++ b/crates/dojo/world/src/remote/events_to_remote.rs
@@ -46,7 +46,8 @@ impl WorldRemote {
         let is_katana =
             chain_id != felt!("0x534e5f5345504f4c4941") && chain_id != felt!("0x534e5f4d41494e");
 
-        match provider.get_class_hash_at(BlockId::Tag(BlockTag::Pending), world_address).await {
+        match provider.get_class_hash_at(BlockId::Tag(BlockTag::PreConfirmed), world_address).await
+        {
             Ok(_) => {
                 // The world contract exists, we can continue and fetch the events.
             }

--- a/crates/sozo/ops/src/model.rs
+++ b/crates/sozo/ops/src/model.rs
@@ -17,7 +17,7 @@ where
     P: Provider + Send + Sync,
 {
     let mut world_reader = WorldContractReader::new(world_address, provider);
-    world_reader.set_block(BlockId::Tag(BlockTag::Pending));
+    world_reader.set_block(BlockId::Tag(BlockTag::PreConfirmed));
 
     let model = world_reader.model_reader_with_tag(&tag).await?;
 
@@ -35,7 +35,7 @@ where
     P: Provider + Send + Sync,
 {
     let mut world_reader = WorldContractReader::new(world_address, provider);
-    world_reader.set_block(BlockId::Tag(BlockTag::Pending));
+    world_reader.set_block(BlockId::Tag(BlockTag::PreConfirmed));
 
     let model = world_reader.model_reader_with_tag(&tag).await?;
 

--- a/scripts/verify_db_balances/src/main.rs
+++ b/scripts/verify_db_balances/src/main.rs
@@ -30,7 +30,7 @@ async fn get_balance_from_starknet(
                         entry_point_selector: selector!("balanceOf"),
                         calldata: vec![account_address],
                     },
-                    BlockId::Tag(starknet::core::types::BlockTag::Pending),
+                    BlockId::Tag(starknet::core::types::BlockTag::PreConfirmed),
                 )
                 .await?;
 
@@ -50,7 +50,7 @@ async fn get_balance_from_starknet(
                         // HACK: assumes token_id.high == 0
                         calldata: vec![token_id, Felt::ZERO],
                     },
-                    BlockId::Tag(starknet::core::types::BlockTag::Pending),
+                    BlockId::Tag(starknet::core::types::BlockTag::PreConfirmed),
                 )
                 .await?;
             if account_address != balance[0] {


### PR DESCRIPTION
Updates all Starknet RPC client to RPC v0.9.0-rc.2. This upgrade requires using `starknet` crate version `0.17.0-rc.2`. 

Upstream dependencies whose `starknet` version that has been updated to `0.17.0-rc.2`: 
* `slot`
* `katana-runner`
* `cainome`