### PR TITLE
fix(sozo): rework the detection of Dojo default package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6593,6 +6593,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "toml 0.8.22",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/dojo/dojo-snf-test/Scarb.lock
+++ b/crates/dojo/dojo-snf-test/Scarb.lock
@@ -3,18 +3,18 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "1.6.0-alpha.1"
+version = "1.7.0-alpha.2"
 dependencies = [
  "dojo_macros",
 ]
 
 [[package]]
 name = "dojo_macros"
-version = "1.6.0-alpha.1"
+version = "1.7.0-alpha.2"
 
 [[package]]
 name = "dojo_snf_test"
-version = "1.6.0-alpha.1"
+version = "1.7.0-alpha.2"
 dependencies = [
  "dojo",
  "snforge_std",
@@ -22,15 +22,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.43.1"
+version = "0.48.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:178e1e2081003ae5e40b5a8574654bed15acbd31cce651d4e74fe2f009bc0122"
+checksum = "sha256:2dd27e8215eea8785b3930e9f452e11b429ca262b1c1fbb071bfc173b9ebc125"
 
 [[package]]
 name = "snforge_std"
-version = "0.43.1"
+version = "0.48.1"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:17bc65b0abfb9b174784835df173f9c81c9ad39523dba760f30589ef53cf8bb5"
+checksum = "sha256:89f759fa685d48ed0ba7152d2ac2eb168da08dfa8b84b2bee96e203dc5b2413e"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/crates/sozo/scarb_metadata_ext/Cargo.toml
+++ b/crates/sozo/scarb_metadata_ext/Cargo.toml
@@ -16,3 +16,4 @@ dunce.workspace = true
 scarb-metadata.workspace = true
 smol_str.workspace = true
 scarb-interop.workspace = true
+tracing.workspace = true


### PR DESCRIPTION
Sozo requires a package name to generate the binding generation if required.

In a workspace, multiple packages may use dojo as a dependency. This PR ensures that we are looking for package that are targeting a starknet contract to be deployed + using the world as an external contract.

Some libraries like budokan are actually `[lib]`, but are also deployed in their own world. To support that, Sozo first check for non library packages, and fallback on library projects afterward.

The rule is still the same for non library and library packages, only one world is supported at the moment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed debug logging for package auto-detection to aid troubleshooting.

* **Bug Fixes**
  * Improved accuracy of automatically selecting the correct dojo package.
  * Clearer outcomes when multiple or no candidate packages are found.

* **Refactor**
  * Updated internal selection criteria to prioritize appropriate targets for more consistent results.

* **Chores**
  * Added a new logging dependency to support enhanced diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->