### PR TITLE
feat(sozo): warn instead of error on RPC spec version mismatch

### DIFF
--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -123,10 +123,16 @@ pub async fn get_world_diff_and_provider(
     let spec_version = provider.spec_version().await?;
     trace!(spec_version);
 
-    if !is_compatible_version(&spec_version, RPC_SPEC_VERSION)? {
-        return Err(anyhow!(
-            "Unsupported Starknet RPC version: {spec_version}, expected {RPC_SPEC_VERSION}.",
-        ));
+    match is_compatible_version(&spec_version, RPC_SPEC_VERSION) {
+        Ok(true) => {}
+        Ok(false) => ui.warn(format!(
+            "Starknet RPC version mismatch: node reports {spec_version}, sozo was built \
+             against {RPC_SPEC_VERSION}. Continuing anyway; operations may fail if RPC \
+             methods differ."
+        )),
+        Err(e) => ui.warn(format!(
+            "Could not parse Starknet RPC version '{spec_version}': {e}. Continuing."
+        )),
     }
 
     let chain_id = provider.chain_id().await?;

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -120,17 +120,24 @@ pub async fn get_world_diff_and_provider(
     let provider = Arc::try_unwrap(provider).map_err(|_| anyhow!("Failed to unwrap Arc"))?;
     trace!(?provider, "Provider initialized.");
 
-    let spec_version = provider.spec_version().await?;
-    trace!(spec_version);
-
-    match is_compatible_version(&spec_version, RPC_SPEC_VERSION) {
-        Ok(true) => {}
-        Ok(false) => ui.warn(format!(
-            "Starknet RPC version mismatch: node reports {spec_version}, sozo was built against \
-             {RPC_SPEC_VERSION}. Continuing anyway; operations may fail if RPC methods differ."
-        )),
+    match provider.spec_version().await {
+        Ok(spec_version) => {
+            trace!(spec_version);
+            match is_compatible_version(&spec_version, RPC_SPEC_VERSION) {
+                Ok(true) => {}
+                Ok(false) => ui.warn(format!(
+                    "Starknet RPC version mismatch: node reports {spec_version}, sozo was built \
+                     against {RPC_SPEC_VERSION}. Continuing anyway; operations may fail if RPC \
+                     methods differ."
+                )),
+                Err(e) => ui.warn(format!(
+                    "Could not parse Starknet RPC version '{spec_version}': {e}. Continuing."
+                )),
+            }
+        }
         Err(e) => ui.warn(format!(
-            "Could not parse Starknet RPC version '{spec_version}': {e}. Continuing."
+            "Could not query Starknet RPC version: {e}. Continuing; operations may fail if RPC \
+             methods differ."
         )),
     }
 

--- a/bin/sozo/src/utils.rs
+++ b/bin/sozo/src/utils.rs
@@ -126,9 +126,8 @@ pub async fn get_world_diff_and_provider(
     match is_compatible_version(&spec_version, RPC_SPEC_VERSION) {
         Ok(true) => {}
         Ok(false) => ui.warn(format!(
-            "Starknet RPC version mismatch: node reports {spec_version}, sozo was built \
-             against {RPC_SPEC_VERSION}. Continuing anyway; operations may fail if RPC \
-             methods differ."
+            "Starknet RPC version mismatch: node reports {spec_version}, sozo was built against \
+             {RPC_SPEC_VERSION}. Continuing anyway; operations may fail if RPC methods differ."
         )),
         Err(e) => ui.warn(format!(
             "Could not parse Starknet RPC version '{spec_version}': {e}. Continuing."


### PR DESCRIPTION
## Summary

When a Starknet RPC node reports a `starknet_specVersion` that does not match the one sozo was built against (`RPC_SPEC_VERSION = "0.9.0"`), sozo aborted every command with:

```
Unsupported Starknet RPC version: <x>, expected 0.9.0.
```

This blocks users whenever a node publishes a spec bump, even though most RPC methods sozo uses are stable across minor bumps. This PR replaces the hard error in `get_world_diff_and_provider` with a `ui.warn(...)` and continues. If the node really is incompatible, the failure still surfaces at the actual RPC call site with a more specific error.

Parse failures on the version string (malformed response) are also downgraded to a warning, for the same reason.

## Changes

- `bin/sozo/src/utils.rs`: replace the early `return Err(...)` on version mismatch with a `match` that emits `ui.warn(...)` for both mismatch and parse failure paths, then proceeds.
- `is_compatible_version`, `RPC_SPEC_VERSION`, and the 0.7/0.6 back-compat carve-out are unchanged.
- No changes at the 11 call sites — they all go through `get_world_diff_and_provider`.

## Test plan

- [x] `cargo build -p sozo` succeeds
- [x] `cargo test -p sozo --bin sozo utils::tests::` passes (5/5 — unchanged `is_compatible_version` tests)
- [ ] Manual smoke: point sozo at a katana/RPC with a mismatched spec version; commands should print the warning and continue instead of aborting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Starknet RPC version issues: the tool now warns and continues when the node reports an incompatible or unparseable version (or when the version query fails), instead of aborting. This reduces interruptions and improves robustness when interacting with nodes reporting unexpected RPC versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->