### PR TITLE
fix: include full error details in sozo execute failures

### DIFF
--- a/crates/dojo/utils/src/tx/error.rs
+++ b/crates/dojo/utils/src/tx/error.rs
@@ -15,7 +15,7 @@ where
     SigningError(S),
     #[error(transparent)]
     Provider(ProviderError),
-    #[error("Transaction execution error")]
+    #[error("Transaction execution error: {0:?}")]
     TransactionExecution(TransactionExecutionErrorData),
     #[error("{0}")]
     TransactionValidation(String),


### PR DESCRIPTION
## Summary
- Updates error display for `sozo execute` to include full error details with stack trace
- Changes error message from generic "Transaction execution error" to include the complete `TransactionExecutionErrorData`

## Problem
When `sozo execute` fails with a transaction execution error, users only see:
```
Caused by:
    Transaction execution error
```

This provides no information about what actually went wrong, making debugging difficult.

## Solution
Modified the error display in `crates/dojo/utils/src/tx/error.rs` to use Debug formatting (`{0:?}`) for `TransactionExecutionErrorData`, which will now show:
- The full error message
- Stack trace information
- Any additional error context from the transaction execution

This gives developers the information they need to diagnose and fix transaction failures.

🤖 Generated with [Claude Code](https://claude.ai/code)