### PR TITLE
fix(torii): update deserializer to handle new Dojo storage system.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,6 +2624,7 @@ name = "dojo-types"
 version = "1.7.0-alpha.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "cainome 0.9.1",
  "crypto-bigint",
  "hex",

--- a/crates/dojo/types/Cargo.toml
+++ b/crates/dojo/types/Cargo.toml
@@ -10,6 +10,7 @@ anyhow.workspace = true
 cainome.workspace = true
 crypto-bigint.workspace = true
 hex.workspace = true
+indexmap.workspace = true
 itertools.workspace = true
 num-traits.workspace = true
 regex.workspace = true
@@ -20,4 +21,6 @@ starknet-crypto.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
-indexmap.workspace = true
+
+[dev-dependencies]
+assert_matches.workspace = true

--- a/crates/dojo/types/src/primitive.rs
+++ b/crates/dojo/types/src/primitive.rs
@@ -1,4 +1,5 @@
 use std::any::type_name;
+use std::ops::RangeInclusive;
 
 use crypto_bigint::{Encoding, U256};
 use num_traits::ToPrimitive;
@@ -52,6 +53,16 @@ pub enum Primitive {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PrimitiveError {
+    #[error("Invalid enum selector `{selector}`; valid range is {}..={}", valid_range.start(), valid_range.end())]
+    InvalidEnumSelector {
+        /// The selector value that was invalid.
+        selector: u8,
+        /// The valid range of enum selector values.
+        ///
+        /// This corresponds to the number of enum variants.
+        valid_range: RangeInclusive<u8>,
+    },
+
     #[error("Value must have at least one FieldElement")]
     MissingFieldElement,
     #[error("Not enough FieldElements for U256")]

--- a/crates/dojo/types/src/primitive.rs
+++ b/crates/dojo/types/src/primitive.rs
@@ -1,5 +1,4 @@
 use std::any::type_name;
-use std::ops::RangeInclusive;
 
 use crypto_bigint::{Encoding, U256};
 use num_traits::ToPrimitive;
@@ -53,14 +52,10 @@ pub enum Primitive {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PrimitiveError {
-    #[error("Invalid enum selector `{selector}`; valid range is {}..={}", valid_range.start(), valid_range.end())]
+    #[error("Invalid enum selector `{actual_selector}`")]
     InvalidEnumSelector {
-        /// The selector value that was invalid.
-        selector: u8,
-        /// The valid range of enum selector values.
-        ///
-        /// This corresponds to the number of enum variants.
-        valid_range: RangeInclusive<u8>,
+        /// The actual selector value that was invalid.
+        actual_selector: u8,
     },
 
     #[error("Value must have at least one FieldElement")]

--- a/crates/dojo/types/src/schema.rs
+++ b/crates/dojo/types/src/schema.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 use starknet::core::types::Felt;
 use strum_macros::AsRefStr;
 

--- a/crates/dojo/types/src/schema.rs
+++ b/crates/dojo/types/src/schema.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use itertools::Itertools;
 use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use starknet::core::types::Felt;
 use strum_macros::AsRefStr;
 
@@ -1064,7 +1064,7 @@ mod tests {
 
         for i in 0..4 {
             let mut felts = vec![Felt::from_i32(i).unwrap()];
-            let _ = ty.deserialize(&mut felts, true).expect("failed to deserialize");
+            ty.deserialize(&mut felts, true).expect("failed to deserialize");
             assert!(felts.is_empty());
             assert_matches!(&ty, Ty::Enum(Enum {  option, .. }) => assert_eq!(option, &Some(i as u8)));
         }
@@ -1097,7 +1097,7 @@ mod tests {
 
         for i in 0..4 {
             let mut felts = vec![Felt::from_i32(i + 1).unwrap()]; // non legacy store enum indices starts from 1
-            let _ = ty.deserialize(&mut felts, false).expect("failed to deserialize");
+            ty.deserialize(&mut felts, false).expect("failed to deserialize");
             assert!(felts.is_empty());
             assert_matches!(&ty, Ty::Enum(Enum {  option, .. }) => assert_eq!(option, &Some(i as u8)));
         }
@@ -1109,7 +1109,7 @@ mod tests {
 
         // deserializes from an uninitialized storage
         let mut felts = vec![felt!("0x0")];
-        let _ = ty.deserialize(&mut felts, false).expect("failed to deserialize");
+        ty.deserialize(&mut felts, false).expect("failed to deserialize");
         assert!(felts.is_empty());
         assert_matches!(&ty, Ty::Enum(Enum { option: None, .. }));
     }

--- a/crates/dojo/world/src/contracts/model.rs
+++ b/crates/dojo/world/src/contracts/model.rs
@@ -146,12 +146,13 @@ where
     }
 
     pub async fn entity(&self, keys: &[Felt]) -> Result<Ty, ModelError> {
+        let has_legacy_storage = self.use_legacy_storage().await?;
         let mut schema = self.schema().await?;
         let values = self.entity_storage(keys).await?;
 
         let mut keys_and_unpacked = [keys, &values].concat();
 
-        schema.deserialize(&mut keys_and_unpacked)?;
+        schema.deserialize(&mut keys_and_unpacked, has_legacy_storage)?;
 
         Ok(schema)
     }


### PR DESCRIPTION
# Description

A new Dojo storage system has been introduced in https://github.com/dojoengine/dojo/pull/3266. As Torii deserializes stored model data, it has to be updated to handle this new storage system.

## Tests

<!--
Please refer to the CONTRIBUTING.md file to know more about the testing process. Ensure you've tested at least the package you're modifying if running all the tests consumes too much memory on your system.
-->

- [ ] Yes
- [ ] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

<!--
If the changes are small, code comments are enough, otherwise, the documentation is needed. It
may be a README.md file added to your module/package, a DojoBook PR or both.
-->

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Deserialization supports both legacy and new enum storage formats and correctly treats uninitialized enum values.
* Improvements
  * Clearer error reporting for invalid enum selectors (includes actual selector).
  * More robust byte-array handling to ensure accurate data consumption.
  * Entity reads now respect legacy vs. new storage mode when interpreting stored values; deserialization now accepts a storage-mode flag.
* Tests
  * Added unit tests covering legacy and new enum storage behaviors.
* Chores
  * Updated dependencies and removed duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->