### PR TITLE
Use app_version_info for cairo_version

### DIFF
--- a/crates/sozo/walnut/src/verification.rs
+++ b/crates/sozo/walnut/src/verification.rs
@@ -42,7 +42,7 @@ pub async fn walnut_verify(scarb_metadata: &Metadata, ui: &SozoUi) -> anyhow::Re
     let root_dir: &Path = manifest.parent().unwrap().as_std_path();
 
     let source_code = collect_source_code(root_dir)?;
-    let cairo_version = scarb_metadata.version;
+    let cairo_version = scarb_metadata.app_version_info.version.clone();
 
     let verification_payload =
         VerificationPayload { source_code, cairo_version: cairo_version.to_string() };


### PR DESCRIPTION
# Description

Fixed Cairo version access in Walnut verification by using `app_version_info.version` instead of direct `version` field. This ensures proper access to the Cairo version information when verifying classes with Walnut backend.

## Related issue

No created issue

## Tests

- [ ] Yes
- [ x] No, because they aren't needed
- [ ] No, because I need help

## Added to documentation?

- [ ] README.md
- [ ] [Dojo Book](https://github.com/dojoengine/book)
- [x ] No documentation needed

## Checklist

- [ ] I've formatted my code (`scripts/rust_fmt.sh`, `scripts/cairo_fmt.sh`)
- [ ] I've linted my code (`scripts/clippy.sh`, `scripts/docs.sh`)
- [ ] I've commented my code
- [ ] I've requested a review after addressing the comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated how the Cairo version is retrieved and included during the verification process to ensure the version is sourced and represented consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->