### PR TITLE
fix(dojo-core): reexport dojo cairo macros

### DIFF
--- a/crates/dojo/core/Scarb.toml
+++ b/crates/dojo/core/Scarb.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/dojoengine/dojo"
 documentation = "https://book.dojoengine.org"
 keywords = ["dojo", "contracts", "starknet"]
 experimental-features = ["negative_impls"]
+re-export-cairo-plugins = ["dojo_cairo_macros"]
 
 [dependencies]
 starknet = "2.12"


### PR DESCRIPTION
# Description

This way if one imports dojo via

```toml
[dependencies]
dojo = "1.7"
```

the `dojo_cairo_macros` plugin will be imported automatically as well.
Users won't have to import both separately (and I assume if one wants to use dojo they 99.9% of times want to use `dojo_cairo_macros` as well). Basically it is the UX vs explicitness tradeoff.

If we ever get proc macros that are accessible by path i.e. `dojo_cairo_macros::some_proc_macro` we would just do public reexport behind a feature flag in `dojo` crate, for example
```cairo
#[cfg(feature: 'macros')]
pub use dojo_cairo_macros::{some_proc_macro, another_one};
```


## Tests

- [ ] Yes
- [x] No, because they aren't needed - no point testing a builtin Scarb mechanism
- [ ] No, because I need help

## Added to documentation?

Idk if you need anything there, lmk

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [ ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The core package now re-exports Cairo plugins, making related macros available out of the box. This reduces setup steps and ensures consistent plugin availability across downstream projects.
  * Improves compatibility with tooling that expects plugins to be exposed by the core package. No action is required for existing users; behavior is additive and build/usage remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->