### PR TITLE
fix(dojo-utils): return real address on already-deployed path

### DIFF
--- a/crates/dojo/utils/src/tx/deployer.rs
+++ b/crates/dojo/utils/src/tx/deployer.rs
@@ -125,3 +125,80 @@ where
         Err(e) => Err(e),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use katana_runner::RunnerCtx;
+    use starknet::core::utils::get_contract_address;
+    use starknet::macros::felt;
+
+    use super::*;
+    use crate::TxnConfig;
+
+    // The default account class that katana dev predeclares on every chain.
+    // Used as the class_hash for our deploy tests so we don't need to declare
+    // a contract first.
+    const KATANA_DEV_ACCOUNT_CLASS_HASH: Felt =
+        felt!("0x07dc7899aa655b0aae51eadff6d801a58e97dd99cf4666ee59e704249e51adf2");
+
+    /// Regression: `deploy_via_udc_getcall` used to return `Option<(Felt, Call)>`
+    /// where `None` meant "already deployed" and the address was dropped on
+    /// the floor. `deploy_via_udc` then mapped that to `(Felt::ZERO, Noop)`.
+    /// After the fix both paths surface the real contract address, so
+    /// deploy is idempotent across re-runs with the same salt.
+    #[tokio::test(flavor = "multi_thread")]
+    #[katana_runner::test(accounts = 2)]
+    async fn deploy_via_udc_idempotent_returns_real_address(sequencer: &RunnerCtx) {
+        let account = sequencer.account(0);
+        let deployer = Deployer::new(account, TxnConfig { wait: true, ..Default::default() });
+
+        let class_hash = KATANA_DEV_ACCOUNT_CLASS_HASH;
+        let salt = felt!("0xabc");
+        // Account class has a single-arg constructor (public_key). Any non-zero
+        // felt works for this test; we never interact with the deployed account.
+        let calldata = vec![felt!("0xdeadbeef")];
+        let deployer_address = Felt::ZERO;
+
+        let expected_address = get_contract_address(salt, class_hash, &calldata, deployer_address);
+
+        // First call: not yet deployed. Returns (addr, Some(call)).
+        let (addr, call) = deployer
+            .deploy_via_udc_getcall(class_hash, salt, &calldata, deployer_address)
+            .await
+            .unwrap();
+        assert_eq!(addr, expected_address);
+        assert!(call.is_some(), "expected deploy Call on the not-yet-deployed path");
+
+        // Actually deploy it.
+        let (deployed_addr, _tx) = deployer
+            .deploy_via_udc(class_hash, salt, &calldata, deployer_address)
+            .await
+            .unwrap();
+        assert_eq!(deployed_addr, expected_address);
+
+        // Second getcall with identical params: contract is already deployed
+        // at the same address. Returns (same addr, None) — this is the path
+        // that used to lose the address before the fix.
+        let (addr, call) = deployer
+            .deploy_via_udc_getcall(class_hash, salt, &calldata, deployer_address)
+            .await
+            .unwrap();
+        assert_eq!(
+            addr, expected_address,
+            "address must be surfaced even when already deployed"
+        );
+        assert!(call.is_none(), "no deploy Call needed on the already-deployed path");
+
+        // Second deploy_via_udc call: returns (real_address, Noop). Before
+        // the fix this returned (Felt::ZERO, Noop).
+        let (addr, tx) = deployer
+            .deploy_via_udc(class_hash, salt, &calldata, deployer_address)
+            .await
+            .unwrap();
+        assert_eq!(addr, expected_address);
+        assert!(
+            matches!(tx, TransactionResult::Noop),
+            "already-deployed path must return Noop, got {tx:?}"
+        );
+    }
+}

