### PR TITLE
ci: pin starknet-foundry to 0.55.0 to unblock test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: foundry-rs/setup-snfoundry@v3
+        with:
+          starknet-foundry-version: "0.55.0"
       - uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: "2.13.1"
@@ -145,6 +147,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: foundry-rs/setup-snfoundry@v3
+        with:
+          starknet-foundry-version: "0.55.0"
       - uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: "2.13.1"


### PR DESCRIPTION
## Summary

CI has been red since `foundry-rs/setup-snfoundry@v3` started pulling snforge **0.59.0**. That version has an ABI break in `starknet::testing::cheatcode` against the `snforge_std = "0.51"` pinned in our Cairo packages, so every run of `dojo-core-test` and `dojo-examples-test` panics:

```
Reading from buffer failed... Probably snforge_std/sncast_std version
is incompatible, check above for incompatibility warning.
```

snforge itself logs the warning right before the panic:

```
[WARNING] Package snforge_std version does not meet the recommended version requirement ^0.59.0
```

## Fix

Pin `starknet-foundry-version: "0.55.0"` on both `setup-snfoundry@v3` steps in `.github/workflows/test.yml`. 0.55.0 is the version that ran on main the last time this workflow was green (2026-01-27, run `21407350594`).

## Follow-up

The proper long-term fix is bumping `snforge_std = "0.51"` → `"0.59"` (or current) across the three `Scarb.toml` files:

- `crates/dojo/core-tests/Scarb.toml`
- `crates/dojo/dojo-snf-test/Scarb.toml`
- `examples/spawn-and-move/Scarb.toml`

…and catching up any cheatcode API changes in the tests. That's left for a separate PR so this one can unblock current work.

## Test plan

- [ ] `dojo-core-test` passes on this PR
- [ ] `dojo-examples-test` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configuration to ensure consistent test environments across builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->