### PR TITLE
feat(rpc): update supported RPC version 

### DIFF
--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -29,7 +29,7 @@ use crate::commands::options::world::WorldOptions;
 /// providers.
 pub const MAX_BLOCK_RANGE: u64 = 200_000;
 
-pub const RPC_SPEC_VERSION: &str = "0.8.1";
+pub const RPC_SPEC_VERSION: &str = "0.9.0-rc.2";
 
 pub const CALLDATA_DOC: &str = "
 Space separated values e.g., 0x12345 128 u256:9999999999 str:'hello world'.


### PR DESCRIPTION
Since #3293, Dojo now supports RPC 0.9.0-rc.2. 

When running Sozo, it will first perform a compatibility check against the chain network that it's interacting with - ensuring the RPC version of the network is supported by Sozo. It uses the `RPC_SPEC_VERSION` constant string to store the version of RPC it currently supports.