### PR TITLE
sozo: display execute & migrate errors

### DIFF
--- a/bin/sozo/src/commands/execute.rs
+++ b/bin/sozo/src/commands/execute.rs
@@ -166,10 +166,17 @@ impl ExecuteArgs {
             });
         }
 
-        let txs_results = invoker.multicall().await?;
-        for r in &txs_results {
-            println!("{}", r);
-        }
+        let txs_results = match invoker.multicall().await {
+            Ok(txs_results) => {
+                for r in &txs_results {
+                    println!("{}", r);
+                }
+                txs_results
+            }
+            Err(e) => {
+                anyhow::bail!("{:?}", e)
+            }
+        };
 
         #[cfg(feature = "walnut")]
         if let Some(walnut_debugger) = walnut_debugger {

--- a/bin/sozo/src/commands/migrate.rs
+++ b/bin/sozo/src/commands/migrate.rs
@@ -81,8 +81,13 @@ impl MigrateArgs {
             is_guest,
         );
 
-        let MigrationResult { manifest, has_changes } =
-            migration.migrate(&mut spinner).await.context("Migration failed.")?;
+        let MigrationResult { manifest, has_changes } = match migration.migrate(&mut spinner).await
+        {
+            Ok(migration_result) => migration_result,
+            Err(e) => {
+                anyhow::bail!("{:?}", e)
+            }
+        };
 
         let ipfs_config =
             ipfs.config().or(profile_config.env.map(|env| env.ipfs_config).unwrap_or(None));


### PR DESCRIPTION
Display error messages for `execute` & `migrate` commands

closes #3298 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Execute: Improved error reporting with clearer messages while preserving per-transaction output on success.
  * Migrate: Fail-fast behavior with explicit error output, reducing ambiguous failures and improving reliability.

* **Refactor**
  * Standardized error handling across execute and migrate commands for consistent, predictable behavior.
  * Enhanced debuggability by unifying how failures are surfaced without altering successful command outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->