### PR TITLE
fix(sozo): default account to pre-confirmed block and make it configurable via CLI

### DIFF
--- a/bin/sozo/src/commands/options/account/mod.rs
+++ b/bin/sozo/src/commands/options/account/mod.rs
@@ -147,9 +147,10 @@ impl AccountOptions {
         let mut account =
             SingleOwnerAccount::new(provider, signer, account_address, chain_id, encoding);
 
-        // Since now the block frequency is higher than before, using latest is
-        // totally fine. We keep it explicitely set here to easy toggle if necessary.
-        account.set_block_id(BlockId::Tag(BlockTag::Latest));
+        // Use the pre-confirmed block so nonce lookups and fee estimation reflect
+        // the block the transaction will actually land in, rather than the
+        // already-mined latest block (whose gas prices may be stale).
+        account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
         Ok(account)
     }
 

--- a/bin/sozo/src/commands/options/account/mod.rs
+++ b/bin/sozo/src/commands/options/account/mod.rs
@@ -153,9 +153,8 @@ impl AccountOptions {
         let mut account =
             SingleOwnerAccount::new(provider, signer, account_address, chain_id, encoding);
 
-        // Default to the pre-confirmed block so nonce lookups and fee estimation
-        // reflect the block the transaction will actually land in, rather than the
-        // already-mined latest block (whose gas prices may be stale).
+        // `PreConfirmed` is already the starknet-rs default; we set it
+        // explicitly so the choice is visible and easy to override.
         let block_id = match &self.block_id {
             Some(s) => dojo_utils::parse_block_id(s.clone())?,
             None => BlockId::Tag(BlockTag::PreConfirmed),

--- a/bin/sozo/src/commands/options/account/mod.rs
+++ b/bin/sozo/src/commands/options/account/mod.rs
@@ -60,6 +60,12 @@ pub struct AccountOptions {
     #[arg(help = "Use legacy account (cairo0 account)")]
     #[arg(global = true)]
     pub legacy: bool,
+
+    #[arg(long = "account-block-id", value_name = "BLOCK_ID")]
+    #[arg(global = true)]
+    #[arg(help = "Block at which the account fetches its nonce and estimates fees. Accepts \
+                  'preconfirmed' (default), 'latest', a block number, or a block hash (0x...).")]
+    pub block_id: Option<String>,
 }
 
 impl AccountOptions {
@@ -147,10 +153,14 @@ impl AccountOptions {
         let mut account =
             SingleOwnerAccount::new(provider, signer, account_address, chain_id, encoding);
 
-        // Use the pre-confirmed block so nonce lookups and fee estimation reflect
-        // the block the transaction will actually land in, rather than the
+        // Default to the pre-confirmed block so nonce lookups and fee estimation
+        // reflect the block the transaction will actually land in, rather than the
         // already-mined latest block (whose gas prices may be stale).
-        account.set_block_id(BlockId::Tag(BlockTag::PreConfirmed));
+        let block_id = match &self.block_id {
+            Some(s) => dojo_utils::parse_block_id(s.clone())?,
+            None => BlockId::Tag(BlockTag::PreConfirmed),
+        };
+        account.set_block_id(block_id);
         Ok(account)
     }
 


### PR DESCRIPTION
The `SingleOwnerAccount` used by `sozo migrate` was setting its block id to `Latest` (changed in https://github.com/dojoengine/dojo/commit/67871d66), which causes starknet-rs to perform both nonce lookups and fee estimation against the most recently mined block; the resulting gas-price estimates therefore reflect that block's prices rather than the pre-confirmed block where the transaction will actually be included, so when prices move between blocks the derived `max_*_price` can fall below what the next block requires and the transaction gets rejected. This change flips the default block id back to `PreConfirmed` (the pre-0.17.0 behavior) so fee estimation and nonce lookups both target the block the transaction will actually land in, and adds a global `--account-block-id` flag that lets users override the default with `latest`, a block number, or a block hash via `dojo_utils::parse_block_id` for cases where the previous behavior is desired.