--- a/crates/dojo/utils/src/tx/deployer.rs
+++ b/crates/dojo/utils/src/tx/deployer.rs
@@ -170,10 +170,8 @@ mod tests {
         assert!(call.is_some(), "expected deploy Call on the not-yet-deployed path");
 
         // Actually deploy it.
-        let (deployed_addr, _tx) = deployer
-            .deploy_via_udc(class_hash, salt, &calldata, deployer_address)
-            .await
-            .unwrap();
+        let (deployed_addr, _tx) =
+            deployer.deploy_via_udc(class_hash, salt, &calldata, deployer_address).await.unwrap();
         assert_eq!(deployed_addr, expected_address);
 
         // Second getcall with identical params: contract is already deployed
@@ -183,18 +181,13 @@ mod tests {
             .deploy_via_udc_getcall(class_hash, salt, &calldata, deployer_address)
             .await
             .unwrap();
-        assert_eq!(
-            addr, expected_address,
-            "address must be surfaced even when already deployed"
-        );
+        assert_eq!(addr, expected_address, "address must be surfaced even when already deployed");
         assert!(call.is_none(), "no deploy Call needed on the already-deployed path");
 
         // Second deploy_via_udc call: returns (real_address, Noop). Before
         // the fix this returned (Felt::ZERO, Noop).
-        let (addr, tx) = deployer
-            .deploy_via_udc(class_hash, salt, &calldata, deployer_address)
-            .await
-            .unwrap();
+        let (addr, tx) =
+            deployer.deploy_via_udc(class_hash, salt, &calldata, deployer_address).await.unwrap();
         assert_eq!(addr, expected_address);
         assert!(
             matches!(tx, TransactionResult::Noop),

--- a/crates/dojo/utils/src/tx/deployer.rs
+++ b/crates/dojo/utils/src/tx/deployer.rs
@@ -35,14 +35,19 @@ where
         Self { account, txn_config }
     }
 
-    /// Get a Call for deploying a contract via the UDC.
+    /// Get the deterministic UDC-derived contract address along with the
+    /// Call required to deploy it (or `None` for the Call if the contract
+    /// is already deployed at that address).
+    ///
+    /// The address is always returned, even on the already-deployed path,
+    /// so callers don't have to re-derive it themselves.
     pub async fn deploy_via_udc_getcall(
         &self,
         class_hash: Felt,
         salt: Felt,
         constructor_calldata: &[Felt],
         deployer_address: Felt,
-    ) -> Result<Option<(Felt, Call)>, TransactionError<A::SignError>> {
+    ) -> Result<(Felt, Option<Call>), TransactionError<A::SignError>> {
         let udc_calldata = [
             vec![class_hash, salt, deployer_address, Felt::from(constructor_calldata.len())],
             constructor_calldata.to_vec(),
@@ -53,13 +58,13 @@ where
             get_contract_address(salt, class_hash, constructor_calldata, deployer_address);
 
         if is_deployed(contract_address, &self.account.provider()).await? {
-            return Ok(None);
+            return Ok((contract_address, None));
         }
 
-        Ok(Some((
+        Ok((
             contract_address,
-            Call { calldata: udc_calldata, selector: UDC_DEPLOY_SELECTOR, to: UDC_ADDRESS },
-        )))
+            Some(Call { calldata: udc_calldata, selector: UDC_DEPLOY_SELECTOR, to: UDC_ADDRESS }),
+        ))
     }
 
     /// Deploys a contract via the UDC.
@@ -70,12 +75,11 @@ where
         constructor_calldata: &[Felt],
         deployer_address: Felt,
     ) -> Result<(Felt, TransactionResult), TransactionError<A::SignError>> {
-        let (contract_address, call) = match self
+        let (contract_address, call) = self
             .deploy_via_udc_getcall(class_hash, salt, constructor_calldata, deployer_address)
-            .await?
-        {
-            Some(res) => res,
-            None => return Ok((Felt::ZERO, TransactionResult::Noop)),
+            .await?;
+        let Some(call) = call else {
+            return Ok((contract_address, TransactionResult::Noop));
         };
 
         let InvokeTransactionResult { transaction_hash } =

--- a/crates/sozo/ops/src/migrate/mod.rs
+++ b/crates/sozo/ops/src/migrate/mod.rs
@@ -917,23 +917,18 @@ where
 
             let deployer = Deployer::new(&self.world.account, self.txn_config);
 
-            match deployer
+            // `deploy_via_udc_getcall` returns the UDC-derived contract
+            // address plus an Option<Call> — None means the contract is
+            // already deployed at that address and no call is needed.
+            let (_contract_address, call) = deployer
                 .deploy_via_udc_getcall(
                     contract.common.class_hash,
                     contract.salt,
                     &contract.encoded_constructor_data,
                     Felt::ZERO,
                 )
-                .await?
-            {
-                Some((_, call)) => deploy_call = Some(call),
-                None => {
-                    deploy_call = {
-                        // Already deployed, no need to deploy again.
-                        None
-                    }
-                }
-            }
+                .await?;
+            deploy_call = call;
 
             is_upgradeable = contract.is_upgradeable;
         }


### PR DESCRIPTION
## Problem

`Deployer::deploy_via_udc` is non-idempotent: if a contract is already deployed at the deterministic UDC-derived address, the second invocation returns `Ok((Felt::ZERO, TransactionResult::Noop))` instead of `Ok((real_address, Noop))`.

The real address IS computed — right before we decide it's already deployed — then dropped:

```rust
// crates/dojo/utils/src/tx/deployer.rs (before)
let contract_address =
    get_contract_address(salt, class_hash, constructor_calldata, deployer_address);

if is_deployed(contract_address, &self.account.provider()).await? {
    return Ok(None);   // ← address thrown away
}
```

The outer `deploy_via_udc` then does:
```rust
None => return Ok((Felt::ZERO, TransactionResult::Noop)),   // ← zero instead of real
```

## Impact

Any caller that relies on the return value to know what got deployed breaks on re-runs. Concrete case: we hit this in `saya-ops core-contract deploy --salt X`. First run: works. Second run with the same salt: returns `contract_address: "0x0"` in both text and `--output json` output. Downstream orchestration (our docker-compose bootstrap, `tests/saya-tee/` when re-run) writes `0x0` into state files and the next step panics on `Requested contract address 0x0 is not deployed.`

## Fix

Change `deploy_via_udc_getcall` to return `(Felt, Option<Call>)` instead of `Option<(Felt, Call)>`. The address is always surfaced; the `Option<Call>` encodes "does a call need to be made":

```rust
// after
pub async fn deploy_via_udc_getcall(
    ...
) -> Result<(Felt, Option<Call>), TransactionError<A::SignError>> {
    ...
    if is_deployed(contract_address, ...).await? {
        return Ok((contract_address, None));
    }

    Ok((contract_address, Some(Call { ... })))
}
```

`deploy_via_udc` unpacks that cleanly:

```rust
let (contract_address, call) = self.deploy_via_udc_getcall(...).await?;
let Some(call) = call else {
    return Ok((contract_address, TransactionResult::Noop));
};
```

## Breaking change?

`deploy_via_udc_getcall` signature changed, so yes — for any direct consumer. There's one in-tree caller (`sozo-ops::migrate`) which was pattern-matching `Some((_, call))` / `None` and discarding the address; it adapts to `let (_, call) = ... ; deploy_call = call` and actually gets shorter.

`deploy_via_udc` return type is unchanged (`(Felt, TransactionResult)`). The only behavior change is "the Felt is now correct when TransactionResult::Noop."

## Test plan

- [x] `cargo check -p dojo-utils -p sozo-ops` clean
- [x] Manually reproduced: `saya-ops core-contract deploy --salt 0x7ee` twice against the same katana L2 dev chain. Before fix: second run returns `0x0`. After fix: returns the real `0x37189b18...`.
- [ ] CI green (full workspace build + tests)
- [ ] sozo migrate flow retested with re-run (already-deployed path exercised)

## Downstream

- Saya's `saya-ops` has a local workaround PR (https://github.com/dojoengine/saya/pull/64) that recomputes the address on the zero-address path. Once this merges and saya's `dojo-utils` git dep advances to a commit including this fix, that workaround becomes a no-op and can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed contract deployment to consistently return the contract address in all deployment scenarios, including when a contract is already deployed. Previously, no address was returned for already-deployed contracts, causing inconsistent behavior in deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->