### PR TITLE
Add docs-sync to Github workflows

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -13,9 +13,7 @@ on:
 
 jobs:
   docs-sync:
-    if:
-      github.event.pull_request.merged == true || github.event_name ==
-      'workflow_dispatch'
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Add a `docs-sync` workflow to Github, cribbing notes from the [Controller action](https://github.com/cartridge-gg/controller/blob/622b3103a6ecbcf5b206a2b0b16f6267b33996e2/.github/workflows/docs-sync.yml)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated documentation sync that runs on merged pull requests or via manual trigger with a commit reference.
  * Detects user-facing/API changes, generates documentation updates when needed, and opens a PR in the docs repository.
  * Reports clearly when no documentation updates are required.

* **Chores**
  * Adds a CI workflow to analyze changes, coordinate cross-repo updates, manage branches/commits, and perform cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->