### PR TITLE
ci: add docs-sync workflow to open PRs against dojoengine/book

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,4 +1,4 @@
-name: doc-sync
+name: docs-sync
 
 on:
   pull_request:
@@ -14,185 +14,22 @@ on:
 jobs:
   docs-sync:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      id-token: write
-
-    steps:
-      - name: Checkout dojo repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Get changed files
-        id: changed-files
-        run: |
-          set -e
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            git fetch origin
-            DIFF_BASE="${{ github.event.inputs.commit_sha }}~1"
-            DIFF_HEAD="${{ github.event.inputs.commit_sha }}"
-          else
-            git fetch origin main
-            DIFF_BASE="${{ github.event.pull_request.base.sha }}"
-            DIFF_HEAD="${{ github.event.pull_request.merge_commit_sha }}"
-          fi
-          CHANGED_FILES=$(git diff --name-only "$DIFF_BASE" "$DIFF_HEAD")
-          DIFF_CONTENT=$(git diff "$DIFF_BASE" "$DIFF_HEAD" -- '*.rs' '*.cairo' '*.toml' '*.md' | head -c 60000)
-          echo "changed_files<<EOF" >> $GITHUB_OUTPUT
-          echo "$CHANGED_FILES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-          echo "diff_content<<EOF" >> $GITHUB_OUTPUT
-          echo "$DIFF_CONTENT" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Check if docs update needed
-        id: check-docs
-        run: |
-          # Check if changes require documentation updates
-          NEEDS_DOCS_UPDATE=false
-
-          # Define patterns that typically require docs updates
-          DOCS_PATTERNS=(
-            "^crates/.*\.rs$"
-            "^crates/.*\.cairo$"
-            "^crates/.*\.toml$"
-            "^bin/.*\.rs$"
-            "^bin/.*\.toml$"
-            "^README\.md$"
-            "^CHANGELOG\.md$"
-          )
-
-          while IFS= read -r file; do
-            for pattern in "${DOCS_PATTERNS[@]}"; do
-              if [[ $file =~ $pattern ]]; then
-                NEEDS_DOCS_UPDATE=true
-                break 2
-              fi
-            done
-          done <<< "${{ steps.changed-files.outputs.changed_files }}"
-
-          echo "needs_update=$NEEDS_DOCS_UPDATE" >> $GITHUB_OUTPUT
-          echo "Files that may need docs updates: $(echo '${{ steps.changed-files.outputs.changed_files }}' | tr '\n' ' ')"
-
-      - name: Checkout docs repository
-        if: steps.check-docs.outputs.needs_update == 'true'
-        uses: actions/checkout@v4
-        with:
-          repository: dojoengine/book
-          token: ${{ secrets.CREATE_PR_TOKEN }}
-          path: docs-repo
-
-      - name: Analyze changes and update docs
-        if: steps.check-docs.outputs.needs_update == 'true'
-        uses: anthropics/claude-code-action@beta
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-5-20250929"
-          direct_prompt: |
-            Analyze changes in this dojo repository and update documentation
-            in the dojoengine/book repository ONLY if user-facing behavior changed.
-
-            **Change Information:**
-            - Title: ${{ github.event.pull_request.title || format('Manual trigger for commit {0}', github.event.inputs.commit_sha) }}
-            - Description: ${{ github.event.pull_request.body || 'Manually triggered documentation sync' }}
-            - Files changed: ${{ steps.changed-files.outputs.changed_files }}
-            - Commit SHA: ${{ github.event.pull_request.merge_commit_sha || github.event.inputs.commit_sha }}
-
-            **Diff of changed files:**
-            ${{ steps.changed-files.outputs.diff_content }}
-
-            **Docs repo structure** (checked out in `docs-repo/`):
-            The site uses Vocs. Content lives in `docs-repo/docs/pages/` with these sections:
-            - `getting-started/` — Your First Dojo App, Understanding the Toolchain, Development Workflow
-            - `framework/` — world/, models/, systems/, testing/, upgrading/, configuration/
-            - `toolchain/` — sozo/, katana/, torii/, saya/, cainome
-            - `client/sdk/` — dojo.js, dojo.c, dojo.unity, dojo.unreal, dojo.godot, dojo.bevy, dojo.rust, dojo.telegram
-            - `tutorials/` — Dojo 101, Deploy to Mainnet, Deploy using Slot
-            - `libraries/` — Origami, Alexandria
-            - `scaling/` — Execution Sharding, Sovereign Rollups
-            Sidebar config is in `docs-repo/routes.ts`, imported by `docs-repo/vocs.config.ts`.
-
-            **Rules — read these carefully:**
-            1. DEFAULT TO NO CHANGES. Most code PRs do not need docs updates. Internal refactors, test changes, CI changes, and dependency bumps need nothing. Only proceed if there is a concrete user-facing change (new API, changed behavior, new feature, removed feature, changed configuration).
-            2. SINGLE CANONICAL LOCATION. Each piece of information belongs on exactly one page. Find the one page that owns the topic and make your substantive edits there. Other pages MAY add a brief cross-reference linking to the canonical page, but do NOT duplicate explanations, code samples, or configuration details across multiple pages.
-            3. MINIMAL EDITS. Update only the specific section affected. Do not rewrite surrounding paragraphs, add new sections for context, or reorganize existing content.
-            4. ONE CODE EXAMPLE per concept. If a code sample is needed, add it once in the canonical location. Do not add the same or similar examples to multiple pages.
-            5. Do NOT create git branches, commits, or PRs — just update files.
-            6. If no documentation updates are needed, state that clearly and exit.
-
-          allowed_tools: "Read,Write,Edit,MultiEdit,Glob,Grep"
-
-      - name: Create branch and commit changes
-        if: steps.check-docs.outputs.needs_update == 'true'
-        working-directory: docs-repo
-        run: |
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Check if there are any changes
-          if [ -n "$(git status --porcelain)" ]; then
-            # Create new branch
-            BRANCH_NAME="docs-update-$(date +%s)"
-            git checkout -b "$BRANCH_NAME"
-
-            # Add and commit changes
-            git add .
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              git commit -m "docs: Update documentation for dojo commit ${{ github.event.inputs.commit_sha }}
-
-              Updates documentation to reflect changes made in commit:
-              ${{ github.event.inputs.commit_sha }}
-
-              Manually triggered documentation sync"
-            else
-              git commit -m "docs: Update documentation for dojo PR #${{ github.event.pull_request.number }}
-
-              Updates documentation to reflect changes made in:
-              ${{ github.event.pull_request.title }}
-
-              Related dojo PR: dojoengine/dojo#${{ github.event.pull_request.number }}"
-            fi
-
-            # Push branch
-            git push origin "$BRANCH_NAME"
-
-            # Create PR
-            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-              PR_URL=$(gh pr create \
-                --title "docs: Update documentation for dojo commit ${{ github.event.inputs.commit_sha }}" \
-                --body "This PR updates the documentation to reflect changes made in dojoengine/dojo commit ${{ github.event.inputs.commit_sha }}
-
-              **Commit Details:**
-              - Commit SHA: ${{ github.event.inputs.commit_sha }}
-              - Files changed: ${{ steps.changed-files.outputs.changed_files }}
-              - Trigger: Manual documentation sync
-
-              Please review the documentation changes to ensure they accurately reflect the dojo updates.")
-              gh pr merge "$PR_URL" --auto --squash
-            else
-              PR_URL=$(gh pr create \
-                --title "docs: Update documentation for dojo PR #${{ github.event.pull_request.number }}" \
-                --body "This PR updates the documentation to reflect changes made in dojoengine/dojo#${{ github.event.pull_request.number }}
-
-              **Original PR Details:**
-              - Title: ${{ github.event.pull_request.title }}
-              - Files changed: ${{ steps.changed-files.outputs.changed_files }}
-
-              Please review the documentation changes to ensure they accurately reflect the dojo updates.")
-              gh pr merge "$PR_URL" --auto --squash
-            fi
-          else
-            echo "No documentation changes were made by Claude"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.CREATE_PR_TOKEN }}
-
-      - name: Cleanup
-        if: always()
-        run: |
-          # Clean up any temporary files or directories
-          rm -rf docs-repo || true
+    uses: dojoengine/book/.github/workflows/docs-sync.yml@main
+    with:
+      target-docs-repo: dojoengine/book
+      source-repo-slug: dojoengine/dojo
+      diff-globs: |
+        *.rs
+        *.cairo
+        *.toml
+        *.md
+      docs-patterns: |
+        ^crates/.*\.(rs|cairo)$
+        ^bin/.*\.(rs|cairo)$
+      canonical-desc: |
+        The Dojo framework and sozo CLI are documented in two sections of dojoengine/book:
+                    - docs-repo/docs/pages/framework/ — World, models, systems, events, testing, authorization, config
+                    - docs-repo/docs/pages/toolchain/sozo/ — sozo CLI commands and workflows
+      docs-structure-desc: |
+        The site uses Vocs. Content lives in `docs-repo/docs/pages/`. Navigation is in `docs-repo/routes.ts`. SDK docs at `docs-repo/docs/pages/client/sdk/` are single `.md` files (bevy.md, javascript.md, unity.md, unrealengine.md, godot.md, rust.md, telegram.md), not subdirectories — the sole exception is `c/` which is a subdir.
+    secrets: inherit


