### PR TITLE
chore: update version registry

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -166,11 +166,21 @@
     ]
   },
   "1.7.0-alpha.0": {
-    "katana": ["1.7.0-alpha.0", "1.7.0-alpha.1", "1.7.0-alpha.2"],
-    "torii": ["1.7.0-alpha.0"]
+    "katana": [
+      "1.7.0-alpha.0",
+      "1.7.0-alpha.1",
+      "1.7.0-alpha.2",
+      "1.7.0-alpha.3"
+    ],
+    "torii": ["1.7.0-alpha.0", "1.7.0-alpha.1", "1.7.0-alpha.2"]
   },
   "1.7.0-alpha.1": {
-    "katana": ["1.7.0-alpha.0", "1.7.0-alpha.1", "1.7.0-alpha.2"],
-    "torii": ["1.7.0-alpha.0"]
+    "katana": [
+      "1.7.0-alpha.0",
+      "1.7.0-alpha.1",
+      "1.7.0-alpha.2",
+      "1.7.0-alpha.3"
+    ],
+    "torii": ["1.7.0-alpha.0", "1.7.0-alpha.1", "1.7.0-alpha.2"]
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added availability of new prerelease versions: Katana 1.7.0-alpha.3 and Torii 1.7.0-alpha.1/alpha.2. These now appear in version selectors for 1.7.0-alpha.0 and 1.7.0-alpha.1 tracks.

- Chores
  - Updated version metadata to reflect the latest Katana and Torii alpha releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->