### PR TITLE
chore: add katana 1.7.0-alpha.2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -166,11 +166,11 @@
     ]
   },
   "1.7.0-alpha.0": {
-    "katana": ["1.7.0-alpha.0", "1.7.0-alpha.1"],
+    "katana": ["1.7.0-alpha.0", "1.7.0-alpha.1", "1.7.0-alpha.2"],
     "torii": ["1.7.0-alpha.0"]
   },
   "1.7.0-alpha.1": {
-    "katana": ["1.7.0-alpha.0", "1.7.0-alpha.1"],
+    "katana": ["1.7.0-alpha.0", "1.7.0-alpha.1", "1.7.0-alpha.2"],
     "torii": ["1.7.0-alpha.0"]
   }
 }


### PR DESCRIPTION
add new katana [1.7.0-alpha.2 pre-release](https://github.com/dojoengine/katana/releases/tag/v1.7.0-alpha.2) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the published version compatibility matrix to include katana 1.7.0-alpha.2 for the 1.7.0-alpha.0 and 1.7.0-alpha.1 releases. Torii compatibility remains unchanged. This ensures users see the latest katana variant as supported for those releases in version pickers and documentation.

* **Chores**
  * Refreshed version metadata to reflect current katana availability for existing 1.7.0 alpha releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->