### PR DESCRIPTION
Adds a caller stub that invokes the shared reusable docs-sync workflow hosted in `dojoengine/book`.

## What it does

On each merged PR to `main` (plus manual `workflow_dispatch`), the stub calls `dojoengine/book/.github/workflows/docs-sync.yml@main` with this repo's parameters (diff globs, `DOCS_PATTERNS`, canonical docs page). The shared workflow diffs the PR, runs `anthropics/claude-code-action@beta` with a tight "default to no changes / single canonical location / minimal edits" ruleset, and — if Claude made edits — opens an **auto-merging** PR to `dojoengine/book` with the suggested changes.

## Per-repo parameters

See the `with:` block in the diff. Canonical docs location for this repo:

dojo: `docs/pages/framework/` and `docs/pages/toolchain/sozo/` in `dojoengine/book`.

## Requires these secrets (forwarded via `secrets: inherit`)

- `CREATE_PR_TOKEN` — PAT with `contents: write` on `dojoengine/book`.
- `ANTHROPIC_API_KEY` — for `anthropics/claude-code-action@beta`.

## Merge order

**Merge `dojoengine/book#504` first** — that's what adds the reusable workflow this stub references. Merging this stub before that one means the workflow will fail at invocation time (the `uses:` ref won't resolve).

## Related

Companion stub PRs across the dojoengine ecosystem, all pointing at the same reusable workflow:

- dojoengine/dojo#3405
- dojoengine/katana#552
- dojoengine/torii#427
- dojoengine/torii-core#68
- dojoengine/saya#71
- dojoengine/dojo.js#528
- dojoengine/dojo.c#165
- dojoengine/dojo.unity#117
- dojoengine/dojo.unreal#2
- dojoengine/dojo.bevy#6

Cross-org companion stub:
- cartridge-gg/controller#2572
