### PR TITLE
Add saya to dojoup install script

### DIFF
--- a/dojoup/install
+++ b/dojoup/install
@@ -16,7 +16,7 @@ fi
 echo "Installing Dojo toolchain with asdf..."
 
 # Install the asdf plugins
-PLUGINS=(sozo katana torii)
+PLUGINS=(sozo katana torii saya)
 for plugin in "${PLUGINS[@]}"; do
 
     # Install plugin from source


### PR DESCRIPTION
## Summary
- Add `saya` to the PLUGINS list in `dojoup/install`
- The `dojoengine/asdf-saya` plugin already exists and works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the saya plugin to the installation process, enabling access to additional functionality during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->