### PR TITLE
feat(sozo): add world factory output

### DIFF
--- a/bin/sozo/src/commands/inspect.rs
+++ b/bin/sozo/src/commands/inspect.rs
@@ -1105,7 +1105,10 @@ fn inspect_world_factory(world_diff: &WorldDiff) -> Result<()> {
     // Print the sozo command line
     println!();
     println!("# Sozo command to execute:");
-    print!("sozo -P <PROFILE> execute factory set_config <VERSION> <MAX_ACTION_default_20_is_good> {}", world_class_hash);
+    print!(
+        "sozo -P <PROFILE> execute factory set_config <VERSION> <MAX_ACTION_default_20_is_good> {}",
+        world_class_hash
+    );
     print!(" str:{}", default_namespace);
     print!(" <BOOL_TO_SET_WRITERS_ALL_CONTRACTS_ON_DEFAULT_NAMESPACE>");
 


### PR DESCRIPTION
This PR adds a `--output-factory` for the `sozo inspect` command to facilitate the onchain world factory initialization.

```
sozo inspect --output-factory
```

This will output both the `FactoryConfig` in Cairo and the `sozo execute` command line to setup the factory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to generate Cairo factory initialization code and example deploy commands when inspecting a whole world.
  * Inspection outputs (interactive display and JSON) now include class-hash information for models and events at both world and resource levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->