### PR TITLE
Add `asdf-install` script

### DIFF
--- a/dojoup/asdf-install
+++ b/dojoup/asdf-install
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Run installer with:
+# curl -L https://raw.githubusercontent.com/dojoengine/dojo/main/dojoup/asdf-install | bash
+
+set -e
+
+# Check if asdf is installed
+if ! command -v asdf &> /dev/null; then
+    echo "Error: asdf is not installed or not in PATH"
+    echo "Please install asdf first by following the instructions at:"
+    echo "https://asdf-vm.com/guide/getting-started.html"
+    exit 1
+fi
+
+echo "Installing Dojo toolchain with asdf..."
+
+# Install the asdf plugins
+PLUGINS=(sozo katana torii)
+for plugin in "${PLUGINS[@]}"; do
+    if ! asdf plugin list | grep -q "^$plugin$"; then
+        asdf plugin add $plugin https://github.com/dojoengine/asdf-$plugin.git
+    fi
+
+    latest=$(asdf latest $plugin)
+    if ! asdf list $plugin 2>/dev/null | grep -q "$latest"; then
+        asdf install $plugin $latest
+        asdf set --home $plugin $latest
+    fi
+done
+
+echo "Dojo toolchain installation complete!"


### PR DESCRIPTION
With the introduction of the `asdf` plugins for sozo, katana, and torii, users now have to run many commands to install the toolchain. This is a bit cumbersome, and so this PR adds a single script which will install the plugins, the latest versions of the tools, and set them as global defaults. A user should be able to run this script and then immediately run `katana --dev` to start a local instance.

To run this installer, the user only needs to run:

```
curl -L https://raw.githubusercontent.com/dojoengine/dojo/main/dojoup/asdf-install | bash
```

In the future we may want to alias this file for brevity, but this url should be fine for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a command-line installer to set up and update the Dojo toolchain via asdf.
  * Ensures required plugins (sozo, katana, torii) are registered and installed at their latest versions.
  * Idempotent: skips already-up-to-date components and shows clear progress and completion messages.
  * Validates asdf is installed and provides guidance if missing; exits on errors for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->