### PR TITLE
chore: bump `katana-runner` rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,8 +4441,8 @@ dependencies = [
 
 [[package]]
 name = "katana-node-bindings"
-version = "1.6.3"
-source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d81afa39a522cdfdc3999c1be5cdb8bd8460893c"
+version = "1.7.0-alpha.3"
+source = "git+https://github.com/dojoengine/katana?rev=eba352a#eba352aa5f12c474732c7db04d9d8369d6f4d4ac"
 dependencies = [
  "regex",
  "serde",
@@ -4455,8 +4455,8 @@ dependencies = [
 
 [[package]]
 name = "katana-runner"
-version = "1.6.3"
-source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d81afa39a522cdfdc3999c1be5cdb8bd8460893c"
+version = "1.7.0-alpha.3"
+source = "git+https://github.com/dojoengine/katana?rev=eba352a#eba352aa5f12c474732c7db04d9d8369d6f4d4ac"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -4469,8 +4469,8 @@ dependencies = [
 
 [[package]]
 name = "katana-runner-macro"
-version = "1.6.3"
-source = "git+https://github.com/dojoengine/katana?branch=rpc%2Fv0.9#d81afa39a522cdfdc3999c1be5cdb8bd8460893c"
+version = "1.7.0-alpha.3"
+source = "git+https://github.com/dojoengine/katana?rev=eba352a#eba352aa5f12c474732c7db04d9d8369d6f4d4ac"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ sozo-walnut = { path = "crates/sozo/walnut" }
 merge-options = { path = "crates/macros/merge-options" }
 
 # On the branch to support rpc 0.9 (incl starknet bump)
-katana-runner = { git = "https://github.com/dojoengine/katana", branch = "rpc/v0.9" }
+katana-runner = { git = "https://github.com/dojoengine/katana", rev = "eba352a" }
 
 anyhow = "1.0.89"
 arbitrary = { version = "1.3.2", features = [ "derive" ] }


### PR DESCRIPTION
ref #3293 

The `rpc/v0.9` branch has been deleted on the `dojoengine/katana` repo but it's been merged to the main branch. This rev belongs to the main branch.
