### PR TITLE
avoid panic on empty input in parse_simple

### DIFF
--- a/crates/dojo/types/src/packing.rs
+++ b/crates/dojo/types/src/packing.rs
@@ -126,6 +126,12 @@ pub fn parse_ty(data: &[Felt]) -> Result<Ty, ParseError> {
 }
 
 fn parse_simple(data: &[Felt]) -> Result<Ty, ParseError> {
+    if data.is_empty() {
+        return Err(ParseError::invalid_schema_with_msg(
+            "parse_simple expects at least one felt",
+        ));
+    }
+
     let ty = parse_cairo_short_string(&data[0])?;
     let primitive = match Primitive::from_str(&ty) {
         Ok(primitive) => primitive,


### PR DESCRIPTION
Prevent panic when parse_simple receives empty input.

Previously the function accessed data[0] without checking length,
which could cause an out-of-bounds panic. Now it returns a proper
ParseError instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid schema inputs by adding validation to catch empty data earlier and provide clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->